### PR TITLE
Fix authentication to `GET /api/v1/countries/visited_cities`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-# 0.23.4 - 2025-01-21
+# 0.23.4 - 2025-01-22
 
 ### Added
 
 - A test for building rc Docker image.
+
+### Fixed
+
+- Fix authentication to `GET /api/v1/countries/visited_cities` with header `Authorization: Bearer YOUR_API_KEY` instead of `api_key` query param. #679
+
 
 # 0.23.3 - 2025-01-21
 

--- a/app/controllers/api/v1/countries/visited_cities_controller.rb
+++ b/app/controllers/api/v1/countries/visited_cities_controller.rb
@@ -17,6 +17,6 @@ class Api::V1::Countries::VisitedCitiesController < ApiController
   private
 
   def required_params
-    %i[start_at end_at api_key]
+    %i[start_at end_at]
   end
 end

--- a/app/services/tasks/imports/google_records.rb
+++ b/app/services/tasks/imports/google_records.rb
@@ -30,11 +30,10 @@ class Tasks::Imports::GoogleRecords
 
   def process_file_in_batches(import_id)
     batch = []
+    index = 0
 
     Oj.load_file(@file_path, mode: :compat) do |record|
       next unless record.is_a?(Hash) && record['locations']
-
-      index = 0
 
       record['locations'].each do |location|
         batch << location
@@ -47,7 +46,7 @@ class Tasks::Imports::GoogleRecords
       end
     end
 
-    Import::GoogleTakeoutJob.perform_later(import_id, Oj.dump(batch)) if batch.any?
+    Import::GoogleTakeoutJob.perform_later(import_id, Oj.dump(batch), index) if batch.any?
   end
 
   def log_start


### PR DESCRIPTION
### Fixed

- Fix authentication to `GET /api/v1/countries/visited_cities` with header `Authorization: Bearer YOUR_API_KEY` instead of `api_key` query param. #679