### PR TITLE
Fix crash when stat.toponyms is nil on stats page

### DIFF
--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -76,7 +76,7 @@ module StatsHelper
     cities = []
 
     year_stats.each do |stat|
-      toponyms = stat.toponyms.flatten
+      toponyms = Array(stat.toponyms).flatten
       toponyms.each do |t|
         city_names = (t['cities'] || []).filter_map { |c| c['city'] }
         cities.concat(city_names)
@@ -91,7 +91,7 @@ module StatsHelper
     grouped = Hash.new { |h, k| h[k] = [] }
 
     year_stats.each do |stat|
-      stat.toponyms.flatten.each do |toponym|
+      Array(stat.toponyms).flatten.each do |toponym|
         country = normalize_country_name(toponym['country'])
         next if country.blank?
 


### PR DESCRIPTION
Fixes a 500 error on the stats page when nil values are found.

It would crash with:
ActionView::Template::Error (undefined method 'flatten' for nil)
when a Stat record had toponyms == nil.

Repro:
Honestly not sure what data source exactly caused it for me, but my stats page had just stopped working a few days after installing it and importing data. I also couldn't find anyone with the same issue so this might just be exceedingly rare but if y'all need my data I could DM it to a trustworthy maintainer.


PS-I also ran into some node dependency issues when building w/docker to test my changes. It might just have been some issue with my setup since I'm no professional dev but I had to add a node install to the dockerfile (not included in the PR since it's unrelated, just thought it was good to let you guys know)