### PR TITLE
Bind to both IPv6 and IPv4 interfaces by default

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,1 +1,1 @@
-web: bin/rails server -p 3000 -b 0.0.0.0
+web: bin/rails server -p 3000 -b ::

--- a/Procfile.prometheus.dev
+++ b/Procfile.prometheus.dev
@@ -1,2 +1,2 @@
-prometheus_exporter: bundle exec prometheus_exporter -b 0.0.0.0
-web: bin/rails server -p 3000 -b 0.0.0.0
+prometheus_exporter: bundle exec prometheus_exporter -b ANY
+web: bin/rails server -p 3000 -b ::

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -50,7 +50,7 @@ if ENV['PROMETHEUS_EXPORTER_ENABLED'].to_s == 'true'
 
   before_fork do
     PrometheusExporter::Client.default = PrometheusExporter::Client.new(
-      host: ENV.fetch('PROMETHEUS_EXPORTER_HOST', '0.0.0.0'),
+      host: ENV.fetch('PROMETHEUS_EXPORTER_HOST', 'ANY'),
       port: ENV.fetch('PROMETHEUS_EXPORTER_PORT', 9394)
     )
   end

--- a/docs/How_to_install_Dawarich_in_k8s.md
+++ b/docs/How_to_install_Dawarich_in_k8s.md
@@ -7,6 +7,7 @@
 - Working Postgres and Redis instances. In this example Postgres lives in 'db' namespace and Redis in 'redis' namespace.
 - Ngingx ingress controller with Letsencrypt integeation.
 - This example uses 'example.com' as a domain name, you want to change it to your own.
+- This will work on IPv4 and IPv6 Single Stack clusters, as well as Dual Stack deployments.
 
 ## Installation
 
@@ -149,7 +150,7 @@ spec:
           command:
             - "dev-entrypoint.sh"
           args:
-            - "bin/rails server -p 3000 -b 0.0.0.0"
+            - "bin/rails server -p 3000 -b ::"
           resources:
             requests:
               memory: "1Gi"


### PR DESCRIPTION
This Pull Request binds the Rails server and Prometheus Exporter to both IPv6 and IPv4 interfaces by default, and updates the K8s deployment documentation to reflect this.

Not tested as there appears to be no scaffolding to test this functionality?

Closes https://github.com/Freika/dawarich/issues/498