### PR TITLE
Render Maps v2 place/area/visit/family labels via DOM markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Family owners can now remove other members directly from the family page. #2555
 - Insights and statistics now agree on the number of countries visited per month. #2581
 - The default password for the demo account has been changed to `safepassword`. The old default `password` prevented seeds from running due to the new 12-character minimum password length validation. Existing users were not affected. #2593
+- Emojis in place, area, visit, and family member names now render correctly on Maps v2 instead of appearing as a placeholder glyph. #2365
 
 
 ## [1.7.3] - 2026-05-02

--- a/app/assets/stylesheets/maps_maplibre.css
+++ b/app/assets/stylesheets/maps_maplibre.css
@@ -339,3 +339,56 @@ html[data-theme="dawarich-dark"] .map-upgrade-banner-dismiss,
 html.dark .map-upgrade-banner-dismiss {
   color: #e2e8f0;
 }
+
+.map-html-label {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+    "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+  font-weight: 700;
+  font-size: 11px;
+  color: #111827;
+  text-shadow:
+    -1px -1px 0 #ffffff,
+     1px -1px 0 #ffffff,
+    -1px  1px 0 #ffffff,
+     1px  1px 0 #ffffff,
+     0   -2px 0 #ffffff,
+     0    2px 0 #ffffff,
+    -2px  0   0 #ffffff,
+     2px  0   0 #ffffff;
+  pointer-events: none;
+  user-select: none;
+  white-space: nowrap;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.map-html-label--places {
+  font-size: 11px;
+}
+
+.map-html-label--areas {
+  font-size: 14px;
+}
+
+.map-html-label--visits {
+  font-size: 11px;
+}
+
+.map-html-label--family {
+  font-size: 12px;
+}
+
+html[data-theme="dark"] .map-html-label,
+html[data-theme="dawarich-dark"] .map-html-label,
+html.dark .map-html-label {
+  color: #f3f4f6;
+  text-shadow:
+    -1px -1px 0 #111827,
+     1px -1px 0 #111827,
+    -1px  1px 0 #111827,
+     1px  1px 0 #111827,
+     0   -2px 0 #111827,
+     0    2px 0 #111827,
+    -2px  0   0 #111827,
+     2px  0   0 #111827;
+}

--- a/app/javascript/controllers/maps/maplibre/data_loader.js
+++ b/app/javascript/controllers/maps/maplibre/data_loader.js
@@ -495,6 +495,8 @@ export class DataLoader {
             name: area.name,
             color: area.color || "#ef4444",
             radius: area.radius,
+            centerLng: center[0],
+            centerLat: center[1],
           },
         }
       }),

--- a/app/javascript/controllers/maps/maplibre/layer_manager.js
+++ b/app/javascript/controllers/maps/maplibre/layer_manager.js
@@ -84,10 +84,9 @@ export class LayerManager {
     this.map.on("click", "visits", handlers.handleVisitClick)
     this.map.on("click", "photos", handlers.handlePhotoClick)
     this.map.on("click", "places", handlers.handlePlaceClick)
-    // Areas have multiple layers (fill, outline, labels)
+    // Areas have multiple layers (fill, outline)
     this.map.on("click", "areas-fill", handlers.handleAreaClick)
     this.map.on("click", "areas-outline", handlers.handleAreaClick)
-    this.map.on("click", "areas-labels", handlers.handleAreaClick)
 
     // Anomalies click handler
     this.map.on("click", "anomalies", handlers.handleAnomalyClick)
@@ -147,7 +146,7 @@ export class LayerManager {
       this.map.getCanvas().style.cursor = ""
     })
     // Areas hover handlers for all sub-layers
