### PR TITLE
Fix: Weak Password Protection Method Used in File Download System in spec/services/imports/secure_file_downloader_spec.rb

### DIFF
--- a/spec/services/imports/secure_file_downloader_spec.rb
+++ b/spec/services/imports/secure_file_downloader_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Imports::SecureFileDownloader do
   let(:file_content) { 'test content' }
   let(:file_size) { file_content.bytesize }
-  let(:checksum) { Base64.strict_encode64(Digest::MD5.digest(file_content)) }
+  let(:checksum) { Base64.strict_encode64(Digest::SHA256.digest(file_content)) }
   let(:blob) { double('ActiveStorage::Blob', byte_size: file_size, checksum: checksum) }
   # Create a mock that mimics ActiveStorage::Attached::One
   let(:storage_attachment) { double('ActiveStorage::Attached::One', blob: blob) }


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Should not use md5 to generate hashes. md5 is proven to be vulnerable through the use of brute-force attacks. Could also result in collisions, leading to potential collision attacks. Use SHA256 or other hashing functions instead.
- **Rule ID:** ruby.lang.security.weak-hashes-md5.weak-hashes-md5
- **Severity:** HIGH
- **File:** spec/services/imports/secure_file_downloader_spec.rb
- **Lines Affected:** 8 - 8

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `spec/services/imports/secure_file_downloader_spec.rb` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.