### PR TITLE
Remove public directory copy from Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,10 +71,6 @@ RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rake assets:precompile \
 RUN mkdir -p tmp/pids tmp/cache tmp/sockets \
     && chmod -R 777 tmp
 
-# Copy public directory to temp location for syncing with volume at runtime
-# This allows new static files to be added to the persistent volume
-RUN cp -r public /tmp/public_assets
-
 # Copy entrypoint scripts and grant execution permissions
 COPY ./docker/web-entrypoint.sh /usr/local/bin/web-entrypoint.sh
 RUN chmod +x /usr/local/bin/web-entrypoint.sh

--- a/docker/web-entrypoint.sh
+++ b/docker/web-entrypoint.sh
@@ -39,16 +39,6 @@ export DATABASE_NAME
 # Remove pre-existing puma/passenger server.pid
 rm -f "$APP_PATH/tmp/pids/server.pid"
 
-# Sync static assets from image to volume
-# This ensures new and updated files are copied to the persistent volume
-if [ -d "/tmp/public_assets" ]; then
-  echo "📦 Syncing static assets to public volume..."
-  # Remove old compiled assets to prevent stale files from persisting
-  rm -rf $APP_PATH/public/assets
-  cp -r /tmp/public_assets/* $APP_PATH/public/
-  echo "✅ Static assets synced!"
-fi
-
 # Function to check and create a PostgreSQL database
 create_database() {
   local db_name=$1


### PR DESCRIPTION
Removed copying of public directory to temporary location for syncing with volume.

AFAICT this is completely pointless in release/production deployments because it just creates a duplicate of the files in the image and the files that get overwritten by it are identical, and the APP_PATH isn't mounted as a volume anywhere anyway. Also, it breaks running the image as a non-root user and/or with a readonly root fs. (permission denied when trying to delete the asset files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the runtime static asset synchronization step and related conditional logic, simplifying container startup and deployment flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->