### PR TITLE
Allow using s3 storage when self_hosted=true

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -98,5 +98,7 @@ Rails.application.configure do
   config.lograge.enabled = true
   config.lograge.formatter = Lograge::Formatters::Json.new
 
-  config.active_storage.service = ENV['SELF_HOSTED'] == 'true' ? :local : :s3
+  # Store uploaded files either on the local file system or in S3-compatible object storage
+  # (see config/storage.yml for options).
+  config.active_storage.service = ENV.fetch('STORAGE_BACKEND', local)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,8 +42,9 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = ENV['SELF_HOSTED'] == 'true' ? :local : :s3
+  # Store uploaded files either on the local file system or in S3-compatible object storage
+  # (see config/storage.yml for options).
+  config.active_storage.service = ENV.fetch('STORAGE_BACKEND', local)
 
   config.silence_healthcheck_path = '/api/v1/health'
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,13 +7,14 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Only load S3 config if not in test environment
-<% if !Rails.env.test? && ENV['AWS_ACCESS_KEY_ID'] && ENV['AWS_SECRET_ACCESS_KEY'] && ENV['AWS_REGION'] && ENV['AWS_BUCKET'] %>
+<% if !Rails.env.test? && ENV['AWS_ACCESS_KEY_ID'] && ENV['AWS_SECRET_ACCESS_KEY'] && ENV['AWS_REGION'] && ENV['AWS_BUCKET'] && ENV['AWS_ENDPOINT_URL'] %>
 s3:
   service: S3
   access_key_id: <%= ENV.fetch("AWS_ACCESS_KEY_ID") %>
   secret_access_key: <%= ENV.fetch("AWS_SECRET_ACCESS_KEY") %>
   region: <%= ENV.fetch("AWS_REGION") %>
   bucket: <%= ENV.fetch("AWS_BUCKET") %>
+  endpoint: <%= ENV.fetch("AWS_ENDPOINT_URL") %>
 <% end %>
 
 # Remember not to checkin your GCS keyfile to a repository

--- a/docs/How_to_install_Dawarich_in_k8s.md
+++ b/docs/How_to_install_Dawarich_in_k8s.md
@@ -160,6 +160,11 @@ spec:
               value: photon.komoot.io
             - name: PHOTON_API_USE_HTTPS
               value: "true"
+              # If you have s3-compatible object storage, (e.g. minio or ceph), 
+              # you can set this to "s3" and set the necessary "AWS_" environment variables 
+              # to use s3 storage for imports and exports
+            - name: STORAGE_BACKEND
+              value: "local"
           image: freikin/dawarich:latest
           imagePullPolicy: Always
           volumeMounts:


### PR DESCRIPTION
Hi! Thank you for the great software.

I run kubernetes at a large scale in my homelab and I prefer to use s3 object storage whenever possible instead of volumes. I saw that Dawarich supports s3 storage, but only when running as a SaaS (self_hosted=false). I have tested out the s3 support in my homelab and it seems to work well, so I would like the ability to use s3 storage without losing the features that self_hosted=true gives me.

This pull request adds the ability to set the STORAGE_BACKEND, to enable s3 storage, independent of SELF_HOSTED.

I have never coded in ruby before, so please let me know if my code has any mistakes.