### PR TITLE
Fix Google Phone Takeout array format detection for large files

### DIFF
--- a/app/services/imports/source_detector.rb
+++ b/app/services/imports/source_detector.rb
@@ -213,6 +213,10 @@ class Imports::SourceDetector
       :google_semantic_history
     elsif content.include?('"locations"') && content.include?('"latitudeE7"')
       :google_records
+    elsif content.include?('"visit"') &&
+        content.include?('"topCandidate"') &&
+        content.include?('"placeLocation"')
+      :google_phone_takeout
     elsif content.include?('"FeatureCollection"') && content.include?('"features"')
       :geojson
     end

--- a/spec/services/imports/source_detector_spec.rb
+++ b/spec/services/imports/source_detector_spec.rb
@@ -244,7 +244,21 @@ RSpec.describe Imports::SourceDetector do
       let(:file_content) do
         # Simulates 8KB read truncating mid-string in deeply nested structure
         '{"semanticSegments": [{"startTime": "2013-03-16T03:00:00.000+01:00", ' \
-        '"timelinePath": [{"point": "43.7283°, 10.4047°", "time": "2013-03-16T04:15'
+        '"timelinePath": [{"point": "43.7283\u00b0, 10.4047\u00b0", "time": "2013-03-16T04:15'
+      end
+
+      it 'detects google_phone_takeout via raw content fallback' do
+        expect(detector.detect_source).to eq(:google_phone_takeout)
+      end
+    end
+
+    context 'with truncated Google Phone Takeout array format' do
+      let(:file_content) do
+        # Simulates 8KB read truncating mid-string in array-format location-history.json
+        '[{"endTime": "2023-08-27T17:04:26.999-05:00", "startTime": "2023-08-27T15:48:56.000-05:00", ' \
+        '"visit": {"hierarchyLevel": "0", "topCandidate": {"probability": "0.785181", ' \
+        '"semanticType": "Unknown", "placeID": "ChIJxxP_Qwb2aIYRTwDNDLkUmD0", ' \
+        '"placeLocation": "geo:27.720022,-97'
       end
 
       it 'detects google_phone_takeout via raw content fallback' do


### PR DESCRIPTION
## Summary

Follow-up to #2427 — the fix in v1.6.0 added Pattern 3 to `DETECTION_RULES` for array-format Google Phone Takeout files (`location-history.json`), but the `detect_from_raw_content` fallback was not updated to match this pattern.

### Problem

When a `location-history.json` file is large (e.g. 8MB+), the detector reads only the first 8KB (`MAX_DETECTION_BYTES`). For array-format files starting with `[{...}, ...]`, the 8KB truncation often lands mid-string (e.g. `"geo:27.720022,-97`), which causes:

1. `parse_json` fails — truncated JSON is invalid
2. `attempt_partial_json_parse` fails — appending `]`/`}]`/`}}]` can't fix a truncation inside a string value
3. `detect_from_raw_content` falls through — it checks for `semanticSegments`, `timelineObjects`, `latitudeE7`, and `FeatureCollection`, but **not** for the array-format keys (`visit`, `topCandidate`, `placeLocation`)
4. Returns `nil` → import fails with "Unable to detect file format"

Small files (like the existing test fixture at 2.2KB) parse successfully as JSON, so Pattern 3 in `DETECTION_RULES` works. The bug only manifests with real-world large files.

### Fix

Add a raw content fallback pattern in `detect_from_raw_content` that checks for `"visit"`, `"topCandidate"`, and `"placeLocation"` string patterns — matching the same structure as Pattern 3 in `DETECTION_RULES` but via string matching instead of JSON structure analysis.

### Changes

- **`app/services/imports/source_detector.rb`**: Add `elsif` clause in `detect_from_raw_content` for array-format Google Phone Takeout
- **`spec/services/imports/source_detector_spec.rb`**: Add test case for truncated array-format content in the raw content fallback context

## Test plan

- [x] New spec passes: truncated array-format content is detected as `:google_phone_takeout`
- [x] Existing specs continue to pass (no regressions)
- [x] Manual test: import a large (>8KB) `location-history.json` in array format succeeds