### PR TITLE
Fix fog gets displaced when dragging map

### DIFF
--- a/app/javascript/maps/fog_of_war.js
+++ b/app/javascript/maps/fog_of_war.js
@@ -85,15 +85,12 @@ export function createFogOverlay() {
     onAdd: (map) => {
       initializeFogCanvas(map);
 
-      // Add drag event handlers to update fog during marker movement
-      map.on('drag', () => {
-        const fog = document.getElementById('fog');
-        if (fog) {
-          // Update fog canvas position to match map position
-          const mapPos = map.getContainer().getBoundingClientRect();
-          fog.style.left = `${mapPos.left}px`;
-          fog.style.top = `${mapPos.top}px`;
-        }
+      // Add resize event handlers to update fog size
+      map.on('resize', () => {
+       // Set canvas size to match map container
+       const mapSize = map.getSize();
+       fog.width = mapSize.x;
+       fog.height = mapSize.y;
       });
     },
     onRemove: (map) => {
@@ -102,7 +99,7 @@ export function createFogOverlay() {
         fog.remove();
       }
       // Clean up event listener
-      map.off('drag');
+      map.off('resize');
     }
   });
 }


### PR DESCRIPTION
Closes #774

Problems:

- Fix: When draging map the 'Fog of War'gets displaced (#774).
- Fix: If the size of the browser window is changed, the size of the fog is not recalculated.
