### PR TITLE
Convert the headers to string

### DIFF
--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -12,8 +12,8 @@ class Api::V1::PointsController < ApiController
              .page(params[:page])
              .per(params[:per_page] || 100)
 
-    response.set_header('X-Current-Page', points.current_page)
-    response.set_header('X-Total-Pages', points.total_pages)
+    response.set_header('X-Current-Page', points.current_page.to_s)
+    response.set_header('X-Total-Pages', points.total_pages.to_s)
 
     render json: points
   end


### PR DESCRIPTION
It seems like all HTTP headers are string, while other types may work, its more safe to convert the types to strings to ensure no trouble is caused by non string types. Even if it does work, at least now the types are consistent, as headers are being put as string and they are also retrieved as string.