### PR TITLE
feat: lightweight support for docker secrets

### DIFF
--- a/docker/sidekiq-entrypoint.sh
+++ b/docker/sidekiq-entrypoint.sh
@@ -5,6 +5,43 @@ unset BUNDLE_BIN
 
 set -e
 
+load_env_from_files() {
+  # Iterate over all env var names that end with _FILE
+  # POSIX note: use env | awk to collect variable names reliably.
+  for VAR_NAME in $(env | awk -F= '/_FILE=/{print $1}'); do
+    BASE_NAME="${VAR_NAME%_FILE}"
+
+    # Expand current values of BASE_NAME and VAR_NAME (POSIX-friendly; no ${!var})
+    eval "BASE_VAL=\"\${${BASE_NAME}:-}\""
+    eval "FILE_PATH=\"\${${VAR_NAME}:-}\""
+
+    # If both are provided, fail fast to avoid ambiguity
+    if [ -n "$BASE_VAL" ] && [ -n "$FILE_PATH" ]; then
+      echo "❌ Both $BASE_NAME and ${BASE_NAME}_FILE are set; please set only one." >&2
+      exit 1
+    fi
+
+    # If *_FILE is provided, read file content and export into BASE_NAME
+    if [ -n "$FILE_PATH" ]; then
+      if [ ! -r "$FILE_PATH" ]; then
+        echo "❌ ${BASE_NAME}_FILE points to an unreadable file: $FILE_PATH" >&2
+        exit 1
+      fi
+
+      # Read file; command substitution strips trailing newline.
+      VAL=$(cat "$FILE_PATH")
+
+      echo "🔐 Read secret for $BASE_NAME from $FILE_PATH; exporting $BASE_NAME"
+
+      export "$BASE_NAME=$VAL"
+      unset "$VAR_NAME"
+    fi
+  done
+}
+
+# Run before anything else uses env vars
+load_env_from_files
+
 echo "⚠️ Starting Sidekiq in $RAILS_ENV environment ⚠️"
 
 # Parse DATABASE_URL if present, otherwise use individual variables


### PR DESCRIPTION
I never use secrets withing environment variables directly, but always leveraging `docker secrets`. This way I always know where stuff is and can also assign different permissions to these secrets files.

I saw someone asking for it (https://github.com/Freika/dawarich/discussions/656), so I implemented a very lightweight solution just leveraging the entrypoints. This could also be done somewhere else (maybe somewhere in ruby), but up to you.

I have tested this successfully like so:
```yaml
secrets:
  dawarich_db_password:
    file: $SECRETSDIR/dawarich_db_password
  dawarich_secret_key_base:
    file: $SECRETSDIR/dawarich_secret_key_base
  dawarich-app:
    image: freikin/dawarich:latest
    volumes:
      - $DOCKERDIR/dawarich/web-entrypoint.sh:/usr/local/bin/web-entrypoint.sh
    environment:
      DATABASE_PASSWORD_FILE: /run/secrets/dawarich_db_password
      SECRET_KEY_BASE_FILE: /run/secrets/dawarich_secret_key_base
    secrets:
      - dawarich_db_password
      - dawarich_secret_key_base
```

The entrypoint mount of course is only for this testing purpose. You can see, that all this does is take any environment variable with suffix `_FILE` and try to read the contents of that file. Postgres is doing exactly the same which means we can re-use secrets like so:

```yaml
  dawarich-postgis:
    image: imresamu/postgis:17-3.5-alpine
    container_name: dawarich-postgis
    shm_size: 500M
    <<: [ *common-keys-always ]
    volumes:
      - $DOCKERDIR/dawarich/database:/var/lib/postgresql/data
      - $DOCKERDIR/dawarich/shared:/var/shared
    environment:
      POSTGRES_USER: ${POSTGRES_USER:-postgres}
      POSTGRES_DB: ${POSTGRES_DB:-dawarich_development}
      POSTGRES_PASSWORD_FILE: /run/secrets/dawarich_db_password
    healthcheck:
      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-dawarich_development}" ]
      interval: 10s
      retries: 5
      start_period: 30s
      timeout: 10s
    secrets:
      - dawarich_db_password
```
Log also looks nice:
```
🔐 Read secret for SECRET_KEY_BASE from /run/secrets/dawarich_secret_key_base; exporting SECRET_KEY_BASE
🔐 Read secret for DATABASE_PASSWORD from /run/secrets/dawarich_db_password; exporting DATABASE_PASSWORD
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment variables can now be loaded from external files during Docker container startup for both web and sidekiq services. Configuration values can be sourced from files during container initialization, providing more flexible deployment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->