### PR TITLE
Feat/multi redis url conf

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,11 +1,11 @@
 development:
   adapter: redis
-  url: <%= "#{ENV.fetch("REDIS_URL")}/2" %>
+  url: <%= ENV.fetch("REDIS_WS_URL") ? "#{ENV['REDIS_WS_URL']}" : "#{ENV['REDIS_URL']}/2" %>
 
 test:
   adapter: test
 
 production:
   adapter: redis
-  url: <%= "#{ENV.fetch("REDIS_URL")}/2" %>
+  url: <%= ENV.fetch("REDIS_WS_URL") ? "#{ENV['REDIS_WS_URL']}" : "#{ENV['REDIS_URL']}/2" %>
   channel_prefix: dawarich_production

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -4,7 +4,7 @@ settings = {
   debug_mode: true,
   timeout: 5,
   units: :km,
-  cache: Redis.new(url: "#{ENV['REDIS_URL']}/0"),
+  cache: Redis.new(url: ENV.fetch('REDIS_GEOCODER_URL') ? ENV['REDIS_GEOCODER_URL'] : "#{ENV.fetch('REDIS_URL')}/0"),
   always_raise: :all,
   http_headers: {
     'User-Agent' => "Dawarich #{APP_VERSION} (https://dawarich.app)"

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
+sk_redis_url = ENV.fetch('REDIS_SIDEKIQ_URL') ? ENV['REDIS_SIDEKIQ_URL'] : "#{ENV.fetch('REDIS_URL')}/1"
+
 Sidekiq.configure_server do |config|
-  config.redis = { url: "#{ENV['REDIS_URL']}/1" }
+  config.redis = { url: sk_redis_url }
   config.logger = Sidekiq::Logger.new($stdout)
 
   if ENV['PROMETHEUS_EXPORTER_ENABLED'].to_s == 'true'
@@ -24,7 +26,7 @@ Sidekiq.configure_server do |config|
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: "#{ENV['REDIS_URL']}/1" }
+  config.redis = { url: sk_redis_url }
 end
 
 Sidekiq::Queue['reverse_geocoding'].limit = 1 if Sidekiq.server? && DawarichSettings.photon_uses_komoot_io?


### PR DESCRIPTION
This feature will address #1420 issue, allowing users to set individual `REDIS_URL` for Geocoder, Sidekiq, and Websocket.

Three additional optional environment variables are introduced in this commit, namely:
 - `REDIS_GEOCODER_URL` -> For Geocoder cache (REDIS_URL DB: `0`)
 - `REDIS_SIDEKIQ_URL`-> For Sidekiq cache (REDIS_URL DB: `1`)
 - `REDIS_WS_URL`-> For Websocket cache (REDIS_URL DB: `2`)

#### Behaviour
- These environment variables will takes priority over `REDIS_URL` env variable if set.
- This change does not break any existing flows.
   - This change will not break any of the existing workflow, test cases or deployment.
   - This change also does not require any action from the user for existing deployment.

#### Advantage
In addition to providing the user freedom to configure Redis DB for individual cache, this change also provide option to configure different Redis cache servers/clusters for services if they wish to. 

**Note:** Changes has to be made to [Environment variables and Settings page](https://dawarich.app/docs/environment-variables-and-settings/) if the maintainer is happy with this change. 

There is a possibility for a potential bug where the user can accidentally set the same values for two of the newly created env variables. I did not implement the condition to check this scenario since it could complicate the code, but can implement if needed.

I have tested this change on both development and production setting and it worked as intended on my deployment.

This is my first contribution to ruby codebase, so corrections and guidance are welcomed 😄 