### PR TITLE
fix: Redis container missing name in compose-file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ networks:
 services:
   dawarich_redis:
     image: redis:7.0-alpine
+    container_name: dawarich_redis
     command: redis-server
     networks:
       - dawarich


### PR DESCRIPTION
This fixes a bug where the other containers are not able to reach redis on the network because docker does not assign the expected DNS entry to the container.