### PR TITLE
feat: enable starttls

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,7 +117,7 @@ Rails.application.configure do
     user_name:       ENV['SMTP_USERNAME'],
     password:        ENV['SMTP_PASSWORD'],
     authentication:  'plain',
-    enable_starttls: true,
+    enable_starttls: ENV.fetch('SMTP_STARTTLS', 'true') == 'true',
     open_timeout:    5,
     read_timeout:    5
   }

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -114,7 +114,7 @@ Rails.application.configure do
     user_name:       ENV['SMTP_USERNAME'],
     password:        ENV['SMTP_PASSWORD'],
     authentication:  'plain',
-    enable_starttls: true,
+    enable_starttls: ENV.fetch('SMTP_STARTTLS', 'true') == 'true',
     open_timeout:    5,
     read_timeout:    5
   }


### PR DESCRIPTION
Allow setting disabling starttls with `SMTP_STARTTLS` environment variable. 

Tiny change as requested by user in discord. Still defaults to true.
 
