### PR TITLE
Stamp reverse_geocoded_at when geocoder returns no result (#2271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ scrape_configs:
 - Fixed monthly stats failing with a "Stats update failed" notification when the month's distance exceeded the int4 limit (2,147,483,647 m ≈ 2.15M km). Affected months stayed stuck on the prior value until recalculated. #1996
 - 500 error on the imports page. #2683
 - Insights weekly pattern now refreshes after monthly stats change, instead of showing a stale snapshot until the next monthly digest job runs. #2478
+- Points with no reverse-geocoding result (ocean, wilderness) are now marked as attempted instead of being re-queued every nightly run; use "Start Reverse Geocoding" to retry after switching providers. #2271
 
 ## [1.7.6] - 2026-05-09
 

--- a/app/services/reverse_geocoding/points/fetch_data.rb
+++ b/app/services/reverse_geocoding/points/fetch_data.rb
@@ -26,7 +26,13 @@ class ReverseGeocoding::Points::FetchData
 
   def update_point_with_geocoding_data
     response = Geocoder.search([point.lat, point.lon]).first
-    return if response.blank? || response.data['error'].present?
+
+    if response.blank?
+      with_deadlock_retry { point.update!(reverse_geocoded_at: Time.current) }
+      return
+    end
+
+    return if response.data['error'].present?
 
     country_record = Country.find_by(name: response.country) if response.country
 

--- a/spec/regressions/blank_geocoder_response_marks_point_as_attempted_spec.rb
+++ b/spec/regressions/blank_geocoder_response_marks_point_as_attempted_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Blank geocoder response marks the point as attempted' do
+  subject(:fetch_data) { ReverseGeocoding::Points::FetchData.new(point.id).call }
+
+  let(:point) { create(:point) }
+
+  context 'when Geocoder returns no results (e.g. point over the ocean)' do
+    before { allow(Geocoder).to receive(:search).and_return([]) }
+
+    it 'sets reverse_geocoded_at so the point is not re-queued forever' do
+      expect { fetch_data }.to change { point.reload.reverse_geocoded_at }.from(nil)
+    end
+
+    it 'removes the point from the not_reverse_geocoded scope' do
+      fetch_data
+      expect(Point.not_reverse_geocoded).not_to include(point.reload)
+    end
+
+    it 'leaves city, country_id, and geodata empty' do
+      fetch_data
+      point.reload
+      expect(point.city).to be_blank
+      expect(point.country_id).to be_nil
+      expect(point.geodata).to eq({})
+    end
+  end
+
+  context 'when Geocoder returns a result with an error field' do
+    before do
+      allow(Geocoder).to receive(:search).and_return(
+        [double(city: nil, country: nil, data: { 'error' => 'boom' })]
+      )
+    end
+
+    it 'does not mark the point as attempted, so it stays eligible for retry' do
+      expect { fetch_data }.not_to(change { point.reload.reverse_geocoded_at })
+      expect(Point.not_reverse_geocoded).to include(point.reload)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes [#2271](https://github.com/Freika/dawarich/issues/2271) — points in oceans / wilderness with no geocoder result were re-enqueued every night by the nightly reverse-geocoding job, looping forever and hammering Photon.

## Root cause

`ReverseGeocoding::Points::FetchData#update_point_with_geocoding_data` returned early when `response.blank?` (the legitimate \"no result\" case) without setting `reverse_geocoded_at`. The point stayed in the `not_reverse_geocoded` scope and the nightly job kept retrying.

## Fix

Set `reverse_geocoded_at` on the empty-result branch so the point exits the `not_reverse_geocoded` scope and isn't re-tried on the next nightly run.

## Test plan

- [x] Regression spec: `spec/regressions/blank_geocoder_response_marks_point_as_attempted_spec.rb`
- [ ] Confirm nightly job no longer re-enqueues ocean points after a single attempt

Closes #2271