### PR TITLE
Respect visits_suggestions_enabled for area, place, and visit suggest jobs

### DIFF
--- a/app/jobs/area_visits_calculating_job.rb
+++ b/app/jobs/area_visits_calculating_job.rb
@@ -9,9 +9,10 @@ class AreaVisitsCalculatingJob < ApplicationJob
   def perform(user_id)
     user = find_user_or_skip(user_id) || return
 
+    return unless user.safe_settings.visits_suggestions_enabled?
+
     with_user_timezone(user) do
-      areas = user.areas
-      Areas::Visits::Create.new(user, areas).call
+      Areas::Visits::Create.new(user, user.areas).call
     end
   end
 end

--- a/app/jobs/area_visits_calculation_scheduling_job.rb
+++ b/app/jobs/area_visits_calculation_scheduling_job.rb
@@ -6,6 +6,8 @@ class AreaVisitsCalculationSchedulingJob < ApplicationJob
 
   def perform
     User.find_each do |user|
+      next unless user.safe_settings.visits_suggestions_enabled?
+
       AreaVisitsCalculatingJob.perform_later(user.id)
       PlaceVisitsCalculatingJob.perform_later(user.id)
     end

--- a/app/jobs/place_visits_calculating_job.rb
+++ b/app/jobs/place_visits_calculating_job.rb
@@ -7,8 +7,9 @@ class PlaceVisitsCalculatingJob < ApplicationJob
   def perform(user_id)
     user = find_user_or_skip(user_id) || return
 
-    places = user.places # Only user-owned places (with user_id)
+    return unless user.safe_settings.visits_suggestions_enabled?
 
-    Places::Visits::Create.new(user, places).call
+    # Only user-owned places (with user_id)
+    Places::Visits::Create.new(user, user.places).call
   end
 end

--- a/app/jobs/visit_suggesting_job.rb
+++ b/app/jobs/visit_suggesting_job.rb
@@ -10,6 +10,8 @@ class VisitSuggestingJob < ApplicationJob
   def perform(user_id:, start_at:, end_at:)
     user = find_user_or_skip(user_id) || return
 
+    return unless user.safe_settings.visits_suggestions_enabled?
+
     with_user_timezone(user) do
       start_time = parse_date(start_at)
       end_time = parse_date(end_at)

--- a/spec/jobs/area_visits_calculating_job_spec.rb
+++ b/spec/jobs/area_visits_calculating_job_spec.rb
@@ -14,5 +14,17 @@ RSpec.describe AreaVisitsCalculatingJob, type: :job do
         described_class.new.perform(user.id)
       end
     end
+
+    context 'when visits_suggestions_enabled is false' do
+      before do
+        user.update!(settings: user.settings.merge('visits_suggestions_enabled' => 'false'))
+      end
+
+      it 'does not run area visit creation' do
+        expect(Areas::Visits::Create).not_to receive(:new)
+
+        described_class.new.perform(user.id)
+      end
+    end
   end
 end

--- a/spec/jobs/area_visits_calculation_scheduling_job_spec.rb
+++ b/spec/jobs/area_visits_calculation_scheduling_job_spec.rb
@@ -7,8 +7,25 @@ RSpec.describe AreaVisitsCalculationSchedulingJob, type: :job do
     let!(:user) { create(:user) }
     let(:area) { create(:area, user: user) }
 
-    it 'enqueues the AreaVisitsCalculatingJob' do
-      expect { described_class.new.perform }.to have_enqueued_job(AreaVisitsCalculatingJob).with(user.id)
+    it 'enqueues area and place visit jobs when visit suggestions are enabled' do
+      expect { described_class.new.perform }
+        .to have_enqueued_job(AreaVisitsCalculatingJob).with(user.id)
+        .and have_enqueued_job(PlaceVisitsCalculatingJob).with(user.id)
+    end
+
+    context 'when visits_suggestions_enabled is false' do
+      let!(:user_disabled) do
+        u = create(:user)
+        u.update!(settings: u.settings.merge('visits_suggestions_enabled' => 'false'))
+        u
+      end
+
+      it 'does not enqueue area or place visit jobs for that user' do
+        described_class.new.perform
+
+        expect(AreaVisitsCalculatingJob).not_to have_been_enqueued.with(user_disabled.id)
+        expect(PlaceVisitsCalculatingJob).not_to have_been_enqueued.with(user_disabled.id)
+      end
     end
   end
 end

--- a/spec/jobs/place_visits_calculating_job_spec.rb
+++ b/spec/jobs/place_visits_calculating_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PlaceVisitsCalculatingJob, type: :job do
+  describe '#perform' do
+    let(:user) { create(:user) }
+    let!(:place) { create(:place, user: user) }
+
+    it 'calls Places::Visits::Create with the user places relation' do
+      expect(Places::Visits::Create).to receive(:new).with(
+        user,
+        satisfy { |places| places.map(&:id) == [place.id] }
+      ).and_call_original
+
+      described_class.new.perform(user.id)
+    end
+
+    context 'when visits_suggestions_enabled is false' do
+      before do
+        user.update!(settings: user.settings.merge('visits_suggestions_enabled' => 'false'))
+      end
+
+      it 'does not run place visit creation' do
+        expect(Places::Visits::Create).not_to receive(:new)
+
+        described_class.new.perform(user.id)
+      end
+    end
+  end
+end

--- a/spec/jobs/visit_suggesting_job_spec.rb
+++ b/spec/jobs/visit_suggesting_job_spec.rb
@@ -103,6 +103,18 @@ RSpec.describe VisitSuggestingJob, type: :job do
         subject
       end
     end
+
+    context 'when visits_suggestions_enabled is false' do
+      before do
+        user.update!(settings: user.settings.merge('visits_suggestions_enabled' => 'false'))
+      end
+
+      it 'does not call Visits::Suggest' do
+        expect(Visits::Suggest).not_to receive(:new)
+
+        described_class.perform_now(user_id: user.id, start_at: start_at, end_at: end_at)
+      end
+    end
   end
 
   describe 'queue name' do


### PR DESCRIPTION
## Background

`BulkVisitsSuggestingJob` already skipped users when visit suggestions were disabled and only enqueued `VisitSuggestingJob` for eligible users.

https://github.com/Freika/dawarich/blob/5ec829b68be82821903979687c2c4f108eb368af/app/jobs/bulk_visits_suggesting_job.rb#L20

## Problem

`AreaVisitsCalculationSchedulingJob` enqueues `AreaVisitsCalculatingJob` and `PlaceVisitsCalculatingJob` for every user at midnight with no setting check.

## Solution
Add the check for `AreaVisitsCalculationSchedulingJob` to prevent enqueuing. 

Also add the check in `AreaVisitsCalculatingJob`, `PlaceVisitsCalculatingJob`, and `VisitSuggestingJob`. This serves as defense-in-depth (e.g. `VisitSuggestingJob` is also created by imports), and also prevents running the jobs if a user disables the option while the queue is full.

## Testing Done

Unit tests with RSpec