### PR TITLE
Creating exports directory if it doesn't exist

### DIFF
--- a/app/services/exports/create.rb
+++ b/app/services/exports/create.rb
@@ -72,8 +72,9 @@ class Exports::Create
   end
 
   def create_export_file(data)
-    file_path = Rails.root.join('public', 'exports', "#{export.name}.#{file_format}")
-
+    dir_path = Rails.root.join('public', 'exports')
+    Dir.mkdir(dir_path) unless Dir.exist?(dir_path)
+    file_path = dir_path.join("#{export.name}.#{file_format}")
     File.open(file_path, 'w') { |file| file.write(data) }
   end
 end


### PR DESCRIPTION
On my first export I found out that it failed because the exports directory didn't exist. Creating the directory and retrying the export fixed it.