### PR TITLE
Fog of war improvements

### DIFF
--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -30,7 +30,7 @@ class Api::V1::SettingsController < ApiController
       :time_threshold_minutes, :merge_threshold_minutes, :route_opacity,
       :preferred_map_layer, :points_rendering_mode, :live_map_enabled,
       :immich_url, :immich_api_key, :photoprism_url, :photoprism_api_key,
-      :speed_colored_routes, :speed_color_scale
+      :speed_colored_routes, :speed_color_scale, :fog_of_war_threshold
     )
   end
 end

--- a/app/javascript/maps/fog_of_war.js
+++ b/app/javascript/maps/fog_of_war.js
@@ -23,7 +23,7 @@ export function initializeFogCanvas(map) {
   return fog;
 }
 
-export function drawFogCanvas(map, markers, clearFogRadius) {
+export function drawFogCanvas(map, markers, clearFogRadius, fogLinethreshold) {
   const fog = document.getElementById('fog');
   // Return early if fog element doesn't exist or isn't a canvas
   if (!fog || !(fog instanceof HTMLCanvasElement)) return;
@@ -42,7 +42,6 @@ export function drawFogCanvas(map, markers, clearFogRadius) {
   ctx.globalCompositeOperation = 'destination-out';
 
   // 3) Build & sort points
-  const thresholdSec = 90; // points will be joined if < 1m30 of time difference
   const pts = markers
     .map(pt => {
       const pixel = map.latLngToContainerPoint(L.latLng(pt[0], pt[1]));
@@ -56,7 +55,7 @@ export function drawFogCanvas(map, markers, clearFogRadius) {
   // 4) Mark which pts are part of a line
   const connected = new Array(pts.length).fill(false);
   for (let i = 0; i < pts.length - 1; i++) {
-    if (pts[i + 1].time - pts[i].time <= thresholdSec) {
+    if (pts[i + 1].time - pts[i].time <= fogLinethreshold) {
       connected[i]     = true;
       connected[i + 1] = true;
     }
@@ -79,7 +78,7 @@ export function drawFogCanvas(map, markers, clearFogRadius) {
   ctx.strokeStyle = 'rgba(255,255,255,1)';
 
   for (let i = 0; i < pts.length - 1; i++) {
-    if (pts[i + 1].time - pts[i].time <= thresholdSec) {
+    if (pts[i + 1].time - pts[i].time <= fogLinethreshold) {
       ctx.beginPath();
       ctx.moveTo(pts[i].pixel.x, pts[i].pixel.y);
       ctx.lineTo(pts[i + 1].pixel.x, pts[i + 1].pixel.y);

--- a/app/views/map/_settings_modals.html.erb
+++ b/app/views/map/_settings_modals.html.erb
@@ -27,6 +27,20 @@
   <label class="modal-backdrop" for="fog_of_war_meters_info">Close</label>
 </div>
 
+<input type="checkbox" id="fog_of_war_threshold_info" class="modal-toggle" />
+<div class="modal focus:z-99" role="dialog">
+  <div class="modal-box">
+    <h3 class="text-lg font-bold">Fog of War Line Threshold</h3>
+    <p class="py-4">
+      Value in seconds.
+    </p>
+    <p class="py-4">
+      Points in the fog are connected by lines. This value is the maximum time between two points to be connected by a line. If the time between two points is greater than this value, they will not be connected.
+    </p>
+  </div>
+  <label class="modal-backdrop" for="fog_of_war_threshold_info">Close</label>
+</div>
+
 <input type="checkbox" id="meters_between_routes_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">


### PR DESCRIPTION
I have made improvements to the fog of war map mode :

\- Neighbor points are now joined together, with a configurable maximum time threshold (default 1m30).
This fixes the issue with sparse points leaving gaps behind (more frequent when going at high speeds, or from Google Timeline imports).

|  Before  |  After  | 
|---|---|
|  ![Screenshot_246](https://github.com/user-attachments/assets/8f2086c0-2cfa-49d8-a10d-c2cb9b7ce1be)  |  ![Screenshot_244](https://github.com/user-attachments/assets/5f1d0ec1-2502-4a40-b3fe-e1ce708c7e6e)  |

<img src="https://github.com/user-attachments/assets/5f89a10a-7459-49bf-bcef-83c53f201d53" width="300px">

Example above with gaps being filled. The only issue with this change is the lack of gradient on the sides; I have been unable to apply a proper gradient with lines.

\- Minimum line width
The line width has a minimum value of 2px, regardless of the configured radius. This allows displaying the fog of war when zooming out a lot, whereas before, the fog of war would disappear due to too small width.

<img src="https://github.com/user-attachments/assets/019ebbe7-f957-4a05-916b-0bb02c70b2bb" width="450px">

Example above with a country-level zoom.


**TODO**
- [x] Join points with lines
- [x] Low zoom display
- [x] Configurable time threshold for line creation