### PR TITLE
Return 404 instead of 403 for users not in a family

### DIFF
--- a/app/controllers/api/v1/families/locations_controller.rb
+++ b/app/controllers/api/v1/families/locations_controller.rb
@@ -42,6 +42,6 @@ class Api::V1::Families::LocationsController < ApiController
   def ensure_user_in_family!
     return if current_api_user&.in_family?
 
-    render json: { error: 'User is not part of a family' }, status: :forbidden
+    render json: { error: 'User is not part of a family' }, status: :not_found
   end
 end

--- a/app/controllers/family/location_sharing_controller.rb
+++ b/app/controllers/family/location_sharing_controller.rb
@@ -45,9 +45,9 @@ class Family::LocationSharingController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: stream_flash(:error, 'User is not part of a family'), status: :forbidden
+        render turbo_stream: stream_flash(:error, 'User is not part of a family'), status: :not_found
       end
-      format.json { render json: { error: 'User is not part of a family' }, status: :forbidden }
+      format.json { render json: { error: 'User is not part of a family' }, status: :not_found }
     end
   end
 end

--- a/spec/requests/api/v1/families/locations_spec.rb
+++ b/spec/requests/api/v1/families/locations_spec.rb
@@ -69,10 +69,10 @@ RSpec.describe 'Api::V1::Families::Locations', type: :request do
     context 'when user is not in a family' do
       let(:solo_user) { create(:user) }
 
-      it 'returns forbidden' do
+      it 'returns not_found' do
         get '/api/v1/families/locations', params: { api_key: solo_user.api_key }
 
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:not_found)
         json_response = JSON.parse(response.body)
         expect(json_response['error']).to eq('User is not part of a family')
       end

--- a/spec/requests/family/location_sharing_spec.rb
+++ b/spec/requests/family/location_sharing_spec.rb
@@ -94,12 +94,12 @@ RSpec.describe 'Family::LocationSharing', type: :request do
         sign_in solo_user
       end
 
-      it 'returns forbidden' do
+      it 'returns not_found' do
         patch '/family/location_sharing',
               params: { enabled: true, duration: '1h' },
               as: :json
 
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:not_found)
         json_response = JSON.parse(response.body)
         expect(json_response['error']).to eq('User is not part of a family')
       end
@@ -178,7 +178,7 @@ RSpec.describe 'Family::LocationSharing', type: :request do
               params: { enabled: true, duration: '1h' },
               as: :turbo_stream
 
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:not_found)
         expect_turbo_stream_response
         expect_flash_stream('User is not part of a family')
       end

--- a/spec/swagger/api/v1/families/locations_controller_spec.rb
+++ b/spec/swagger/api/v1/families/locations_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Families Locations API', type: :request do
         run_test!
       end
 
-      response '403', 'user not in a family' do
+      response '404', 'user not in a family' do
         run_test!
       end
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -706,7 +706,7 @@ paths:
                   sharing_enabled:
                     type: boolean
                     description: Whether the current user has sharing enabled
-        '403':
+        '404':
           description: user not in a family
         '401':
           description: unauthorized


### PR DESCRIPTION
The frontend pings family endpoints by default. When the feature is unconfigured, repeated 403s look like brute-force attempts and trip firewall blocks. 404 reflects that the resource simply isn't there for that user.

By comparison, see how Github returns 404 instead of 403 when the user tries to access a repo they don't have permissions to: https://github.com/funk66/test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API response status codes for family location features. When users attempt to access family locations without being part of the required family, endpoints now return HTTP 404 (Not Found) instead of 403 (Forbidden), providing more accurate error signaling while preserving error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->