### PR TITLE
Sample k8s deployment and Doker image for own photon image

### DIFF
--- a/docs/photon/Dokerimage/Dockerfile
+++ b/docs/photon/Dokerimage/Dockerfile
@@ -1,0 +1,17 @@
+FROM openjdk:24-slim-bullseye
+
+# Install pbzip2 for parallel extraction
+RUN apt update && apt-get upgrade -y && \
+    apt-get -y install wget bzip2 curl vim && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR /photon
+ADD https://github.com/komoot/photon/releases/download/0.6.0/photon-0.6.0.jar /photon/photon.jar
+COPY entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
+VOLUME /photon/photon_data
+EXPOSE 2322
+
+ENTRYPOINT ["/photon/entrypoint.sh"]

--- a/docs/photon/Dokerimage/entrypoint.sh
+++ b/docs/photon/Dokerimage/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+
+# Download elasticsearch index
+if [ ! -d "/photon/photon_data/elasticsearch" ]; then
+    echo "Downloading search index"
+
+    # Let graphhopper know where the traffic is coming from
+    USER_AGENT="docker: dawarich/photon-geocoder"
+    # If you want to install a specific region only, enable the line below and disable the current 'wget' row.
+    # Take a look at http://download1.graphhopper.com/public/extracts/by-country-code for your country
+    # wget --user-agent="$USER_AGENT" -O - http://download1.graphhopper.com/public/extracts/by-country-code/nl/photon-db-nl-latest.tar.bz2 | bzip2 -cd | tar x
+    wget --user-agent="$USER_AGENT" -O - http://download1.graphhopper.com/public/photon-db-latest.tar.bz2 | bzip2 -cd | tar x
+fi
+
+# Start photon if elastic index exists
+if [ -d "/photon/photon_data/elasticsearch" ]; then
+    echo "Start photon"
+    java -jar photon.jar $@
+else
+    echo "Could not start photon, the search index could not be found"
+fi
+while true; do sleep 1; done;

--- a/docs/photon/README.md
+++ b/docs/photon/README.md
@@ -1,0 +1,10 @@
+# Own Photon instance deployment
+
+The Dawarich utilises reverse geodata and a default Poton instance is [Komoot.oi](https://photon.komoot.io) that is throttled to 1 request per second. That makes decoding millions of records time consuming. The Dawarich can be configured to use your own Photon instance by setting the `PHOTON_URL` environment variable.
+
+This folder contains Dockerfile and sample Kubernetes deployment. About 200Gb of persistenet storage is reqired.
+
+##Building
+```bash
+docker build -t photon .
+```

--- a/docs/photon/k8s/photon-deployment.yaml
+++ b/docs/photon/k8s/photon-deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: photon
+  namespace: dawarich
+  labels:
+    app: photon
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: photon
+  template:
+    metadata:
+      labels:
+        app: photon
+      containers:
+        - name: photon
+          image: your-registry/photon:latest
+          ports:
+            - containerPort: 2322
+          volumeMounts:
+            - name: photon-data
+              mountPath: /photon/photon_data
+      volumes:
+        - name: photon-data
+          persistentVolumeClaim:
+            claimName: photon-data
+      imagePullSecrets:
+        - name: my-private-registry

--- a/docs/photon/k8s/photon-pvc.yaml
+++ b/docs/photon/k8s/photon-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: dawarich
+  name: photon-data
+  labels:
+    storage.k8s.io/name: longhorn
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 200Gi

--- a/docs/photon/k8s/photon-service.yaml
+++ b/docs/photon/k8s/photon-service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: dawarich
+  labels:
+    service: photon
+  name: photon
+spec:
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 2322
+  selector:
+    app: photon


### PR DESCRIPTION
This is to adress https://github.com/Freika/dawarich/issues/614. The deployment is trivial, the goal is to place documentation as close to the user as possible.