### PR TITLE
Fix Maps v1 area-drawing toolbar missing after toggle and refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- The Maps v1 area-drawing toolbar no longer disappears after toggling the Areas layer or refreshing the page. (#1938)
+
+
 ## [1.7.4] - 2026-05-03
 
 ### Fixed

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -743,11 +743,9 @@ export default class extends BaseController {
         }
       } else if (event.name === "Tracks") {
         this.handleRouteLayerToggle("tracks")
-      } else if (event.name === "Areas") {
-        // Show draw control when Areas layer is enabled
+      } else if (event.layer === this.areasLayer) {
         if (
           this.drawControl &&
-          !this.map.hasControl &&
           !this.map._controlCorners.topleft.querySelector(".leaflet-draw")
         ) {
           this.map.addControl(this.drawControl)
@@ -813,8 +811,7 @@ export default class extends BaseController {
 
         // Manage pane visibility when layers are manually toggled
         this.updatePaneVisibilityAfterLayerChange()
-      } else if (event.name === "Areas") {
-        // Hide draw control when Areas layer is disabled
+      } else if (event.layer === this.areasLayer) {
         if (
           this.drawControl &&
           this.map._controlCorners.topleft.querySelector(".leaflet-draw")


### PR DESCRIPTION
## Summary

- Bug: enabling the **Areas** layer on Maps v1 drew the area circle but never attached the L.Control.Draw circle toolbar; refreshing the page kept the layer toggle checked but the toolbar stayed gone. Closes #1938.
- Root cause: `maps_controller.js` had two handlers — `overlayadd` and `overlayremove` — that branched on `event.name === "Areas"`. `L.Control.Layers.Tree` fires those events with `event.name` set to the layer's internal `_leaflet_id` (a numeric string like `"15"`), not the human-readable label. Both branches were dead code. The original July-2025 fix (#1583) had been silently broken since.
- Fix: switch both branches to `event.layer === this.areasLayer`, matching the working pattern already used for `this.photoMarkers` a few lines below in the same file. 2 insertions, 5 deletions in `maps_controller.js` + a one-line CHANGELOG entry.

## Evidence

Pre-fix instrumentation against the dev server captured:

\`\`\`
overlayLog: [{ev:"add", name:"15"}]
drawInDom: false
\`\`\`

Post-fix runtime probe confirmed \`event.layer === this.areasLayer\` returns \`true\` (\`sameRef: true\`, both \`_leaflet_id: 134\`).

## Scope

- Maps v2 (MapLibre) uses a separate code path (\`area_drawer_controller.js\`) and is unaffected.
- Other branches in the same file that key off \`event.name === "<Label>"\` (Routes, Tracks, Suggested, Confirmed, Scratch map) may be similarly dead — out of scope here, worth a follow-up audit.
- The user's secondary complaint about no UI to list/delete areas (\`config/routes.rb:103\` exposes only \`resources :areas, only: [:create]\` on web) is a real gap but a separate enhancement.

## Test plan

- [ ] Run the regression spec: \`npx playwright test map/areas-toolbar-on-refresh.spec.js --workers=1\` against this branch. Spec lives in the sibling \`e2e-dawarich-playwright\` repo on a parallel branch of the same name (not yet pushed — that repo has no remote configured locally).
- [ ] Manual: open \`/map\`, ensure Areas is initially off, toggle Areas on — toolbar appears in the top-left. Refresh — toolbar is still there.
- [ ] Manual: toggle Areas off — toolbar disappears.

**Note on automated verification**: end-to-end re-run of the regression spec was blocked locally by rack-attack rate-limit cross-talk between four parallel \`auth.setup.js\` files in sibling worktrees. The fix logic is confirmed via runtime instrumentation; please re-run the regression spec on a clean checkout.