### PR TITLE
fix: set dbname in psql entrypoint commands

### DIFF
--- a/docker/sidekiq-entrypoint.sh
+++ b/docker/sidekiq-entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 # Wait for the database to become available
 echo "⏳ Waiting for database to be ready..."
-until PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -d "$DATABASE_NAME" -d "$DATABASE_NAME" -c '\q'; do
+until PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -d "$DATABASE_NAME" -c '\q'; do
   >&2 echo "Postgres is unavailable - retrying..."
   sleep 2
 done

--- a/docker/sidekiq-entrypoint.sh
+++ b/docker/sidekiq-entrypoint.sh
@@ -24,7 +24,7 @@ fi
 
 # Wait for the database to become available
 echo "⏳ Waiting for database to be ready..."
-until PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -c '\q'; do
+until PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -d "$DATABASE_NAME" -d "$DATABASE_NAME" -c '\q'; do
   >&2 echo "Postgres is unavailable - retrying..."
   sleep 2
 done

--- a/docker/web-entrypoint.sh
+++ b/docker/web-entrypoint.sh
@@ -29,14 +29,14 @@ rm -f $APP_PATH/tmp/pids/server.pid
 
 # Wait for the database to become available
 echo "⏳ Waiting for database to be ready..."
-until PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -c '\q'; do
+until PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -d "$DATABASE_NAME" -c '\q'; do
   >&2 echo "Postgres is unavailable - retrying..."
   sleep 2
 done
 echo "✅ PostgreSQL is ready!"
 
 # Create database if it doesn't exist
-if ! PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -c "SELECT 1 FROM pg_database WHERE datname='$DATABASE_NAME'" | grep -q 1; then
+if ! PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -d "$DATABASE_NAME" -c "SELECT 1 FROM pg_database WHERE datname='$DATABASE_NAME'" | grep -q 1; then
   echo "Creating database $DATABASE_NAME..."
   bundle exec rails db:create
 fi


### PR DESCRIPTION
> not setting this breaks init if a custom dbname is used. This was discussed on discord last week but that context understandably got lost (https://discord.com/channels/1233340338865963079/1251100415034921052/1333517972106383411):

    /var/app # env | grep DATABASE
    DATABASE_NAME=dawarich
    DATABASE_USERNAME=dawarich-bliT1A
    DATABASE_PASSWORD=CFKsnipsx
    DATABASE_HOST=app-db-rw.database.svc

>    These are my env vars, but it seems like dawarich is trying to use the username as the database name
    psql: error: connection to server at "app-db-rw.database.svc" (10.43.162.18), port 5432 failed: FATAL: database "dawarich-bliT1A" does not exist
