### PR TITLE
Addressing Issue #2448 , using timezone latitudes to determine if user lives Northern or Southern Hemisphere so that seasons, under Insights, shows correctly.

### DIFF
--- a/app/services/users/digests/seasonality_calculator.rb
+++ b/app/services/users/digests/seasonality_calculator.rb
@@ -3,13 +3,32 @@
 module Users
   module Digests
     class SeasonalityCalculator
-      # Northern hemisphere seasons by month
-      SEASONS = {
+      NORTHERN_SEASONS = {
         'winter' => [12, 1, 2],
         'spring' => [3, 4, 5],
         'summer' => [6, 7, 8],
-        'fall' => [9, 10, 11]
+        'fall'   => [9, 10, 11]
       }.freeze
+
+      SOUTHERN_SEASONS = {
+        'winter' => [6, 7, 8],
+        'spring' => [9, 10, 11],
+        'summer' => [12, 1, 2],
+        'fall'   => [3, 4, 5]
+      }.freeze
+
+      # Build a one-time lookup of IANA timezone identifier → latitude (Float).
+      # TZInfo::Country.all covers ~400 named zones; we take the first latitude
+      # seen for each identifier (multiple countries can share a zone).
+      TIMEZONE_LATITUDES = begin
+        TZInfo::Country.all.each_with_object({}) do |country, hash|
+          country.zones.each do |zone|
+            hash[zone.identifier] ||= zone.latitude.to_f
+          end
+        end.freeze
+      rescue StandardError
+        {}
+      end
 
       def initialize(user, year)
         @user = user
@@ -22,7 +41,7 @@ module Users
 
         return empty_result if total.zero?
 
-        SEASONS.keys.index_with do |season|
+        seasons.keys.index_with do |season|
           ((distances_by_season[season].to_f / total) * 100).round
         end
       end
@@ -31,10 +50,22 @@ module Users
 
       attr_reader :user, :year
 
+      def seasons
+        southern_hemisphere? ? SOUTHERN_SEASONS : NORTHERN_SEASONS
+      end
+
+      def southern_hemisphere?
+        tz_name = user.timezone.presence
+        return false if tz_name.blank?
+
+        latitude = TIMEZONE_LATITUDES[tz_name]
+        latitude.present? && latitude < 0
+      end
+
       def calculate_distances_by_season
         stats = user.stats.where(year: year)
 
-        SEASONS.transform_values do |months|
+        seasons.transform_values do |months|
           stats.where(month: months).sum(:distance)
         end
       end

--- a/spec/services/users/digests/seasonality_calculator_spec.rb
+++ b/spec/services/users/digests/seasonality_calculator_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::Digests::SeasonalityCalculator do
+  describe '#call' do
+    subject(:result) { described_class.new(user, year).call }
+
+    let(:year) { 2024 }
+
+    context 'with a Northern Hemisphere user (Europe/London)' do
+      let(:user) { create(:user, settings: { 'timezone' => 'Europe/London' }) }
+
+      context 'when the user has no stats' do
+        it 'returns zeroed seasonality' do
+          expect(result).to eq({ 'winter' => 0, 'spring' => 0, 'summer' => 0, 'fall' => 0 })
+        end
+      end
+
+      context 'when stats exist across months' do
+        before do
+          # Summer months (NH): June, July, August
+          create(:stat, user: user, year: year, month: 6,  distance: 300)
+          create(:stat, user: user, year: year, month: 7,  distance: 300)
+          create(:stat, user: user, year: year, month: 8,  distance: 400)
+          # Winter months (NH): December, January, February
+          create(:stat, user: user, year: year, month: 12, distance: 500)
+          create(:stat, user: user, year: year, month: 1,  distance: 200)
+        end
+
+        it 'assigns June–August distance to summer' do
+          expect(result['summer']).to eq(59) # (1000 / 1700.0 * 100).round
+        end
+
+        it 'assigns December–January distance to winter' do
+          expect(result['winter']).to eq(41) # (700 / 1700.0 * 100).round
+        end
+
+        it 'assigns zero to untravelled seasons' do
+          expect(result['spring']).to eq(0)
+          expect(result['fall']).to eq(0)
+        end
+
+        it 'percentages sum to 100' do
+          expect(result.values.sum).to eq(100)
+        end
+      end
+    end
+
+    context 'with a Southern Hemisphere user (Australia/Sydney)' do
+      let(:user) { create(:user, settings: { 'timezone' => 'Australia/Sydney' }) }
+
+      context 'when stats exist across months' do
+        before do
+          # June–August are WINTER in SH
+          create(:stat, user: user, year: year, month: 6,  distance: 500)
+          create(:stat, user: user, year: year, month: 7,  distance: 500)
+          # December–February are SUMMER in SH
+          create(:stat, user: user, year: year, month: 12, distance: 1000)
+        end
+
+        it 'maps June–August to winter (SH)' do
+          expect(result['winter']).to eq(50) # 1000 / 2000 * 100
+        end
+
+        it 'maps December to summer (SH)' do
+          expect(result['summer']).to eq(50) # 1000 / 2000 * 100
+        end
+
+        it 'assigns zero to untravelled seasons' do
+          expect(result['spring']).to eq(0)
+          expect(result['fall']).to eq(0)
+        end
+      end
+
+      context 'when the same months would be labelled differently for a NH user' do
+        before do
+          # March–May are FALL in SH (not spring as in NH)
+          create(:stat, user: user, year: year, month: 3, distance: 1000)
+        end
+
+        it 'labels March as fall, not spring' do
+          expect(result['fall']).to eq(100)
+          expect(result['spring']).to eq(0)
+        end
+      end
+    end
+
+    context 'when the user has no timezone set' do
+      let(:user) { create(:user, settings: {}) }
+
+      it 'defaults to Northern Hemisphere season mapping' do
+        create(:stat, user: user, year: year, month: 7, distance: 1000)
+
+        expect(result['summer']).to eq(100)
+      end
+    end
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved seasonality calculations to accurately reflect travel patterns based on user location, with proper support for both hemispheres.

* **Tests**
  * Added comprehensive test coverage for seasonality calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->