### PR TITLE
add matrix build to build_and_push workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,11 @@
 !/public/exports/.keep
 /public/imports/*
 !/public/imports/.keep
+
+.git/
+.github/
+docs/
+.circleci/
+.devcontainer/
+screenshots/
+.ruby-lsp/

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -11,7 +11,38 @@ on:
     types: [created]
 
 jobs:
+  prepare:
+    runs-on: ubuntu-22.04
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
+      platforms: ${{ steps.meta.outputs.platforms }}
+    steps:
+      - name: Compute version and platforms
+        id: meta
+        run: |
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION=$GITHUB_REF_NAME
+          fi
+          if [ -z "$VERSION" ]; then
+            VERSION="rc"
+          fi
+
+          IS_PRERELEASE="${{ github.event.release.prerelease }}"
+          PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
+
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            PLATFORMS="linux/amd64"
+          fi
+
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "is_prerelease=${IS_PRERELEASE}" >> $GITHUB_OUTPUT
+          echo "platforms=${PLATFORMS}" >> $GITHUB_OUTPUT
+
   build-and-push-docker:
+    needs: prepare
     strategy:
       fail-fast: false
       matrix:
@@ -54,7 +85,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: freikin/dawarich
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/dawarich
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.1.0
@@ -62,54 +93,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set Docker tags
-        id: docker_meta
-        run: |
-          # Debug output
-          echo "GITHUB_REF: $GITHUB_REF"
-          echo "GITHUB_REF_NAME: $GITHUB_REF_NAME"
-
-          # Extract version from GITHUB_REF or use GITHUB_REF_NAME
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          else
-            VERSION=$GITHUB_REF_NAME
-          fi
-
-          # Additional safety check - if VERSION is empty, use a default
-          if [ -z "$VERSION" ]; then
-            VERSION="rc"
-          fi
-
-          echo "Using VERSION: $VERSION"
-
-          TAGS="freikin/dawarich:${VERSION}"
-
-          # Set platforms based on version type and release type
-          PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
-
-          # Add :rc tag for pre-releases
-          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            TAGS="${TAGS},freikin/dawarich:rc"
-            # For RC builds, only use amd64
-            PLATFORMS="linux/amd64"
-          fi
-
-          # Add :latest tag only if release is not a pre-release
-          if [ "${{ github.event.release.prerelease }}" != "true" ]; then
-            TAGS="${TAGS},freikin/dawarich:latest"
-          fi
-
-          echo "Final TAGS: $TAGS"
-          echo "PLATFORMS: $PLATFORMS"
-
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
-          echo "platforms=${PLATFORMS}" >> $GITHUB_OUTPUT
-
       - name: Check if platform should build
         id: should_build
         run: |
-          PLATFORMS="${{ steps.docker_meta.outputs.platforms }}"
+          PLATFORMS="${{ needs.prepare.outputs.platforms }}"
           if echo "$PLATFORMS" | tr ',' '\n' | grep -qx "${{ matrix.platform }}"; then
             echo "skip=false" >> $GITHUB_OUTPUT
           else
@@ -131,7 +118,7 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=freikin/dawarich,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ secrets.DOCKERHUB_USERNAME }}/dawarich,push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
@@ -153,37 +140,13 @@ jobs:
           retention-days: 1
 
   merge:
-    needs: build-and-push-docker
+    needs: [prepare, build-and-push-docker]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch || github.ref_name }}
-
-      - name: Set Docker tags
-        id: docker_meta
-        run: |
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          else
-            VERSION=$GITHUB_REF_NAME
-          fi
-          if [ -z "$VERSION" ]; then
-            VERSION="rc"
-          fi
-
-          TAGS="freikin/dawarich:${VERSION}"
-
-          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            TAGS="${TAGS},freikin/dawarich:rc"
-          fi
-
-          if [ "${{ github.event.release.prerelease }}" != "true" ]; then
-            TAGS="${TAGS},freikin/dawarich:latest"
-          fi
-
-          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3.1.0
@@ -201,10 +164,27 @@ jobs:
           pattern: digest-*
           merge-multiple: true
 
+      - name: Build Docker tags
+        id: docker_tags
+        run: |
+          IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/dawarich"
+          VERSION="${{ needs.prepare.outputs.version }}"
+          IS_PRERELEASE="${{ needs.prepare.outputs.is_prerelease }}"
+
+          TAGS="${IMAGE}:${VERSION}"
+
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            TAGS="${TAGS},${IMAGE}:rc"
+          else
+            TAGS="${TAGS},${IMAGE}:latest"
+          fi
+
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
-          TAGS="${{ steps.docker_meta.outputs.tags }}"
+          TAGS="${{ steps.docker_tags.outputs.tags }}"
 
           TAG_ARGS=""
           IFS=',' read -ra TAG_LIST <<< "$TAGS"
@@ -212,12 +192,12 @@ jobs:
             TAG_ARGS="${TAG_ARGS} -t ${TAG}"
           done
 
-          SOURCES=$(printf "freikin/dawarich@sha256:%s " *)
+          SOURCES=$(printf "${{ secrets.DOCKERHUB_USERNAME }}/dawarich@sha256:%s " *)
 
           docker buildx imagetools create ${TAG_ARGS} ${SOURCES}
 
       - name: Inspect final image
         run: |
-          TAGS="${{ steps.docker_meta.outputs.tags }}"
+          TAGS="${{ steps.docker_tags.outputs.tags }}"
           FIRST_TAG="${TAGS%%,*}"
           docker buildx imagetools inspect "${FIRST_TAG}"


### PR DESCRIPTION
- adds matrix build to speed up
- uses native runners for arm builds (not possible for armv7)
- adds to `.dockerignore` to decrease image size 
- moves `.dockerignore` to project root, as its ignored in docker/
- infers dockerhub name using DOCKERHUB_USERNAME (allows build and push in forks)
- removes armv8 build as its the same as arm64

Builds in around 22 minutes:
https://github.com/rtuszik/dawarich/actions/runs/21803567634


It may be possible to leave the `.dockerignore` inside `docker/` if its renamed to `Dockerfile.dockerignore`, but I am not sure if thats preferred. 

