### PR TITLE
Avoid Redis connectivity on initialization

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -25,4 +25,6 @@ Sidekiq.configure_client do |config|
   config.redis = { url: ENV['REDIS_URL'] }
 end
 
-Sidekiq::Queue['reverse_geocoding'].limit = 1 if PHOTON_API_HOST == 'photon.komoot.io'
+if (defined?(Rails::Server) || Sidekiq.server?) && PHOTON_API_HOST == 'photon.komoot.io'
+    Sidekiq::Queue['reverse_geocoding'].limit = 1
+end


### PR DESCRIPTION
Certain scenarios (for instance, if one wants to perform an isolated `rake assets:precompile`) fails if Redis is not configured --and there are scenarios that do not need Redis configuration.

The edited initialization code was always triggering. It makes sense to add an `if` there and only do it in the scenarios where it is really necessary.

I am not an expert and have performed limited testing, but it seems like this allows the assets:precompile to run properly and does not break the server nor sidekiq startups.