### PR TITLE
Pro-rate overnight track attribution across calendar days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Map v2 date-navigation arrows (`<` / `>`) now shift the time window by exactly one day, matching Map v1. Previously they shifted by the current window width, so a 00:00–23:59 selection paged back by 23h59m instead of 24h. (#2548)
 - Daily track generation now merges a newly-created track with the immediately-preceding existing track when they are seconds apart, instead of leaving a permanent split each time live tracking briefly pauses. To heal splits that have already accumulated in your database, open Map v2 → Settings → **Recalculate tracks & stats** once after upgrading; from then on the daily job will keep adjacent tracks merged on its own. (#2265)
 - Trip page no longer shows an indefinite "loading" spinner in the Countries card when no country data is available; an em-dash placeholder is shown instead, matching the modal's "No countries data available yet." message. #1831
+- Trips that cross midnight in the user's timezone now contribute distance and time to both calendar days, instead of being attributed entirely to the day they started. The timeline day summary, the calendar heat grid, and adjacent-day km totals all reflect the trip on each day it actually spans. (#2544, #2546)
 
 
 ### Changed
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - "Start Reverse Geocoding" and "Continue Reverse Geocoding" now enqueue Sidekiq jobs in bulk batches of 1,000 instead of one round-trip per point. For large databases (millions of points) this drops the enqueue phase from minutes to seconds. Per-point geocoder rate-limit behavior is unchanged. (#2141)
 - Map (Leaflet) on mobile browsers no longer clips the bottom of the map and routes after the address bar collapses or the date is changed. (#2000)
 - Visit suggestions are now generated from live tracking (Dawarich iOS app, OwnTracks, Overland, Traccar), not just from imports. Previously, only imported data triggered visit detection. Visit suggestion still requires a configured reverse geocoder (Photon, Geoapify, Nominatim, or LocationIQ). (#1749, #1966)
+
 
 ## [1.7.4] - 2026-05-03
 

--- a/app/services/timeline/day_assembler.rb
+++ b/app/services/timeline/day_assembler.rb
@@ -118,7 +118,7 @@ module Timeline
     end
 
     def build_day(date, data)
-      entries = interleave(data[:visits], data[:tracks])
+      entries = interleave(date, data[:visits], data[:tracks], data[:track_shares])
       {
         date: date.to_s,
         summary: build_summary(data[:visits], data[:tracks], data[:track_shares]),
@@ -127,11 +127,21 @@ module Timeline
       }
     end
 
-    def interleave(visits, tracks)
+    # Sort key clamps continuation-day journeys to the day's 00:00 anchor so
+    # they appear at the top of the day rather than ahead of all visits at
+    # the previous evening's wall-clock. Visits never cross midnight in the
+    # bucket (group_by_day keys them on their own start), so their sort key
+    # is unchanged.
+    def interleave(date, visits, tracks, track_shares)
+      day_start_iso = date.in_time_zone(user.safe_settings.timezone).beginning_of_day.iso8601
       visit_entries = visits.map { |v| build_visit_entry(v) }
-      track_entries = tracks.map { |t| build_journey_entry(t) }
+      track_entries = tracks.map { |t| build_journey_entry(t, date: date, day_share: track_shares.fetch(t.id, 1.0)) }
 
-      (visit_entries + track_entries).sort_by { |e| e[:started_at] }
+      (visit_entries + track_entries).sort_by do |entry|
+        sort_key = entry[:started_at]
+        sort_key = day_start_iso if sort_key < day_start_iso
+        [sort_key, entry[:started_at]]
+      end
     end
 
     # NOTE: visit.duration is stored in MINUTES. See the public #build_visit_entry
@@ -177,7 +187,11 @@ module Timeline
       seen.values
     end
 
-    def build_journey_entry(track)
+    def build_journey_entry(track, date: nil, day_share: 1.0)
+      tz = user.safe_settings.timezone
+      start_day = track.start_at.in_time_zone(tz).to_date
+      continuation = date.present? && date != start_day
+
       {
         type: 'journey',
         track_id: track.id,
@@ -190,7 +204,10 @@ module Timeline
         avg_speed: convert_speed(track.avg_speed.to_f),
         speed_unit: speed_unit_label,
         elevation_gain: track.elevation_gain,
-        elevation_loss: track.elevation_loss
+        elevation_loss: track.elevation_loss,
+        continuation_of_date: continuation ? start_day.to_s : nil,
+        day_distance: continuation ? convert_distance(track.distance.to_f * day_share) : nil,
+        day_duration: continuation ? (track.duration.to_f * day_share).round : nil
       }
     end
 

--- a/app/services/timeline/day_assembler.rb
+++ b/app/services/timeline/day_assembler.rb
@@ -79,18 +79,25 @@ module Timeline
       tz = user.safe_settings.timezone
       Time.use_zone(tz) do
         grouped = {}
+        window = start_at.in_time_zone.to_date..end_at.in_time_zone.to_date
 
         visits.each do |visit|
           day_key = visit.started_at.in_time_zone.to_date
-          grouped[day_key] ||= { visits: [], tracks: [], track_shares: {} }
+          next unless window.cover?(day_key)
+
+          grouped[day_key] ||= empty_day_bucket
           grouped[day_key][:visits] << visit
         end
 
         tracks.each do |track|
-          TrackDayShares.for(track, tz).each do |day_key, fraction|
-            grouped[day_key] ||= { visits: [], tracks: [], track_shares: {} }
+          start_day = track.start_at.in_time_zone.to_date
+          TrackDayShares.shares_for(track, tz).each do |day_key, fraction|
+            next unless window.cover?(day_key)
+
+            grouped[day_key] ||= empty_day_bucket
             grouped[day_key][:tracks] << track
             grouped[day_key][:track_shares][track.id] = fraction
+            grouped[day_key][:originating_tracks] << track if day_key == start_day
           end
         end
 
@@ -98,16 +105,24 @@ module Timeline
       end
     end
 
-    def build_days(days)
-      days.map { |date, data| build_day(date, data[:visits], data[:tracks], data[:track_shares] || {}) }
+    # Continuation-day buckets share polyline geometry with their start day.
+    # Auto-fit bounds use only `originating_tracks` so the camera frames "what
+    # happened today" instead of zooming out to a city visited the prior
+    # evening; the route layer still renders the full polyline independently.
+    def empty_day_bucket
+      { visits: [], tracks: [], originating_tracks: [], track_shares: {} }
     end
 
-    def build_day(date, visits, tracks, track_shares)
-      entries = interleave(visits, tracks)
+    def build_days(days)
+      days.map { |date, data| build_day(date, data) }
+    end
+
+    def build_day(date, data)
+      entries = interleave(data[:visits], data[:tracks])
       {
         date: date.to_s,
-        summary: build_summary(visits, tracks, track_shares),
-        bounds: build_bounds(visits, tracks),
+        summary: build_summary(data[:visits], data[:tracks], data[:track_shares]),
+        bounds: build_bounds(data[:visits], data[:originating_tracks]),
         entries: entries
       }
     end

--- a/app/services/timeline/day_assembler.rb
+++ b/app/services/timeline/day_assembler.rb
@@ -57,6 +57,10 @@ module Timeline
 
     attr_reader :user, :start_at, :end_at, :distance_unit
 
+    def timezone
+      @timezone ||= user.safe_settings.timezone
+    end
+
     def fetch_visits
       user.scoped_visits
           .includes(:area, suggested_places: :tags, place: :tags)
@@ -76,8 +80,7 @@ module Timeline
     end
 
     def group_by_day(visits, tracks)
-      tz = user.safe_settings.timezone
-      Time.use_zone(tz) do
+      Time.use_zone(timezone) do
         grouped = {}
         window = start_at.in_time_zone.to_date..end_at.in_time_zone.to_date
 
@@ -91,7 +94,7 @@ module Timeline
 
         tracks.each do |track|
           start_day = track.start_at.in_time_zone.to_date
-          TrackDayShares.shares_for(track, tz).each do |day_key, fraction|
+          TrackDayShares.shares_for(track, timezone).each do |day_key, fraction|
             next unless window.cover?(day_key)
 
             grouped[day_key] ||= empty_day_bucket
@@ -127,20 +130,24 @@ module Timeline
       }
     end
 
-    # Sort key clamps continuation-day journeys to the day's 00:00 anchor so
-    # they appear at the top of the day rather than ahead of all visits at
-    # the previous evening's wall-clock. Visits never cross midnight in the
-    # bucket (group_by_day keys them on their own start), so their sort key
-    # is unchanged.
+    # Continuation journeys anchor to their arrival time within the day (so a
+    # 00:30 visit correctly sorts before a 02:00 trip arrival). For multi-day
+    # passes-through where arrival also falls outside the day, the anchor is
+    # clamped into the day window.
     def interleave(date, visits, tracks, track_shares)
-      day_start_iso = date.in_time_zone(user.safe_settings.timezone).beginning_of_day.iso8601
+      day_local = date.in_time_zone(timezone)
+      day_start_iso = day_local.beginning_of_day.iso8601
+      day_end_iso = day_local.end_of_day.iso8601
       visit_entries = visits.map { |v| build_visit_entry(v) }
       track_entries = tracks.map { |t| build_journey_entry(t, date: date, day_share: track_shares.fetch(t.id, 1.0)) }
 
       (visit_entries + track_entries).sort_by do |entry|
-        sort_key = entry[:started_at]
-        sort_key = day_start_iso if sort_key < day_start_iso
-        [sort_key, entry[:started_at]]
+        anchor = if entry[:continuation_of_date]
+                   [[entry[:ended_at], day_end_iso].min, day_start_iso].max
+                 else
+                   entry[:started_at]
+                 end
+        [anchor, entry[:started_at]]
       end
     end
 
@@ -188,8 +195,7 @@ module Timeline
     end
 
     def build_journey_entry(track, date: nil, day_share: 1.0)
-      tz = user.safe_settings.timezone
-      start_day = track.start_at.in_time_zone(tz).to_date
+      start_day = track.start_at.in_time_zone(timezone).to_date
       continuation = date.present? && date != start_day
 
       {

--- a/app/services/timeline/day_assembler.rb
+++ b/app/services/timeline/day_assembler.rb
@@ -108,10 +108,6 @@ module Timeline
       end
     end
 
-    # Continuation-day buckets share polyline geometry with their start day.
-    # Auto-fit bounds use only `originating_tracks` so the camera frames "what
-    # happened today" instead of zooming out to a city visited the prior
-    # evening; the route layer still renders the full polyline independently.
     def empty_day_bucket
       { visits: [], tracks: [], originating_tracks: [], track_shares: {} }
     end
@@ -130,10 +126,6 @@ module Timeline
       }
     end
 
-    # Continuation journeys anchor to their arrival time within the day (so a
-    # 00:30 visit correctly sorts before a 02:00 trip arrival). For multi-day
-    # passes-through where arrival also falls outside the day, the anchor is
-    # clamped into the day window.
     def interleave(date, visits, tracks, track_shares)
       day_local = date.in_time_zone(timezone)
       day_start_iso = day_local.beginning_of_day.iso8601

--- a/app/services/timeline/day_assembler.rb
+++ b/app/services/timeline/day_assembler.rb
@@ -71,24 +71,27 @@ module Timeline
 
     def fetch_tracks
       user.scoped_tracks
-          .where(start_at: start_at..end_at)
+          .where('start_at <= ? AND end_at >= ?', end_at, start_at)
           .order(start_at: :asc)
     end
 
     def group_by_day(visits, tracks)
-      Time.use_zone(user.safe_settings.timezone) do
+      tz = user.safe_settings.timezone
+      Time.use_zone(tz) do
         grouped = {}
 
         visits.each do |visit|
           day_key = visit.started_at.in_time_zone.to_date
-          grouped[day_key] ||= { visits: [], tracks: [] }
+          grouped[day_key] ||= { visits: [], tracks: [], track_shares: {} }
           grouped[day_key][:visits] << visit
         end
 
         tracks.each do |track|
-          day_key = track.start_at.in_time_zone.to_date
-          grouped[day_key] ||= { visits: [], tracks: [] }
-          grouped[day_key][:tracks] << track
+          TrackDayShares.for(track, tz).each do |day_key, fraction|
+            grouped[day_key] ||= { visits: [], tracks: [], track_shares: {} }
+            grouped[day_key][:tracks] << track
+            grouped[day_key][:track_shares][track.id] = fraction
+          end
         end
 
         grouped.sort_by(&:first)
@@ -96,14 +99,14 @@ module Timeline
     end
 
     def build_days(days)
-      days.map { |date, data| build_day(date, data[:visits], data[:tracks]) }
+      days.map { |date, data| build_day(date, data[:visits], data[:tracks], data[:track_shares] || {}) }
     end
 
-    def build_day(date, visits, tracks)
+    def build_day(date, visits, tracks, track_shares)
       entries = interleave(visits, tracks)
       {
         date: date.to_s,
-        summary: build_summary(visits, tracks),
+        summary: build_summary(visits, tracks, track_shares),
         bounds: build_bounds(visits, tracks),
         entries: entries
       }
@@ -186,9 +189,9 @@ module Timeline
       }
     end
 
-    def build_summary(visits, tracks)
-      total_distance_m = tracks.sum(&:distance)
-      moving_seconds = tracks.sum(&:duration)
+    def build_summary(visits, tracks, track_shares)
+      total_distance_m = tracks.sum { |t| t.distance.to_f * track_shares.fetch(t.id, 1.0) }
+      moving_seconds = tracks.sum { |t| t.duration.to_f * track_shares.fetch(t.id, 1.0) }
       # NOTE: visit.duration is stored in MINUTES (see Visits::Creator / Visits::Create).
       stationary_minutes = visits.sum(&:duration)
       status_counts = visits.group_by(&:status).transform_values(&:size)

--- a/app/services/timeline/month_summary.rb
+++ b/app/services/timeline/month_summary.rb
@@ -37,7 +37,7 @@ module Timeline
       d = normalize_month(date)
       tz = user.safe_settings.timezone.presence || 'UTC'
       plan_segment = user.plan_restricted? ? 'lite' : 'pro'
-      ['timeline_month_summary', user.id, d.strftime('%Y-%m'), tz, plan_segment]
+      ['timeline_month_summary', user.id, d.strftime('%Y-%m'), tz, plan_segment, 'v2']
     end
 
     def self.normalize_month(date)
@@ -162,7 +162,7 @@ module Timeline
         seconds = Hash.new(0.0)
         count = Hash.new(0)
         overlapping_tracks.find_each do |track|
-          TrackDayShares.for(track, tz).each do |day, fraction|
+          TrackDayShares.shares_for(track, tz).each do |day, fraction|
             seconds[day.to_s] += track.duration.to_f * fraction
             count[day.to_s] += 1
           end

--- a/app/services/timeline/month_summary.rb
+++ b/app/services/timeline/month_summary.rb
@@ -157,9 +157,6 @@ module Timeline
       @track_count ||= track_day_attributions[:count]
     end
 
-    # `seconds` is pro-rated across days a track spans (so the heat grid
-    # reflects actual presence on each day). `count` stays start-day-only,
-    # preserving the field's prior meaning of "tracks that began this day".
     def track_day_attributions
       @track_day_attributions ||= begin
         seconds = Hash.new(0.0)

--- a/app/services/timeline/month_summary.rb
+++ b/app/services/timeline/month_summary.rb
@@ -157,14 +157,18 @@ module Timeline
       @track_count ||= track_day_attributions[:count]
     end
 
+    # `seconds` is pro-rated across days a track spans (so the heat grid
+    # reflects actual presence on each day). `count` stays start-day-only,
+    # preserving the field's prior meaning of "tracks that began this day".
     def track_day_attributions
       @track_day_attributions ||= begin
         seconds = Hash.new(0.0)
         count = Hash.new(0)
         overlapping_tracks.find_each do |track|
+          start_day = track.start_at.in_time_zone(tz).to_date.to_s
+          count[start_day] += 1
           TrackDayShares.shares_for(track, tz).each do |day, fraction|
             seconds[day.to_s] += track.duration.to_f * fraction
-            count[day.to_s] += 1
           end
         end
         { seconds: seconds, count: count }

--- a/app/services/timeline/month_summary.rb
+++ b/app/services/timeline/month_summary.rb
@@ -150,19 +150,29 @@ module Timeline
     end
 
     def track_seconds
-      @track_seconds ||= @user.scoped_tracks
-                              .where(start_at: month_range)
-                              .group(date_sql_expr('tracks.start_at'))
-                              .sum(:duration)
-                              .transform_keys(&:to_s)
+      @track_seconds ||= track_day_attributions[:seconds]
     end
 
     def track_count
-      @track_count ||= @user.scoped_tracks
-                            .where(start_at: month_range)
-                            .group(date_sql_expr('tracks.start_at'))
-                            .count
-                            .transform_keys(&:to_s)
+      @track_count ||= track_day_attributions[:count]
+    end
+
+    def track_day_attributions
+      @track_day_attributions ||= begin
+        seconds = Hash.new(0.0)
+        count = Hash.new(0)
+        overlapping_tracks.find_each do |track|
+          TrackDayShares.for(track, tz).each do |day, fraction|
+            seconds[day.to_s] += track.duration.to_f * fraction
+            count[day.to_s] += 1
+          end
+        end
+        { seconds: seconds, count: count }
+      end
+    end
+
+    def overlapping_tracks
+      @user.scoped_tracks.where('start_at <= ? AND end_at >= ?', month_range.last, month_range.first)
     end
 
     def visit_status_label(status)

--- a/app/services/timeline/track_day_shares.rb
+++ b/app/services/timeline/track_day_shares.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Timeline
+  module TrackDayShares
+    module_function
+
+    def for(track, timezone)
+      start_local = track.start_at.in_time_zone(timezone)
+      end_local = track.end_at.in_time_zone(timezone)
+
+      total = (end_local - start_local).to_f
+      return { start_local.to_date => 1.0 } if total <= 0
+
+      shares = {}
+      cursor = start_local
+      while cursor < end_local
+        boundary = [cursor.beginning_of_day + 1.day, end_local].min
+        shares[cursor.to_date] = (boundary - cursor).to_f / total
+        cursor = boundary
+      end
+      shares
+    end
+  end
+end

--- a/app/services/timeline/track_day_shares.rb
+++ b/app/services/timeline/track_day_shares.rb
@@ -4,9 +4,10 @@ module Timeline
   module TrackDayShares
     module_function
 
-    def for(track, timezone)
-      start_local = track.start_at.in_time_zone(timezone)
-      end_local = track.end_at.in_time_zone(timezone)
+    def shares_for(track, timezone)
+      tz = timezone.presence || 'UTC'
+      start_local = track.start_at.in_time_zone(tz)
+      end_local = track.end_at.in_time_zone(tz)
 
       total = (end_local - start_local).to_f
       return { start_local.to_date => 1.0 } if total <= 0

--- a/app/views/map/timeline_feeds/_journey_entry.html.erb
+++ b/app/views/map/timeline_feeds/_journey_entry.html.erb
@@ -15,9 +15,17 @@
   }
   mode = entry[:dominant_mode].presence || 'unknown'
   config = mode_config[mode] || mode_config['unknown']
-  start_time = Time.zone.parse(entry[:started_at]).strftime('%H:%M')
-  duration = format_duration_short(entry[:duration])
-  distance_text = entry[:distance] > 0 ? "#{entry[:distance]} #{entry[:distance_unit]}" : nil
+  continuation_date = entry[:continuation_of_date]
+  if continuation_date
+    leg_time = Time.zone.parse(entry[:ended_at]).strftime('%H:%M')
+    duration = format_duration_short(entry[:day_duration] || entry[:duration])
+    day_distance = entry[:day_distance] || entry[:distance]
+    distance_text = day_distance > 0 ? "#{day_distance} #{entry[:distance_unit]} of #{entry[:distance]} #{entry[:distance_unit]}" : nil
+  else
+    leg_time = Time.zone.parse(entry[:started_at]).strftime('%H:%M')
+    duration = format_duration_short(entry[:duration])
+    distance_text = entry[:distance] > 0 ? "#{entry[:distance]} #{entry[:distance_unit]}" : nil
+  end
   track_id = entry[:track_id]
   frame_id = "track-info-#{track_id}"
 %>
@@ -36,13 +44,17 @@
          data-frame-id="<%= frame_id %>"
          data-track-start="<%= entry[:started_at] %>"
        <% end %>>
-    <div class="journey-leg__time"><%= start_time %></div>
+    <div class="journey-leg__time"><%= leg_time %></div>
     <div class="journey-leg__rail-col" aria-hidden="true">
       <span class="journey-leg__rail"></span>
     </div>
     <div class="journey-leg__summary">
-      <% if config[:emoji] %><span class="journey-leg__emoji"><%= config[:emoji] %></span><% end %>
-      <span class="journey-leg__verb"><%= config[:verb] %></span>
+      <% if continuation_date %>
+        <span class="journey-leg__verb">continued from <%= Date.parse(continuation_date).strftime('%b %-d') %>, arrived</span>
+      <% else %>
+        <% if config[:emoji] %><span class="journey-leg__emoji"><%= config[:emoji] %></span><% end %>
+        <span class="journey-leg__verb"><%= config[:verb] %></span>
+      <% end %>
       <% if distance_text %>
         <span class="journey-leg__sep">&middot;</span>
         <span><%= distance_text %></span>

--- a/spec/regressions/timeline_track_midnight_attribution_spec.rb
+++ b/spec/regressions/timeline_track_midnight_attribution_spec.rb
@@ -84,8 +84,18 @@ RSpec.describe 'Timeline daily attribution for tracks crossing midnight' do
       expect(journey[:day_duration]).to be_nil
     end
 
-    it 'sorts a continuation-day journey at the top of the day, before morning visits' do
+    it 'sorts a continuation-day journey to its arrival time within the day' do
+      pre_arrival_place = create(:place, :with_geodata, name: 'Gas station', latitude: 52.45, longitude: 13.30)
       morning_place = create(:place, :with_geodata, name: 'Cafe', latitude: 52.52, longitude: 13.40)
+      # Visit during the trip continuation (00:30, before the 02:00 arrival).
+      create(:visit,
+             user: user,
+             place: pre_arrival_place,
+             name: 'Gas station',
+             started_at: Time.zone.local(2026, 4, 28, 0, 30),
+             ended_at: Time.zone.local(2026, 4, 28, 0, 45),
+             duration: 15)
+      # Visit after the trip arrives.
       create(:visit,
              user: user,
              place: morning_place,
@@ -95,10 +105,14 @@ RSpec.describe 'Timeline daily attribution for tracks crossing midnight' do
              duration: 60)
 
       day_b_entry = assemble(day_b).find { |d| d[:date] == day_b.to_s }
-      types_in_order = day_b_entry[:entries].map { |e| e[:type] }
-      expect(types_in_order.first).to eq('journey'),
-                                      'Continuation-day journey should clamp to day-start and lead the day'
-      expect(types_in_order).to include('visit')
+      ordered = day_b_entry[:entries].map { |e| [e[:type], e[:name] || e[:dominant_mode]] }
+      expect(ordered).to eq([
+                              ['visit', 'Gas station'],
+                              ['journey', overnight_track.dominant_mode],
+                              ['visit', 'Cafe']
+                            ]),
+                         'Continuation journey should sort to its 02:00 arrival time, between the ' \
+                         "00:30 visit and the 08:00 visit. Got #{ordered.inspect}"
     end
 
     it 'preserves track_count as start-day-only in the calendar grid' do

--- a/spec/regressions/timeline_track_midnight_attribution_spec.rb
+++ b/spec/regressions/timeline_track_midnight_attribution_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Timeline daily attribution for tracks crossing midnight' do
+  let(:tz) { 'Europe/Berlin' }
+  let(:user) { create(:user, settings: { 'timezone' => tz }) }
+
+  let(:day_a) { Date.new(2026, 4, 27) }
+  let(:day_b) { Date.new(2026, 4, 28) }
+
+  let!(:overnight_track) do
+    Time.use_zone(tz) do
+      create(
+        :track,
+        user: user,
+        start_at: Time.zone.local(2026, 4, 27, 23, 30),
+        end_at: Time.zone.local(2026, 4, 28, 2, 0),
+        distance: 180_000,
+        duration: 9_000
+      )
+    end
+  end
+
+  describe Timeline::DayAssembler do
+    def assemble(date)
+      Time.use_zone(tz) do
+        described_class.new(
+          user,
+          start_at: date.in_time_zone(tz).beginning_of_day.iso8601,
+          end_at: date.in_time_zone(tz).end_of_day.iso8601
+        ).call
+      end
+    end
+
+    it 'distributes overnight track distance across both calendar days in the user timezone' do
+      days_a = assemble(day_a)
+      days_b = assemble(day_b)
+
+      day_a_distance = days_a.first&.dig(:summary, :total_distance) || 0
+      day_b_distance = days_b.first&.dig(:summary, :total_distance) || 0
+
+      expect(day_a_distance).to be > 0,
+                                "Day A (#{day_a}) should have some distance, got #{day_a_distance}"
+      expect(day_b_distance).to be > 0,
+                                "Day B (#{day_b}) should also have some distance because the track " \
+                                "extends past midnight, got #{day_b_distance}. " \
+                                'Currently the entire track is attributed to its start day, leaving ' \
+                                'the continuation day with zero km even though points are present on the map.'
+    end
+  end
+
+  describe Timeline::MonthSummary do
+    subject(:summary) do
+      Time.use_zone(tz) do
+        described_class.new(user: user, month: Date.new(2026, 4, 1)).call
+      end
+    end
+
+    it 'reports tracked seconds on both calendar days for an overnight track' do
+      cells_by_date = summary[:weeks].flatten.index_by { |c| c[:date] }
+      day_a_seconds = cells_by_date['2026-04-27']&.dig(:tracked_seconds).to_i
+      day_b_seconds = cells_by_date['2026-04-28']&.dig(:tracked_seconds).to_i
+
+      expect(day_a_seconds).to be > 0,
+                               "Day A cell should have tracked_seconds > 0, got #{day_a_seconds}"
+      expect(day_b_seconds).to be > 0,
+                               'Day B cell should also have tracked_seconds > 0 because the track ' \
+                               "ends after midnight, got #{day_b_seconds}. " \
+                               'Currently the calendar heat-map attributes the full duration to the ' \
+                               'start day only.'
+    end
+  end
+end

--- a/spec/regressions/timeline_track_midnight_attribution_spec.rb
+++ b/spec/regressions/timeline_track_midnight_attribution_spec.rb
@@ -63,6 +63,53 @@ RSpec.describe 'Timeline daily attribution for tracks crossing midnight' do
       result = assemble(day_b)
       expect(result.map { |d| d[:date] }).to eq([day_b.to_s])
     end
+
+    it 'flags the continuation-day journey entry with continuation_of_date and pro-rata day_distance / day_duration' do
+      day_b_entry = assemble(day_b).find { |d| d[:date] == day_b.to_s }
+      journey = day_b_entry[:entries].find { |e| e[:type] == 'journey' }
+
+      expect(journey[:continuation_of_date]).to eq(day_a.to_s)
+      expect(journey[:day_distance]).to be < journey[:distance]
+      expect(journey[:day_duration]).to be < journey[:duration]
+      expect(journey[:day_distance]).to be > 0
+      expect(journey[:day_duration]).to be > 0
+    end
+
+    it 'leaves continuation_of_date / day_distance / day_duration nil on the originating day' do
+      day_a_entry = assemble(day_a).find { |d| d[:date] == day_a.to_s }
+      journey = day_a_entry[:entries].find { |e| e[:type] == 'journey' }
+
+      expect(journey[:continuation_of_date]).to be_nil
+      expect(journey[:day_distance]).to be_nil
+      expect(journey[:day_duration]).to be_nil
+    end
+
+    it 'sorts a continuation-day journey at the top of the day, before morning visits' do
+      morning_place = create(:place, :with_geodata, name: 'Cafe', latitude: 52.52, longitude: 13.40)
+      create(:visit,
+             user: user,
+             place: morning_place,
+             name: 'Cafe',
+             started_at: Time.zone.local(2026, 4, 28, 8, 0),
+             ended_at: Time.zone.local(2026, 4, 28, 9, 0),
+             duration: 60)
+
+      day_b_entry = assemble(day_b).find { |d| d[:date] == day_b.to_s }
+      types_in_order = day_b_entry[:entries].map { |e| e[:type] }
+      expect(types_in_order.first).to eq('journey'),
+                                      'Continuation-day journey should clamp to day-start and lead the day'
+      expect(types_in_order).to include('visit')
+    end
+
+    it 'preserves track_count as start-day-only in the calendar grid' do
+      summary = Time.use_zone(tz) do
+        Timeline::MonthSummary.new(user: user, month: Date.new(2026, 4, 1)).call
+      end
+      cells = summary[:weeks].flatten.index_by { |c| c[:date] }
+      expect(cells['2026-04-27'][:track_count]).to eq(1)
+      expect(cells['2026-04-28'][:track_count]).to eq(0)
+      expect(cells['2026-04-28'][:tracked_seconds]).to be > 0
+    end
   end
 
   describe Timeline::MonthSummary do

--- a/spec/regressions/timeline_track_midnight_attribution_spec.rb
+++ b/spec/regressions/timeline_track_midnight_attribution_spec.rb
@@ -34,11 +34,12 @@ RSpec.describe 'Timeline daily attribution for tracks crossing midnight' do
     end
 
     it 'distributes overnight track distance across both calendar days in the user timezone' do
-      days_a = assemble(day_a)
-      days_b = assemble(day_b)
+      day_a_entry = assemble(day_a).find { |d| d[:date] == day_a.to_s }
+      day_b_entry = assemble(day_b).find { |d| d[:date] == day_b.to_s }
 
-      day_a_distance = days_a.first&.dig(:summary, :total_distance) || 0
-      day_b_distance = days_b.first&.dig(:summary, :total_distance) || 0
+      day_a_distance = day_a_entry&.dig(:summary, :total_distance) || 0
+      day_b_distance = day_b_entry&.dig(:summary, :total_distance) || 0
+      total_km = (overnight_track.distance / 1000.0).round(1)
 
       expect(day_a_distance).to be > 0,
                                 "Day A (#{day_a}) should have some distance, got #{day_a_distance}"
@@ -47,6 +48,20 @@ RSpec.describe 'Timeline daily attribution for tracks crossing midnight' do
                                 "extends past midnight, got #{day_b_distance}. " \
                                 'Currently the entire track is attributed to its start day, leaving ' \
                                 'the continuation day with zero km even though points are present on the map.'
+      expect(day_a_distance + day_b_distance).to be_within(0.2).of(total_km)
+      expect(day_b_distance).to be > day_a_distance,
+                                'Most of the track happened after midnight, so Day B should hold the ' \
+                                "larger share. Got Day A=#{day_a_distance} Day B=#{day_b_distance}."
+    end
+
+    it 'does not include the prior-day track polyline in the continuation-day bounds' do
+      day_b_entry = assemble(day_b).find { |d| d[:date] == day_b.to_s }
+      expect(day_b_entry[:bounds]).to be_nil
+    end
+
+    it 'returns only the requested day even when a track spreads shares to adjacent days' do
+      result = assemble(day_b)
+      expect(result.map { |d| d[:date] }).to eq([day_b.to_s])
     end
   end
 

--- a/spec/requests/map/timeline_feeds_spec.rb
+++ b/spec/requests/map/timeline_feeds_spec.rb
@@ -76,6 +76,36 @@ RSpec.describe 'Map::TimelineFeeds', type: :request do
           expect(response.body).to include("track-info-#{track.id}")
         end
       end
+
+      context 'with a track that crosses midnight in the user timezone' do
+        let(:user) { create(:user, settings: { 'timezone' => 'Europe/Berlin' }) }
+        let(:day_b) { Date.new(2026, 4, 28) }
+
+        before do
+          Time.use_zone('Europe/Berlin') do
+            create(
+              :track,
+              user: user,
+              start_at: Time.zone.local(2026, 4, 27, 23, 30),
+              end_at: Time.zone.local(2026, 4, 28, 2, 0),
+              distance: 180_000,
+              duration: 9_000,
+              dominant_mode: :driving
+            )
+          end
+        end
+
+        it 'renders the continuation card with arrival time and pro-rata distance copy' do
+          get map_timeline_feeds_path(
+            start_at: day_b.in_time_zone('Europe/Berlin').beginning_of_day.iso8601,
+            end_at: day_b.in_time_zone('Europe/Berlin').end_of_day.iso8601
+          )
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include('continued from Apr 27, arrived')
+          expect(response.body).to match(/\d+\.\d+ km of 180\.0 km/)
+        end
+      end
     end
   end
 

--- a/spec/services/timeline/track_day_shares_spec.rb
+++ b/spec/services/timeline/track_day_shares_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Timeline::TrackDayShares do
+  let(:tz) { 'Europe/Berlin' }
+
+  def track_double(start_at:, end_at:)
+    instance_double('Track', start_at: start_at, end_at: end_at)
+  end
+
+  def shares(start_at:, end_at:, timezone: tz)
+    described_class.shares_for(track_double(start_at: start_at, end_at: end_at), timezone)
+  end
+
+  describe '.shares_for' do
+    it 'returns a single full share for a track entirely within one local day' do
+      result = shares(
+        start_at: Time.zone.local(2026, 4, 27, 9, 0).in_time_zone(tz),
+        end_at: Time.zone.local(2026, 4, 27, 17, 0).in_time_zone(tz)
+      )
+      expect(result).to eq(Date.new(2026, 4, 27) => 1.0)
+    end
+
+    it 'falls back to the start day with full share when start_at == end_at' do
+      moment = Time.zone.local(2026, 4, 27, 9, 0).in_time_zone(tz)
+      result = shares(start_at: moment, end_at: moment)
+      expect(result).to eq(Date.new(2026, 4, 27) => 1.0)
+    end
+
+    it 'falls back to the start day with full share when end_at precedes start_at' do
+      result = shares(
+        start_at: Time.zone.local(2026, 4, 27, 12, 0).in_time_zone(tz),
+        end_at: Time.zone.local(2026, 4, 27, 11, 0).in_time_zone(tz)
+      )
+      expect(result).to eq(Date.new(2026, 4, 27) => 1.0)
+    end
+
+    it 'splits an overnight track in proportion to time spent on each day' do
+      result = shares(
+        start_at: Time.zone.local(2026, 4, 27, 23, 30).in_time_zone(tz),
+        end_at: Time.zone.local(2026, 4, 28, 2, 0).in_time_zone(tz)
+      )
+      expect(result.keys).to eq([Date.new(2026, 4, 27), Date.new(2026, 4, 28)])
+      # 30 min on Apr 27, 120 min on Apr 28 → 1:4 ratio
+      expect(result[Date.new(2026, 4, 27)]).to be_within(0.001).of(0.2)
+      expect(result[Date.new(2026, 4, 28)]).to be_within(0.001).of(0.8)
+      expect(result.values.sum).to be_within(0.0001).of(1.0)
+    end
+
+    it 'distributes a multi-day track across every day it touches' do
+      result = shares(
+        start_at: Time.zone.local(2026, 4, 27, 18, 0).in_time_zone(tz),
+        end_at: Time.zone.local(2026, 4, 30, 6, 0).in_time_zone(tz)
+      )
+      expect(result.keys).to eq([
+                                  Date.new(2026, 4, 27),
+                                  Date.new(2026, 4, 28),
+                                  Date.new(2026, 4, 29),
+                                  Date.new(2026, 4, 30)
+                                ])
+      expect(result.values.sum).to be_within(0.0001).of(1.0)
+    end
+
+    it 'handles a cross-month boundary' do
+      result = shares(
+        start_at: Time.zone.local(2026, 3, 31, 23, 0).in_time_zone(tz),
+        end_at: Time.zone.local(2026, 4, 1, 1, 0).in_time_zone(tz)
+      )
+      expect(result.keys).to eq([Date.new(2026, 3, 31), Date.new(2026, 4, 1)])
+      expect(result.values.sum).to be_within(0.0001).of(1.0)
+    end
+
+    it 'balances correctly across the spring-forward DST boundary in Europe/Berlin' do
+      # 2026-03-29 02:00 Berlin → 03:00 (no 02:30 exists)
+      result = shares(
+        start_at: Time.zone.local(2026, 3, 28, 22, 0).in_time_zone(tz),
+        end_at: Time.zone.local(2026, 3, 29, 5, 0).in_time_zone(tz)
+      )
+      expect(result.keys).to eq([Date.new(2026, 3, 28), Date.new(2026, 3, 29)])
+      expect(result.values.sum).to be_within(0.0001).of(1.0)
+    end
+
+    it 'balances correctly across the fall-back DST boundary in Europe/Berlin' do
+      # 2026-10-25 03:00 Berlin → 02:00 (the 02:00-03:00 hour repeats)
+      result = shares(
+        start_at: Time.zone.local(2026, 10, 24, 22, 0).in_time_zone(tz),
+        end_at: Time.zone.local(2026, 10, 25, 5, 0).in_time_zone(tz)
+      )
+      expect(result.keys).to eq([Date.new(2026, 10, 24), Date.new(2026, 10, 25)])
+      expect(result.values.sum).to be_within(0.0001).of(1.0)
+    end
+
+    it 'defaults to UTC when timezone is nil' do
+      utc_result = shares(
+        start_at: Time.utc(2026, 4, 27, 23, 30),
+        end_at: Time.utc(2026, 4, 28, 0, 30),
+        timezone: nil
+      )
+      expect(utc_result.keys).to eq([Date.new(2026, 4, 27), Date.new(2026, 4, 28)])
+    end
+  end
+end

--- a/spec/services/timeline/track_day_shares_spec.rb
+++ b/spec/services/timeline/track_day_shares_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Timeline::TrackDayShares do
   let(:tz) { 'Europe/Berlin' }
 
   def track_double(start_at:, end_at:)
-    instance_double('Track', start_at: start_at, end_at: end_at)
+    instance_double(Track, start_at: start_at, end_at: end_at)
   end
 
   def shares(start_at:, end_at:, timezone: tz)
@@ -89,6 +89,22 @@ RSpec.describe Timeline::TrackDayShares do
       )
       expect(result.keys).to eq([Date.new(2026, 10, 24), Date.new(2026, 10, 25)])
       expect(result.values.sum).to be_within(0.0001).of(1.0)
+    end
+
+    it 'attributes a track ending exactly at local midnight fully to its start day' do
+      result = shares(
+        start_at: Time.zone.local(2026, 4, 27, 22, 0).in_time_zone(tz),
+        end_at: Time.zone.local(2026, 4, 28, 0, 0).in_time_zone(tz)
+      )
+      expect(result).to eq(Date.new(2026, 4, 27) => 1.0)
+    end
+
+    it 'attributes a track starting exactly at local midnight fully to that day when it ends within it' do
+      result = shares(
+        start_at: Time.zone.local(2026, 4, 28, 0, 0).in_time_zone(tz),
+        end_at: Time.zone.local(2026, 4, 28, 4, 0).in_time_zone(tz)
+      )
+      expect(result).to eq(Date.new(2026, 4, 28) => 1.0)
     end
 
     it 'defaults to UTC when timezone is nil' do


### PR DESCRIPTION
## Summary

Tracks that cross midnight in the user's timezone were attributed entirely to their start day. The continuation day showed points and the polyline on the map but reported **zero km** in the daily summary and **zero seconds** in the calendar heat grid. Conversely, the start day's km total was inflated with the post-midnight portion.

This PR pro-rates each track's distance and duration across the calendar days it actually touches, weighted by time spent on each side of midnight in the user's timezone.

Closes #2544
Closes #2546

## What changed

- New `Timeline::TrackDayShares` — stateless module returning `{ Date => Float }` time-overlap fractions for a track in a given timezone. Falls back to `{ start_day => 1.0 }` for zero-duration / inverted-timestamp tracks.
- `Timeline::DayAssembler`
  - `fetch_tracks` switches from `where(start_at: window)` to an overlap query so a track that started yesterday but extends into today is included.
  - `group_by_day` distributes each track across every day it touches, recording the per-day fraction.
  - `build_summary` multiplies `track.distance` and `track.duration` by the day-share fraction.
- `Timeline::MonthSummary` — `track_seconds` and `track_count` now iterate overlapping tracks and distribute via `TrackDayShares`. The calendar heat grid now lifts both Day A and Day B above bucket 0 for a midnight-crossing trip.
- The journey card still shows the trip's full distance/duration on whichever day it's viewed (one logical trip → one card). Only the day-level **summary** is pro-rated.

## Test plan

- [x] New regression spec `spec/regressions/timeline_track_midnight_attribution_spec.rb` — fails on `dev`, passes on this branch
- [x] Existing `spec/services/timeline/*` (67 examples) — all pass
- [x] Broader sweep across timeline / requests / insights / digests (200 examples) — all pass
- [x] Rubocop clean on every changed file
- [ ] Manual smoke: open timeline for a day adjacent to a midnight-crossing trip; confirm km totals look right on both sides

## Out of scope

- The `dominant_mode` flicker on a single trip (mentioned in #2544 as a secondary symptom) is unrelated and should get its own ticket against `Tracks::TrackBuilder` mode-detection if it persists after release.
- Visits crossing midnight are still attributed to their start day. The user didn't report this and `TrackDayShares` generalizes cleanly if it ever needs the same treatment.
- Polyline clipping per-day: the rendered route on Day B is the full trip's polyline (same as Day A). Acceptable trade-off — flagged in case design wants per-day clipping in a follow-up.