### PR TITLE
Fix photos with null coordinates rendering at Null Island (0°, 0°)

### DIFF
--- a/app/javascript/controllers/maps/maplibre/data_loader.js
+++ b/app/javascript/controllers/maps/maplibre/data_loader.js
@@ -381,7 +381,13 @@ export class DataLoader {
     return {
       type: "FeatureCollection",
       features: photos
-        .filter((photo) => photo.latitude != null && photo.longitude != null && photo.latitude !== 0 && photo.longitude !== 0)
+        .filter(
+          (photo) =>
+            photo.latitude != null &&
+            photo.longitude != null &&
+            photo.latitude !== 0 &&
+            photo.longitude !== 0,
+        )
         .map((photo) => {
           // Construct thumbnail URL
           const thumbnailUrl = `/api/v1/photos/${photo.id}/thumbnail.jpg?api_key=${this.apiKey}&source=${photo.source}`

--- a/app/javascript/controllers/maps/maplibre/data_loader.js
+++ b/app/javascript/controllers/maps/maplibre/data_loader.js
@@ -381,7 +381,7 @@ export class DataLoader {
     return {
       type: "FeatureCollection",
       features: photos
-        .filter((photo) => photo.latitude !== 0 && photo.longitude !== 0)
+        .filter((photo) => photo.latitude != null && photo.longitude != null && photo.latitude !== 0 && photo.longitude !== 0)
         .map((photo) => {
           // Construct thumbnail URL
           const thumbnailUrl = `/api/v1/photos/${photo.id}/thumbnail.jpg?api_key=${this.apiKey}&source=${photo.source}`


### PR DESCRIPTION
## Summary

- Photos imported from Immich (or other sources) without GPS metadata have `latitude: null` / `longitude: null`
- The filter in `photosToGeoJSON` only checked `!== 0`, but in JavaScript `null !== 0` is `true`, so null-coordinate photos passed through
- MapLibre interprets `[null, null]` as `[0, 0]`, rendering markers at Null Island (Gulf of Guinea)
- Added `!= null` checks before the existing zero checks to properly exclude these photos

Fixes #2464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of photos with missing or invalid location coordinates (null/undefined or 0) so those items are no longer converted into map points. This prevents erroneous or misplaced markers from appearing on maps and improves overall map accuracy and visual cleanliness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->