### PR TITLE
fix null type error and update heatmap styling

### DIFF
--- a/app/javascript/maps_maplibre/layers/heatmap_layer.js
+++ b/app/javascript/maps_maplibre/layers/heatmap_layer.js
@@ -30,7 +30,7 @@ export class HeatmapLayer extends BaseLayer {
           // Fixed weight
           'heatmap-weight': 1,
 
-          // low intensity to view major clustors
+          // low intensity to view major clusters
           'heatmap-intensity': [
             'interpolate',
             ['linear'],


### PR DESCRIPTION
This fixes the `Expected value to be of type number, but found null instead.`, caused by heatmap-weight ['get', 'weight'] as points don't have a weight property.

The heatmap only showed at up to zoom level 9 and was just a large blob.  

The styling is obviously subjective, and I went with something that looked good to me for the data that I have. 

I could imagine having some sort of "heatmap-sensitivity" slider that maps to values of some of the style dimensions. 

Example of a single day of data:

<img width="1950" height="1698" alt="Screenshot 2025-12-15 at 12  19 09@2x" src="https://github.com/user-attachments/assets/cedf89f6-fc41-4e8d-bd8f-ff673741f3b3" />
<img width="1955" height="1698" alt="Screenshot 2025-12-15 at 12  19 26@2x" src="https://github.com/user-attachments/assets/c361f964-08e0-4c92-8a72-2c6269d29947" />
<img width="1958" height="1704" alt="Screenshot 2025-12-15 at 12  19 38@2x" src="https://github.com/user-attachments/assets/39cb8604-e973-45b9-a986-1837b96a0fc1" />
