### PR TITLE
Recalculate tracks after bulk point delete

### DIFF
--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -95,8 +95,19 @@ class Api::V1::PointsController < ApiController
 
     render json: { error: 'No points selected' }, status: :unprocessable_entity and return if point_ids.blank?
 
+    # Capture affected tracks before deletion so we can recalculate cached track geometry.
+    # Deleting points does not automatically update tracks.original_path.
+    affected_track_ids = current_api_user.points.where(id: point_ids).where.not(track_id: nil).distinct.pluck(:track_id)
+
     deleted_count = current_api_user.points.where(id: point_ids).destroy_all.count
     User.update_counters(current_api_user.id, points_count: -deleted_count) if deleted_count.positive?
+
+    affected_track_ids.each do |track_id|
+      Rails.logger.info(
+        "[PointsController] bulk_destroy deleted points, enqueuing Tracks::RecalculateJob for track #{track_id}"
+      )
+      Tracks::RecalculateJob.perform_later(track_id)
+    end
 
     render json: { message: 'Points were successfully destroyed', count: deleted_count }, status: :ok
   end

--- a/spec/requests/api/v1/points_bulk_destroy_spec.rb
+++ b/spec/requests/api/v1/points_bulk_destroy_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::PointsController bulk_destroy', type: :request do
+  describe 'DELETE /api/v1/points/bulk_destroy' do
+    let(:user) { create(:user) }
+
+    before do
+      # Make sure the request is treated as authenticated API request
+      allow_any_instance_of(ApiController).to receive(:current_api_user).and_return(user)
+      allow_any_instance_of(ApiController).to receive(:authenticate_active_api_user!).and_return(true)
+      allow_any_instance_of(ApiController).to receive(:require_write_api!).and_return(true)
+    end
+
+    it 'enqueues track recalculation jobs for affected tracks' do
+      track1 = create(:track, user: user)
+      track2 = create(:track, user: user)
+
+      p1 = create(:point, user: user, track: track1)
+      p2 = create(:point, user: user, track: track1)
+      p3 = create(:point, user: user, track: track2)
+      p4 = create(:point, user: user, track: nil)
+
+      expect {
+        delete '/api/v1/points/bulk_destroy', params: { point_ids: [p1.id, p2.id, p3.id, p4.id] }
+      }.to have_enqueued_job(Tracks::RecalculateJob).with(track1.id)
+        .and have_enqueued_job(Tracks::RecalculateJob).with(track2.id)
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'does not enqueue jobs when no tracks are affected' do
+      p1 = create(:point, user: user, track: nil)
+
+      expect {
+        delete '/api/v1/points/bulk_destroy', params: { point_ids: [p1.id] }
+      }.not_to have_enqueued_job(Tracks::RecalculateJob)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
When deleting points via DELETE /api/v1/points/bulk_destroy, tracks.original_path can remain stale until recalculated.

This PR captures affected track_ids before deletion and enqueues Tracks::RecalculateJob for each track after the points are destroyed.

Also adds request specs asserting the job enqueue behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk point deletion now ensures that cached track information is properly recalculated and updated for all affected tracks after deletion.

* **Tests**
  * Added comprehensive test coverage for the bulk point deletion endpoint, verifying correct behavior for points across multiple tracks and untracked points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->