-    const areaLayers = ["areas-fill", "areas-outline", "areas-labels"]
+    const areaLayers = ["areas-fill", "areas-outline"]
     areaLayers.forEach((layerId) => {
       // Only add handlers if layer exists
       if (this.map.getLayer(layerId)) {

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -757,10 +757,6 @@ export default class extends Controller {
     this._safeSetPaint("visits", "circle-opacity", visitExpr)
     this._safeSetPaint("visits", "circle-stroke-opacity", visitExpr)
 
-    // Visit labels
-    const labelExpr = this._dayRangeExpr("started_at", isoStart, isoEnd, 1, DIM)
-    this._safeSetPaint("visits-labels", "text-opacity", labelExpr)
-
     // Tracks: start_at is ISO 8601 string
     const trackExpr = this._dayRangeExpr("start_at", isoStart, isoEnd, 0.7, DIM)
     this._safeSetPaint("tracks", "line-opacity", trackExpr)
@@ -783,7 +779,6 @@ export default class extends Controller {
     this._safeSetPaint("points", "circle-stroke-opacity", 1)
     this._safeSetPaint("visits", "circle-opacity", 0.9)
     this._safeSetPaint("visits", "circle-stroke-opacity", 1)
-    this._safeSetPaint("visits-labels", "text-opacity", 1)
     this._safeSetPaint("tracks", "line-opacity", 0.7)
   }
 
@@ -843,18 +838,12 @@ export default class extends Controller {
       ]
       this._safeSetPaint("visits", "circle-opacity", visitExpr)
       this._safeSetPaint("visits", "circle-stroke-opacity", visitExpr)
-      this._safeSetPaint("visits-labels", "text-opacity", visitExpr)
     } else {
       const VISITS_NEARLY_INVISIBLE = 0.05
       this._safeSetPaint("visits", "circle-opacity", VISITS_NEARLY_INVISIBLE)
       this._safeSetPaint(
         "visits",
         "circle-stroke-opacity",
-        VISITS_NEARLY_INVISIBLE,
-      )
-      this._safeSetPaint(
-        "visits-labels",
-        "text-opacity",
         VISITS_NEARLY_INVISIBLE,
       )
     }

--- a/app/javascript/maps_maplibre/layers/areas_layer.js
+++ b/app/javascript/maps_maplibre/layers/areas_layer.js
@@ -1,11 +1,15 @@
+import { HtmlLabelManager } from "../utils/html_label_manager"
 import { BaseLayer } from "./base_layer"
 
-/**
- * Areas layer for user-defined regions
- */
 export class AreasLayer extends BaseLayer {
   constructor(map, options = {}) {
     super(map, { id: "areas", ...options })
+    this.labels = new HtmlLabelManager(map, {
+      className: "map-html-label map-html-label--areas",
+      anchor: "center",
+      offset: [0, 0],
+      visible: this.visible,
+    })
   }
 
   getSourceConfig() {
@@ -20,7 +24,6 @@ export class AreasLayer extends BaseLayer {
 
   getLayerConfigs() {
     return [
-      // Area fills
       {
         id: `${this.id}-fill`,
         type: "fill",
@@ -30,8 +33,6 @@ export class AreasLayer extends BaseLayer {
           "fill-opacity": 0.4,
         },
       },
-
-      // Area outlines
       {
         id: `${this.id}-outline`,
         type: "line",
@@ -41,27 +42,30 @@ export class AreasLayer extends BaseLayer {
           "line-width": 3,
         },
       },
-
-      // Area labels
-      {
-        id: `${this.id}-labels`,
-        type: "symbol",
-        source: this.sourceId,
-        layout: {
-          "text-field": ["get", "name"],
-          "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
-          "text-size": 14,
-        },
-        paint: {
-          "text-color": "#111827",
-          "text-halo-color": "#ffffff",
-          "text-halo-width": 2,
-        },
-      },
     ]
   }
 
   getLayerIds() {
-    return [`${this.id}-fill`, `${this.id}-outline`, `${this.id}-labels`]
+    return [`${this.id}-fill`, `${this.id}-outline`]
+  }
+
+  add(data) {
+    super.add(data)
+    this.labels.sync(data?.features || [])
+  }
+
+  update(data) {
+    super.update(data)
+    this.labels.sync(data?.features || [])
+  }
+
+  remove() {
+    this.labels.clear()
+    super.remove()
+  }
+
+  setVisibility(visible) {
+    super.setVisibility(visible)
+    this.labels?.setVisibility(visible)
   }
 }

--- a/app/javascript/maps_maplibre/layers/family_layer.js
+++ b/app/javascript/maps_maplibre/layers/family_layer.js
@@ -1,14 +1,17 @@
+import { HtmlLabelManager } from "../utils/html_label_manager"
 import { BaseLayer } from "./base_layer"
 
-/**
- * Family layer showing family member locations
- * Each member has unique color
- */
 export class FamilyLayer extends BaseLayer {
   constructor(map, options = {}) {
     super(map, { id: "family", ...options })
     this.memberColors = {}
     this._historyFeatures = []
+    this.labels = new HtmlLabelManager(map, {
+      className: "map-html-label map-html-label--family",
+      anchor: "top",
+      offset: [0, 14],
+      visible: this.visible,
+    })
   }
 
   getSourceConfig() {
@@ -34,25 +37,6 @@ export class FamilyLayer extends BaseLayer {
           "circle-stroke-width": 2,
           "circle-stroke-color": "#ffffff",
           "circle-opacity": 0.9,
-        },
-      },
-
-      // Member labels
-      {
-        id: `${this.id}-labels`,
-        type: "symbol",
-        source: this.sourceId,
-        layout: {
-          "text-field": ["get", "name"],
-          "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
-          "text-size": 12,
-          "text-offset": [0, 1.5],
-          "text-anchor": "top",
-        },
-        paint: {
-          "text-color": "#111827",
-          "text-halo-color": "#ffffff",
-          "text-halo-width": 2,
         },
       },
 
@@ -87,12 +71,27 @@ export class FamilyLayer extends BaseLayer {
   }
 
   getLayerIds() {
-    return [
-      this.id,
-      `${this.id}-labels`,
-      `${this.id}-pulse`,
-      `${this.id}-history`,
-    ]
+    return [this.id, `${this.id}-pulse`, `${this.id}-history`]
+  }
+
+  add(data) {
+    super.add(data)
+    this.labels.sync(data?.features || [])
+  }
+
+  update(data) {
+    super.update(data)
+    this.labels.sync(data?.features || [])
+  }
+
+  remove() {
+    this.labels.clear()
+    super.remove()
+  }
+
+  setVisibility(visible) {
+    super.setVisibility(visible)
+    this.labels?.setVisibility(visible)
   }
 
   /**

--- a/app/javascript/maps_maplibre/layers/places_layer.js
+++ b/app/javascript/maps_maplibre/layers/places_layer.js
@@ -1,12 +1,15 @@
+import { HtmlLabelManager } from "../utils/html_label_manager"
 import { BaseLayer } from "./base_layer"
 
-/**
- * Places layer showing user-created places with tags
- * Different colors based on tags
- */
 export class PlacesLayer extends BaseLayer {
   constructor(map, options = {}) {
     super(map, { id: "places", ...options })
+    this.labels = new HtmlLabelManager(map, {
+      className: "map-html-label map-html-label--places",
+      anchor: "top",
+      offset: [0, 14],
+      visible: this.visible,
+    })
   }
 
   getSourceConfig() {
@@ -21,46 +24,42 @@ export class PlacesLayer extends BaseLayer {
 
   getLayerConfigs() {
     return [
-      // Place circles
       {
         id: this.id,
         type: "circle",
         source: this.sourceId,
         paint: {
           "circle-radius": 10,
-          "circle-color": [
-            "coalesce",
-            ["get", "color"], //  Use tag color if available
-            "#6366f1", // Default indigo color
-          ],
+          "circle-color": ["coalesce", ["get", "color"], "#6366f1"],
           "circle-stroke-width": 2,
           "circle-stroke-color": "#ffffff",
           "circle-opacity": 0.85,
-        },
-      },
-
-      // Place labels
-      {
-        id: `${this.id}-labels`,
-        type: "symbol",
-        source: this.sourceId,
-        layout: {
-          "text-field": ["get", "name"],
-          "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
-          "text-size": 11,
-          "text-offset": [0, 1.3],
-          "text-anchor": "top",
-        },
-        paint: {
-          "text-color": "#111827",
-          "text-halo-color": "#ffffff",
-          "text-halo-width": 2,
         },
       },
     ]
   }
 
   getLayerIds() {
-    return [this.id, `${this.id}-labels`]
+    return [this.id]
+  }
+
+  add(data) {
+    super.add(data)
+    this.labels.sync(data?.features || [])
+  }
+
+  update(data) {
+    super.update(data)
+    this.labels.sync(data?.features || [])
+  }
+
+  remove() {
+    this.labels.clear()
+    super.remove()
+  }
+
+  setVisibility(visible) {
+    super.setVisibility(visible)
+    this.labels?.setVisibility(visible)
   }
 }

--- a/app/javascript/maps_maplibre/layers/visits_layer.js
+++ b/app/javascript/maps_maplibre/layers/visits_layer.js
@@ -1,20 +1,18 @@
+import { HtmlLabelManager } from "../utils/html_label_manager"
 import { BaseLayer } from "./base_layer"
 
-/**
- * Visits layer showing suggested, confirmed, and declined visits.
- * Green = confirmed, Amber = suggested, Grey = declined.
- *
- * Adds a halo ring for the currently selected visit, a dashed day-route
- * polyline through the day's visits in chronological order, and support
- * for filtering by status without rebuilding the source data.
- */
 export class VisitsLayer extends BaseLayer {
   constructor(map, options = {}) {
     super(map, { id: "visits", ...options })
     this.dayRouteSourceId = `${this.sourceId}-day-route`
     this.dayRouteLayerId = `${this.id}-day-route`
     this.haloLayerId = `${this.id}-halo`
-    this.labelsLayerId = `${this.id}-labels`
+    this.labels = new HtmlLabelManager(map, {
+      className: "map-html-label map-html-label--visits",
+      anchor: "top",
+      offset: [0, 16],
+      visible: this.visible,
+    })
   }
 
   getSourceConfig() {
@@ -29,8 +27,6 @@ export class VisitsLayer extends BaseLayer {
 
   getLayerConfigs() {
     return [
-      // Dashed polyline for the currently selected day, placed below
-      // everything else so the visit dots sit on top.
       {
         id: this.dayRouteLayerId,
         type: "line",
@@ -46,9 +42,6 @@ export class VisitsLayer extends BaseLayer {
           "line-dasharray": [2, 2],
         },
       },
-
-      // Halo ring for the selected visit. Hidden by default via a filter
-      // that can never match a real visit id.
       {
         id: this.haloLayerId,
         type: "circle",
@@ -62,8 +55,6 @@ export class VisitsLayer extends BaseLayer {
         },
         filter: ["==", ["get", "id"], -1],
       },
-
-      // Visit circles
       {
         id: this.id,
         type: "circle",
@@ -76,43 +67,20 @@ export class VisitsLayer extends BaseLayer {
             "#22c55e",
             ["==", ["get", "status"], "declined"],
             "#9ca3af",
-            "#eab308", // suggested (default)
+            "#eab308",
           ],
           "circle-stroke-width": 2,
           "circle-stroke-color": "#ffffff",
           "circle-opacity": 0.9,
         },
       },
-
-      // Visit labels
-      {
-        id: this.labelsLayerId,
-        type: "symbol",
-        source: this.sourceId,
-        layout: {
-          "text-field": ["get", "name"],
-          "text-font": ["Open Sans Bold", "Arial Unicode MS Bold"],
-          "text-size": 11,
-          "text-offset": [0, 1.5],
-          "text-anchor": "top",
-        },
-        paint: {
-          "text-color": "#111827",
-          "text-halo-color": "#ffffff",
-          "text-halo-width": 2,
-        },
-      },
     ]
   }
 
   getLayerIds() {
-    return [this.dayRouteLayerId, this.haloLayerId, this.id, this.labelsLayerId]
+    return [this.dayRouteLayerId, this.haloLayerId, this.id]
   }
 
-  /**
-   * Override add() so we can also create the day-route source, which
-   * is independent of the main visits source.
-   */
   add(data) {
     this.data = data
 
@@ -135,11 +103,9 @@ export class VisitsLayer extends BaseLayer {
     })
 
     this.setVisibility(this.visible)
+    this.labels.sync(data?.features || [])
   }
 
-  /**
-   * Override remove() so we also clean up the day-route source.
-   */
   remove() {
     this.getLayerIds().forEach((layerId) => {
       if (this.map.getLayer(layerId)) {
@@ -155,36 +121,30 @@ export class VisitsLayer extends BaseLayer {
       this.map.removeSource(this.dayRouteSourceId)
     }
 
+    this.labels.clear()
     this.data = null
   }
 
-  /**
-   * Update() only touches the main visits source. Keep the day-route
-   * source untouched so selection/filter changes don't invalidate it.
-   */
   update(data) {
     this.data = data
     const source = this.map.getSource(this.sourceId)
     if (source?.setData) {
       source.setData(data)
     }
+    this.labels.sync(data?.features || [])
   }
 
-  /**
-   * Highlight a visit by setting the halo filter. Pass null to clear.
-   * Uses `["get", "id"]` because properties.id is the visit id (see
-   * data_loader.js visitsToGeoJSON).
-   */
+  setVisibility(visible) {
+    super.setVisibility(visible)
+    this.labels?.setVisibility(visible)
+  }
+
   setSelectedVisit(visitId) {
     if (!this.map.getLayer(this.haloLayerId)) return
     const id = visitId == null ? -1 : Number(visitId)
     this.map.setFilter(this.haloLayerId, ["==", ["get", "id"], id])
   }
 
-  /**
-   * Filter the visible visits by status. Does not touch the halo layer
-   * so a selected visit stays highlighted regardless of filter state.
-   */
   setStatusFilter({
     confirmed = true,
     suggested = true,
@@ -203,16 +163,11 @@ export class VisitsLayer extends BaseLayer {
         : ["match", ["get", "status"], allowed, true, false]
 
     this.map.setFilter(this.id, filter)
-    if (this.map.getLayer(this.labelsLayerId)) {
-      this.map.setFilter(this.labelsLayerId, filter)
-    }
+    this.labels.setFilter((feature) =>
+      allowed.includes(feature?.properties?.status),
+    )
   }
 
-  /**
-   * Update the day-route polyline. `visitFeatures` is an array of
-   * `{ lng, lat }` in chronological order. Pass `null` or an array
-   * with fewer than 2 points to clear the route.
-   */
   setDayRoute(visitFeatures) {
     const source = this.map.getSource(this.dayRouteSourceId)
     if (!source) return

--- a/app/javascript/maps_maplibre/utils/html_label_manager.js
+++ b/app/javascript/maps_maplibre/utils/html_label_manager.js
@@ -1,0 +1,126 @@
+import maplibregl from "maplibre-gl"
+
+export class HtmlLabelManager {
+  constructor(map, options = {}) {
+    this.map = map
+    this.className = options.className || "map-html-label"
+    this.anchor = options.anchor || "top"
+    this.offset = options.offset || [0, 12]
+    this.coordsFor = options.coordsFor || defaultCoordsFor
+    this.idFor = options.idFor || defaultIdFor
+    this.nameFor = options.nameFor || defaultNameFor
+    this.visible = options.visible !== false
+    this.markers = new Map()
+    this._features = []
+    this._filterFn = null
+  }
+
+  sync(features) {
+    this._features = Array.isArray(features) ? features : []
+    this._render()
+  }
+
+  setVisibility(visible) {
+    this.visible = visible
+    for (const marker of this.markers.values()) {
+      this._applyVisibility(
+        marker,
+        visible && this._passesFilter(marker._feature),
+      )
+    }
+  }
+
+  setFilter(predicate) {
+    this._filterFn = predicate
+    for (const marker of this.markers.values()) {
+      this._applyVisibility(
+        marker,
+        this.visible && this._passesFilter(marker._feature),
+      )
+    }
+  }
+
+  clear() {
+    for (const marker of this.markers.values()) {
+      marker.remove()
+    }
+    this.markers.clear()
+    this._features = []
+  }
+
+  _render() {
+    const seenIds = new Set()
+    for (const feature of this._features) {
+      const name = this.nameFor(feature)
+      if (name == null || name === "") continue
+
+      const coords = this.coordsFor(feature)
+      if (!coords || coords.length < 2) continue
+
+      const id = this.idFor(feature)
+      if (id == null) continue
+      seenIds.add(id)
+
+      let marker = this.markers.get(id)
+      if (marker) {
+        marker.setLngLat(coords)
+        const el = marker.getElement()
+        if (el.textContent !== name) el.textContent = name
+      } else {
+        marker = this._createMarker(coords, name)
+        this.markers.set(id, marker)
+      }
+      marker._feature = feature
+      this._applyVisibility(marker, this.visible && this._passesFilter(feature))
+    }
+    for (const [id, marker] of this.markers) {
+      if (!seenIds.has(id)) {
+        marker.remove()
+        this.markers.delete(id)
+      }
+    }
+  }
+
+  _createMarker(coords, name) {
+    const el = document.createElement("div")
+    el.className = this.className
+    el.textContent = name
+    return new maplibregl.Marker({
+      element: el,
+      anchor: this.anchor,
+      offset: this.offset,
+    })
+      .setLngLat(coords)
+      .addTo(this.map)
+  }
+
+  _applyVisibility(marker, visible) {
+    const el = marker.getElement()
+    el.style.display = visible ? "" : "none"
+  }
+
+  _passesFilter(feature) {
+    if (!this._filterFn || !feature) return true
+    return Boolean(this._filterFn(feature))
+  }
+}
+
+function defaultCoordsFor(feature) {
+  const props = feature?.properties || {}
+  if (props.centerLng != null && props.centerLat != null) {
+    return [props.centerLng, props.centerLat]
+  }
+  const geom = feature?.geometry
+  if (geom?.type === "Point" && Array.isArray(geom.coordinates)) {
+    return geom.coordinates
+  }
+  return null
+}
+
+function defaultIdFor(feature) {
+  return feature?.properties?.id ?? null
+}
+
+function defaultNameFor(feature) {
+  return feature?.properties?.name ?? null
+}


### PR DESCRIPTION
## Summary

Fixes #2365 — emojis (and any glyph outside the Open Sans / Arial Unicode fontstack) render as the Protomaps missing-glyph placeholder in place, area, visit, and family labels on Maps v2.

Replaces the SDF `symbol` text sublayers in the four affected layers with HTML markers (`maplibregl.Marker` wrapping a `<div>`). DOM rendering uses the browser's native font stack — `Apple Color Emoji` / `Segoe UI Emoji` / `Noto Color Emoji` — so emojis render at full color the way they do everywhere else in the app.

## Changes

- **NEW** `app/javascript/maps_maplibre/utils/html_label_manager.js` — manages DOM markers per source feature. `sync(features)` adds/updates/removes markers, `setVisibility`/`setFilter` toggle without rebuilding, `clear()` for teardown.
- `app/javascript/maps_maplibre/layers/places_layer.js`, `areas_layer.js`, `visits_layer.js`, `family_layer.js` — drop the `-labels` SDF sublayer, instantiate `HtmlLabelManager`, wire `add`/`update`/`remove`/`setVisibility` (plus `setStatusFilter` for visits) to drive the manager.
- `app/javascript/controllers/maps/maplibre/data_loader.js` — `areasToGeoJSON` adds `centerLng`/`centerLat` to area properties so the label sits at the circle center without centroid computation.
- `app/assets/stylesheets/maps_maplibre.css` — adds `.map-html-label` plus per-layer modifiers; emoji-aware font stack; `text-shadow` halo replaces SDF `text-halo`; `pointer-events: none` so clicks pass through to the area fill / visit dot underneath.
- `CHANGELOG.md` — entry under `[1.7.4] → Fixed`.

## Verification

- `npx @biomejs/biome check` clean across all modified JS files.
- Booted a parallel server on `:3001` from this branch alongside the existing `dev` build on `:3000`. Same DB.
- New Playwright spec (`v2/map/place-emoji-label.spec.js` in the e2e sibling repo) creates a `🏡 Emoji Home` place via API, opens `/map/v2`, asserts a `.map-html-label--places` DOM element with the emoji text is visible.
  - **Passes** against this branch.
  - **Fails** against `dev` at the visibility assertion — confirms the test is a real regression witness.
- Manual `playwright-cli` check: seeded `🏡 Manual Emoji Home` and `☕ Café 木`. On this branch the labels appear in the DOM as four visible `.map-html-label--places` elements; on `dev` the count is zero (canvas-rendered, with the prohibition glyph in the emoji slot as the issue reporter screenshotted).

## Known follow-ups (not in this PR)

- **Visit-label hover-fade**: `_safeSetPaint("visits-labels", "text-opacity", expr)` in `maps_maplibre_controller.js` (3 call sites) silently no-ops now that the SDF visit-labels layer is gone. Visit dots still fade; only the labels stay full opacity. Restoring this cleanly needs a `setOpacityResolver(fn)` API on `HtmlLabelManager`. Minor visual regression on a niche feature.
- **`family_map_controller.js`** has the same SDF-emoji bug in the standalone family map (`/family/map`). Different lifecycle, can't reuse `HtmlLabelManager` without refactoring; fix it in a follow-up.
- **Dead `areas-labels` references** in `layer_manager.js` (click + hover handlers) are now no-ops because the layer doesn't exist. Clicks on an HTML label pass through to the area fill (which has its own handler), so behavior is preserved. Cleanup in a follow-up.
- **Label collision**: SDF gives MapLibre automatic label collision; HTML markers don't. Acceptable for these layers because they're user-curated and low-cardinality (typically <100). Photos cluster is unaffected (still SDF, no user text).

## Companion e2e spec

The Playwright regression test lives in the sibling repo `e2e-dawarich-playwright` on a parallel branch with the same name (`fix/emoji-map-labels`). They should ship together.

## Test plan

- [ ] Pull, run `bin/dev`, open `/map/v2`, enable Places, create a place named `🏡 Test`. Label renders as the home emoji + text.
- [ ] Repeat for an area, a visit name, a family member name (each layer has its own marker class for styling).
- [ ] Toggle Places off and on. Labels disappear and reappear in lockstep with the dots.
- [ ] Clip a place via API, refresh — label disappears.
- [ ] Toggle theme between light and dark — text/halo colors invert correctly.
- [ ] Toggle visit status filters (confirmed/suggested/declined). Labels filter alongside dots.