### PR TITLE
Docker ARM64/AMD64 image workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: Deploy Production
+on:
+  workflow_dispatch:
+jobs:
+  build-and-push-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_REGISTRY }}/freika/dawarich:latest,${{ secrets.DOCKER_REGISTRY }}/freika/dawarich:${{ github.run_number }}
+          platforms: linux/amd64,linux/arm64/v8
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
Following from [this medium article](https://www.agas.dev/github-actions-docker-build) by [Agastya Darma Laksana](https://github.com/gedeagas). This workflow allows for either the automation of or manual creation of docker images for the AMD64 and ARM64 architectures and automatically push it to a registry of choosing. 

The secrets can be set via the [project's settings](https://github.com/Freika/dawarich/settings/secrets/actions) under `Repository secrets`.

Tested with a private docker registry so can't comment on using docker hub.