### PR TITLE
fix imports of owntracks .rec files containing log types other than events

### DIFF
--- a/app/services/own_tracks/rec_parser.rb
+++ b/app/services/own_tracks/rec_parser.rb
@@ -9,7 +9,12 @@ class OwnTracks::RecParser
 
   def call
     file.split("\n").map do |line|
-      JSON.parse(line.split("\t*                 \t")[1])
-    end
+      parts = line.split("\t")
+      if parts.size > 2 && parts[1].strip == '*'
+        JSON.parse(parts[2])
+      else
+        nil
+      end
+    end.compact
   end
 end

--- a/spec/fixtures/files/owntracks/2024-03.rec
+++ b/spec/fixtures/files/owntracks/2024-03.rec
@@ -6,5 +6,8 @@
 2024-03-01T18:33:03Z	*                 	{"cog":18,"batt":85,"lon":13.337,"acc":5,"bs":1,"p":100.347,"vel":4,"vac":3,"lat":52.230,"topic":"owntracks/test/iPhone 12 Pro","conn":"m","m":1,"tst":1709317983,"alt":36,"_type":"location","tid":"RO","_http":true}
 2024-03-01T18:40:11Z	*                 	{"cog":43,"batt":85,"lon":13.338,"acc":5,"bs":1,"p":100.348,"vel":6,"vac":3,"lat":52.231,"topic":"owntracks/test/iPhone 12 Pro","conn":"m","m":1,"tst":1709318411,"alt":37,"_type":"location","tid":"RO","_http":true}
 2024-03-01T18:42:57Z	*                 	{"cog":320,"batt":85,"lon":13.339,"acc":5,"bs":1,"p":100.353,"vel":3,"vac":3,"lat":52.232,"topic":"owntracks/test/iPhone 12 Pro","t":"v","conn":"m","m":1,"tst":1709318577,"alt":37,"_type":"location","tid":"RO","_http":true}
+2024-03-01T18:40:08Z	lwt               	{"_type":"lwt","tst":1717459208}
+2024-03-01T18:40:09Z	waypoints         	{"_type":"waypoint","desc":"Home","lat":52.232,"lon":13.339,"rad":50,"tst":1717459768}
+2024-03-01T18:40:10Z	event             	{"_type":"transition","acc":5,"desc":"Home","event":"enter","lat":52.232,"lon":13.339,"t":"l","tid":"s8","tst":1717460098,"wtst":1717459768}
 2024-03-01T18:40:11Z	*                 	{"cog":43,"batt":85,"lon":13.338,"acc":5,"bs":1,"p":100.348,"vel":6,"vac":3,"lat":52.231,"topic":"owntracks/test/iPhone 12 Pro","conn":"m","m":1,"tst":1709318411,"alt":37,"_type":"location","tid":"RO","_http":true}
 2024-03-01T18:40:11Z	*                 	{"cog":43,"batt":85,"lon":13.341,"acc":5,"bs":1,"p":100.348,"created_at":1709318940,"vel":6,"vac":3,"lat":52.234,"topic":"owntracks/test/iPhone 12 Pro","conn":"m","m":1,"tst":1709318411,"alt":37,"_type":"location","tid":"RO","_http":true}


### PR DESCRIPTION
This pull request aims to fix the issue in #464 

After investigating further from what I had posted on the issue, I realized the issue was with how the importer handled lines which didn't follow the structure of a log line of `type: location`.

For example, lines like 

```
2024-03-01T18:40:08Z	lwt               	{"_type":"lwt","tst":1717459208}
2024-03-01T18:40:09Z	waypoints         	{"_type":"waypoint","desc":"Home","lat":52.232,"lon":13.339,"rad":50,"tst":1717459768}
2024-03-01T18:40:10Z	event             	{"_type":"transition","acc":5,"desc":"Home","event":"enter","lat":52.232,"lon":13.339,"t":"l","tid":"s8","tst":1717460098,"wtst":1717459768}
```

which are valid event log lines in Owntracks would break the parser which expects a `"\t* \t"` structure.

This change should fix that. I adapted the .rec test fixture to reflect this and was able to import all of my old .rec files successfully running a local environment with this change.

On a side note, when trying to run the tests all of them would fail unless I disabled the Shoulda configuration in `spec/rails_helper.rb`. I've never done anything in Ruby before so it might be something I'm doing wrong, and I was curious on what that could be. I tried running the tests with `bundle exec rspec`.