### PR TITLE
Fixed $HOSTNAME variable usage in healthcheck command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
         max-size: "100m"
         max-file: "5"
     healthcheck:
-      test: [ "CMD-SHELL", "bundle exec sidekiqmon processes | grep ${HOSTNAME}" ]
+      test: [ "CMD-SHELL", "bundle exec sidekiqmon processes | grep $${HOSTNAME}" ]
       interval: 10s
       retries: 5
       start_period: 30s


### PR DESCRIPTION
After adopting changes suggested in [version 0.15.11](https://github.com/Freika/dawarich/releases/tag/0.15.11) it seems healthcheck command broke. Docker compose is trying to resolve `$HOSTNAME` variable when deploying instead of resolving it on execution time. Fixed this escaping variable character with double dollar sign, `$$`.