### PR TITLE
Confirm suggested visit on inline-rename and persist user-named place (#2621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - The slider knob inside settings and map-layer toggles now slides over to the new position when clicked, instead of staying on the left while only the track colour changes. (#2566)
-- Renaming a suggested visit in the timeline now confirms it with the typed name and saves it as a place under your account, instead of leaving the visit in the "needs review" state with no way to confirm the new name. (#2621)
+- Renaming a suggested visit in the timeline now confirms it and saves the typed name as a place under your account. (#2621)
 
 ## [1.7.5] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - The slider knob inside settings and map-layer toggles now slides over to the new position when clicked, instead of staying on the left while only the track colour changes. (#2566)
+- Renaming a suggested visit in the timeline now confirms it with the typed name and saves it as a place under your account, instead of leaving the visit in the "needs review" state with no way to confirm the new name. (#2621)
 
 ## [1.7.5] - 2026-05-04
 

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -44,7 +44,8 @@ class VisitsController < ApplicationController
     params_to_update = visit_params.to_h
     params_to_update.delete(:name) if params_to_update[:name].is_a?(String) && params_to_update[:name].strip.empty?
 
-    maybe_auto_confirm_with_user_place!(params_to_update)
+    auto_confirm_result = maybe_auto_confirm_with_user_place!(params_to_update)
+    return render_unprocessable('Could not save the typed name as a place.') if auto_confirm_result == :place_invalid
 
     # Cross-tenant IDOR guard: place_id must belong to current_user.
     # Suggested places (visit.suggested_places) are also acceptable since
@@ -259,23 +260,32 @@ class VisitsController < ApplicationController
     params_to_update[:status] == 'confirmed' && @visit.suggested? && params_to_update[:name].blank?
   end
 
-  def maybe_auto_confirm_with_user_place!(params_to_update)
-    return unless @visit.suggested?
-    return if params_to_update[:place_id].present?
-    return if params_to_update[:status].present? && params_to_update[:status] != 'suggested'
+  PLACE_NAME_MAX_LENGTH = 200
 
-    name = params_to_update[:name]
-    return if name.blank?
+  def maybe_auto_confirm_with_user_place!(params_to_update)
+    return :noop unless @visit.suggested?
+    return :noop if params_to_update[:place_id].present?
+    return :noop if params_to_update[:status].present? && params_to_update[:status] != 'suggested'
+
+    name = params_to_update[:name].to_s.strip
+    return :noop if name.blank?
+
+    name = name[0, PLACE_NAME_MAX_LENGTH]
+    params_to_update[:name] = name
 
     place = find_or_create_user_place_for_rename(name)
-    return unless place
+    return :place_invalid unless place
 
     params_to_update[:place_id] = place.id
     params_to_update[:status] = 'confirmed'
+    :auto_confirmed
   end
 
   def find_or_create_user_place_for_rename(name)
     lat, lon = @visit.center
+    return nil if lat.blank? || lon.blank?
+    return nil if lat.to_f.zero? && lon.to_f.zero?
+
     existing = current_user.places.where(name: name).near([lat, lon], 50, :m).first
     return existing if existing
 
@@ -283,7 +293,6 @@ class VisitsController < ApplicationController
       name: name,
       latitude: lat,
       longitude: lon,
-      lonlat: "POINT(#{lon} #{lat})",
       source: :manual
     )
   rescue ActiveRecord::RecordInvalid

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -44,6 +44,8 @@ class VisitsController < ApplicationController
     params_to_update = visit_params.to_h
     params_to_update.delete(:name) if params_to_update[:name].is_a?(String) && params_to_update[:name].strip.empty?
 
+    maybe_auto_confirm_with_user_place!(params_to_update)
+
     # Cross-tenant IDOR guard: place_id must belong to current_user.
     # Suggested places (visit.suggested_places) are also acceptable since
     # they're already user-scoped via the visit relationship.
@@ -255,6 +257,37 @@ class VisitsController < ApplicationController
 
   def confirming_suggested_visit?(params_to_update = visit_params)
     params_to_update[:status] == 'confirmed' && @visit.suggested? && params_to_update[:name].blank?
+  end
+
+  def maybe_auto_confirm_with_user_place!(params_to_update)
+    return unless @visit.suggested?
+    return if params_to_update[:place_id].present?
+    return if params_to_update[:status].present? && params_to_update[:status] != 'suggested'
+
+    name = params_to_update[:name]
+    return if name.blank?
+
+    place = find_or_create_user_place_for_rename(name)
+    return unless place
+
+    params_to_update[:place_id] = place.id
+    params_to_update[:status] = 'confirmed'
+  end
+
+  def find_or_create_user_place_for_rename(name)
+    lat, lon = @visit.center
+    existing = current_user.places.where(name: name).near([lat, lon], 50, :m).first
+    return existing if existing
+
+    current_user.places.create!(
+      name: name,
+      latitude: lat,
+      longitude: lon,
+      lonlat: "POINT(#{lon} #{lat})",
+      source: :manual
+    )
+  rescue ActiveRecord::RecordInvalid
+    nil
   end
 
   def auto_name_on_confirm

--- a/spec/regressions/visit_inline_rename_confirms_suggested_spec.rb
+++ b/spec/regressions/visit_inline_rename_confirms_suggested_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Inline rename of a suggested visit', type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  describe 'PATCH /visits/:id with only visit[name] on a suggested visit' do
+    let!(:nearby_place_a) { create(:place, user:, name: 'Cafe A', latitude: 54.2905, longitude: 13.0948) }
+    let!(:nearby_place_b) { create(:place, user:, name: 'Cafe B', latitude: 54.2906, longitude: 13.0949) }
+    let(:visit) do
+      v = create(:visit, user:, status: :suggested, name: 'Visit')
+      v.update!(place: nearby_place_a)
+      v
+    end
+
+    before do
+      create(:place_visit, visit:, place: nearby_place_a)
+      create(:place_visit, visit:, place: nearby_place_b)
+    end
+
+    it 'sets visit.name to the typed value' do
+      patch visit_url(visit), params: { visit: { name: 'My Coffee Spot' } }, as: :turbo_stream
+
+      expect(visit.reload.name).to eq('My Coffee Spot')
+    end
+
+    it 'auto-confirms the visit' do
+      patch visit_url(visit), params: { visit: { name: 'My Coffee Spot' } }, as: :turbo_stream
+
+      expect(visit.reload.status).to eq('confirmed')
+    end
+
+    it 'creates a new user-owned Place from the typed name and links it to the visit' do
+      expect do
+        patch visit_url(visit), params: { visit: { name: 'My Coffee Spot' } }, as: :turbo_stream
+      end.to change(Place, :count).by(1)
+
+      created = user.places.find_by(name: 'My Coffee Spot')
+      expect(created).to be_present
+      expect(created.user_id).to eq(user.id)
+      expect(visit.reload.place_id).to eq(created.id)
+    end
+
+    it 'positions the new Place at the visit center' do
+      patch visit_url(visit), params: { visit: { name: 'My Coffee Spot' } }, as: :turbo_stream
+
+      created = user.places.find_by(name: 'My Coffee Spot')
+      lat, lon = visit.reload.center
+      expect(created.latitude.to_f).to be_within(0.0001).of(lat)
+      expect(created.longitude.to_f).to be_within(0.0001).of(lon)
+    end
+
+    it 'reuses an existing user-owned Place near the visit when the typed name matches' do
+      lat, lon = visit.center
+      existing = create(:place, user:, name: 'My Coffee Spot', latitude: lat, longitude: lon)
+
+      expect do
+        patch visit_url(visit), params: { visit: { name: 'My Coffee Spot' } }, as: :turbo_stream
+      end.not_to change(Place, :count)
+
+      expect(visit.reload.place_id).to eq(existing.id)
+    end
+
+    it 'does not reuse another user\'s same-name place near the visit center' do
+      lat, lon = visit.center
+      other_user = create(:user)
+      create(:place, user: other_user, name: 'My Coffee Spot', latitude: lat, longitude: lon)
+
+      expect do
+        patch visit_url(visit), params: { visit: { name: 'My Coffee Spot' } }, as: :turbo_stream
+      end.to change(Place, :count).by(1)
+
+      created = user.places.find_by(name: 'My Coffee Spot')
+      expect(created).to be_present
+      expect(created.user_id).to eq(user.id)
+    end
+  end
+
+  describe 'PATCH /visits/:id with only visit[name] on a confirmed visit' do
+    let(:visit) { create(:visit, user:, status: :confirmed, name: 'Old Name') }
+
+    it 'updates the name without creating a Place or changing status' do
+      expect do
+        patch visit_url(visit), params: { visit: { name: 'Edited Name' } }, as: :turbo_stream
+      end.not_to change(Place, :count)
+
+      expect(visit.reload.name).to eq('Edited Name')
+      expect(visit.reload.status).to eq('confirmed')
+    end
+  end
+
+  describe 'PATCH /visits/:id with blank visit[name] on a suggested visit' do
+    let(:visit) { create(:visit, user:, status: :suggested, name: 'Original') }
+
+    it 'is a no-op for name and does not auto-confirm or create a Place' do
+      expect do
+        patch visit_url(visit), params: { visit: { name: '   ' } }, as: :turbo_stream
+      end.not_to change(Place, :count)
+
+      expect(visit.reload.name).to eq('Original')
+      expect(visit.reload.status).to eq('suggested')
+    end
+  end
+
+  describe 'PATCH /visits/:id picker confirm (place_id + status)' do
+    let!(:nearby_place) { create(:place, user:, name: 'Cafe A', latitude: 54.2905, longitude: 13.0948) }
+    let(:visit) { create(:visit, user:, status: :suggested, name: 'Visit') }
+
+    before { create(:place_visit, visit:, place: nearby_place) }
+
+    it 'still confirms via the picker without creating an extra Place' do
+      expect do
+        patch visit_url(visit),
+              params: { visit: { place_id: nearby_place.id, status: :confirmed } },
+              as: :turbo_stream
+      end.not_to change(Place, :count)
+
+      expect(visit.reload.place_id).to eq(nearby_place.id)
+      expect(visit.reload.status).to eq('confirmed')
+      expect(visit.reload.name).to eq('Cafe A')
+    end
+  end
+end

--- a/spec/regressions/visit_inline_rename_confirms_suggested_spec.rb
+++ b/spec/regressions/visit_inline_rename_confirms_suggested_spec.rb
@@ -105,6 +105,40 @@ RSpec.describe 'Inline rename of a suggested visit', type: :request do
     end
   end
 
+  describe 'PATCH /visits/:id with rename on a suggested visit that has no resolvable center' do
+    let(:visit) { create(:visit, user:, area: nil, place: nil, status: :suggested, name: 'Visit') }
+
+    it 'does not create a Place at [0, 0] and surfaces a 422' do
+      expect(visit.center).to eq([0, 0])
+
+      expect do
+        patch visit_url(visit), params: { visit: { name: 'My Coffee Spot' } }, as: :turbo_stream
+      end.not_to change(Place, :count)
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(visit.reload.status).to eq('suggested')
+    end
+  end
+
+  describe 'PATCH /visits/:id with surrounding whitespace in visit[name] on a suggested visit' do
+    let!(:nearby_place) { create(:place, user:, name: 'Cafe A', latitude: 54.2905, longitude: 13.0948) }
+    let(:visit) do
+      v = create(:visit, user:, status: :suggested, name: 'Visit')
+      v.update!(place: nearby_place)
+      v
+    end
+
+    before { create(:place_visit, visit:, place: nearby_place) }
+
+    it 'stores the trimmed name on both visit and Place' do
+      patch visit_url(visit), params: { visit: { name: '  My Coffee Spot  ' } }, as: :turbo_stream
+
+      created = user.places.find_by(name: 'My Coffee Spot')
+      expect(created).to be_present
+      expect(visit.reload.name).to eq('My Coffee Spot')
+    end
+  end
+
   describe 'PATCH /visits/:id picker confirm (place_id + status)' do
     let!(:nearby_place) { create(:place, user:, name: 'Cafe A', latitude: 54.2905, longitude: 13.0948) }
     let(:visit) { create(:visit, user:, status: :suggested, name: 'Visit') }


### PR DESCRIPTION
## Summary

Fixes [#2621](https://github.com/Freika/dawarich/issues/2621) — when the timeline picker is open and a user inline-renames a `suggested` visit, the typed name was discarded and the picker stayed open.

## Fix

Treat the inline-rename PATCH on a `suggested` visit as a confirmation:
- Find-or-create a user-owned `Place` at `visit.center` with the typed name (deduped by name within 50m)
- Inject `place_id` and `status: 'confirmed'` into params
- Existing IDOR guard / update flow handles the rest
- Turbo Stream re-render replaces the row and the picker disappears

The user's typed name persists on the visit AND on a new Place.

## Test plan

- [x] Regression spec added: `spec/regressions/visit_inline_rename_confirms_suggested_spec.rb`
- [ ] Inline-rename a suggested visit in the UI — confirm picker disappears and name persists
- [ ] New Place is created (or matched within 50m) and owned by the current user
- [ ] Cross-user IDOR remains blocked

Closes #2621