### PR TITLE
Fix missing file extension in gpx export files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Admins can now provide custom password for new users and update passwords for existing users on the Users page.
 
+### Fixed
+
+- Exported files will now always have an extension when downloaded. Previously, the extension was missing in case of GPX export.
+
 # 0.16.3 - 2024-11-10
 
 ### Fixed

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -9,7 +9,7 @@ class ExportsController < ApplicationController
   end
 
   def create
-    export_name = "export_from_#{params[:start_at].to_date}_to_#{params[:end_at].to_date}"
+    export_name = "export_from_#{params[:start_at].to_date}_to_#{params[:end_at].to_date}.#{params[:file_format]}"
     export = current_user.exports.create(name: export_name, status: :created)
 
     ExportJob.perform_later(export.id, params[:start_at], params[:end_at], file_format: params[:file_format])


### PR DESCRIPTION
### Fixed

- Exported files will now always have an extension when downloaded. Previously, the extension was missing in case of GPX export. #377 