### PR TITLE
Fix LocationIQ support

### DIFF
--- a/config/initializers/03_dawarich_settings.rb
+++ b/config/initializers/03_dawarich_settings.rb
@@ -6,7 +6,7 @@ class DawarichSettings
 
   class << self
     def reverse_geocoding_enabled?
-      @reverse_geocoding_enabled ||= photon_enabled? || geoapify_enabled? || nominatim_enabled?
+      @reverse_geocoding_enabled ||= photon_enabled? || geoapify_enabled? || nominatim_enabled? || locationiq_enabled?
     end
 
     def photon_enabled?
@@ -19,6 +19,10 @@ class DawarichSettings
 
     def geoapify_enabled?
       @geoapify_enabled ||= GEOAPIFY_API_KEY.present?
+    end
+
+    def locationiq_enabled?
+      @locationiq_enabled ||= LOCATIONIQ_API_KEY.present?
     end
 
     def self_hosted?


### PR DESCRIPTION
**Describe the bug**
I'm unable to setup LocationIQ for reverse geocoding, I followed the steps of the release of version [0.27.3](https://github.com/Freika/dawarich/releases/tag/0.27.3) even when LOCATIONIQ_API_KEY is present, the reverse geocoding background job won't start because the reverse_geocoding_enabled? check doesn't account for LocationIQ.

**To Reproduce**
Steps to reproduce the behavior:
1. Set LOCATIONIQ_API_KEY
2. Launch Dawarich
3. Start Reverse Geocoding Background Job

**Expected behavior**
Reverse Geocoding Job starts

**The Root Cause**
In config/initializers/03_dawarich_settings.rb, the method reverse_geocoding_enabled? only checks for Photon, Nominatim and Geoapify. Additionally, the locationiq_enabled? helper method is missing.

**Proposed Fix**
Add the locationiq_enabled? method and update the boolean check:

```ruby
def reverse_geocoding_enabled?
      @reverse_geocoding_enabled ||= photon_enabled? || geoapify_enabled? || nominatim_enabled? || locationiq_enabled?
    end

def locationiq_enabled?
      @locationiq_enabled ||= LOCATIONIQ_API_KEY.present?
    end
```  

This fix solves discussion [#1334](https://github.com/Freika/dawarich/discussions/1334#discussioncomment-13395175
)

I've already tested with 

**OS & Hardware**
Windows 10
Docker Engine: 27.0.3
Docker Compose: v2.28.1-desktop.1

**Dawarich Version**
1.3.1 

The background job starts correctly and requests are visible in LocationIQ Dashboard, this is the console check:

```powershell
[1] pry(main)> DawarichSettings.reverse_geocoding_enabled?=> true
[2] pry(main)> DawarichSettings.locationiq_enabled?=> true 
``` 
Hope this helps!