### PR TITLE
feat(build): add oci labels

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: freikin/dawarich
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -67,6 +73,7 @@ jobs:
           file: ./docker/Dockerfile.dev
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
Uses the docker metadata action to generate labels for the docker image which can be used by tools like renovate to display the proper source repo of the image and add the changelog for example.  Inspired by: https://github.com/immich-app/immich/pull/17378

I've tested this on my fork and renovate  picks up the labels correctly.

Note: this action can also be used to tag the image (and therefore replace the current "Set docker tags" step, but that can be done on a separate PR as I believe that warrants some discussion first)


![image](https://github.com/user-attachments/assets/6facfbf5-c645-4966-b3e6-5c7588fc5c2e)
