### PR TITLE
Fix default password in docs

### DIFF
--- a/docs/How_to_install_Dawarich_using_Docker.md
+++ b/docs/How_to_install_Dawarich_using_Docker.md
@@ -8,4 +8,4 @@ This command use [docker-compose.yml](../docker-compose.yml) to build your local
 
 When this command done successfully and all services in containers will start you can open Dawarich web UI by this link [http://127.0.0.1:3000](http://127.0.0.1:3000).
 
-Default credentials for first login in are `demo@dawarich.app` and `password`.
+Default credentials for first login in are `demo@dawarich.app` and `safepassword`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker installation guide with revised default login credentials for first-time setup. The default username remains `demo@dawarich.app`, while the default password has been changed to `safepassword`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->