### PR TITLE
Stage 2: enforce places.user_id NOT NULL after stage 1 backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - "Re-run detection on full history" button under Settings → Visits. Confirmed visits and named places are preserved.
 - Account lockout after 10 failed 2FA attempts (30-minute auto-unlock or password reset). Applies to both the mobile API (`POST /api/v1/auth/otp_challenge`) and the web sign-in flow. Backup codes still work during a lockout so users with one stored can recover immediately. A notification email is sent to the account owner when a lockout is triggered. #2575
 
+### Changed
+
+- Places are now strictly per-user. Suggestion, photo-geotagging, and reverse-geocoding all use your own place catalogue exclusively; no places are shared across users. Existing shared places have been backfilled to their most-active owner. Self-hosted single-user instances see no behaviour change.
+- Internal: `places.user_id` is now NOT NULL at the database level, completing the per-user ownership migration. No user-visible effect.
+
 ### Fixed
 
 - Fix support of FIT files from Garmin Connect. #2686

--- a/app/services/reverse_geocoding/places/fetch_data.rb
+++ b/app/services/reverse_geocoding/places/fetch_data.rb
@@ -142,17 +142,18 @@ class ReverseGeocoding::Places::FetchData
 
     return unless places_to_update.any?
 
-    update_attributes = places_to_update.uniq(&:id).map do |place|
+    update_attributes = places_to_update.uniq(&:id).map do |existing|
       {
-        id: place.id,
-        name: place.name,
-        latitude: place.latitude,
-        longitude: place.longitude,
-        lonlat: place.lonlat,
-        city: place.city,
-        country: place.country,
-        geodata: place.geodata,
-        source: place.source,
+        id: existing.id,
+        user_id: existing.user_id,
+        name: existing.name,
+        latitude: existing.latitude,
+        longitude: existing.longitude,
+        lonlat: existing.lonlat,
+        city: existing.city,
+        country: existing.country,
+        geodata: existing.geodata,
+        source: existing.source,
         updated_at: Time.current
       }
     end

--- a/db/migrate/20260508102340_add_places_user_id_not_null_check.rb
+++ b/db/migrate/20260508102340_add_places_user_id_not_null_check.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddPlacesUserIdNotNullCheck < ActiveRecord::Migration[8.0]
+  def change
+    add_check_constraint :places, 'user_id IS NOT NULL',
+                         name: 'places_user_id_null', validate: false, if_not_exists: true
+  end
+end

--- a/db/migrate/20260508102341_validate_places_user_id_not_null.rb
+++ b/db/migrate/20260508102341_validate_places_user_id_not_null.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class ValidatePlacesUserIdNotNull < ActiveRecord::Migration[8.0]
+  CONSTRAINT_NAME = 'places_user_id_null'
+
+  def up
+    validate_check_constraint :places, name: CONSTRAINT_NAME if check_constraint_exists?
+    change_column_null :places, :user_id, false unless column_not_null?
+    remove_check_constraint :places, name: CONSTRAINT_NAME, if_exists: true
+  end
+
+  def down
+    add_check_constraint :places, 'user_id IS NOT NULL',
+                         name: CONSTRAINT_NAME, validate: false, if_not_exists: true
+    change_column_null :places, :user_id, true if column_not_null?
+  end
+
+  private
+
+  def check_constraint_exists?
+    connection.select_value(<<~SQL).to_i.positive?
+      SELECT COUNT(*) FROM pg_constraint
+      WHERE conname = '#{CONSTRAINT_NAME}' AND conrelid = 'places'::regclass
+    SQL
+  end
+
+  def column_not_null?
+    connection.select_value(<<~SQL) == 'NO'
+      SELECT is_nullable FROM information_schema.columns
+      WHERE table_name = 'places' AND column_name = 'user_id'
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -242,7 +242,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_14_120100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.geography "lonlat", limit: {srid: 4326, type: "st_point", geographic: true}
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.text "note"
     t.index "(((geodata -> 'properties'::text) ->> 'osm_id'::text))", name: "index_places_on_geodata_osm_id"
     t.index ["lonlat"], name: "index_places_on_lonlat", using: :gist

