### PR TITLE
Updated the reverse proxy instructions for Apache2

### DIFF
--- a/docs/how_to_setup_reverse_proxy.md
+++ b/docs/how_to_setup_reverse_proxy.md
@@ -111,12 +111,11 @@ With the above commands entered, the configuration below should work properly.
 	<Proxy *>
 		Require all granted
 	</Proxy>
-
-	Header always set X-Real-IP %{REMOTE_ADDR}s
-	Header always set X-Forwarded-For %{REMOTE_ADDR}s
-	Header always set X-Forwarded-Proto https
-	Header always set X-Forwarded-Server %{SERVER_NAME}s
-	Header always set Host %{HTTP_HOST}s
+    RequestHeader set X-Real-IP %{REMOTE_ADDR}s
+    RequestHeader set X-Forwarded-For %{REMOTE_ADDR}s
+    RequestHeader set X-Forwarded-Proto https
+    RequestHeader set X-Forwarded-Server %{SERVER_NAME}s
+    RequestHeader set Host %{HTTP_HOST}s
 
 	SetOutputFilter BROTLI
 	AddOutputFilterByType BROTLI_COMPRESS text/css text/plain text/xml text/javascript application/javascript application/json application/manifest+json application/vnd.api+json application/xml application/xhtml+xml application/rss+xml application/atom+xml application/vnd.ms-fontobject application/x-font-ttf application/x-font-opentype application/x-font-truetype image/svg+xml image/x-icon image/vnd.microsoft.icon font/ttf font/eot font/otf font/opentype


### PR DESCRIPTION
The request headers are set incorrectly according to the documentation. 

This fixes the doc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reverse proxy setup documentation with refined Apache configuration directives for header handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->