### PR TITLE
Set auto restart to DB & Redis in case it crashes or shuts down.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - dawarich
     volumes:
       - shared_data:/var/shared/redis
+    restart: always
   dawarich_db:
     image: postgres:14.2-alpine
     container_name: dawarich_db
@@ -20,6 +21,7 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
+    restart: always
   dawarich_app:
     image: freikin/dawarich:latest
     container_name: dawarich_app


### PR DESCRIPTION
This PR addresses issue #176, but does not fully solve it. In this PR, we simply set the restart policy for Redis and the database so that it is always up. This does not solve the root cause of the issue, and I believe this issue should be researched further, but I think this is a good start. 