### PR TITLE
Allow alternate Postgres port and DB name in Docker (fixes #88)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,11 @@
 FROM ruby:3.3.4-alpine
 
-ENV APP_PATH /var/app
-ENV BUNDLE_VERSION 2.5.9
-ENV BUNDLE_PATH /usr/local/bundle/gems
-ENV TMP_PATH /tmp/
-ENV RAILS_LOG_TO_STDOUT true
-ENV RAILS_PORT 3000
-
-# Copy entrypoint scripts and grant execution permissions
-COPY ./dev-docker-entrypoint.sh /usr/local/bin/dev-entrypoint.sh
-RUN chmod +x /usr/local/bin/dev-entrypoint.sh
-
-# Copy application files to workdir
-COPY . $APP_PATH
+ENV APP_PATH=/var/app
+ENV BUNDLE_VERSION=2.5.9
+ENV BUNDLE_PATH=/usr/local/bundle/gems
+ENV TMP_PATH=/tmp/
+ENV RAILS_LOG_TO_STDOUT=true
+ENV RAILS_PORT=3000
 
 # Install dependencies for application
 RUN apk -U add --no-cache \
@@ -39,13 +32,17 @@ RUN gem install bundler --version "$BUNDLE_VERSION" \
 # Navigate to app directory
 WORKDIR $APP_PATH
 
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock vendor .ruby-version ./
 
 # Install missing gems
 RUN bundle config set --local path 'vendor/bundle' \
     && bundle install --jobs 20 --retry 5
 
 COPY . ./
+
+# Copy entrypoint scripts and grant execution permissions
+COPY ./dev-docker-entrypoint.sh /usr/local/bin/dev-entrypoint.sh
+RUN chmod +x /usr/local/bin/dev-entrypoint.sh
 
 EXPOSE $RAILS_PORT
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,38 +1,37 @@
 FROM ruby:3.3.4-alpine
 
-ENV APP_PATH /var/app
-ENV BUNDLE_VERSION 2.5.9
-ENV BUNDLE_PATH /usr/local/bundle/gems
-ENV TMP_PATH /tmp/
-ENV RAILS_LOG_TO_STDOUT true
-ENV RAILS_PORT 3000
+ENV APP_PATH=/var/app
+ENV BUNDLE_VERSION=2.5.9
+ENV BUNDLE_PATH=/usr/local/bundle/gems
+ENV TMP_PATH=/tmp/
+ENV RAILS_LOG_TO_STDOUT=true
+ENV RAILS_PORT=3000
+
+# install dependencies for application
+RUN apk -U add --no-cache \
+  build-base \
+  git \
+  postgresql-dev \
+  postgresql-client \
+  libxml2-dev \
+  libxslt-dev \
+  nodejs \
+  yarn \
+  imagemagick \
+  tzdata \
+  less \
+  # gcompat for nokogiri on mac m1
+  gcompat \
+  && rm -rf /var/cache/apk/* \
+  && mkdir -p $APP_PATH
+
+RUN gem install bundler --version "$BUNDLE_VERSION" \
+  && rm -rf $GEM_HOME/cache/*
 
 # copy entrypoint scripts and grant execution permissions
 COPY ./dev-docker-entrypoint.sh /usr/local/bin/dev-entrypoint.sh
 COPY ./test-docker-entrypoint.sh /usr/local/bin/test-entrypoint.sh
 RUN chmod +x /usr/local/bin/dev-entrypoint.sh && chmod +x /usr/local/bin/test-entrypoint.sh
-
-# install dependencies for application
-RUN apk -U add --no-cache \
-build-base \
-git \
-postgresql-dev \
-postgresql-client \
-libxml2-dev \
-libxslt-dev \
-nodejs \
-yarn \
-imagemagick \
-tzdata \
-less \
-# gcompat for nokogiri on mac m1
-gcompat \
-&& rm -rf /var/cache/apk/* \
-&& mkdir -p $APP_PATH
-
-
-RUN gem install bundler --version "$BUNDLE_VERSION" \
-&& rm -rf $GEM_HOME/cache/*
 
 # navigate to app directory
 WORKDIR $APP_PATH

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,13 +11,13 @@ default: &default
 
 development:
   <<: *default
-  database: dawarich_development
+  database: <%= ENV['DATABASE_NAME'] || 'dawarich_development' %>
 
 test:
   <<: *default
-  database: dawarich_test
+  database: <%= ENV['DATABASE_NAME'] || 'dawarich_test' %>
 
 production:
   <<: *default
-  database: dawarich_production
+  database: <%= ENV['DATABASE_NAME'] || 'dawarich_production' %>
   url: <%= ENV['DATABASE_URL'] %>

--- a/dev-docker-sidekiq-entrypoint.sh
+++ b/dev-docker-sidekiq-entrypoint.sh
@@ -4,8 +4,15 @@ set -e
 
 echo "Environment: $RAILS_ENV"
 
+# set env var defaults
+DATABASE_HOST=${DATABASE_HOST:-"dawarich_db"}
+DATABASE_PORT=${DATABASE_PORT:-5432}
+DATABASE_USER=${DATABASE_USER:-"postgres"}
+DATABASE_PASSWORD=${DATABASE_PASSWORD:-"password"}
+DATABASE_NAME=${DATABASE_NAME:-"dawarich_development"}
+
 # Wait for the database to be ready
-until nc -zv $DATABASE_HOST 5432; do
+until nc -zv $DATABASE_HOST ${DATABASE_PORT:-5432}; do
   echo "Waiting for PostgreSQL to be ready..."
   sleep 1
 done


### PR DESCRIPTION
Hey!

This PR fixes #88 by modifying `dev-docker-entrypoint.sh` to use alternative ports when the env var is specified and make sure that the DB does not exist before attempting to create it. It also modifies `config/database.yml` to not override the database name when one is specified as an env var.

I also reordered the Dockerfile to optimize layer caching. This means docker builds with a cache will be near-instant as long as dependency inputs don't change.

Let me know what you think! Thank you for this project! Excited to be able to see my data in a way that OwnTracks is sorely lacking.