### PR TITLE
Cap the load and display of points from DB to 20000 to be faster for long ranges. 

### DIFF
--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -3,6 +3,8 @@
 class Api::V1::PointsController < ApiController
   include SafeTimestampParser
 
+  DEFAULT_MAX_SAMPLED_POINTS = 20_000
+
   before_action :authenticate_active_api_user!, only: %i[create update destroy bulk_destroy]
   before_action :require_write_api!, only: %i[update destroy bulk_destroy]
   before_action :validate_points_limit, only: %i[create]
@@ -15,6 +17,7 @@ class Api::V1::PointsController < ApiController
     points = scoped_points
              .without_raw_data
              .where(timestamp: start_at..end_at)
+    points_before_sampling = points
 
     if params[:min_longitude].present? && params[:max_longitude].present? &&
        params[:min_latitude].present? && params[:max_latitude].present?
@@ -27,6 +30,19 @@ class Api::V1::PointsController < ApiController
         'ST_X(lonlat::geometry) BETWEEN ? AND ? AND ST_Y(lonlat::geometry) BETWEEN ? AND ?',
         min_lng, max_lng, min_lat, max_lat
       )
+    end
+
+    if sampling_requested?
+      sampling_result = Points::Downsampler.new(
+        relation: points,
+        order:,
+        max_points: sampled_points_limit
+      ).call
+
+      points = sampling_result.relation
+      response.set_header('X-Points-Sampled', sampling_result.sampled.to_s)
+      response.set_header('X-Total-Points-Before-Sampling', sampling_result.total_count.to_s)
+      response.set_header('X-Sampled-Points-Limit', sampled_points_limit.to_s)
     end
 
     points = points
@@ -44,7 +60,7 @@ class Api::V1::PointsController < ApiController
     if !DawarichSettings.self_hosted? && current_api_user.lite?
       total_in_range = current_api_user.points
                                        .where(timestamp: start_at..end_at).count
-      scoped_count = points.except(:select, :order).count
+      scoped_count = points_before_sampling.except(:select, :order, :includes, :preload, :eager_load).count
       response.set_header('X-Total-Points-In-Range', total_in_range.to_s)
       response.set_header('X-Scoped-Points', scoped_count.to_s)
     end
@@ -111,5 +127,16 @@ class Api::V1::PointsController < ApiController
 
   def point_serializer
     params[:slim] == 'true' ? Api::SlimPointSerializer : Api::PointSerializer
+  end
+
+  def sampling_requested?
+    params[:sample] == 'true'
+  end
+
+  def sampled_points_limit
+    requested = params[:max_points].to_i
+    return DEFAULT_MAX_SAMPLED_POINTS if requested <= 0
+
+    requested.clamp(1, DEFAULT_MAX_SAMPLED_POINTS)
   end
 end

--- a/app/controllers/map/leaflet_controller.rb
+++ b/app/controllers/map/leaflet_controller.rb
@@ -3,11 +3,13 @@
 class Map::LeafletController < ApplicationController
   include SafeTimestampParser
 
+  MAX_RENDERED_POINTS = 20_000
+
   before_action :authenticate_user!
   layout 'map', only: :index
 
   def index
-    @points = filtered_points
+    @points = sampled_points.relation
     @coordinates = build_coordinates
     @tracks = build_tracks
     @distance = calculate_distance
@@ -20,6 +22,14 @@ class Map::LeafletController < ApplicationController
   end
 
   private
+
+  def sampled_points
+    @sampled_points ||= Points::Downsampler.new(
+      relation: filtered_points,
+      order: :asc,
+      max_points: MAX_RENDERED_POINTS
+    ).call
+  end
 
   def filtered_points
     points.where('timestamp >= ? AND timestamp <= ?', start_at, end_at)
@@ -41,7 +51,7 @@ class Map::LeafletController < ApplicationController
   end
 
   def calculate_distance
