### PR TITLE
Lock account after 10 failed 2FA attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - "Re-run detection on full history" button under Settings → Visits. Confirmed visits and named places are preserved.
+- Account lockout after 10 failed 2FA attempts (30-minute auto-unlock or password reset). Applies to both the mobile API (`POST /api/v1/auth/otp_challenge`) and the web sign-in flow. A notification email is sent to the account owner when a lockout is triggered. #2575
 
 ### Fixed
 

--- a/app/controllers/api/v1/auth/otp_challenges_controller.rb
+++ b/app/controllers/api/v1/auth/otp_challenges_controller.rb
@@ -7,11 +7,20 @@ class Api::V1::Auth::OtpChallengesController < Api::V1::Auth::BaseController
   rescue Auth::VerifyOtpChallengeToken::InvalidToken => e
     render_auth_error("Invalid or expired challenge: #{e.message}")
   else
+    if user.otp_locked?
+      return render_auth_error(
+        'Account temporarily locked due to too many failed 2FA attempts. Try again in 30 minutes.',
+        http_status: :locked
+      )
+    end
+
     otp_code = params[:otp_code].to_s.strip
     if user.validate_and_consume_otp!(otp_code) || user.invalidate_otp_backup_code!(otp_code)
       verifier.mark_consumed!
+      user.reset_failed_otp_attempts!
       render_auth_success(user)
     else
+      user.register_failed_otp_attempt!
       render_auth_error('Invalid two-factor code')
     end
   end

--- a/app/controllers/users/otp_challenge_controller.rb
+++ b/app/controllers/users/otp_challenge_controller.rb
@@ -13,13 +13,23 @@ class Users::OtpChallengeController < ApplicationController
       return
     end
 
+    if user.otp_locked?
+      clear_otp_session
+      redirect_to new_user_session_path,
+                  alert: 'Account temporarily locked due to too many failed 2FA attempts. Try again in 30 minutes or reset your password.'
+      return
+    end
+
     otp_code = params[:otp_attempt]
 
     if user.validate_and_consume_otp!(otp_code) || user.invalidate_otp_backup_code!(otp_code)
       clear_otp_session
+      user.reset_failed_otp_attempts!
       sign_in(user)
       redirect_to after_sign_in_path_for(user), notice: 'Signed in successfully.'
     else
+      user.register_failed_otp_attempt!
+
       session[:otp_failed_attempts] = (session[:otp_failed_attempts] || 0) + 1
       if session[:otp_failed_attempts] >= MAX_FAILED_ATTEMPTS
         clear_otp_session

--- a/app/mailers/users_mailer.rb
+++ b/app/mailers/users_mailer.rb
@@ -69,4 +69,10 @@ class UsersMailer < ApplicationMailer
 
     mail(to: @user.email, subject: 'Confirm Dawarich account deletion')
   end
+
+  def otp_account_locked
+    @user = params[:user]
+
+    mail(to: @user.email, subject: 'Dawarich account temporarily locked')
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,43 @@ class User < ApplicationRecord
   enum :subscription_source, { none: 0, paddle: 1, apple_iap: 2, google_play: 3 }, default: :none, prefix: :sub_source
   enum :plan, { lite: 0, pro: 1 }, default: :pro
 
