### PR TITLE
fix(api-point-serializer): API serialize points with null coordinates

### DIFF
--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -58,10 +58,20 @@ class Point < ApplicationRecord
   end
 
   def lon
+    if lonlat.nil?
+      Rails.logger.warn("Point #{id} has nil lonlat")
+      return nil
+    end
+
     lonlat.x
   end
 
   def lat
+    if lonlat.nil?
+      Rails.logger.warn("Point #{id} has nil lonlat")
+      return nil
+    end
+
     lonlat.y
   end
 


### PR DESCRIPTION
When the API attempts to serialize a point that is undefined, the application throws an error and the API returns a 500 response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when geographical coordinates are missing: the app no longer errors if location data is absent and instead returns empty values while emitting diagnostic warnings. This prevents crashes and improves resilience when location points are incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->