### PR TITLE
Fix flaky import temp file handling

### DIFF
--- a/app/services/imports/secure_file_downloader.rb
+++ b/app/services/imports/secure_file_downloader.rb
@@ -55,10 +55,11 @@ class Imports::SecureFileDownloader
     raise 'Download completed but no content was received' if temp_file.size.zero? # rubocop:disable Style/ZeroLengthPredicate -- Tempfile has no .empty?
 
     verify_temp_file_integrity(temp_file)
-    temp_file.path
+    path = temp_file.path
+    temp_file.close
+    path
 
-    # Keep temp file open so it can be read by other processes
-    # Caller is responsible for cleanup
+    # Caller is responsible for deleting the returned path.
   end
 
   private
@@ -114,14 +115,16 @@ class Imports::SecureFileDownloader
   def create_temp_file
     extension = File.extname(storage_attachment.filename.to_s)
     basename = File.basename(storage_attachment.filename.to_s, extension)
-    Tempfile.new(["#{basename}_#{Time.now.to_i}", extension], binmode: true)
+    Tempfile.create(["#{basename}_#{Time.now.to_i}", extension], binmode: true)
   end
 
   def cleanup_temp_file(temp_file)
     return unless temp_file
 
-    temp_file.close unless temp_file.closed?
-    temp_file.unlink if File.exist?(temp_file.path)
+    temp_file.close if temp_file.respond_to?(:close) && !temp_file.closed?
+
+    path = temp_file.respond_to?(:path) ? temp_file.path : nil
+    File.delete(path) if path && File.exist?(path)
   rescue StandardError => e
     Rails.logger.warn("Failed to cleanup temp file: #{e.message}")
   end

--- a/app/views/imports/_table_row.html.erb
+++ b/app/views/imports/_table_row.html.erb
@@ -2,6 +2,11 @@
     id="<%= dom_id(import) %>"
     data-points-total="<%= import.processed %>"
     class="hover:bg-base-200/50 transition-colors">
+  <% import_show_path = if respond_to?(:main_app) && main_app.respond_to?(:import_path)
+                          main_app.import_path(import)
+                        else
+                          import_path(import)
+                        end %>
   <td class="px-4 py-3">
     <div class="flex items-center gap-3">
       <div class="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0 <%= import_source_icon_class(import.source) %>">
@@ -9,7 +14,7 @@
       </div>
       <div>
         <div class="font-medium">
-          <%= link_to import.name, import, class: 'link link-hover' %>
+          <%= link_to import.name, import_show_path, class: 'link link-hover' %>
           <% if import.demo? %>
             <span class="badge badge-accent badge-sm ml-1">Demo</span>
           <% end %>
@@ -50,7 +55,7 @@
           </div>
         <% end %>
         <div class="tooltip" data-tip="Delete import">
-          <%= link_to import, data: { turbo_confirm: "Are you sure?", turbo_method: :delete }, class: "btn btn-ghost btn-xs text-error hover:bg-error/10" do %>
+          <%= link_to import_show_path, data: { turbo_confirm: "Are you sure?", turbo_method: :delete }, class: "btn btn-ghost btn-xs text-error hover:bg-error/10" do %>
             <%= icon 'trash-2', class: 'w-4 h-4' %>
           <% end %>
         </div>

--- a/spec/services/imports/secure_file_downloader_spec.rb
+++ b/spec/services/imports/secure_file_downloader_spec.rb
@@ -106,4 +106,24 @@ RSpec.describe Imports::SecureFileDownloader do
       end
     end
   end
+
+  describe '#download_to_temp_file' do
+    before do
+      allow(storage_attachment).to receive(:filename).and_return('track.gpx')
+      allow(storage_attachment).to receive(:download) do |&block|
+        block.call(file_content)
+      end
+    end
+
+    it 'returns a temp path that remains readable after GC runs' do
+      path = subject.download_to_temp_file
+
+      GC.start(full_mark: true, immediate_sweep: true)
+
+      expect(File.exist?(path)).to be(true)
+      expect(File.read(path)).to eq(file_content)
+    ensure
+      File.delete(path) if path && File.exist?(path)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

This PR fixes an intermittent import failure where the same GPX file can sometimes import successfully and sometimes fail during batch/background processing.

From the reported traces, the primary failure mode was:

- `No such file or directory @ rb_sysopen - /tmp/...gpx`

A secondary failure could then appear while rendering the import row update:

- `undefined method 'import_path'`

## Changes

1. Fix temp file lifetime in `Imports::SecureFileDownloader`

`download_to_temp_file` previously created the file with `Tempfile.new` and returned only `temp_file.path`.
That means the path was backed by a `Tempfile` object that could later be garbage-collected and auto-unlinked before the importer had a chance to read it.

This PR changes the downloader to:

- use `Tempfile.create(...)` instead of `Tempfile.new(...)`
- capture the path explicitly after integrity verification
- close the file handle before returning
- delete the file path explicitly during cleanup

This makes the returned temp path independent from the lifetime of the original `Tempfile` object and avoids flaky `rb_sysopen` failures on `/tmp/...gpx`.

2. Stop masking import errors with a secondary route helper failure

When an import enters an error state, Dawarich broadcasts an updated row using `imports/_table_row`.
That partial used polymorphic `link_to import`, which can fail in this rendering context with:

- `undefined method 'import_path'`

This PR replaces the polymorphic calls with an explicit show path, preferring `main_app.import_path(import)` when that route context is available.
This keeps the row render stable and prevents the UI update from hiding the original import failure behind a second exception.

3. Add a regression spec for the temp file race

A new spec covers `download_to_temp_file` by:

- downloading fixture content into a temp file
- forcing `GC.start(full_mark: true, immediate_sweep: true)`
- asserting that the returned path still exists and remains readable

This specifically guards the temp file lifetime problem described above.

## Why this matters

The user report behind this change was not a deterministic parser failure: the exact same GPX file could fail in one import attempt and succeed on retry.
That behavior is consistent with a temp file lifetime / timing issue rather than invalid GPX content.
