### PR TITLE
Fix imports to schedule track generation for the imported point range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Confirmed and declined visits inside an area or assigned to a place are no longer reverted to "suggested" — and any name you gave them is no longer overwritten — by the nightly visit-recompute job. (#2048, #2484)
 - GPX import now streams the file rather than loading the entire XML into memory, so multi-hundred-MB GPX files (e.g. long-running activity exports) no longer OOM the Sidekiq worker. (#2296)
 - Viewing an import on Map v2 or the Points page now selects the import's full date range, instead of defaulting to today or the last month. #1857
+- Imports (GPX, KML, GeoJSON, FIT, TCX, Google Timeline, OwnTracks .rec, CSV, Polarsteps) now generate tracks for the imported point range. Previously, only points coming through the real-time APIs (OwnTracks, Overland, generic Points) had tracks built automatically; bulk imports left their points untracked until a separate manual recalculation was run. Track generation triggered by imports is non-destructive: tracks already built from real-time data (with their per-segment transportation-mode corrections) are preserved, and only points that weren't already part of a track are segmented. To rebuild every track in a range — including manually-corrected ones — use Map v2 → Settings → **Recalculate tracks & stats**. (#2224)
 
 ## [1.7.7] - 2026-05-09
 

--- a/app/jobs/tracks/parallel_generator_job.rb
+++ b/app/jobs/tracks/parallel_generator_job.rb
@@ -5,7 +5,7 @@
 class Tracks::ParallelGeneratorJob < ApplicationJob
   queue_as :tracks
 
-  def perform(user_id, start_at: nil, end_at: nil, mode: :bulk, chunk_size: 1.day)
+  def perform(user_id, start_at: nil, end_at: nil, mode: :bulk, chunk_size: 1.day, untracked_only: false)
     user = find_user_or_skip(user_id) || return
 
     Tracks::ParallelGenerator.new(
@@ -13,7 +13,8 @@ class Tracks::ParallelGeneratorJob < ApplicationJob
       start_at: start_at,
       end_at: end_at,
       mode: mode,
-      chunk_size: chunk_size
+      chunk_size: chunk_size,
+      untracked_only: untracked_only
     ).call
   rescue StandardError => e
     ExceptionReporter.call(e, 'Failed to start parallel track generation')

--- a/app/jobs/tracks/time_chunk_processor_job.rb
+++ b/app/jobs/tracks/time_chunk_processor_job.rb
@@ -60,9 +60,11 @@ class Tracks::TimeChunkProcessorJob < ApplicationJob
   end
 
   def load_chunk_points
-    user.points
-        .where(timestamp: chunk_data[:buffer_start_timestamp]..chunk_data[:buffer_end_timestamp])
-        .order(:timestamp)
+    relation = user.points
+                   .where(timestamp: chunk_data[:buffer_start_timestamp]..chunk_data[:buffer_end_timestamp])
+                   .order(:timestamp)
+    relation = relation.where(track_id: nil) if chunk_data[:untracked_only]
+    relation
   end
 
   def segment_chunk_points(points)

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -35,6 +35,7 @@ class Imports::Create
     filter_anomalies(user, import)
     schedule_stats_creating(user.id)
     schedule_visit_suggesting(user.id, import)
+    schedule_track_generation(user.id, import)
     update_import_points_count(import)
   rescue StandardError => e
     return if import.destroyed?
@@ -114,6 +115,21 @@ class Imports::Create
     end_at = Time.zone.at(min_max[1])
 
     VisitSuggestingJob.perform_later(user_id:, start_at:, end_at:)
+  end
+
+  def schedule_track_generation(user_id, import)
+    min_max = import.points.pick('MIN(timestamp), MAX(timestamp)')
+    return if min_max.compact.empty?
+
+    start_at = Time.zone.at(min_max[0])
+    end_at = Time.zone.at(min_max[1])
+
+    Tracks::ParallelGeneratorJob.perform_later(
+      user_id,
+      start_at: start_at,
+      end_at: end_at,
+      mode: 'bulk'
+    )
   end
 
   def create_import_failed_notification(import, user, error)

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -108,28 +108,36 @@ class Imports::Create
   def schedule_visit_suggesting(user_id, import)
     return unless user.safe_settings.visits_suggestions_enabled?
 
-    min_max = import.points.pick('MIN(timestamp), MAX(timestamp)')
-    return if min_max.compact.empty?
+    summary = import_points_summary(import)
+    return if summary.nil?
 
-    start_at = Time.zone.at(min_max[0])
-    end_at = Time.zone.at(min_max[1])
-
-    VisitSuggestingJob.perform_later(user_id:, start_at:, end_at:)
+    VisitSuggestingJob.perform_later(user_id:, start_at: summary[:start_at], end_at: summary[:end_at])
   end
 
   def schedule_track_generation(user_id, import)
-    min_max = import.points.pick('MIN(timestamp), MAX(timestamp)')
-    return if min_max.compact.empty?
-
-    start_at = Time.zone.at(min_max[0])
-    end_at = Time.zone.at(min_max[1])
+    summary = import_points_summary(import)
+    return if summary.nil? || summary[:count] < 2
 
     Tracks::ParallelGeneratorJob.perform_later(
       user_id,
-      start_at: start_at,
-      end_at: end_at,
-      mode: 'bulk'
+      start_at: summary[:start_at],
+      end_at: summary[:end_at],
+      mode: :bulk,
+      untracked_only: true
     )
+  end
+
+  def import_points_summary(import)
+    return @import_points_summary if defined?(@import_points_summary)
+
+    count, min_ts, max_ts = import.points.pick(Arel.sql('COUNT(*), MIN(timestamp), MAX(timestamp)'))
+
+    @import_points_summary =
+      if min_ts.nil? || max_ts.nil?
+        nil
+      else
+        { count: count, start_at: Time.zone.at(min_ts), end_at: Time.zone.at(max_ts) }
+      end
   end
 
   def create_import_failed_notification(import, user, error)

--- a/app/services/tracks/parallel_generator.rb
+++ b/app/services/tracks/parallel_generator.rb
@@ -6,18 +6,19 @@ class Tracks::ParallelGenerator
   include Tracks::Segmentation
   include Tracks::TrackBuilder
 
-  attr_reader :user, :start_at, :end_at, :mode, :chunk_size
+  attr_reader :user, :start_at, :end_at, :mode, :chunk_size, :untracked_only
 
-  def initialize(user, start_at: nil, end_at: nil, mode: :bulk, chunk_size: 1.day)
+  def initialize(user, start_at: nil, end_at: nil, mode: :bulk, chunk_size: 1.day, untracked_only: false)
     @user = user
     @start_at = start_at
     @end_at = end_at
     @mode = mode.to_sym
     @chunk_size = chunk_size
+    @untracked_only = untracked_only
   end
 
   def call
-    Tracks::PerUserLock.with_user_lock(user.id) { clean_existing_tracks } if mode.in?(%i[bulk daily])
+    Tracks::PerUserLock.with_user_lock(user.id) { clean_existing_tracks } if mode.in?(%i[bulk daily]) && !untracked_only
 
     time_chunks = generate_time_chunks
     return 0 if time_chunks.empty?
@@ -75,7 +76,7 @@ class Tracks::ParallelGenerator
       Tracks::TimeChunkProcessorJob.perform_later(
         user.id,
         session_id,
-        chunk
+        chunk.merge(untracked_only: untracked_only)
       )
     end
   end

--- a/spec/jobs/tracks/parallel_generator_job_spec.rb
+++ b/spec/jobs/tracks/parallel_generator_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Tracks::ParallelGeneratorJob do
 
       it 'calls Tracks::ParallelGenerator with correct parameters' do
         expect(Tracks::ParallelGenerator).to receive(:new)
-          .with(user, start_at: nil, end_at: nil, mode: :bulk, chunk_size: 1.day)
+          .with(user, start_at: nil, end_at: nil, mode: :bulk, chunk_size: 1.day, untracked_only: false)
           .and_call_original
 
         job.perform(user_id)
@@ -45,7 +45,7 @@ RSpec.describe Tracks::ParallelGeneratorJob do
         chunk_size = 2.days
 
         expect(Tracks::ParallelGenerator).to receive(:new)
-          .with(user, start_at: start_at, end_at: end_at, mode: mode, chunk_size: chunk_size)
+          .with(user, start_at: start_at, end_at: end_at, mode: mode, chunk_size: chunk_size, untracked_only: false)
           .and_call_original
 
         job.perform(user_id, start_at: start_at, end_at: end_at, mode: mode, chunk_size: chunk_size)
@@ -72,7 +72,7 @@ RSpec.describe Tracks::ParallelGeneratorJob do
 
       it 'handles bulk mode' do
         expect(Tracks::ParallelGenerator).to receive(:new)
-          .with(user, start_at: nil, end_at: nil, mode: :bulk, chunk_size: 1.day)
+          .with(user, start_at: nil, end_at: nil, mode: :bulk, chunk_size: 1.day, untracked_only: false)
           .and_call_original
 
         job.perform(user_id, mode: :bulk)
@@ -80,7 +80,7 @@ RSpec.describe Tracks::ParallelGeneratorJob do
 
       it 'handles incremental mode' do
         expect(Tracks::ParallelGenerator).to receive(:new)
-          .with(user, start_at: nil, end_at: nil, mode: :incremental, chunk_size: 1.day)
+          .with(user, start_at: nil, end_at: nil, mode: :incremental, chunk_size: 1.day, untracked_only: false)
           .and_call_original
 
         job.perform(user_id, mode: :incremental)
@@ -89,7 +89,7 @@ RSpec.describe Tracks::ParallelGeneratorJob do
       it 'handles daily mode' do
         start_at = Date.current
         expect(Tracks::ParallelGenerator).to receive(:new)
-          .with(user, start_at: start_at, end_at: nil, mode: :daily, chunk_size: 1.day)
+          .with(user, start_at: start_at, end_at: nil, mode: :daily, chunk_size: 1.day, untracked_only: false)
           .and_call_original
 
         job.perform(user_id, start_at: start_at, mode: :daily)
@@ -103,7 +103,7 @@ RSpec.describe Tracks::ParallelGeneratorJob do
 
       it 'passes time range to generator' do
         expect(Tracks::ParallelGenerator).to receive(:new)
-          .with(user, start_at: start_at, end_at: end_at, mode: :bulk, chunk_size: 1.day)
+          .with(user, start_at: start_at, end_at: end_at, mode: :bulk, chunk_size: 1.day, untracked_only: false)
           .and_call_original
 
         job.perform(user_id, start_at: start_at, end_at: end_at)
@@ -116,7 +116,7 @@ RSpec.describe Tracks::ParallelGeneratorJob do
 
       it 'passes chunk size to generator' do
         expect(Tracks::ParallelGenerator).to receive(:new)
-          .with(user, start_at: nil, end_at: nil, mode: :bulk, chunk_size: chunk_size)
+          .with(user, start_at: nil, end_at: nil, mode: :bulk, chunk_size: chunk_size, untracked_only: false)
           .and_call_original
 
         job.perform(user_id, chunk_size: chunk_size)

--- a/spec/regressions/imports_schedule_track_generation_spec.rb
+++ b/spec/regressions/imports_schedule_track_generation_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Imports schedule track generation for the imported point range' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, source: 'owntracks', status: 'created', user: user) }
+  let(:file_path) { Rails.root.join('spec/fixtures/files/owntracks/2024-03.rec') }
+  let(:service) { Imports::Create.new(user, import) }
+
+  before do
+    import.file.attach(
+      io: File.open(file_path),
+      filename: '2024-03.rec',
+      content_type: 'application/octet-stream'
+    )
+  end
+
+  it 'enqueues a parallel track generation job covering the imported range' do
+    Sidekiq::Testing.inline! do
+      expect { service.call }.to have_enqueued_job(Tracks::ParallelGeneratorJob)
+    end
+  end
+
+  it 'covers exactly the timestamp range of imported points' do
+    service.call
+
+    min_ts, max_ts = import.reload.points.pick('MIN(timestamp), MAX(timestamp)')
+
+    expect(Tracks::ParallelGeneratorJob).to have_been_enqueued.with(
+      user.id,
+      start_at: Time.zone.at(min_ts),
+      end_at: Time.zone.at(max_ts),
+      mode: 'bulk'
+    )
+  end
+
+  context 'when the import produced no points' do
+    it 'does not enqueue a track generation job' do
+      allow_any_instance_of(OwnTracks::Importer).to receive(:call) # no-op importer
+      expect { service.call }.not_to have_enqueued_job(Tracks::ParallelGeneratorJob)
+    end
+  end
+end

--- a/spec/regressions/imports_schedule_track_generation_spec.rb
+++ b/spec/regressions/imports_schedule_track_generation_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Imports schedule track generation for the imported point range' do
+  include ActiveJob::TestHelper
+
   let(:user) { create(:user) }
   let(:import) { create(:import, source: 'owntracks', status: 'created', user: user) }
   let(:file_path) { Rails.root.join('spec/fixtures/files/owntracks/2024-03.rec') }
@@ -17,12 +19,10 @@ RSpec.describe 'Imports schedule track generation for the imported point range' 
   end
 
   it 'enqueues a parallel track generation job covering the imported range' do
-    Sidekiq::Testing.inline! do
-      expect { service.call }.to have_enqueued_job(Tracks::ParallelGeneratorJob)
-    end
+    expect { service.call }.to have_enqueued_job(Tracks::ParallelGeneratorJob)
   end
 
-  it 'covers exactly the timestamp range of imported points' do
+  it 'covers exactly the timestamp range of imported points and runs in untracked-only bulk mode' do
     service.call
 
     min_ts, max_ts = import.reload.points.pick('MIN(timestamp), MAX(timestamp)')
@@ -31,14 +31,103 @@ RSpec.describe 'Imports schedule track generation for the imported point range' 
       user.id,
       start_at: Time.zone.at(min_ts),
       end_at: Time.zone.at(max_ts),
-      mode: 'bulk'
+      mode: :bulk,
+      untracked_only: true
     )
   end
 
   context 'when the import produced no points' do
+    let(:noop_importer) { instance_double(OwnTracks::Importer, call: nil) }
+
+    before do
+      allow(OwnTracks::Importer).to receive(:new).and_return(noop_importer)
+    end
+
     it 'does not enqueue a track generation job' do
-      allow_any_instance_of(OwnTracks::Importer).to receive(:call) # no-op importer
       expect { service.call }.not_to have_enqueued_job(Tracks::ParallelGeneratorJob)
+    end
+  end
+
+  context 'when the import produced fewer than two points' do
+    before do
+      allow(OwnTracks::Importer).to receive(:new) do
+        Class.new do
+          def initialize(import, user_id, _file_path)
+            @import = import
+            @user_id = user_id
+          end
+
+          def call
+            Point.create!(
+              user_id: @user_id,
+              import_id: @import.id,
+              timestamp: 1_700_000_000,
+              lonlat: 'POINT(13.33 52.22)'
+            )
+          end
+        end.new(import, user.id, nil)
+      end
+    end
+
+    it 'does not enqueue a track generation job' do
+      expect { service.call }.not_to have_enqueued_job(Tracks::ParallelGeneratorJob)
+    end
+  end
+
+  describe 'untracked-only semantics in the parallel generator' do
+    it 'preserves existing tracks that overlap the import range and segments only untracked points into new tracks' do
+      existing_track = create(
+        :track,
+        user: user,
+        start_at: Time.zone.parse('2024-03-01T10:00:00Z'),
+        end_at: Time.zone.parse('2024-03-01T11:00:00Z')
+      )
+      tracked_point = create(
+        :point,
+        user: user,
+        track: existing_track,
+        timestamp: Time.zone.parse('2024-03-01T10:30:00Z').to_i,
+        lonlat: 'POINT(13.40 52.52)'
+      )
+      [
+        Time.zone.parse('2024-03-01T15:00:00Z'),
+        Time.zone.parse('2024-03-01T15:00:30Z'),
+        Time.zone.parse('2024-03-01T15:01:00Z')
+      ].each do |ts|
+        create(:point, user: user, track: nil, timestamp: ts.to_i, lonlat: 'POINT(13.41 52.53)')
+      end
+
+      perform_enqueued_jobs do
+        Tracks::ParallelGenerator.new(
+          user,
+          start_at: Time.zone.parse('2024-03-01T00:00:00Z'),
+          end_at: Time.zone.parse('2024-03-02T00:00:00Z'),
+          mode: :bulk,
+          untracked_only: true
+        ).call
+      end
+
+      expect(Track.exists?(existing_track.id)).to be(true)
+      expect(tracked_point.reload.track_id).to eq(existing_track.id)
+      expect(user.tracks.where.not(id: existing_track.id).exists?).to be(true)
+    end
+
+    it 'destroys overlapping tracks when untracked_only is false (default bulk semantics)' do
+      existing_track = create(
+        :track,
+        user: user,
+        start_at: Time.zone.parse('2024-03-01T10:00:00Z'),
+        end_at: Time.zone.parse('2024-03-01T11:00:00Z')
+      )
+
+      Tracks::ParallelGenerator.new(
+        user,
+        start_at: Time.zone.parse('2024-03-01T00:00:00Z'),
+        end_at: Time.zone.parse('2024-03-02T00:00:00Z'),
+        mode: :bulk
+      ).call
+
+      expect(Track.exists?(existing_track.id)).to be(false)
     end
   end
 end

--- a/spec/services/tracks/parallel_generator_spec.rb
+++ b/spec/services/tracks/parallel_generator_spec.rb
@@ -280,8 +280,12 @@ RSpec.describe Tracks::ParallelGenerator do
       it 'passes correct parameters to each job' do
         generator.send(:enqueue_chunk_jobs, session_id, chunks)
 
-        expect(Tracks::TimeChunkProcessorJob).to have_been_enqueued.with(user.id, session_id, chunks[0])
-        expect(Tracks::TimeChunkProcessorJob).to have_been_enqueued.with(user.id, session_id, chunks[1])
+        expect(Tracks::TimeChunkProcessorJob).to have_been_enqueued.with(
+          user.id, session_id, chunks[0].merge(untracked_only: false)
+        )
+        expect(Tracks::TimeChunkProcessorJob).to have_been_enqueued.with(
+          user.id, session_id, chunks[1].merge(untracked_only: false)
+        )
       end
     end
 


### PR DESCRIPTION
## Summary

Fixes [#2224](https://github.com/Freika/dawarich/issues/2224) — bulk imports (GPX, KML, GeoJSON, FIT, TCX, Google Timeline, OwnTracks .rec, CSV, Polarsteps) didn't trigger track generation. Imported points stayed untracked until the user manually clicked Map v2 → Settings → **Recalculate tracks & stats**.

## Fix

`Imports::Create#schedule_track_generation` enqueues `Tracks::ParallelGeneratorJob` with the import's full timestamp range, in non-destructive mode (`untracked_only: true`).

- New `untracked_only:` kwarg on `Tracks::ParallelGenerator`, `Tracks::ParallelGeneratorJob`, and `Tracks::TimeChunkProcessorJob`. When true, `clean_existing_tracks` is skipped and the chunk processor only segments points where `track_id IS NULL`. Imports opt in; the daily job and manual recalc keep their existing destructive bulk semantics.
- Skip the enqueue if the import yielded fewer than 2 points (the segmenter requires ≥ 2).
- `import_points_summary` memoizes a single `pick(COUNT(*), MIN(timestamp), MAX(timestamp))` query shared by the visit-suggesting and track-generation hooks.

## Behavior

| Caller | Mode | Destructive? | Notes |
|---|---|---|---|
| Imports | `bulk`, `untracked_only: true` | No | Preserves existing tracks; segments only untracked points |
| Daily job | `daily` | Yes | Unchanged |
| Manual recalc | `bulk` | Yes | Unchanged |

Users who want to fully rebuild tracks for a range — including manually-corrected segments — keep using **Recalculate tracks & stats**.

## Test plan

- [x] Regression: `spec/regressions/imports_schedule_track_generation_spec.rb` (6 examples)
  - Enqueue happens with the right range and `untracked_only: true`
  - Empty imports / < 2-point imports skip the enqueue
  - Existing tracks survive when `untracked_only: true`; untracked points form new tracks
  - Default `bulk` (no `untracked_only`) still destroys overlapping tracks

Closes #2224