### PR TITLE
Installation: use `docker compose`, not `docker-compose`

### DIFF
--- a/docs/How_to_install_Dawarich_using_Docker.md
+++ b/docs/How_to_install_Dawarich_using_Docker.md
@@ -2,7 +2,7 @@
 
 > To do that you need previously install [Docker](https://docs.docker.com/get-docker/) on your system.
 
-To quick Dawarich install copy the contents of the `docker-compose.yml` file from project root folder to dedicated folder in your server and run `docker-compose up` in this folder.
+To quick Dawarich install copy the contents of the `docker-compose.yml` file from project root folder to dedicated folder in your server and run `docker compose up` in this folder.
 
 This command use [docker-compose.yml](../docker-compose.yml) to build your local environment.
 


### PR DESCRIPTION
I'm somewhat new to Docker, but `docker-compose` had issues with running this. `docker compose` seems to be the new standard going forward, and it indeed works when the other one fails.