### PR TITLE
fix gem paths in compose.yml & k8s instructions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     image: freikin/dawarich:latest
     container_name: dawarich_app
     volumes:
-      - dawarich_gem_cache_app:/usr/local/bundle/gems_app
+      - dawarich_gem_cache_app:/usr/local/bundle/gems
       - dawarich_public:/var/app/public
       - dawarich_watched:/var/app/tmp/imports/watched
     networks:
@@ -96,7 +96,7 @@ services:
     image: freikin/dawarich:latest
     container_name: dawarich_sidekiq
     volumes:
-      - dawarich_gem_cache_sidekiq:/usr/local/bundle/gems_sidekiq
+      - dawarich_gem_cache_sidekiq:/usr/local/bundle/gems
       - dawarich_public:/var/app/public
       - dawarich_watched:/var/app/tmp/imports/watched
     networks:

--- a/docs/How_to_install_Dawarich_in_k8s.md
+++ b/docs/How_to_install_Dawarich_in_k8s.md
@@ -140,8 +140,8 @@ spec:
           image: freikin/dawarich:0.16.4
           imagePullPolicy: Always
           volumeMounts:
-            - mountPath: /usr/local/bundle/gems_app
-              name: gem-cache
+            - mountPath: /usr/local/bundle/gems
+              name: gem-app
             - mountPath: /var/app/public
               name: public
             - mountPath: /var/app/tmp/imports/watched
@@ -196,7 +196,7 @@ spec:
           image: freikin/dawarich:0.16.4
           imagePullPolicy: Always
           volumeMounts:
-            - mountPath: /usr/local/bundle/gems_sidekiq
+            - mountPath: /usr/local/bundle/gems
               name: gem-sidekiq
             - mountPath: /var/app/public
               name: public


### PR DESCRIPTION
It appears that gems aren't being stored in the defined volumes. I think this is a result of the change in [`d3f6d0d`](https://github.com/Freika/dawarich/commit/d3f6d0da7bc500e6af42cced82e46d7d5b783f7d#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3).

Looks like either supporting changes to write gems to a different path in app/sidekiq weren't added or the change to the path was supposed to be on the host side rather than the container side.

I'm assuming it's the latter. If so, this PR will fix the paths. The host-side paths in the compose file were already fixed in d3c80e2b18ef87af1d7927ebc88a6831bb5abd1e.