### PR TITLE
fix(docker): app and sidekiq containers ignore signals

### DIFF
--- a/docker/web-entrypoint.sh
+++ b/docker/web-entrypoint.sh
@@ -105,4 +105,4 @@ if [ "$PROMETHEUS_EXPORTER_ENABLED" = "true" ]; then
 fi
 
 # run passed commands
-exec bundle exec ${@}
+exec bundle exec "${@}"


### PR DESCRIPTION
Typically, when attempting to stop a container via `docker stop` or `podman stop`, the container engine will send a stop signal (SIGTERM by default) to the container's main process. There are two common ways this can go wrong:

1. The main process is run as PID 1 and doesn't register a signal handler for the stop signal and is consequently ignored
2. The main process is a shell script running a foreground process with no `trap`s and is consequently ignored by the *shell*

In either case, because the graceful stop signal is ignored, the container engine will then send a `SIGKILL` to the container process after a default timeout of 10 seconds. This is why some containers can be observed to "hang" when being stopped when they have no other reason to do so. Unlike `SIGTERM` or `SIGINT`, `SIGKILL` is an immediate, ungraceful stop that doesn't give the process time to clean up.

There is a fair bit of nuance in how `sh` and `bash` handle signals in different circumstances. The behavior relevant to the second case above and Dawarich's entrypoints in particular is that the shell ignores signals like `SIGTERM` and `SIGINT` when waiting on a foreground job; in this case, that would be: `bundle exec ${@}`. The reason that `SIGINT` is not ignored after pressing `Ctrl+C` while running the docker compose stack is because in that case the shell is **interactive** and the shell *does* respond to `SIGINT` then (c.f. the aforementioned nuance).

Thankfully, the fix is simple: `exec` the main process, which causes the server process to *replace* the shell process and directly receive any signals sent. Additionally, the stop signal for the app process should be set to `SIGINT`, as that is the expected signal for graceful shutdown. Sidekiq is fine with either `SIGTERM` or `SIGINT`, which is convenient.

## Bottom Line

Running the server as a foreground process in a shell script means the server process doesn't receive signals, which consequently means that the container cannot be cleanly stopped by signals. Importantly, means that `docker stop`, `podman stop`, or `systemctl stop` (Podman Quadlets) cannot cleanly stop the container; it will always be `SIGKILL`ed after a 10 second timeout.

Replacing the shell process with the server process via `exec ...` allows the server process to directly receive signals. Setting `STOPSIGNAL` to `SIGINT` in the Dockerfile means that the container engine will send the interrupt signal (same as pressing `Ctrl+C`) to the process, which is what puma is expecting.