+  MAX_FAILED_OTP_ATTEMPTS = 10
+  OTP_LOCK_DURATION = 30.minutes
+
+  def otp_locked?
+    otp_locked_at.present? && otp_locked_at > OTP_LOCK_DURATION.ago
+  end
+
+  def register_failed_otp_attempt!
+    return if otp_locked?
+
+    # Stale (expired) lockout — start a fresh counting window.
+    User.where(id: id).update_all(failed_otp_attempts: 0, otp_locked_at: nil) if otp_locked_at.present?
+
+    User.where(id: id).update_all('failed_otp_attempts = failed_otp_attempts + 1')
+    reload
+
+    return if failed_otp_attempts < MAX_FAILED_OTP_ATTEMPTS
+
+    transitioned = User.where(id: id, otp_locked_at: nil).update_all(otp_locked_at: Time.current)
+    return unless transitioned.positive?
+
+    reload
+    UsersMailer.with(user: self).otp_account_locked.deliver_later
+  end
+
+  def reset_failed_otp_attempts!
+    return if failed_otp_attempts.zero? && otp_locked_at.nil?
+
+    update_columns(failed_otp_attempts: 0, otp_locked_at: nil)
+  end
+
+  # Devise hook: clearing the password should also clear the OTP lockout so
+  # the user-facing "or reset your password" guidance actually works.
+  def reset_password(*)
+    super.tap { |success| reset_failed_otp_attempts! if success }
+  end
+
   def oauth_user?
     provider.present?
   end

