### PR TITLE
Install wget in Dockerfile.dev - 0.26.4

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -24,6 +24,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no
     nodejs \
     yarn \
     less \
+    wget \
     libjemalloc2 libjemalloc-dev \
     && mkdir -p $APP_PATH \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The new slim image introduced in 0.26.4 does not seem to include wget, which is why health checks seem to not work. fixes #1231