### PR TITLE
Update How_to_install_Dawarich_using_Docker.md

### DIFF
--- a/docs/How_to_install_Dawarich_using_Docker.md
+++ b/docs/How_to_install_Dawarich_using_Docker.md
@@ -8,4 +8,4 @@ This command use [docker-compose.yml](../docker-compose.yml) to build your local
 
 When this command done successfully and all services in containers will start you can open Dawarich web UI by this link [http://127.0.0.1:3000](http://127.0.0.1:3000).
 
-Default credentials for first login in are `user@domain.com` and `password`.
+Default credentials for first login in are `demo@dawarich.app` and `password`.


### PR DESCRIPTION
it looks like there's an error in the docker compose example. readme was updated with new login example but this file never was.