### PR TITLE
fix database name in entrypoint files

### DIFF
--- a/docker/sidekiq-entrypoint.sh
+++ b/docker/sidekiq-entrypoint.sh
@@ -14,17 +14,19 @@ if [ -n "$DATABASE_URL" ]; then
   DATABASE_PORT=$(echo $DATABASE_URL | awk -F[@/:] '{print $5}')
   DATABASE_USERNAME=$(echo $DATABASE_URL | awk -F[:/@] '{print $4}')
   DATABASE_PASSWORD=$(echo $DATABASE_URL | awk -F[:/@] '{print $5}')
+  DATABASE_NAME=$(echo $DATABASE_URL | awk -F[@/] '{print $5}')
 else
   # Use existing environment variables
   DATABASE_HOST=${DATABASE_HOST}
   DATABASE_PORT=${DATABASE_PORT}
   DATABASE_USERNAME=${DATABASE_USERNAME}
   DATABASE_PASSWORD=${DATABASE_PASSWORD}
+  DATABASE_NAME=${DATABASE_NAME}
 fi
 
 # Wait for the database to become available
 echo "⏳ Waiting for database to be ready..."
-until PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -c '\q'; do
+until PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -d "$DATABASE_NAME" -c '\q'; do
   >&2 echo "Postgres is unavailable - retrying..."
   sleep 2
 done

--- a/docker/web-entrypoint.sh
+++ b/docker/web-entrypoint.sh
@@ -29,14 +29,14 @@ rm -f $APP_PATH/tmp/pids/server.pid
 
 # Wait for the database to become available
 echo "⏳ Waiting for database to be ready..."
-until PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -c '\q'; do
+until PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -d "$DATABASE_NAME" -c '\q'; do
   >&2 echo "Postgres is unavailable - retrying..."
   sleep 2
 done
 echo "✅ PostgreSQL is ready!"
 
 # Create database if it doesn't exist
-if ! PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -c "SELECT 1 FROM pg_database WHERE datname='$DATABASE_NAME'" | grep -q 1; then
+if ! PGPASSWORD=$DATABASE_PASSWORD psql -h "$DATABASE_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USERNAME" -d "$DATABASE_NAME" -c "SELECT 1 FROM pg_database WHERE datname='$DATABASE_NAME'" | grep -q 1; then
   echo "Creating database $DATABASE_NAME..."
   bundle exec rails db:create
 fi


### PR DESCRIPTION
since #748 didn't add the database name to the sidekiq entrypoint, i made a new pr based on that & adding the variable

if the database is not specifiedin the command, postgres will default to username as database name, which will fail the command

see #856 