--- a/spec/services/reverse_geocoding/places/fetch_data_spec.rb
+++ b/spec/services/reverse_geocoding/places/fetch_data_spec.rb
@@ -417,7 +417,7 @@ RSpec.describe ReverseGeocoding::Places::FetchData do
     describe '#save_places' do
       it 'saves new places when places_to_create is present' do
         place # Ensure place exists
-        new_place = build(:place)
+        new_place = build(:place, user: place.user)
         places_to_create = [new_place]
         places_to_update = []
 
@@ -426,7 +426,7 @@ RSpec.describe ReverseGeocoding::Places::FetchData do
       end
 
       it 'saves updated places when places_to_update is present' do
-        existing_place = create(:place, name: 'Old Name')
+        existing_place = create(:place, user: place.user, name: 'Old Name')
         existing_place.name = 'New Name'
         places_to_create = []
         places_to_update = [existing_place]
@@ -441,7 +441,7 @@ RSpec.describe ReverseGeocoding::Places::FetchData do
       end
 
       context 'when a deadlock occurs' do
-        let(:new_place) { build(:place) }
+        let(:new_place) { build(:place, user: place.user) }
 
         it 'retries on ActiveRecord::Deadlocked and succeeds' do
           call_count = 0

--- a/spec/services/visits/creator_spec.rb
+++ b/spec/services/visits/creator_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Visits::Creator do
     context 'when a confirmed visit already exists at the same location' do
       let(:place) do
         create(:place, lonlat: 'POINT(-74.0060 40.7128)', name: 'Existing Place',
-                      latitude: 40.7128, longitude: -74.0060, user_id: nil)
+                      latitude: 40.7128, longitude: -74.0060, user: user)
       end
       let!(:existing_visit) do
         create(
@@ -79,7 +79,7 @@ RSpec.describe Visits::Creator do
         create(
           :place,
           lonlat: 'POINT(-74.0060 40.7128)', name: 'Existing Place',
-          latitude: 40.7128, longitude: -74.0060, user_id: nil
+          latitude: 40.7128, longitude: -74.0060, user: user
         )
       end
       let!(:existing_visit) do
@@ -108,7 +108,7 @@ RSpec.describe Visits::Creator do
         create(
           :place,
           lonlat: 'POINT(-74.0060 40.7128)', name: 'Existing Place',
-          latitude: 40.7128, longitude: -74.0060, user_id: nil
+          latitude: 40.7128, longitude: -74.0060, user: user
         )
       end
       let!(:existing_visit) do
@@ -139,7 +139,7 @@ RSpec.describe Visits::Creator do
         create(
           :place,
           lonlat: 'POINT(-74.0060 40.7128)', name: 'Existing Place',
-          latitude: 40.7128, longitude: -74.0060, user_id: nil
+          latitude: 40.7128, longitude: -74.0060, user: user
         )
       end
       let!(:existing_visit) do
@@ -200,7 +200,7 @@ RSpec.describe Visits::Creator do
           name: 'New York Place',
           latitude: 40.7128,
           longitude: -74.0060,
-          user_id: nil
+          user: user
         )
       end
       let(:area) do # Berlin


### PR DESCRIPTION
## Summary

**Stage 2 of the places user-ownership migration. DO NOT MERGE until stage 1 (`fix/place-user-ownership-closure`) has shipped to production and the backfill migration has completed across all environments.**

This stage:
- Adds the `NOT NULL` check on `places.user_id` (NOT VALID first, then validate)
- Adds the explicit `validates :user_id, presence: true` on the `Place` model

## Files

- `db/migrate/...add_places_user_id_not_null_check.rb`
- `db/migrate/...validate_places_user_id_not_null.rb`
- `app/models/place.rb`

## Sequencing

1. Stage 1 ships and runs the backfill migration
2. Verify `Place.where(user_id: nil).count == 0` on prod
3. Merge this PR

If stage 2 ships before the backfill finishes, the validation migration will fail on rows that haven't been backfilled.

## Test plan

- [ ] On a database where backfill has run cleanly, validation succeeds
- [ ] Model rejects unsaved Place records with no `user_id`