### PR TITLE
Update map popup to format dates with the locale from the browser

### DIFF
--- a/app/javascript/maps/helpers.js
+++ b/app/javascript/maps/helpers.js
@@ -55,7 +55,14 @@ export function minutesToDaysHoursMinutes(minutes) {
 
 export function formatDate(timestamp, timezone) {
   const date = new Date(timestamp * 1000);
-  const locale = navigator.languages !== undefined ? navigator.languages[0] : navigator.language;
+  let locale;
+  if (navigator.languages !== undefined) {
+    locale = navigator.languages[0];
+  } else if (navigator.language) {
+    locale = navigator.language;
+  } else {
+    locale = 'en-GB';
+  }
   return date.toLocaleString(locale, { timeZone: timezone });
 }
 

--- a/app/javascript/maps/helpers.js
+++ b/app/javascript/maps/helpers.js
@@ -55,7 +55,8 @@ export function minutesToDaysHoursMinutes(minutes) {
 
 export function formatDate(timestamp, timezone) {
   const date = new Date(timestamp * 1000);
-  return date.toLocaleString("en-GB", { timeZone: timezone });
+  const locale = navigator.languages !== undefined ? navigator.languages[0] : navigator.language;
+  return date.toLocaleString(locale, { timeZone: timezone });
 }
 
 export function haversineDistance(lat1, lon1, lat2, lon2, unit = 'km') {

--- a/app/javascript/maps/polylines.js
+++ b/app/javascript/maps/polylines.js
@@ -1,3 +1,4 @@
+import { formatDate } from "../maps/helpers";
 import { formatDistance } from "../maps/helpers";
 import { getUrlParameter } from "../maps/helpers";
 import { minutesToDaysHoursMinutes } from "../maps/helpers";
@@ -12,8 +13,8 @@ export function addHighlightOnHover(polyline, map, polylineCoordinates, userSett
   const startPoint = polylineCoordinates[0];
   const endPoint = polylineCoordinates[polylineCoordinates.length - 1];
 
-  const firstTimestamp = new Date(startPoint[4] * 1000).toLocaleString("en-GB", { timeZone: userSettings.timezone });
-  const lastTimestamp = new Date(endPoint[4] * 1000).toLocaleString("en-GB", { timeZone: userSettings.timezone });
+  const firstTimestamp = formatDate(startPoint[4], userSettings.timezone);
+  const lastTimestamp = formatDate(endPoint[4], userSettings.timezone);
 
   const minutes = Math.round((endPoint[4] - startPoint[4]) / 60);
   const timeOnRoute = minutesToDaysHoursMinutes(minutes);


### PR DESCRIPTION
This PR just removes the hardcoded `en-GB` locale in favor of using the locale from the browser's setting. The `navigator.languages` property is supported by all major browsers ([MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/languages)).