### PR TITLE
use ISO 8601 dates to fix MapLibre WebKit behaviour

### DIFF
--- a/app/views/map/maplibre/index.html.erb
+++ b/app/views/map/maplibre/index.html.erb
@@ -5,8 +5,8 @@
 <div id="maps-maplibre-container"
      data-controller="maps--maplibre area-drawer maps--maplibre-realtime"
      data-maps--maplibre-api-key-value="<%= current_user.api_key %>"
-     data-maps--maplibre-start-date-value="<%= @start_at.to_s %>"
-     data-maps--maplibre-end-date-value="<%= @end_at.to_s %>"
+     data-maps--maplibre-start-date-value="<%= @start_at.iso8601 %>"
+     data-maps--maplibre-end-date-value="<%= @end_at.iso8601 %>"
      data-maps--maplibre-timezone-value="<%= current_user.timezone %>"
      data-maps--maplibre-realtime-enabled-value="true"
      style="width: 100%; height: 100%; position: relative;">


### PR DESCRIPTION
WebKit is strict about date parsing and expects correct iso8601 date formatting. 

This lead to invalid dates for end date and start date on WebKit browsers resulting in queries like:

```
api/v1/points?start_at=NaN-NaN-NaNTNaN%3ANaN&end_at=NaN-NaN-NaNTNaN%3ANaN&page=1&per_page=1000
```


Fix tested with image `rtuszik/dawarich:dev` on Safari - iOS26.1, Orion - iOS26.1.

Possibly #2021, #2012 ?
