### PR TITLE
Fix Prometheus exporter for Sidekiq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-# 0.19.0 - 2024-12-03
+# 0.19.1 - 2024-12-04
+
+### Fixed
+
+- Sidekiq is now being correctly exported to Prometheus with `PROMETHEUS_EXPORTER_ENABLED=true` env var in `dawarich_sidekiq` service.
+
+# 0.19.0 - 2024-12-04
 
 ## The Photoprism integration release
 

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -7,7 +7,7 @@ if !Rails.env.test? && ENV['PROMETHEUS_EXPORTER_ENABLED'].to_s == 'true'
   # This reports stats per request like HTTP status and timings
   Rails.application.middleware.unshift PrometheusExporter::Middleware
 
-  # this reports basic process stats like RSS and GC info
+  # This reports basic process stats like RSS and GC info
   PrometheusExporter::Instrumentation::Process.start(type: 'web')
 
   # Add ActiveRecord instrumentation

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,14 +6,16 @@ Sidekiq.configure_server do |config|
   if ENV['PROMETHEUS_EXPORTER_ENABLED'].to_s == 'true'
     require 'prometheus_exporter/instrumentation'
 
+    # Add middleware for collecting job-level metrics
     config.server_middleware do |chain|
       chain.add PrometheusExporter::Instrumentation::Sidekiq
     end
 
+    # Capture metrics for failed jobs
     config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
 
+    # Start Prometheus instrumentation
     config.on :startup do
-      PrometheusExporter::Instrumentation::Process.start type: 'sidekiq'
       PrometheusExporter::Instrumentation::SidekiqProcess.start
       PrometheusExporter::Instrumentation::SidekiqQueue.start
       PrometheusExporter::Instrumentation::SidekiqStats.start
@@ -25,6 +27,4 @@ Sidekiq.configure_client do |config|
   config.redis = { url: ENV['REDIS_URL'] }
 end
 
-if (defined?(Rails::Server) || Sidekiq.server?) && PHOTON_API_HOST == 'photon.komoot.io'
-    Sidekiq::Queue['reverse_geocoding'].limit = 1
-end
+Sidekiq::Queue['reverse_geocoding'].limit = 1 if Sidekiq.server? && PHOTON_API_HOST == 'photon.komoot.io'


### PR DESCRIPTION
### Fixed

- Sidekiq is now being correctly exported to Prometheus with `PROMETHEUS_EXPORTER_ENABLED=true` env var in `dawarich_sidekiq` service.