### PR TITLE
Support API key in Authorization header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- In addition to `api_key` parameter, `Authorization` header is now being used to authenticate API requests. #543
+
+Example:
+
+```
+Authorization: Bearer YOUR_API_KEY
+```
+
+# 0.20.3 - 2024-12-20
+
+### Added
+
 - A button on a year stats card to update stats for the whole year.
 - A button on a month stats card to update stats for a specific month.
 - A confirmation alert on the Notifications page before deleting all notifications.

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -13,7 +13,11 @@ class ApiController < ApplicationController
   end
 
   def current_api_user
-    @current_api_user ||= User.find_by(api_key: params[:api_key])
+    @current_api_user ||= User.find_by(api_key:)
+  end
+
+  def api_key
+    params[:api_key] || request.headers['Authorization']&.split(' ')&.last
   end
 
   def validate_params

--- a/spec/requests/api/v1/areas_spec.rb
+++ b/spec/requests/api/v1/areas_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe '/api/v1/areas', type: :request do
 
   describe 'GET /index' do
     it 'renders a successful response' do
-      get api_v1_areas_url(api_key: user.api_key)
+      get api_v1_areas_url, headers: { 'Authorization' => "Bearer #{user.api_key}" }
       expect(response).to be_successful
     end
   end
@@ -20,12 +20,14 @@ RSpec.describe '/api/v1/areas', type: :request do
 
       it 'creates a new Area' do
         expect do
-          post api_v1_areas_url(api_key: user.api_key), params: { area: valid_attributes }
+          post api_v1_areas_url, headers: { 'Authorization' => "Bearer #{user.api_key}" },
+                                 params: { area: valid_attributes }
         end.to change(Area, :count).by(1)
       end
 
       it 'redirects to the created api_v1_area' do
-        post api_v1_areas_url(api_key: user.api_key), params: { area: valid_attributes }
+        post api_v1_areas_url, headers: { 'Authorization' => "Bearer #{user.api_key}" },
+                              params: { area: valid_attributes }
 
         expect(response).to have_http_status(:created)
       end
@@ -38,12 +40,15 @@ RSpec.describe '/api/v1/areas', type: :request do
 
       it 'does not create a new Area' do
         expect do
-          post api_v1_areas_url(api_key: user.api_key), params: { area: invalid_attributes }
+          post api_v1_areas_url, headers: { 'Authorization' => "Bearer #{user.api_key}" },
+                                 params: { area: invalid_attributes }
         end.to change(Area, :count).by(0)
       end
 
       it 'renders a response with 422 status' do
-        post api_v1_areas_url(api_key: user.api_key), params: { area: invalid_attributes }
+        post api_v1_areas_url, headers: { 'Authorization' => "Bearer #{user.api_key}" },
+                               params: { area: invalid_attributes }
+
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end
@@ -56,14 +61,16 @@ RSpec.describe '/api/v1/areas', type: :request do
       let(:new_attributes) { attributes_for(:area).merge(name: 'New Name') }
 
       it 'updates the requested api_v1_area' do
-        patch api_v1_area_url(area, api_key: user.api_key), params: { area: new_attributes }
+        patch api_v1_area_url(area), headers: { 'Authorization' => "Bearer #{user.api_key}" },
+                                     params: { area: new_attributes }
         area.reload
 
         expect(area.reload.name).to eq('New Name')
       end
 
       it 'redirects to the api_v1_area' do
-        patch api_v1_area_url(area, api_key: user.api_key), params: { area: new_attributes }
+        patch api_v1_area_url(area), headers: { 'Authorization' => "Bearer #{user.api_key}" },
+                                     params: { area: new_attributes }
         area.reload
 
         expect(response).to have_http_status(:ok)
@@ -75,7 +82,8 @@ RSpec.describe '/api/v1/areas', type: :request do
       let(:invalid_attributes) { attributes_for(:area, name: nil) }
 
       it 'renders a response with 422 status' do
-        patch api_v1_area_url(area, api_key: user.api_key), params: { area: invalid_attributes }
+        patch api_v1_area_url(area), headers: { 'Authorization' => "Bearer #{user.api_key}" },
+                                     params: { area: invalid_attributes }
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
@@ -87,12 +95,12 @@ RSpec.describe '/api/v1/areas', type: :request do
 
     it 'destroys the requested api_v1_area' do
       expect do
-        delete api_v1_area_url(area, api_key: user.api_key)
+        delete api_v1_area_url(area), headers: { 'Authorization' => "Bearer #{user.api_key}" }
       end.to change(Area, :count).by(-1)
     end
 
     it 'redirects to the api_v1_areas list' do
-      delete api_v1_area_url(area, api_key: user.api_key)
+      delete api_v1_area_url(area), headers: { 'Authorization' => "Bearer #{user.api_key}" }
 
       expect(response).to have_http_status(:ok)
     end


### PR DESCRIPTION
### Added

- In addition to `api_key` parameter, `Authorization` header is now being used to authenticate API requests. #543

Example:

```
Authorization: Bearer YOUR_API_KEY
```