### PR TITLE
Fix points params preserved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Exported files will now always have an extension when downloaded. Previously, the extension was missing in case of GPX export.
+- Deleting and sorting points on the Points page will now preserve filtering and sorting params when points are deleted or sorted. Previously, the page was being reloaded and filtering and sorting params were lost.
 
 # 0.16.3 - 2024-11-10
 

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -19,7 +19,6 @@ class PointsController < ApplicationController
 
   def bulk_destroy
     current_user.tracked_points.where(id: params[:point_ids].compact).destroy_all
-
     redirect_to points_url(preserved_params),
                 notice: 'Points were successfully destroyed.',
                 status: :see_other

--- a/app/views/points/index.html.erb
+++ b/app/views/points/index.html.erb
@@ -88,4 +88,8 @@
       <% end %>
     </div>
   </div>
+
+  <div class='text-center my-5'>
+    <%= paginate @points %>
+  </div>
 </div>

--- a/app/views/points/index.html.erb
+++ b/app/views/points/index.html.erb
@@ -45,7 +45,7 @@
 
   <div id="points" class="min-w-full">
     <div data-controller='checkbox-select-all'>
-      <%= form_with url: bulk_destroy_points_path, method: :delete, id: :bulk_destroy_form do |f| %>
+      <%= form_with url: bulk_destroy_points_path(params.permit!), method: :delete, id: :bulk_destroy_form do |f| %>
 
         <div class="flex justify-between my-5">
           <%= f.submit "Delete Selected", class: "px-4 py-2 bg-red-500 text-white rounded-md", data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" } %>
@@ -54,8 +54,8 @@
           </div>
           <div class="flex justify-end">
             <span class="mr-2">Order by:</span>
-            <%= link_to 'Newest', points_path(order_by: :desc, import_id: params[:import_id]), class: 'btn btn-xs btn-primary mx-1' %>
-            <%= link_to 'Oldest', points_path(order_by: :asc, import_id: params[:import_id]), class: 'btn btn-xs btn-primary mx-1' %>
+            <%= link_to 'Newest', points_path(order_by: :desc, import_id: params[:import_id], start_at: params[:start_at], end_at: params[:end_at]), class: 'btn btn-xs btn-primary mx-1' %>
+            <%= link_to 'Oldest', points_path(order_by: :asc, import_id: params[:import_id], start_at: params[:start_at], end_at: params[:end_at]), class: 'btn btn-xs btn-primary mx-1' %>
           </div>
         </div>
 


### PR DESCRIPTION
### Fixed

- Deleting and sorting points on the Points page will now preserve filtering and sorting params when points are deleted or sorted. Previously, the page was being reloaded and filtering and sorting params were lost. #363 