### PR TITLE
fix: API key copy button works on insecure origins

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -9,16 +9,53 @@ export default class extends Controller {
   static targets = ["icon", "text"]
 
   copy() {
-    navigator.clipboard
-      .writeText(this.textValue)
-      .then(() => {
-        this.showButtonFeedback()
-        Flash.show("notice", "Link copied to clipboard!")
-      })
-      .catch((err) => {
-        console.error("Failed to copy text: ", err)
-        Flash.show("error", "Failed to copy link")
-      })
+    const text = this.textValue
+
+    if (navigator.clipboard && window.isSecureContext) {
+      navigator.clipboard
+        .writeText(text)
+        .then(() => this.handleSuccess())
+        .catch(() => this.fallbackCopy(text))
+      return
+    }
+
+    this.fallbackCopy(text)
+  }
+
+  fallbackCopy(text) {
+    const textarea = document.createElement("textarea")
+    textarea.value = text
+    textarea.setAttribute("readonly", "")
+    textarea.style.position = "fixed"
+    textarea.style.top = "0"
+    textarea.style.left = "0"
+    textarea.style.opacity = "0"
+    textarea.style.pointerEvents = "none"
+    document.body.appendChild(textarea)
+
+    textarea.focus()
+    textarea.select()
+    textarea.setSelectionRange(0, text.length)
+
+    let succeeded = false
+    try {
+      succeeded = document.execCommand("copy")
+    } catch (err) {
+      console.error("Failed to copy text: ", err)
+    }
+
+    document.body.removeChild(textarea)
+
+    if (succeeded) {
+      this.handleSuccess()
+    } else {
+      Flash.show("error", "Failed to copy. Please copy manually.")
+    }
+  }
+
+  handleSuccess() {
+    this.showButtonFeedback()
+    Flash.show("notice", "Copied to clipboard!")
   }
 
   showButtonFeedback() {


### PR DESCRIPTION
Closes #2523.

**Root cause:** `navigator.clipboard.writeText` silently rejects on http:// origins (the API only works in secure contexts: https or localhost). Self-hosted users accessing dawarich at `http://lan-ip` see the copy button do nothing with no visible error in the UI.

**Fix:** detect non-secure context up front and use a `document.execCommand('copy')` + hidden textarea fallback. Modern path is unchanged on https/localhost.

Affects every clipboard button using this controller: `app/views/settings/users/show.html.erb` (the one in the bug report), `app/views/families/show.html.erb`, `app/views/family/invitations/index.html.erb`.

**Manual verification:** clicked the copy icon at `/settings/users/1` over `http://` on a LAN address. API key lands in the clipboard, success flash shows. Tested on Chrome 138 and Safari 18.