--- a/app/views/users_mailer/otp_account_locked.html.erb
+++ b/app/views/users_mailer/otp_account_locked.html.erb
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+    .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+    .header { background: #dc2626; color: white; padding: 20px; text-align: center; }
+    .content { padding: 20px; background: #f9fafb; }
+    .cta { background: #2563eb; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; margin: 20px 0; }
+    .notice { background: #fef3c7; border: 1px solid #f59e0b; padding: 12px; border-radius: 6px; margin: 16px 0; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1>Account temporarily locked</h1>
+    </div>
+    <div class="content">
+      <p>Hi <%= @user.email %>,</p>
+
+      <p>Your Dawarich account has been <strong>temporarily locked</strong> because 10 consecutive failed two-factor authentication attempts were detected.</p>
+
+      <p>The lock will automatically lift after <strong>30 minutes</strong>. No action is required if this was you.</p>
+
+      <div class="notice">
+        <p><strong>Didn't recognise this activity?</strong> Someone may be trying to access your account. We recommend resetting your password immediately.</p>
+      </div>
+
+      <p><a href="<%= new_user_password_url %>" class="cta">Reset your password</a></p>
+
+      <p>If you need further assistance, contact us at <a href="mailto:security@dawarich.app">security@dawarich.app</a>.</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/app/views/users_mailer/otp_account_locked.text.erb
+++ b/app/views/users_mailer/otp_account_locked.text.erb
@@ -1,0 +1,13 @@
+Account temporarily locked
+
+Hi <%= @user.email %>,
+
+Your Dawarich account has been temporarily locked because 10 consecutive failed two-factor authentication attempts were detected.
+
+The lock will automatically lift after 30 minutes. No action is required if this was you.
+
+Didn't recognise this activity? Someone may be trying to access your account. We recommend resetting your password immediately.
+
+Reset your password: <%= new_user_password_url %>
+
+If you need further assistance, contact us at security@dawarich.app.

--- a/db/migrate/20260430000001_add_failed_otp_attempts_to_users.rb
+++ b/db/migrate/20260430000001_add_failed_otp_attempts_to_users.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddFailedOtpAttemptsToUsers < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  INDEX_NAME = 'index_users_on_otp_locked_at_not_null'
+
+  def up
+    add_column :users, :failed_otp_attempts, :integer, default: 0, null: false unless column_exists?(:users, :failed_otp_attempts)
+    add_column :users, :otp_locked_at, :datetime unless column_exists?(:users, :otp_locked_at)
+
+    return if index_name_exists?(:users, INDEX_NAME)
+
+    add_index :users, :otp_locked_at,
+              where: 'otp_locked_at IS NOT NULL',
+              algorithm: :concurrently,
+              name: INDEX_NAME
+  end
+
+  def down
+    remove_index :users, name: INDEX_NAME, algorithm: :concurrently if index_name_exists?(:users, INDEX_NAME)
+    remove_column :users, :otp_locked_at if column_exists?(:users, :otp_locked_at)
+    remove_column :users, :failed_otp_attempts if column_exists?(:users, :failed_otp_attempts)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -466,9 +466,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_09_163901) do
     t.integer "subscription_source", default: 0, null: false
     t.string "signup_variant"
     t.datetime "visits_redetected_at"
+    t.integer "failed_otp_attempts", default: 0, null: false
+    t.datetime "otp_locked_at"
     t.index ["api_key"], name: "index_users_on_api_key"
     t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["otp_locked_at"], name: "index_users_on_otp_locked_at_not_null", where: "(otp_locked_at IS NOT NULL)"
     t.index ["plan"], name: "index_users_on_plan"
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid_present", unique: true, where: "((provider IS NOT NULL) AND (uid IS NOT NULL))"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/mailers/users_mailer_spec.rb
+++ b/spec/mailers/users_mailer_spec.rb
@@ -70,4 +70,25 @@ RSpec.describe UsersMailer, type: :mailer do
       expect(mail.to).to eq([user.email])
     end
   end
+
+  describe 'otp_account_locked' do
+    let(:mail) { UsersMailer.with(user: user).otp_account_locked }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Dawarich account temporarily locked')
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'renders the body with the user email' do
+      expect(mail.body.encoded).to match(user.email)
+    end
+
+    it 'includes password reset link in HTML part' do
+      expect(mail.html_part.body.encoded).to include('password')
+    end
+
+    it 'includes password reset link in text part' do
+      expect(mail.text_part.body.encoded).to include('password')
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -858,4 +858,113 @@ subscription_source: :none)
       end
     end
   end
+
+  describe 'OTP lockout' do
+    let(:user) { create(:user) }
+
+    describe '#otp_locked?' do
+      it 'returns false when otp_locked_at is nil' do
+        expect(user.otp_locked?).to be false
+      end
+
+      it 'returns true when locked within the lock duration' do
+        user.update_columns(otp_locked_at: 1.minute.ago)
+        expect(user.otp_locked?).to be true
+      end
+
+      it 'returns false when lock has expired' do
+        user.update_columns(otp_locked_at: 31.minutes.ago)
+        expect(user.otp_locked?).to be false
+      end
+    end
+
+    describe '#register_failed_otp_attempt!' do
+      it 'increments failed_otp_attempts' do
+        expect { user.register_failed_otp_attempt! }
+          .to change { user.reload.failed_otp_attempts }.from(0).to(1)
+      end
+
+      it 'does not lock the account below the threshold' do
+        (User::MAX_FAILED_OTP_ATTEMPTS - 1).times { user.register_failed_otp_attempt! }
+        expect(user.reload.otp_locked_at).to be_nil
+      end
+
+      it 'locks the account when threshold is reached' do
+        User::MAX_FAILED_OTP_ATTEMPTS.times { user.register_failed_otp_attempt! }
+        expect(user.reload.otp_locked_at).to be_present
+      end
+
+      it 'enqueues a lockout email when threshold is reached' do
+        (User::MAX_FAILED_OTP_ATTEMPTS - 1).times { user.register_failed_otp_attempt! }
+        expect { user.register_failed_otp_attempt! }
+          .to have_enqueued_mail(UsersMailer, :otp_account_locked)
+      end
+
+      it 'does not enqueue a lockout email below the threshold' do
+        expect { user.register_failed_otp_attempt! }
+          .not_to have_enqueued_mail(UsersMailer, :otp_account_locked)
+      end
+
+      it 'is a no-op while the account is already locked' do
+        User::MAX_FAILED_OTP_ATTEMPTS.times { user.register_failed_otp_attempt! }
+        locked_at = user.reload.otp_locked_at
+        count = user.failed_otp_attempts
+
+        expect { user.register_failed_otp_attempt! }
+          .not_to have_enqueued_mail(UsersMailer, :otp_account_locked)
+        user.reload
+        expect(user.otp_locked_at).to eq(locked_at)
+        expect(user.failed_otp_attempts).to eq(count)
+      end
+
+      it 'resets the counter and starts fresh after the lock has expired' do
+        user.update_columns(failed_otp_attempts: User::MAX_FAILED_OTP_ATTEMPTS, otp_locked_at: 31.minutes.ago)
+
+        expect { user.register_failed_otp_attempt! }
+          .not_to have_enqueued_mail(UsersMailer, :otp_account_locked)
+        user.reload
+        expect(user.otp_locked_at).to be_nil
+        expect(user.failed_otp_attempts).to eq(1)
+      end
+    end
+
+    describe '#reset_failed_otp_attempts!' do
+      it 'clears failed_otp_attempts and otp_locked_at' do
+        user.update_columns(failed_otp_attempts: 5, otp_locked_at: 1.minute.ago)
+        user.reset_failed_otp_attempts!
+        user.reload
+        expect(user.failed_otp_attempts).to eq(0)
+        expect(user.otp_locked_at).to be_nil
+      end
+
+      it 'is a no-op when already at defaults' do
+        user.reset_failed_otp_attempts!
+        user.reload
+        expect(user.failed_otp_attempts).to eq(0)
+        expect(user.otp_locked_at).to be_nil
+      end
+    end
+
+    describe '#reset_password' do
+      it 'clears the OTP lockout when the password is successfully reset' do
+        user.update_columns(failed_otp_attempts: User::MAX_FAILED_OTP_ATTEMPTS, otp_locked_at: 1.minute.ago)
+
+        user.reset_password('newpassword12345', 'newpassword12345')
+        user.reload
+
+        expect(user.failed_otp_attempts).to eq(0)
+        expect(user.otp_locked_at).to be_nil
+      end
+
+      it 'does not clear the OTP lockout when the password reset fails validation' do
+        user.update_columns(failed_otp_attempts: User::MAX_FAILED_OTP_ATTEMPTS, otp_locked_at: 1.minute.ago)
+
+        user.reset_password('short', 'short')
+        user.reload
+
+        expect(user.failed_otp_attempts).to eq(User::MAX_FAILED_OTP_ATTEMPTS)
+        expect(user.otp_locked_at).to be_present
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/auth/otp_challenges_spec.rb
+++ b/spec/requests/api/v1/auth/otp_challenges_spec.rb
@@ -74,6 +74,35 @@ RSpec.describe 'POST /api/v1/auth/otp_challenge', type: :request do
     expect(response).to have_http_status(:unauthorized)
   end
 
+  describe 'OTP lockout' do
+    it 'returns 423 Locked when the account is locked' do
+      user.update_columns(otp_locked_at: 1.minute.ago)
+      post '/api/v1/auth/otp_challenge', params: { challenge_token: challenge_token, otp_code: current_totp }
+      expect(response).to have_http_status(:locked)
+      expect(JSON.parse(response.body)['message']).to include('locked')
+    end
+
+    it 'increments failed_otp_attempts on a wrong code' do
+      expect {
+        post '/api/v1/auth/otp_challenge', params: { challenge_token: challenge_token, otp_code: '000000' }
+      }.to change { user.reload.failed_otp_attempts }.by(1)
+    end
+
+    it 'resets failed_otp_attempts on a successful login' do
+      user.update_columns(failed_otp_attempts: 5)
+      post '/api/v1/auth/otp_challenge', params: { challenge_token: challenge_token, otp_code: current_totp }
+      expect(response).to have_http_status(:ok)
+      expect(user.reload.failed_otp_attempts).to eq(0)
+    end
+
+    it 'enqueues the lockout email when the threshold is reached' do
+      user.update_columns(failed_otp_attempts: User::MAX_FAILED_OTP_ATTEMPTS - 1)
+      expect {
+        post '/api/v1/auth/otp_challenge', params: { challenge_token: challenge_token, otp_code: '000000' }
+      }.to have_enqueued_mail(UsersMailer, :otp_account_locked)
+    end
+  end
+
   describe 'brute-force protection keyed on challenge_token' do
     it 'throttles repeated guesses against the same challenge_token to 5 per window' do
       # 5 wrong attempts should not be throttled; the 6th should

--- a/spec/requests/users/otp_challenge_spec.rb
+++ b/spec/requests/users/otp_challenge_spec.rb
@@ -61,6 +61,35 @@ RSpec.describe 'Users::Sessions OTP Challenge', type: :request do
         expect(response).to redirect_to(new_user_session_path)
         expect(flash[:alert]).to include('Too many invalid')
       end
+
+      it 'increments failed_otp_attempts' do
+        post user_session_path, params: { user: { email: user.email, password: password } }
+        expect do
+          post user_otp_challenge_path, params: { otp_attempt: '000000' }
+        end.to change { user.reload.failed_otp_attempts }.by(1)
+      end
+    end
+
+    context 'when the account is locked' do
+      before do
+        user.update_columns(otp_locked_at: 1.minute.ago)
+        post user_session_path, params: { user: { email: user.email, password: password } }
+      end
+
+      it 'redirects to login with a locked message' do
+        post user_otp_challenge_path, params: { otp_attempt: user.current_otp }
+        expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to include('locked')
+      end
+    end
+
+    context 'when OTP succeeds after previous failures' do
+      it 'resets the failed_otp_attempts counter' do
+        user.update_columns(failed_otp_attempts: 5)
+        post user_session_path, params: { user: { email: user.email, password: password } }
+        post user_otp_challenge_path, params: { otp_attempt: user.current_otp }
+        expect(user.reload.failed_otp_attempts).to eq(0)
+      end
     end
 
     context 'when backup code is used' do


### PR DESCRIPTION
## Summary

Follow-up to PR #2550 (security review item M1). Adds a per-user lockout on the 2FA verification step.

- 10 consecutive failed OTP attempts (mobile or web) → 30-minute lockout
- Lockout state stored on `users.otp_locked_at`; partial index (`WHERE otp_locked_at IS NOT NULL`) for efficient sparse lookup added via `algorithm: :concurrently`
- API returns 423 Locked; web flow redirects to login with flash message
- `UsersMailer#otp_account_locked` email notifies the account owner when a lockout triggers, with a password-reset link
- Counter resets on successful authentication
- Separate from Devise's built-in `failed_attempts`/`locked_at` (password lockout) — these columns are OTP-specific

Closes the gap where credential stuffing + per-token throttle alone allowed ~25 OTP guesses/min/user.

## Changed files

| File | Change |
|------|--------|
| `db/migrate/20260430000001_add_failed_otp_attempts_to_users.rb` | Migration: new columns + concurrent partial index |
| `app/models/user.rb` | `MAX_FAILED_OTP_ATTEMPTS`, `OTP_LOCK_DURATION`, `otp_locked?`, `register_failed_otp_attempt!`, `reset_failed_otp_attempts!` |
| `app/controllers/api/v1/auth/otp_challenges_controller.rb` | 423 on locked, increment on fail, reset on success |
| `app/controllers/users/otp_challenge_controller.rb` | Same lockout logic for web sign-in flow |
| `app/mailers/users_mailer.rb` | `otp_account_locked` mailer method |
| `app/views/users_mailer/otp_account_locked.{html,text}.erb` | Lockout email views |

## Test plan

- [ ] `bundle exec rspec spec/models/user_spec.rb spec/requests/api/v1/auth/otp_challenges_spec.rb spec/requests/users/otp_challenge_spec.rb spec/mailers/users_mailer_spec.rb`
- [ ] Manually verify: enable 2FA, fail OTP 10 times via mobile API, confirm 423 + lockout email received
- [ ] Manually verify: same flow via web sign-in → redirect to login with locked alert
- [ ] Verify counter resets after one successful login
- [ ] Verify `rails db:migrate && rails db:rollback && rails db:migrate` — migration is reversible

https://claude.ai/code/session_01EuEDx4oQb5j5MGgigVsEBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuEDx4oQb5j5MGgigVsEBD)_