### PR TITLE
fix(imports): detect iOS Google Maps Timeline array format in raw content fallback

### DIFF
--- a/app/services/imports/source_detector.rb
+++ b/app/services/imports/source_detector.rb
@@ -215,6 +215,9 @@ class Imports::SourceDetector
       :google_records
     elsif content.include?('"FeatureCollection"') && content.include?('"features"')
       :geojson
+    elsif content.include?('"visit"') && content.include?('"activity"') &&
+          content.include?('"endTime"') && content.include?('"startTime"')
+      :google_phone_takeout
     end
   end
 

--- a/spec/services/imports/source_detector_spec.rb
+++ b/spec/services/imports/source_detector_spec.rb
@@ -262,6 +262,21 @@ RSpec.describe Imports::SourceDetector do
       end
     end
 
+    context 'with truncated iOS Google Phone Takeout (array format without semanticSegments)' do
+      let(:file_content) do
+        # iOS Google Maps Timeline export: array of visit/activity objects
+        '[{"endTime": "2018-12-26T18:55:26.237Z", "startTime": "2018-12-26T15:23:48.869Z", ' \
+        '"visit": {"hierarchyLevel": "0", "topCandidate": {"probability": "0.461223", ' \
+        '"placeLocation": "geo:41.570045,-8.468077"}}}, ' \
+        '{"endTime": "2018-12-27T10:35:33.000Z", "startTime": "2018-12-26T18:55:26.237Z", ' \
+        '"activity": {"end": "geo:41.640695,-8.333'
+      end
+
+      it 'detects google_phone_takeout via raw content fallback' do
+        expect(detector.detect_source).to eq(:google_phone_takeout)
+      end
+    end
+
     context 'with truncated Google Semantic History' do
       let(:file_content) do
         '{"timelineObjects": [{"activitySegment": {"duration": {"startTimestamp": "2024-01'


### PR DESCRIPTION
## Summary

**⚠️ Note:** I cannot verify this fully fixes the issue — I don't have access to test with the exact Docker setup. This is a best-effort analysis and fix based on source code inspection.

## Suspected root cause

The error in #2587 occurs at `Imports::SourceDetector#detect_source!` (`source_detector.rb:97`), meaning the format detector returned `nil` — it couldn't identify the file format.

The iOS Google Maps Timeline export (`location-history.json`) is a **flat JSON array** of `visit`/`activity` objects — it has `endTime`, `startTime`, `visit`, `activity` but does **not** have a top-level `semanticSegments` key.

The detection has two paths:
1. **`parse_json` (structured detection):** reads the first 8KB and tries to parse valid JSON. Pattern 3 of `google_phone_takeout` already matches this array format. **However**, if the 8KB truncation lands mid-string, `Oj.load` fails and partial JSON patching (`content}`, `content}]`, `content}}]`) can't close an unterminated string — so `parse_json` returns `nil`.

2. **`detect_from_raw_content` (fallback):** when step 1 fails, it checks for raw substrings. The existing check requires `"semanticSegments"` to be present, which **doesn't exist** in the iOS format. So this fallback also returns `nil`, and the importer raises `UnknownSourceError`.

## What the fix does

Adds a new `elsif` branch in `detect_from_raw_content` that detects the iOS format by checking for the combination of `"visit"`, `"activity"`, `"endTime"`, and `"startTime"` — all present in the iOS export but absent from the `semanticSegments`-based Android format.

This is placed **after** the existing checks so it doesn't interfere with Android detections, and only activates as a last-resort fallback.

Closes #2587 (hopefully)