### PR TITLE
Fix photos without GPS coordinates showing at (0,0) on map

### DIFF
--- a/app/services/photos/search.rb
+++ b/app/services/photos/search.rb
@@ -50,6 +50,10 @@ class Photos::Search
     asset_type = asset['type'] || asset['Type']
     return if asset_type.downcase == 'video'
 
+    lat = asset.dig('exifInfo', 'latitude') || asset['Lat']
+    lon = asset.dig('exifInfo', 'longitude') || asset['Lng']
+    return if lat.nil? || lon.nil? || lat == 0 || lon == 0
+
     asset.merge(source: source)
   end
 end


### PR DESCRIPTION
## Summary

- Filter out photos with `nil` or `0` coordinates in `Photos::Search#transform_asset` (backend) to prevent them from being serialized and sent to the frontend
- Fix JS filter in `data_loader.js#photosToGeoJSON` to also catch `null`/`undefined` latitude/longitude values (previously only filtered `!== 0`, which let `null` pass through and get rendered as markers at 0°, 0°)

## Context

When Immich/Photoprism integration is enabled, photos without EXIF GPS data have `null` latitude/longitude. The previous filter (`!== 0`) in JS didn't catch these, causing MapLibre to render photo markers at (0,0) in the Gulf of Guinea. The import geodata path (`Immich::ImportGeodata#valid?`) already had correct filtering — this aligns the map display path to match.

## Test plan

- [ ] Configure Immich integration with a library containing photos that have no GPS data
- [ ] Open the map view with photos enabled
- [ ] Verify no photo markers appear at (0,0) coordinates
- [ ] Verify photos with valid GPS coordinates still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)