### PR TITLE
fix: provide OTP encryption env vars during Docker asset precompile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,11 @@ RUN bundle config set --local path 'vendor/bundle' \
 COPY ../. ./
 
 # Precompile assets
-RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rake assets:precompile \
+RUN SECRET_KEY_BASE_DUMMY=1 \
+    OTP_ENCRYPTION_PRIMARY_KEY=dummy \
+    OTP_ENCRYPTION_DETERMINISTIC_KEY=dummy \
+    OTP_ENCRYPTION_KEY_DERIVATION_SALT=dummy \
+    bundle exec rake assets:precompile \
     && rm -rf node_modules tmp/cache
 
 # Ensure tmp directory exists and is writable by any user (for custom uid:gid support)


### PR DESCRIPTION
## Problem

The 1.7.0 Docker image build fails on all platforms (amd64, arm64, armv7) at the asset precompile step:

```
rake aborted!
OTP_ENCRYPTION_PRIMARY_KEY required in production
/var/app/config/application.rb:43:in 'Dawarich::Application.env_or_dev_default'
```

`config/application.rb` raises when `OTP_ENCRYPTION_*` env vars are missing in production. The Dockerfile runs `rake assets:precompile` with `RAILS_ENV=production` but only provides `SECRET_KEY_BASE_DUMMY=1`.

Failing run: https://github.com/Freika/dawarich/actions/runs/24969113670

## Solution

Add dummy build-time values for `OTP_ENCRYPTION_PRIMARY_KEY`, `OTP_ENCRYPTION_DETERMINISTIC_KEY`, and `OTP_ENCRYPTION_KEY_DERIVATION_SALT` to the Dockerfile's asset precompile `RUN` step, matching the existing `SECRET_KEY_BASE_DUMMY` pattern.

These values are scoped to the `RUN` layer and never reach the runtime container.

Fixes #2533