-    return 0 if @points.count(:id) < 2
+    return 0 if sampled_points.total_count < 2
 
     # Use PostGIS window function for efficient distance calculation
     # This is O(1) database operation vs O(n) Ruby iteration

--- a/app/javascript/maps_maplibre/services/api_client.js
+++ b/app/javascript/maps_maplibre/services/api_client.js
@@ -3,6 +3,8 @@
  * Wraps all API endpoints with consistent error handling
  */
 export class ApiClient {
+  static MAX_RENDERED_POINTS = 20000
+
   constructor(apiKey) {
     this.apiKey = apiKey
     this.baseURL = "/api/v1"
@@ -19,6 +21,8 @@ export class ApiClient {
       end_at,
       page: page.toString(),
       per_page: per_page.toString(),
+      sample: "true",
+      max_points: ApiClient.MAX_RENDERED_POINTS.toString(),
       slim: "true",
       order: "asc",
     })

--- a/app/services/points/downsampler.rb
+++ b/app/services/points/downsampler.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Points
+  class Downsampler
+    Result = Struct.new(:relation, :total_count, :sampled, keyword_init: true)
+
+    def initialize(relation:, order: 'asc', max_points: 20_000)
+      @relation = relation
+      @order = order.to_s
+      @max_points = max_points.to_i
+    end
+
+    def call
+      ordered_relation = relation.reorder(timestamp: sql_direction, id: sql_direction)
+      total_count = count_rows(ordered_relation)
+
+      return Result.new(relation: ordered_relation, total_count:, sampled: false) if total_count <= max_points
+
+      sampled_ids = sampled_ids_for(ordered_relation, total_count)
+      sampled_relation = relation.where(id: sampled_ids).reorder(timestamp: sql_direction, id: sql_direction)
+
+      Result.new(relation: sampled_relation, total_count:, sampled: true)
+    end
+
+    private
+
+    attr_reader :relation, :order, :max_points
+
+    def sql_direction
+      order == 'desc' ? :desc : :asc
+    end
+
+    def count_rows(relation)
+      relation.except(:select, :order, :includes, :preload, :eager_load, :limit, :offset).count(:id)
+    end
+
+    def sampled_ids_for(relation, total_count)
+      step = (total_count.to_f / max_points).ceil
+      direction = sql_direction.to_s.upcase
+
+      ranked_sql = relation
+                   .except(:includes, :preload, :eager_load, :limit, :offset)
+                   .select(
+                     Arel.sql(
+                       "#{Point.table_name}.id AS sampled_id, " \
+                       "ROW_NUMBER() OVER (ORDER BY #{Point.table_name}.timestamp #{direction}, " \
+                       "#{Point.table_name}.id #{direction}) AS row_num"
+                     )
+                   )
+                   .to_sql
+
+      Point.from("(#{ranked_sql}) sampled_points")
+           .where('((row_num - 1) % ?) = 0', step)
+           .limit(max_points)
+           .pluck(Arel.sql('sampled_points.sampled_id'))
+    end
+  end
+end

--- a/app/services/points/downsampler.rb
+++ b/app/services/points/downsampler.rb
@@ -35,22 +35,31 @@ module Points
     end
 
     def sampled_ids_for(relation, total_count)
-      step = (total_count.to_f / max_points).ceil
+      return relation.limit(1).pluck(:id) if max_points == 1
+
       direction = sql_direction.to_s.upcase
+      denominator = max_points - 1
+      table_name = Point.table_name
 
       ranked_sql = relation
                    .except(:select, :includes, :preload, :eager_load, :limit, :offset)
                    .select(
                      Arel.sql(
-                       "#{Point.table_name}.id AS sampled_id, " \
-                       "ROW_NUMBER() OVER (ORDER BY #{Point.table_name}.timestamp #{direction}, " \
-                       "#{Point.table_name}.id #{direction}) AS row_num"
+                       "#{table_name}.id AS sampled_id, " \
+                       "ROW_NUMBER() OVER (ORDER BY #{table_name}.timestamp #{direction}, " \
+                       "#{table_name}.id #{direction}) AS row_num"
                      )
                    )
                    .to_sql
 
+      target_rows_sql = <<~SQL.squish
+        SELECT FLOOR(1 + (series_index * (#{total_count} - 1)::float / #{denominator}))::bigint AS row_num
+        FROM generate_series(0, #{max_points - 1}) AS series_index
+      SQL
+
       Point.from("(#{ranked_sql}) sampled_points")
-           .where('((row_num - 1) % ?) = 0', step)
+           .joins("INNER JOIN (#{target_rows_sql}) target_rows ON target_rows.row_num = sampled_points.row_num")
+           .order(Arel.sql('sampled_points.row_num'))
            .limit(max_points)
            .pluck(Arel.sql('sampled_points.sampled_id'))
     end

--- a/app/services/points/downsampler.rb
+++ b/app/services/points/downsampler.rb
@@ -39,7 +39,7 @@ module Points
       direction = sql_direction.to_s.upcase
 
       ranked_sql = relation
-                   .except(:includes, :preload, :eager_load, :limit, :offset)
+                   .except(:select, :includes, :preload, :eager_load, :limit, :offset)
                    .select(
                      Arel.sql(
                        "#{Point.table_name}.id AS sampled_id, " \

--- a/app/services/points/downsampler.rb
+++ b/app/services/points/downsampler.rb
@@ -2,12 +2,15 @@
 
 module Points
   class Downsampler
+    MAX_POINTS_CAP = 20_000
+    MIN_POINTS = 1
+
     Result = Struct.new(:relation, :total_count, :sampled, keyword_init: true)
 
     def initialize(relation:, order: 'asc', max_points: 20_000)
       @relation = relation
       @order = order.to_s
-      @max_points = max_points.to_i
+      @max_points = max_points.to_i.clamp(MIN_POINTS, MAX_POINTS_CAP)
     end
 
     def call

--- a/app/services/points/downsampler.rb
+++ b/app/services/points/downsampler.rb
@@ -14,13 +14,14 @@ module Points
     end
 
     def call
-      ordered_relation = relation.reorder(timestamp: sql_direction, id: sql_direction)
+      base_relation = relation.unscope(:limit, :offset)
+      ordered_relation = base_relation.reorder(timestamp: sql_direction, id: sql_direction)
       total_count = count_rows(ordered_relation)
 
       return Result.new(relation: ordered_relation, total_count:, sampled: false) if total_count <= max_points
 
       sampled_ids = sampled_ids_for(ordered_relation, total_count)
-      sampled_relation = relation.where(id: sampled_ids).reorder(timestamp: sql_direction, id: sql_direction)
+      sampled_relation = base_relation.where(id: sampled_ids).reorder(timestamp: sql_direction, id: sql_direction)
 
       Result.new(relation: sampled_relation, total_count:, sampled: true)
     end

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,12 +54,15 @@ RUN gem update --system 3.6.9 \
 WORKDIR $APP_PATH
 
 COPY ../Gemfile ../Gemfile.lock ../.ruby-version ../vendor ./
+COPY ../package.json ../package-lock.json ./
 
 # Install production gems only
 RUN bundle config set --local path 'vendor/bundle' \
     && bundle config set --local without 'development test' \
     && bundle install --jobs 4 --retry 3 \
     && rm -rf vendor/bundle/ruby/3.4.0/cache/*.gem
+
+RUN npm ci --no-audit --no-fund
 
 COPY ../. ./
 

--- a/spec/requests/api/v1/points_spec.rb
+++ b/spec/requests/api/v1/points_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe 'Api::V1::Points', type: :request do
         json_response = JSON.parse(response.body)
         expect(json_response.size).to eq(50)
         expect(response.headers['X-Points-Sampled']).to eq('true')
-        expect(response.headers['X-Total-Points-Before-Sampling']).to eq('135')
+        expect(response.headers['X-Total-Points-Before-Sampling']).to eq((points.size + dense_points.size).to_s)
         expect(response.headers['X-Sampled-Points-Limit']).to eq('50')
       end
 

--- a/spec/requests/api/v1/points_spec.rb
+++ b/spec/requests/api/v1/points_spec.rb
@@ -128,6 +128,49 @@ RSpec.describe 'Api::V1::Points', type: :request do
         expect(json_response.first['timestamp']).to be > json_response.last['timestamp']
       end
     end
+
+    context 'when sampling is requested' do
+      let!(:dense_points) do
+        (1..120).map do |i|
+          create(:point, user:, timestamp: 2.days.ago.to_i + i)
+        end
+      end
+
+      it 'caps results to max_points' do
+        get api_v1_points_url(
+          api_key: user.api_key,
+          sample: 'true',
+          max_points: 50,
+          per_page: 1000,
+          order: 'asc'
+        )
+
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        expect(json_response.size).to eq(50)
+        expect(response.headers['X-Points-Sampled']).to eq('true')
+        expect(response.headers['X-Total-Points-Before-Sampling']).to eq('135')
+        expect(response.headers['X-Sampled-Points-Limit']).to eq('50')
+      end
+
+      it 'preserves descending order after sampling' do
+        get api_v1_points_url(
+          api_key: user.api_key,
+          sample: 'true',
+          max_points: 30,
+          per_page: 1000,
+          order: 'desc'
+        )
+
+        expect(response).to have_http_status(:ok)
+
+        json_response = JSON.parse(response.body)
+        timestamps = json_response.map { |point| point['timestamp'] }
+
+        expect(timestamps).to eq(timestamps.sort.reverse)
+      end
+    end
   end
 
   describe 'POST /create' do


### PR DESCRIPTION
## Summary
This PR adds on-the-fly sampling for map point loading and enforces a hard cap of **20,000 points** per selected range to improve performance on large datasets.

## Problem
For users with high-frequency tracking, large date ranges can return very large point sets, causing:
- slow API responses
- heavy payloads
- slow rendering and interaction on the map
Related Issue I made in this regard: https://github.com/Freika/dawarich/issues/2413

## What changed

### Backend
- Added SQL-based point downsampler:
  - `app/services/points/downsampler.rb`
- Extended points API to support sampled retrieval:
  - `sample=true`
  - `max_points` (clamped to 20,000)
  - sampling response headers:
    - `X-Points-Sampled`
    - `X-Total-Points-Before-Sampling`
    - `X-Sampled-Points-Limit`
- Updated Leaflet map path to apply capped sampling for display:
  - `app/controllers/map/leaflet_controller.rb`

### Frontend
- Updated MapLibre API client to request sampled points by default:
  - `app/javascript/maps_maplibre/services/api_client.js`
  - sends `sample=true&max_points=20000`

### Tests
- Added request specs for sampling behavior:
  - caps results to requested max
  - preserves ordering after sampling
  - validates sampling-related headers
  - `spec/requests/api/v1/points_spec.rb`
  - I tested it and it is much faster now and for long ranges my web app does not crash. 

### Docker (build reliability)
- Updated Dockerfile to install JS deps before assets precompile:
  - `docker/Dockerfile`
- This avoids `daisyui` missing errors during image build.

## Result
- Large-range map loading is now bounded to a maximum of 20,000 points.
- Raw source data is unchanged.
- Performance and stability are improved for heavy point histories.

## Notes
- Sampling is retrieval-time only (no data deletion).
- Existing behavior remains unchanged unless sampled mode is requested (v2 requests it by default via API client).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-demand sampling of large point datasets (default cap 20,000); clients can request sampling and set a max-point limit. Map rendering uses the sampled dataset.

* **Bug Fixes**
  * Scoped counts and distance gating use pre-sampling totals; responses include headers for sampling status, pre-sampling total, and applied limit.

* **Tests**
  * Request specs verify sampling behavior, headers, limits, and ordering.

* **Chores**
  * JS dependencies installed during image build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->