### PR TITLE
Fix for #120: Only allow /sidekiq access to authenticated users

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,11 @@ require 'sidekiq/web'
 Rails.application.routes.draw do
   mount Rswag::Api::Engine => '/api-docs'
   mount Rswag::Ui::Engine => '/api-docs'
-  mount Sidekiq::Web => '/sidekiq'
+
+  # Ensure that only authenticated users can access Sidekiq Web UI
+  authenticate :user do
+    mount Sidekiq::Web => '/sidekiq'
+  end
 
   resources :settings, only: :index
   namespace :settings do


### PR DESCRIPTION
Tested locally.  Sidekiq still works fine.  When user is logged out of Dawarich, /sidekiq returns the user to the login screen.  When user is logged into Dawarich, /sidekiq returns as expected.

I was unable to run unit tests successfully - still trying to get my dev env setup for this project.  In addition, I'm not a Ruby guy.  So, due to these two things, please thoroughly check this fix before approving.

Thanks!