### PR TITLE
Using Redis default directory for data

### DIFF
--- a/docker/docker-compose.production.yml
+++ b/docker/docker-compose.production.yml
@@ -8,7 +8,7 @@ services:
     networks:
       - dawarich
     volumes:
-      - dawarich_redis_data:/var/shared/redis
+      - dawarich_redis_data:/data
     restart: always
     healthcheck:
       test: [ "CMD", "redis-cli", "--raw", "incr", "ping" ]


### PR DESCRIPTION
For some reason for original Docker compose configuration path `/data` was correct, but for production this directory is used which isn't used by Redis, except if it's configured expressly.

Checked here: https://github.com/redis/docker-library-redis/blob/master/7.4/alpine/Dockerfile#L134