### PR TITLE
Enhanced import flow with per-import extraction and detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Imports of Google Takeout (phone takeout, Semantic Location History) and Polarsteps now optionally extract **visits**, **named places**, **tracks**, and the source app's **transportation-mode classification** (driving, walking, cycling, transit, …) in addition to raw GPS points. Frequent places named by Google Takeout (Home, Work, etc.) are imported as Place records with their original names. Open an import in the Imports list and click **Extract additional data** to add this to existing imports; new imports run extraction automatically. Untick **Trust the source app's classification** in the Extract dialog to have Dawarich re-detect transportation modes using your settings. Existing visits detected by Dawarich's smart detection are kept side-by-side with the imported ones. Changed your mind? **Remove extracted data** on the same import deletes everything the extraction added and leaves your imported GPS points untouched.
+
 ### Changed
 
 - Ordering a printed poster from the Poster Studio is now available to everyone, instead of sitting behind a feature flag that was off by default. An instance that would rather not offer it can switch the `poster_ordering` flag off at `/admin/flipper`, or leave `PRINT_ORDER_URL` blank.

--- a/app/controllers/imports/extractions_controller.rb
+++ b/app/controllers/imports/extractions_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Imports
+  class ExtractionsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_import
+
+    def create
+      authorize @import, policy_class: Imports::ExtractionPolicy
+
+      trust_source = ActiveModel::Type::Boolean.new.cast(params.fetch(:trust_source, true))
+      payload = @import.additional_data_extraction.merge(
+        'options' => { 'trust_source' => trust_source },
+        'started_at' => Time.current.iso8601
+      )
+
+      @import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:pending],
+        additional_data_extraction: payload
+      )
+
+      EnhancedImport::ExtractJob.perform_later(@import.id)
+
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to import_path(@import), notice: 'Extraction queued.' }
+      end
+    end
+
+    def destroy
+      authorize @import, policy_class: Imports::ExtractionPolicy
+
+      @import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:running],
+        additional_data_extraction: @import.additional_data_extraction.merge('started_at' => Time.current.iso8601)
+      )
+
+      EnhancedImport::DestroyJob.perform_later(@import.id)
+
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to import_path(@import), notice: 'Removing extracted data…' }
+      end
+    end
+
+    private
+
+    def set_import
+      @import = Import.find(params[:import_id])
+    end
+  end
+end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -17,7 +17,8 @@ class ImportsController < ApplicationController
 
   def index
     scope = policy_scope(Import)
-            .select(:id, :name, :source, :created_at, :updated_at, :processed, :doubles, :status, :error_message, :demo)
+            .select(:id, :name, :source, :created_at, :updated_at, :processed, :doubles, :status, :error_message, :demo,
+                    :additional_data_extraction_status)
             .with_attached_file
 
     @imports = sorted(scope).page(params[:page])

--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -15,6 +15,25 @@ module ImportsHelper
     'user_data_archive'      => { css: 'bg-base-200 text-base-content/50', icon: 'file-up' }
   }.freeze
 
+  EXTRACTION_STATUS_BADGES = {
+    'not_attempted' => { label: 'Not extracted', css: 'badge-ghost' },
+    'pending'       => { label: 'Queued',        css: 'badge-info' },
+    'running'       => { label: 'Extracting',    css: 'badge-info gap-1', spinner: true },
+    'completed'     => { label: 'Extracted',     css: 'badge-success' },
+    'failed'        => { label: 'Failed',        css: 'badge-error' },
+    'unsupported'   => { label: 'Not available', css: 'badge-ghost' }
+  }.freeze
+
+  def extraction_status_badge(import)
+    badge = EXTRACTION_STATUS_BADGES[import.additional_data_extraction_status]
+    return if badge.nil?
+
+    tag.span(class: "badge badge-sm #{badge[:css]}") do
+      concat(tag.span(nil, class: 'loading loading-dots loading-xs shrink-0')) if badge[:spinner]
+      concat(badge[:label])
+    end
+  end
+
   def import_source_icon_class(source)
     SOURCE_STYLES.dig(source, :css) || 'bg-base-200 text-base-content/50'
   end

--- a/app/javascript/controllers/import_extraction_controller.js
+++ b/app/javascript/controllers/import_extraction_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { dialogId: String }
+
+  open() {
+    const dialog = document.getElementById(this.dialogIdValue)
+    if (dialog && typeof dialog.showModal === "function") {
+      dialog.showModal()
+    }
+  }
+
+  close(event) {
+    const id = event.params?.dialogId || this.dialogIdValue
+    const dialog = document.getElementById(id)
+    if (dialog && typeof dialog.close === "function") {
+      dialog.close()
+    }
+  }
+}

--- a/app/jobs/enhanced_import/destroy_job.rb
+++ b/app/jobs/enhanced_import/destroy_job.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  class DestroyJob < ApplicationJob
+    queue_as :extractions
+
+    def perform(import_id)
+      import = Import.find_by(id: import_id)
+      return if import.nil?
+
+      EnhancedImport::Destroy.new(import).call
+      broadcast_card(import)
+    rescue StandardError => e
+      # The controller parks the import in `running`; without this it would
+      # spin forever with no way for the user to retry.
+      import&.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:failed],
+        additional_data_extraction: (import.additional_data_extraction || {}).merge(
+          'error_message' => "Removing extracted data failed: #{e.message}"
+        )
+      )
+      broadcast_card(import) if import
+      ExceptionReporter.call(e, 'Failed to remove extracted import data')
+      raise
+    end
+
+    private
+
+    def broadcast_card(import)
+      Turbo::StreamsChannel.broadcast_replace_to(
+        "import_#{import.id}_extraction",
+        target: "import-#{import.id}-extraction",
+        partial: 'imports/extraction_card',
+        locals: { import: import.reload }
+      )
+    rescue StandardError => e
+      Rails.logger.warn("[EnhancedImport::DestroyJob] card broadcast failed import_id=#{import.id}: #{e.message}")
+    end
+  end
+end

--- a/app/jobs/enhanced_import/extract_job.rb
+++ b/app/jobs/enhanced_import/extract_job.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  class ExtractJob < ApplicationJob
+    queue_as :extractions
+
+    def perform(import_id)
+      import = Import.find_by(id: import_id)
+      return if import.nil?
+
+      return unless EnhancedImport::Translator.supported?(import.source)
+
+      run(import)
+    rescue ActiveRecord::RecordNotFound => e
+      ExceptionReporter.call(e)
+    end
+
+    private
+
+    # Import completion schedules track generation too, and both claim the same
+    # untracked points. The generator already serialises on this lock.
+    def run(import)
+      mark_running!(import)
+
+      counts = Tracks::PerUserLock.with_user_lock(import.user_id) do
+        process_stream(import)
+      end
+
+      mark_completed!(import, counts)
+    rescue Tracks::PerUserLock::AcquisitionTimeout
+      # Sibling imports from one archive all finish together; wait our turn
+      # rather than surfacing a red card the user can do nothing about.
+      requeue(import)
+    rescue StandardError => e
+      mark_failed!(import, e)
+      ExceptionReporter.call(e)
+      raise
+    end
+
+    def requeue(import)
+      import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:pending],
+        additional_data_extraction: import.additional_data_extraction.merge('started_at' => Time.current.iso8601)
+      )
+      self.class.set(wait: 1.minute).perform_later(import.id)
+    end
+
+    def process_stream(import)
+      counts = Hash.new(0)
+      user = import.user
+      place_writer = Writers::PlaceWriter.new(user, import)
+      visit_writer = Writers::VisitWriter.new(user, import)
+      track_writer = Writers::TrackWriter.new(user, import)
+      segment_writer = Writers::SegmentWriter.new
+
+      EnhancedImport::Translator.new(import).translate do |item|
+        case item
+        when Extracted::Place
+          place, = place_writer.upsert(item)
+          counts[:places] += 1 if place
+        when Extracted::Visit
+          place, = place_writer.upsert(item.place)
+          counts[:places] += 1 if place
+          visit, = visit_writer.upsert(item, place)
+          counts[:visits] += 1 if visit
+        when Extracted::Track
+          source_segments_take_over = trust_source?(import) && item.segments.any?
+          track, = track_writer.upsert(
+            item,
+            skip_segment_detection: source_segments_take_over
+          )
+          counts[:tracks] += 1 if track
+          if track && source_segments_take_over
+            item.segments.each do |segment|
+              written_segment, = segment_writer.upsert(track, segment)
+              counts[:segments] += 1 if written_segment
+            end
+            track.update_dominant_mode!
+          end
+        end
+      end
+
+      counts
+    end
+
+    def trust_source?(import)
+      import.additional_data_extraction.fetch('options', {}).fetch('trust_source', true)
+    end
+
+    def broadcast_card(import)
+      Turbo::StreamsChannel.broadcast_replace_to(
+        "import_#{import.id}_extraction",
+        target: "import-#{import.id}-extraction",
+        partial: 'imports/extraction_card',
+        locals: { import: import.reload }
+      )
+    rescue StandardError => e
+      Rails.logger.warn("[EnhancedImport::ExtractJob] card broadcast failed import_id=#{import.id}: #{e.message}")
+    end
+
+    def mark_running!(import)
+      payload = import.additional_data_extraction.merge(
+        'started_at' => Time.current.iso8601,
+        'completed_at' => nil,
+        'error_message' => nil
+      )
+      import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:running],
+        additional_data_extraction: payload
+      )
+      broadcast_card(import)
+    end
+
+    def mark_completed!(import, counts)
+      payload = import.additional_data_extraction.merge(
+        'completed_at' => Time.current.iso8601,
+        'counts' => counts.transform_keys(&:to_s),
+        'error_message' => nil
+      )
+      import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:completed],
+        additional_data_extraction: payload
+      )
+      broadcast_card(import)
+    end
+
+    def mark_failed!(import, error)
+      payload = import.additional_data_extraction.merge(
+        'completed_at' => Time.current.iso8601,
+        'error_message' => error.message
+      )
+      import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:failed],
+        additional_data_extraction: payload
+      )
+      broadcast_card(import)
+    end
+  end
+end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -3,11 +3,16 @@
 class Import < ApplicationRecord
   belongs_to :user
   has_many :points, dependent: :destroy
+  has_many :extracted_visits, class_name: 'Visit', dependent: :nullify
+  has_many :extracted_places, class_name: 'Place', dependent: :nullify
+  has_many :extracted_tracks, class_name: 'Track', dependent: :nullify
 
   has_one_attached :file
 
   # Flag to skip background processing during user data import
   attr_accessor :skip_background_processing
+
+  before_save :resolve_additional_data_extraction_availability
 
   after_commit -> { Import::ProcessJob.perform_later(id) unless skip_background_processing }, on: :create
   after_commit :remove_attached_file, on: :destroy
@@ -27,6 +32,18 @@ class Import < ApplicationRecord
     user_data_archive: 8, kml: 9,
     csv: 10, tcx: 11, fit: 12, polarsteps: 13, google_photos: 14
   }, allow_nil: true
+
+  enum :additional_data_extraction_status, {
+    not_attempted: 0,
+    pending: 1,
+    running: 2,
+    completed: 3,
+    failed: 4,
+    unsupported: 5
+  }, prefix: :additional_data_extraction
+
+  after_commit :enqueue_additional_data_extraction, on: :update,
+               if: :should_enqueue_additional_data_extraction?
 
   def process!
     if user_data_archive?
@@ -60,6 +77,41 @@ class Import < ApplicationRecord
     raw_file = File.new(raw_data)
 
     file.attach(io: raw_file, filename: name, content_type: 'application/json')
+  end
+
+  def additional_data_extraction_supported?
+    EnhancedImport::Translator.supported?(source)
+  end
+
+  def extraction_counts
+    additional_data_extraction.fetch('counts', {}).transform_keys(&:to_sym)
+  end
+
+  def extraction_error_message
+    additional_data_extraction['error_message']
+  end
+
+  # Sidekiq loses in-flight jobs on SIGKILL, so an extraction that never
+  # reported back stops counting as running after this window.
+  EXTRACTION_STALE_AFTER = 6.hours
+
+  def extraction_in_flight?
+    additional_data_extraction_pending? || additional_data_extraction_running?
+  end
+
+  def extraction_stalled?
+    return false unless extraction_in_flight?
+
+    started_at = additional_data_extraction['started_at']
+    return false if started_at.blank?
+
+    Time.zone.parse(started_at.to_s) <= EXTRACTION_STALE_AFTER.ago
+  rescue ArgumentError, TypeError
+    false
+  end
+
+  def trust_source_for_extraction?
+    additional_data_extraction.dig('options', 'trust_source') != false
   end
 
   private
@@ -97,5 +149,36 @@ class Import < ApplicationRecord
     years_and_months_tracked.each do |year, month|
       Stats::CalculatingJob.perform_later(user.id, year, month)
     end
+  end
+
+  # Uploads are created before their source is detected, so availability has to
+  # settle in both directions: only the two "nothing has happened yet" states
+  # are ever rewritten, never a finished or in-flight extraction.
+  def resolve_additional_data_extraction_availability
+    if additional_data_extraction_supported?
+      return unless additional_data_extraction_unsupported?
+
+      self.additional_data_extraction_status = :not_attempted
+    else
+      return unless additional_data_extraction_not_attempted?
+
+      self.additional_data_extraction_status = :unsupported
+    end
+  end
+
+  def should_enqueue_additional_data_extraction?
+    return false unless saved_change_to_status? && completed?
+    return false unless additional_data_extraction_supported?
+    return false unless additional_data_extraction_not_attempted?
+
+    true
+  end
+
+  def enqueue_additional_data_extraction
+    update_columns(
+      additional_data_extraction_status: Import.additional_data_extraction_statuses[:pending],
+      additional_data_extraction: additional_data_extraction.merge('started_at' => Time.current.iso8601)
+    )
+    EnhancedImport::ExtractJob.perform_later(id)
   end
 end

--- a/app/policies/imports/extraction_policy.rb
+++ b/app/policies/imports/extraction_policy.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Imports
+  class ExtractionPolicy < ApplicationPolicy
+    def create?
+      user.present? &&
+        record.user == user &&
+        record.additional_data_extraction_supported? &&
+        !in_flight?
+    end
+
+    def destroy?
+      user.present? &&
+        record.user == user &&
+        record.additional_data_extraction_supported? &&
+        !in_flight? &&
+        !record.additional_data_extraction_not_attempted?
+    end
+
+    private
+
+    # A second job would rebuild segments underneath the one already running,
+    # unless that run has gone stale and will never report back.
+    def in_flight?
+      record.extraction_in_flight? && !record.extraction_stalled?
+    end
+  end
+end

--- a/app/services/enhanced_import/adapters/base_adapter.rb
+++ b/app/services/enhanced_import/adapters/base_adapter.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Adapters
+    class BaseAdapter
+      include Imports::FileLoader
+
+      attr_reader :import, :file_path
+
+      def initialize(import, file_path = nil)
+        @import = import
+        @file_path = file_path
+      end
+
+      def translate(&)
+        raise NotImplementedError
+      end
+
+      protected
+
+      # Large exports must never be read into memory whole; hand the caller an
+      # IO over a local copy and clean the copy up afterwards. A single-entry
+      # archive stays attached as the zip, so unwrap it before parsing.
+      def stream_file(&block)
+        path = unwrapped_path(resolve_file_path)
+        File.open(path, 'rb', &block)
+      ensure
+        File.delete(@unwrapped_path) if @unwrapped_path && File.exist?(@unwrapped_path)
+        cleanup_temp_file
+      end
+
+      # Same unwrapping for the adapters that parse the document whole.
+      def load_json_data
+        stream_file { |io| Oj.load(scrub_to_utf8(io.read), mode: :compat) }
+      end
+
+      def unwrapped_path(path)
+        return path unless zip?(path)
+
+        @unwrapped_path = Archive::Unzipper.extract_single(path)
+      end
+
+      def zip?(path)
+        File.open(path, 'rb') { |io| io.read(4) } == "PK\x03\x04".b
+      rescue StandardError
+        false
+      end
+
+      def parse_lat_lng(latlng_string)
+        return nil if latlng_string.blank?
+
+        cleaned = latlng_string.to_s.gsub('°', '').gsub('°', '').strip
+        parts = cleaned.split(/,\s*/)
+        return nil if parts.size < 2
+
+        [parts[0].to_f, parts[1].to_f]
+      end
+
+      def parse_e7(value)
+        return nil if value.nil?
+
+        value.to_f / 10**7
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/adapters/google_phone_takeout_adapter.rb
+++ b/app/services/enhanced_import/adapters/google_phone_takeout_adapter.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Adapters
+    class GooglePhoneTakeoutAdapter < BaseAdapter
+      SOURCE_LABEL = 'google_phone_takeout'
+
+      # Timeline.json runs to hundreds of megabytes; the point importer streams it
+      # for that reason and so does this, rather than materialising the whole
+      # object graph in a Sidekiq worker.
+      def translate(&block)
+        return enum_for(:translate) unless block_given?
+
+        profile = nil
+
+        handler = GoogleMaps::PhoneTakeoutStreamHandler.new(
+          on_entry: ->(section, value) { emit_segment(section, value, &block) },
+          on_profile: ->(value) { profile = value }
+        )
+
+        stream_file { |io| Oj.saj_parse(handler, io) }
+
+        Array(profile&.dig('frequentPlaces')).each do |place|
+          extracted_place = build_frequent_place(place)
+          yield extracted_place if extracted_place
+        end
+      end
+
+      private
+
+      def emit_segment(section, value)
+        return unless section == :semantic_segment
+        return unless value.is_a?(Hash)
+
+        visit = build_visit(value)
+        yield visit if visit
+
+        track = build_track(value)
+        yield track if track
+      end
+
+      include Imports::ActivityTypeMapping
+
+      def build_track(segment)
+        activity = segment['activity']
+        return nil if activity.blank?
+
+        candidate = activity['topCandidate']
+        mode = candidate ? map_activity_type(candidate['type']) : nil
+        return nil if mode.blank?
+
+        started_at = parse_time(segment['startTime'])
+        ended_at   = parse_time(segment['endTime'])
+        return nil if started_at.nil? || ended_at.nil?
+
+        Extracted::Track.new(
+          tracker_id: "import-#{import.id}-activity-#{started_at.to_i}",
+          start_at: started_at,
+          end_at: ended_at,
+          distance_m: activity['distanceMeters']&.to_i,
+          transportation_mode: mode,
+          confidence: candidate['probability'],
+          source_label: SOURCE_LABEL,
+          segments: [
+            Extracted::TrackSegment.new(
+              start_index: 0,
+              end_index: 0,
+              transportation_mode: mode,
+              confidence: candidate['probability'],
+              source_label: SOURCE_LABEL
+            )
+          ]
+        )
+      end
+
+      def build_visit(segment)
+        candidate = segment.dig('visit', 'topCandidate')
+        return nil if candidate.blank?
+
+        coords = parse_lat_lng(candidate.dig('placeLocation', 'latLng'))
+        return nil if coords.nil?
+
+        started_at = parse_time(segment['startTime'])
+        ended_at   = parse_time(segment['endTime'])
+        return nil if started_at.nil? || ended_at.nil?
+
+        place = Extracted::Place.new(
+          external_place_id: "google:#{candidate['placeId']}",
+          name: humanize_semantic_type(candidate['semanticType']) || 'Unknown',
+          latitude: coords[0],
+          longitude: coords[1],
+          semantic_type: candidate['semanticType']
+        )
+
+        Extracted::Visit.new(
+          started_at: started_at,
+          ended_at: ended_at,
+          place: place,
+          name: place.name,
+          confidence: candidate['probability'],
+          source_label: SOURCE_LABEL
+        )
+      end
+
+      def parse_time(value)
+        return nil if value.blank?
+
+        Time.zone.parse(value)
+      rescue ArgumentError
+        nil
+      end
+
+      def humanize_semantic_type(type)
+        return nil if type.blank?
+
+        type.to_s.sub(/^TYPE_/, '').sub(/^INFERRED_/, '').tr('_', ' ').titleize
+      end
+
+      def build_frequent_place(place)
+        return nil if place.blank?
+        return nil if place['placeId'].blank?
+
+        coords = parse_lat_lng(place['placeLocation']) || parse_e7_pair(place)
+        return nil if coords.nil?
+
+        Extracted::Place.new(
+          external_place_id: "google:#{place['placeId']}",
+          name: place['label'].presence || place['name'].presence || 'Frequent place',
+          latitude: coords[0],
+          longitude: coords[1],
+          semantic_type: place['semanticType'] || 'FREQUENT_PLACE'
+        )
+      end
+
+      def parse_e7_pair(place)
+        latitude  = parse_e7(place['latitudeE7'])
+        longitude = parse_e7(place['longitudeE7'])
+        return nil if latitude.nil? || longitude.nil?
+
+        [latitude, longitude]
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/adapters/google_records_adapter.rb
+++ b/app/services/enhanced_import/adapters/google_records_adapter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Adapters
+    class GoogleRecordsAdapter < BaseAdapter
+      def translate
+        enum_for(:translate) unless block_given?
+
+        # Records.json carries no visit / track / place metadata.
+        # Wave 3 (per-point activity hints) writes into points.motion_data
+        # at point-import time, not here.
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/adapters/google_semantic_history_adapter.rb
+++ b/app/services/enhanced_import/adapters/google_semantic_history_adapter.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Adapters
+    class GoogleSemanticHistoryAdapter < BaseAdapter
+      SOURCE_LABEL = 'google_semantic_history'
+
+      def translate
+        return enum_for(:translate) unless block_given?
+
+        json = load_json_data
+        Array(json['timelineObjects']).each do |obj|
+          if obj['placeVisit']
+            visit = build_visit(obj['placeVisit'])
+            yield visit if visit
+          elsif obj['activitySegment']
+            track = build_track(obj['activitySegment'])
+            yield track if track
+          end
+        end
+      end
+
+      private
+
+      include Imports::ActivityTypeMapping
+
+      def build_track(activity)
+        mode = map_activity_type(activity['activityType'])
+        return nil if mode.blank?
+
+        duration = activity['duration'] || {}
+        started_at = parse_time(duration['startTimestamp'])
+        ended_at   = parse_time(duration['endTimestamp'])
+        return nil if started_at.nil? || ended_at.nil?
+
+        Extracted::Track.new(
+          tracker_id: "import-#{import.id}-activity-#{started_at.to_i}",
+          start_at: started_at,
+          end_at: ended_at,
+          distance_m: activity['distance']&.to_i,
+          transportation_mode: mode,
+          confidence: activity['confidence'],
+          source_label: SOURCE_LABEL,
+          segments: [
+            Extracted::TrackSegment.new(
+              start_index: 0,
+              end_index: 0,
+              transportation_mode: mode,
+              confidence: activity['confidence'],
+              source_label: SOURCE_LABEL
+            )
+          ]
+        )
+      end
+
+      def build_visit(place_visit)
+        location = place_visit['location']
+        return nil if location.blank?
+        return nil if location['placeId'].blank?
+
+        latitude  = parse_e7(location['latitudeE7'])
+        longitude = parse_e7(location['longitudeE7'])
+        return nil if latitude.nil? || longitude.nil?
+
+        started_at = parse_time(place_visit.dig('duration', 'startTimestamp'))
+        ended_at   = parse_time(place_visit.dig('duration', 'endTimestamp'))
+        return nil if started_at.nil? || ended_at.nil?
+
+        place = Extracted::Place.new(
+          external_place_id: "google:#{location['placeId']}",
+          name: location['name'].presence || humanize_semantic_type(location['semanticType']) || 'Unknown',
+          latitude: latitude,
+          longitude: longitude,
+          semantic_type: location['semanticType']
+        )
+
+        Extracted::Visit.new(
+          started_at: started_at,
+          ended_at: ended_at,
+          place: place,
+          name: place.name,
+          confidence: place_visit['visitConfidence'],
+          source_label: SOURCE_LABEL
+        )
+      end
+
+      def parse_time(value)
+        return nil if value.blank?
+
+        Time.zone.parse(value)
+      rescue ArgumentError
+        nil
+      end
+
+      def humanize_semantic_type(type)
+        return nil if type.blank?
+
+        type.to_s.sub(/^TYPE_/, '').sub(/^INFERRED_/, '').tr('_', ' ').titleize
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/adapters/polarsteps_adapter.rb
+++ b/app/services/enhanced_import/adapters/polarsteps_adapter.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Adapters
+    class PolarstepsAdapter < BaseAdapter
+      SOURCE_LABEL = 'polarsteps'
+
+      def translate
+        return enum_for(:translate) unless block_given?
+
+        steps(load_json_data).each do |step|
+          next unless step.is_a?(Hash)
+
+          visit = build_visit(step)
+          yield visit if visit
+        end
+      end
+
+      private
+
+      # Polarsteps exports either a {"locations": [...]} GPS trail, which carries
+      # no visit metadata at all, or a bare array of steps with arrival and
+      # departure times. Only the latter describes visits.
+      def steps(json)
+        return json if json.is_a?(Array)
+        return Array(json['steps']) if json.is_a?(Hash) && json['steps'].is_a?(Array)
+
+        []
+      end
+
+      def build_visit(step)
+        location = step['location']
+        location = step if location.blank? && step['lat']
+        return nil if location.blank?
+
+        latitude  = location['lat']&.to_f
+        longitude = (location['lon'] || location['lng'])&.to_f
+        return nil if latitude.nil? || longitude.nil?
+
+        started_at = parse_unix(step['arrived'] || step['start_time'])
+        ended_at   = parse_unix(step['departed'] || step['end_time'])
+        return nil if started_at.nil? || ended_at.nil?
+
+        place_name = step['display_name'].presence || step['name'].presence || location['detail'].presence || 'Unknown'
+
+        place = Extracted::Place.new(
+          external_place_id: "polarsteps:#{step['id']}",
+          name: place_name,
+          latitude: latitude,
+          longitude: longitude,
+          semantic_type: 'polarsteps_step'
+        )
+
+        Extracted::Visit.new(
+          started_at: started_at,
+          ended_at: ended_at,
+          place: place,
+          name: place_name,
+          confidence: nil,
+          source_label: SOURCE_LABEL
+        )
+      end
+
+      def parse_unix(value)
+        return nil if value.blank?
+
+        Time.zone.at(value.to_i)
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/destroy.rb
+++ b/app/services/enhanced_import/destroy.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  class Destroy
+    attr_reader :import
+
+    def initialize(import)
+      @import = import
+    end
+
+    BATCH_SIZE = 500
+
+    def call
+      place_ids = extracted_place_ids
+
+      destroy_in_batches(owned(Visit))
+      destroy_in_batches(owned(Track))
+      destroy_orphaned_places(place_ids)
+
+      reset_extraction_state
+
+      true
+    end
+
+    private
+
+    def owned(klass)
+      klass.where(user_id: import.user_id, import_id: import.id)
+    end
+
+    def extracted_place_ids
+      owned(Place).pluck(:id)
+    end
+
+    # Places outlive their extraction when Dawarich's own detection later
+    # attached a visit to them; dropping those would strand a visit the user
+    # never imported.
+    def destroy_orphaned_places(place_ids)
+      return if place_ids.empty?
+
+      still_referenced = Visit.where(place_id: place_ids).distinct.pluck(:place_id)
+      destroy_in_batches(Place.where(user_id: import.user_id, id: place_ids - still_referenced))
+    end
+
+    # One transaction per batch: a multi-thousand-visit undo must not hold a
+    # single long write transaction on a production database.
+    def destroy_in_batches(relation)
+      relation.in_batches(of: BATCH_SIZE) do |batch|
+        ActiveRecord::Base.transaction { batch.each(&:destroy) }
+      end
+    end
+
+    def reset_extraction_state
+      import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:not_attempted],
+        additional_data_extraction: {}
+      )
+    end
+  end
+end

--- a/app/services/enhanced_import/extracted/place.rb
+++ b/app/services/enhanced_import/extracted/place.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Extracted
+    Place = Data.define(
+      :external_place_id,
+      :name,
+      :latitude,
+      :longitude,
+      :semantic_type,
+      :geodata_extras
+    ) do
+      def initialize(external_place_id:, name:, latitude:, longitude:, semantic_type: nil, geodata_extras: {})
+        super
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/extracted/track.rb
+++ b/app/services/enhanced_import/extracted/track.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Extracted
+    Track = Data.define(
+      :tracker_id,
+      :start_at,
+      :end_at,
+      :distance_m,
+      :transportation_mode,
+      :confidence,
+      :source_label,
+      :segments
+    ) do
+      def initialize(tracker_id:, start_at:, end_at:, distance_m: nil,
+                     transportation_mode: nil, confidence: nil,
+                     source_label: nil, segments: [])
+        super
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/extracted/track_segment.rb
+++ b/app/services/enhanced_import/extracted/track_segment.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Extracted
+    TrackSegment = Data.define(
+      :start_index,
+      :end_index,
+      :transportation_mode,
+      :confidence,
+      :source_label
+    ) do
+      def initialize(start_index:, end_index:, transportation_mode:, confidence: nil, source_label: nil)
+        super
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/extracted/visit.rb
+++ b/app/services/enhanced_import/extracted/visit.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Extracted
+    Visit = Data.define(
+      :started_at,
+      :ended_at,
+      :place,
+      :name,
+      :confidence,
+      :source_label
+    ) do
+      def initialize(started_at:, ended_at:, place:, name: nil, confidence: nil, source_label: nil)
+        super
+      end
+
+      def duration_seconds
+        (ended_at - started_at).to_i
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/translator.rb
+++ b/app/services/enhanced_import/translator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  class Translator
+    # google_records is deliberately absent: Records.json carries no visit,
+    # track or place metadata, so offering extraction for it is a dead end.
+    SUPPORTED_SOURCES = %w[
+      google_phone_takeout
+      google_semantic_history
+      polarsteps
+    ].freeze
+
+    ADAPTER_LOOKUP = {
+      'google_records' => 'EnhancedImport::Adapters::GoogleRecordsAdapter',
+      'google_phone_takeout' => 'EnhancedImport::Adapters::GooglePhoneTakeoutAdapter',
+      'google_semantic_history' => 'EnhancedImport::Adapters::GoogleSemanticHistoryAdapter',
+      'polarsteps' => 'EnhancedImport::Adapters::PolarstepsAdapter'
+    }.freeze
+
+    def self.supported?(source)
+      SUPPORTED_SOURCES.include?(source.to_s)
+    end
+
+    def initialize(import)
+      @import = import
+    end
+
+    def translate(&block)
+      return enum_for(:translate) unless block_given?
+
+      adapter = adapter_for(@import.source)
+      return if adapter.nil?
+
+      adapter.new(@import).translate(&block)
+    end
+
+    private
+
+    def adapter_for(source)
+      class_name = ADAPTER_LOOKUP[source.to_s]
+      return nil if class_name.nil?
+
+      class_name.safe_constantize
+    end
+  end
+end

--- a/app/services/enhanced_import/writers/place_writer.rb
+++ b/app/services/enhanced_import/writers/place_writer.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Writers
+    class PlaceWriter
+      def initialize(user, import)
+        @user = user
+        @import = import
+      end
+
+      NEARBY_METERS = 75
+
+      def upsert(extracted)
+        existing = find_by_external_id(extracted) || find_nearby(extracted)
+        return [existing, false] if existing
+
+        place = Place.create!(
+          user_id: @user.id,
+          import_id: @import.id,
+          name: extracted.name.presence || 'Unknown',
+          latitude: extracted.latitude,
+          longitude: extracted.longitude,
+          lonlat: "POINT(#{extracted.longitude} #{extracted.latitude})",
+          source: :photon,
+          geodata: build_geodata(extracted)
+        )
+        [place, true]
+      rescue ActiveRecord::RecordNotUnique
+        existing = Place.where(user_id: @user.id)
+                        .where("geodata ->> 'external_place_id' = ?", extracted.external_place_id)
+                        .first
+        [existing, false]
+      end
+
+      private
+
+      def find_by_external_id(extracted)
+        Place.where(user_id: @user.id)
+             .where("geodata ->> 'external_place_id' = ?", extracted.external_place_id)
+             .first
+      end
+
+      # Without this, a Google "Home" lands on the map beside the place Dawarich
+      # already geocoded at the same spot. Names must agree before reusing a row,
+      # or two genuinely different places within 75 m would collapse into one.
+      def find_nearby(extracted)
+        name = extracted.name.to_s.strip
+        return nil if name.empty?
+
+        lon = extracted.longitude.to_f
+        lat = extracted.latitude.to_f
+
+        Place.where(user_id: @user.id)
+             .where('LOWER(places.name) = ?', name.downcase)
+             .where(
+               'ST_DWithin(places.lonlat::geography, ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)',
+               lon, lat, NEARBY_METERS
+             )
+             .order(Arel.sql(
+                      ActiveRecord::Base.sanitize_sql_array(
+                        ['places.lonlat::geography <-> ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography', lon, lat]
+                      )
+                    ))
+             .first
+      end
+
+      def build_geodata(extracted)
+        {
+          'external_place_id' => extracted.external_place_id,
+          'semantic_type' => extracted.semantic_type
+        }.merge(extracted.geodata_extras || {}).compact
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/writers/segment_writer.rb
+++ b/app/services/enhanced_import/writers/segment_writer.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Writers
+    class SegmentWriter
+      def upsert(track, extracted)
+        return nil if track.nil?
+
+        existing = TrackSegment.find_by(track_id: track.id, start_index: extracted.start_index)
+        return [existing, false] if existing
+
+        segment = track.track_segments.create!(
+          start_index: extracted.start_index,
+          end_index: resolve_end_index(track, extracted),
+          transportation_mode: extracted.transportation_mode,
+          confidence: confidence_level(extracted.confidence),
+          source: extracted.source_label
+        )
+        [segment, true]
+      rescue ActiveRecord::RecordNotUnique
+        existing = TrackSegment.find_by(track_id: track.id, start_index: extracted.start_index)
+        [existing, false]
+      end
+
+      private
+
+      # Google emits one activity per track without point offsets, so a source
+      # segment arrives as 0..0 and must be stretched over the track it describes.
+      def resolve_end_index(track, extracted)
+        return extracted.end_index if extracted.end_index > extracted.start_index
+
+        last_index = track.points.count - 1
+        return extracted.end_index if last_index <= extracted.start_index
+
+        last_index
+      end
+
+      STRING_CONFIDENCE = { 'high' => :high, 'medium' => :medium, 'low' => :low }.freeze
+
+      def confidence_level(value)
+        return :low if value.nil?
+
+        mapped = STRING_CONFIDENCE[value.to_s.strip.downcase]
+        return mapped if mapped
+
+        numeric = value.to_f
+        return :high if numeric >= 0.8 && numeric <= 1.0
+        return :high if numeric >= 80
+        return :medium if numeric >= 0.5 && numeric < 0.8
+        return :medium if numeric >= 50
+
+        :low
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/writers/track_writer.rb
+++ b/app/services/enhanced_import/writers/track_writer.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Writers
+    class TrackWriter
+      include Tracks::TrackBuilder
+
+      attr_reader :user
+
+      def initialize(user, import)
+        @user = user
+        @import = import
+      end
+
+      def upsert(extracted, skip_segment_detection: false)
+        existing = find_existing(extracted)
+
+        return [rebuild_segments(existing, skip_segment_detection), false] if existing
+
+        points = matching_points(extracted)
+
+        # Backfilling an old import finds every point already owned by a
+        # generated track. Stealing them would empty that track, so annotate it
+        # with the source's classification instead of building a duplicate.
+        if points.size < 2
+          adopted = adopt_generated_track(extracted)
+          return [adopted, false] if adopted
+
+          return [nil, false]
+        end
+
+        track = create_track_from_points(
+          points,
+          extracted.distance_m || 0,
+          tracker_id: extracted.tracker_id,
+          skip_segment_detection: skip_segment_detection
+        )
+        track&.update_column(:import_id, @import.id)
+        [track, true]
+      rescue ActiveRecord::RecordNotUnique
+        existing = find_existing(extracted)
+        [existing, false]
+      end
+
+      private
+
+      # The stored start_at is the first matching point's timestamp, not the
+      # activity boundary, so tracker_id is the only stable key here.
+      def find_existing(extracted)
+        Track.where(user_id: user.id, tracker_id: extracted.tracker_id).first
+      end
+
+      # The track that already owns this import's points for the same window.
+      def adopt_generated_track(extracted)
+        track_ids = Point.where(
+          user_id: user.id,
+          import_id: @import.id,
+          timestamp: extracted.start_at.to_i..extracted.end_at.to_i
+        ).where.not(track_id: nil).distinct.pluck(:track_id)
+
+        return nil unless track_ids.size == 1
+
+        track = Track.find_by(id: track_ids.first, user_id: user.id)
+        return nil if track.nil?
+
+        # This track belongs to Dawarich's own generation, not to the
+        # extraction, so its segmentation is never overwritten and undo can
+        # never reach it. Only classify it when it carries none of its own.
+        return nil if track.track_segments.exists?
+
+        track
+      end
+
+      # A re-extraction may flip "trust the source app's classification", so the
+      # existing segments are rebuilt to match whichever side the user picked.
+      def rebuild_segments(track, skip_segment_detection)
+        track.track_segments.destroy_all
+
+        unless skip_segment_detection
+          points = track.points.order(:timestamp).to_a
+          detect_and_create_segments(track, points) if points.size >= 2
+        end
+
+        track.update_dominant_mode!
+        track
+      end
+
+      # Track generation runs against the same import; claiming a point that
+      # already belongs to a generated track would empty that track out.
+      def matching_points(extracted)
+        points = Point.where(
+          user_id: user.id,
+          import_id: @import.id,
+          track_id: nil,
+          timestamp: extracted.start_at.to_i..extracted.end_at.to_i
+        ).order(:timestamp).to_a
+
+        dominant_device_points(points)
+      end
+
+      # A track must never span two devices: Google's Records.json carries every
+      # device on one account, so a window can hold points the user recorded on a
+      # phone and a tablet at once. Stitching them produces invented travel
+      # between the two. Keep the device with the most points in the window and
+      # leave the rest for their own activity.
+      def dominant_device_points(points)
+        grouped = points.group_by(&:tracker_id)
+        return points if grouped.size <= 1
+
+        grouped.values.min_by { |group| [-group.size, group.first.timestamp] }
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/writers/visit_writer.rb
+++ b/app/services/enhanced_import/writers/visit_writer.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module EnhancedImport
+  module Writers
+    class VisitWriter
+      def initialize(user, import)
+        @user = user
+        @import = import
+      end
+
+      def upsert(extracted, place)
+        return nil if place.nil?
+
+        existing = Visit.where(
+          user_id: @user.id,
+          started_at: extracted.started_at,
+          place_id: place.id
+        ).first
+        return [existing, false] if existing
+
+        visit = Visit.create!(
+          user_id: @user.id,
+          import_id: @import.id,
+          place_id: place.id,
+          started_at: extracted.started_at,
+          ended_at: extracted.ended_at,
+          duration: (extracted.duration_seconds / 60.0).round,
+          name: extracted.name.presence || place.name,
+          status: 0
+        )
+        [visit, true]
+      rescue ActiveRecord::RecordInvalid
+        [nil, false]
+      rescue ActiveRecord::RecordNotUnique
+        existing = Visit.where(
+          user_id: @user.id,
+          started_at: extracted.started_at,
+          place_id: place.id
+        ).first
+        [existing, false]
+      end
+    end
+  end
+end

--- a/app/services/imports/destroy.rb
+++ b/app/services/imports/destroy.rb
@@ -13,6 +13,8 @@ class Imports::Destroy
   def call
     track_ids = @import.points.where.not(track_id: nil).distinct.pluck(:track_id)
 
+    EnhancedImport::Destroy.new(@import).call
+
     total_deleted = delete_points_in_batches
     User.update_counters(@user.id, points_count: -total_deleted) if total_deleted.positive?
 

--- a/app/services/track_segments/bulk_inserter.rb
+++ b/app/services/track_segments/bulk_inserter.rb
@@ -14,7 +14,7 @@ module TrackSegments
     def call
       return [] if segment_data.empty?
 
-      TrackSegment.insert_all(rows)
+      TrackSegment.insert_all(rows, unique_by: %i[track_id start_index])
       segment_data
     end
 

--- a/app/services/tracks/track_builder.rb
+++ b/app/services/tracks/track_builder.rb
@@ -56,7 +56,8 @@ module Tracks::TrackBuilder
   # but bad data is rarely useful.
   MAX_DISTANCE_METERS = 100_000_000
 
-  def create_track_from_points(points, pre_calculated_distance, tracker_id: nil)
+  def create_track_from_points(points, pre_calculated_distance, tracker_id: nil,
+                               skip_segment_detection: false)
     return nil if points.size < 2
 
     resolved_tracker_id = tracker_id || points.first.tracker_id
@@ -90,7 +91,7 @@ module Tracks::TrackBuilder
     ActiveRecord::Base.transaction(requires_new: true) do
       if track.save
         Point.where(id: points.map(&:id)).update_all(track_id: track.id)
-        detect_and_create_segments(track, points)
+        detect_and_create_segments(track, points) unless skip_segment_detection
         saved_track = track
       else
         Rails.logger.error "Failed to create track for user #{user.id}: #{track.errors.full_messages.join(', ')}"

--- a/app/services/users/export_data/places.rb
+++ b/app/services/users/export_data/places.rb
@@ -6,7 +6,7 @@ class Users::ExportData::Places
   end
 
   def call
-    user.places.as_json(except: %w[user_id id])
+    user.places.as_json(except: %w[user_id id import_id])
   end
 
   private

--- a/app/services/users/export_data/visits.rb
+++ b/app/services/users/export_data/visits.rb
@@ -52,7 +52,7 @@ class Users::ExportData::Visits
   end
 
   def build_visit_hash(visit)
-    visit_hash = visit.as_json(except: %w[user_id place_id id])
+    visit_hash = visit.as_json(except: %w[user_id place_id id import_id])
 
     visit_hash['place_reference'] = if visit.place
                                       {

--- a/app/services/users/import_data/visits.rb
+++ b/app/services/users/import_data/visits.rb
@@ -56,7 +56,7 @@ class Users::ImportData::Visits
 
   def create_visit_record(visit_data)
     visit_attributes = prepare_visit_attributes(visit_data)
-    user.visits.create!(visit_attributes)
+    ActiveRecord::Base.transaction(requires_new: true) { user.visits.create!(visit_attributes) }
   end
 
   def prepare_visit_attributes(visit_data)

--- a/app/services/visits/create.rb
+++ b/app/services/visits/create.rb
@@ -19,6 +19,11 @@ module Visits
         visit = create_visit(place)
         visit
       end
+    rescue ActiveRecord::RecordNotUnique
+      @visit = existing_visit
+      @errors = 'Failed to create visit: duplicate visit' unless @visit
+
+      @visit || false
     rescue ActiveRecord::RecordInvalid => e
       ExceptionReporter.call(e, "Failed to create visit: #{e.message}")
 
@@ -40,6 +45,13 @@ module Visits
       return existing_place if existing_place
 
       create_new_place
+    end
+
+    def existing_visit
+      place = find_existing_place
+      return nil unless place
+
+      user.visits.find_by(place_id: place.id, started_at: Time.zone.parse(params[:started_at]))
     end
 
     def find_existing_place

--- a/app/services/visits/creator.rb
+++ b/app/services/visits/creator.rb
@@ -15,28 +15,36 @@ module Visits
         existing_visit = find_existing_visit(visit_data)
         next nil if existing_visit
 
-        ActiveRecord::Base.transaction do
-          area = find_matching_area(visit_data)
-          main_place = area ? nil : PlaceFinder.new(user).find_or_create_place(visit_data)
-
-          visit_instance = Visit.create!(
-            {
-              user: user, area: area, place: main_place,
-              started_at: Time.zone.at(visit_data[:start_time]),
-              ended_at:   Time.zone.at(visit_data[:end_time]),
-              duration:   visit_data[:duration] / 60,
-              name:       generate_visit_name(area, main_place, visit_data[:suggested_name]),
-              status:     :suggested
-            }.merge(confidence_attributes(visit_data, area, main_place))
-          )
-
-          Point.where(id: visit_data[:points].map(&:id)).update_all(visit_id: visit_instance.id)
-          visit_instance
-        end
+        create_visit(visit_data)
       end.compact
     end
 
     private
+
+    # The fuzzy `find_existing_visit` lookup can miss a visit the unique index
+    # still rejects; drop that one instead of losing the rest of the batch.
+    def create_visit(visit_data)
+      ActiveRecord::Base.transaction(requires_new: true) do
+        area = find_matching_area(visit_data)
+        main_place = area ? nil : PlaceFinder.new(user).find_or_create_place(visit_data)
+
+        visit_instance = Visit.create!(
+          {
+            user: user, area: area, place: main_place,
+            started_at: Time.zone.at(visit_data[:start_time]),
+            ended_at:   Time.zone.at(visit_data[:end_time]),
+            duration:   visit_data[:duration] / 60,
+            name:       generate_visit_name(area, main_place, visit_data[:suggested_name]),
+            status:     :suggested
+          }.merge(confidence_attributes(visit_data, area, main_place))
+        )
+
+        Point.where(id: visit_data[:points].map(&:id)).update_all(visit_id: visit_instance.id)
+        visit_instance
+      end
+    rescue ActiveRecord::RecordNotUnique
+      nil
+    end
 
     def confidence_attributes(visit_data, area, main_place)
       return {} unless @scoring_on

--- a/app/views/imports/_extraction_card.html.erb
+++ b/app/views/imports/_extraction_card.html.erb
@@ -1,0 +1,78 @@
+<%= turbo_frame_tag "import-#{import.id}-extraction", data: { controller: "import-extraction" } do %>
+  <div class="card bg-base-200 mt-6 max-w-2xl">
+    <div class="card-body">
+      <div class="flex items-center gap-2 mb-2">
+        <%= icon 'layer', class: 'w-5 h-5 text-base-content/60' %>
+        <h3 class="text-lg font-semibold">Additional data</h3>
+        <%= extraction_status_badge(import) %>
+      </div>
+
+      <% if import.additional_data_extraction_unsupported? %>
+        <p class="text-sm text-base-content/70">
+          This import format doesn't carry visits, named places, or transportation modes,
+          so there's nothing additional to extract.
+        </p>
+      <% elsif import.additional_data_extraction_completed? %>
+        <% counts = import.extraction_counts %>
+        <p class="text-sm text-base-content/70 mb-4">
+          Extracted
+          <strong><%= counts[:visits] || 0 %></strong> visits,
+          <strong><%= counts[:places] || 0 %></strong> places,
+          <strong><%= counts[:tracks] || 0 %></strong> tracks,
+          <strong><%= counts[:segments] || 0 %></strong> transportation-mode segments.
+        </p>
+        <div class="flex flex-wrap gap-2">
+          <button class="btn btn-sm btn-outline"
+                  data-action="click->import-extraction#open"
+                  data-import-extraction-dialog-id-value="extraction-dialog-<%= import.id %>">
+            Re-extract
+          </button>
+          <%= render 'imports/extraction_remove_button', import: import %>
+        </div>
+      <% elsif import.additional_data_extraction_running? || import.additional_data_extraction_pending? %>
+        <% if import.extraction_stalled? %>
+          <p class="text-sm text-warning mb-2">
+            This extraction stopped responding. It's safe to start it again.
+          </p>
+          <div class="flex flex-wrap gap-2">
+            <button class="btn btn-sm btn-outline"
+                    data-action="click->import-extraction#open"
+                    data-import-extraction-dialog-id-value="extraction-dialog-<%= import.id %>">
+              Start over
+            </button>
+            <%= render 'imports/extraction_remove_button', import: import %>
+          </div>
+        <% else %>
+          <p class="text-sm text-base-content/70 flex items-center gap-2">
+            <span class="loading loading-dots loading-sm shrink-0"></span>
+            <%= import.additional_data_extraction_running? ? 'Extracting…' : 'Queued…' %>
+          </p>
+        <% end %>
+      <% elsif import.additional_data_extraction_failed? %>
+        <p class="text-sm text-error mb-2">
+          Extraction failed: <%= import.extraction_error_message %>
+        </p>
+        <div class="flex flex-wrap gap-2">
+          <button class="btn btn-sm btn-outline"
+                  data-action="click->import-extraction#open"
+                  data-import-extraction-dialog-id-value="extraction-dialog-<%= import.id %>">
+            Retry extraction
+          </button>
+          <%= render 'imports/extraction_remove_button', import: import %>
+        </div>
+      <% else %>
+        <p class="text-sm text-base-content/70 mb-4">
+          Dawarich originally imported your file as raw GPS points. Click below to also
+          extract visits, places, tracks, and transportation modes.
+        </p>
+        <button class="btn btn-sm btn-primary"
+                data-action="click->import-extraction#open"
+                data-import-extraction-dialog-id-value="extraction-dialog-<%= import.id %>">
+          Extract additional data
+        </button>
+      <% end %>
+    </div>
+  </div>
+
+  <%= render 'imports/extraction_dialog', import: import unless import.additional_data_extraction_unsupported? %>
+<% end %>

--- a/app/views/imports/_extraction_dialog.html.erb
+++ b/app/views/imports/_extraction_dialog.html.erb
@@ -1,0 +1,45 @@
+<dialog id="extraction-dialog-<%= import.id %>" class="modal">
+  <div class="modal-box max-w-xl">
+    <h3 class="font-bold text-lg">Extract additional data from this import</h3>
+
+    <div class="prose prose-sm mt-4 text-base-content/80">
+      <p>
+        Dawarich originally imported your file as raw GPS points. The file also contains:
+      </p>
+      <ul>
+        <li><strong>Visits</strong> — places where the source app recorded you spending time, with start and end times.</li>
+        <li><strong>Tracks</strong> — journeys identified between those visits, with their classified transportation mode (driving, walking, cycling, transit, …).</li>
+        <li><strong>Places</strong> — the named places (home, work, frequent restaurants) the source app associated with your visits.</li>
+      </ul>
+      <p>
+        Click <strong>Extract</strong> to add this data to your Dawarich account. Existing points are not modified.
+        Visits and places already detected from your points by Dawarich are kept side-by-side with the imported ones.
+      </p>
+    </div>
+
+    <%= form_with url: import_extraction_path(import), method: :post, data: { turbo_frame: "import-#{import.id}-extraction" } do |f| %>
+      <div class="form-control mt-4">
+        <label class="label cursor-pointer justify-start gap-3">
+          <%= f.check_box :trust_source, { checked: true, class: 'checkbox checkbox-primary' }, 'true', 'false' %>
+          <div>
+            <div class="label-text font-medium">Trust the source app's classification</div>
+            <div class="label-text-alt text-base-content/60">
+              When checked, transportation modes (driving, walking, cycling, transit) the source app
+              assigned are kept as-is. When unchecked, Dawarich re-runs its own detector using your settings.
+            </div>
+          </div>
+        </label>
+      </div>
+
+      <div class="modal-action">
+        <button type="button" class="btn btn-ghost"
+                data-action="click->import-extraction#close"
+                data-import-extraction-dialog-id-param="extraction-dialog-<%= import.id %>">
+          Cancel
+        </button>
+        <%= f.submit 'Extract', class: 'btn btn-primary' %>
+      </div>
+    <% end %>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>

--- a/app/views/imports/_extraction_remove_button.html.erb
+++ b/app/views/imports/_extraction_remove_button.html.erb
@@ -1,0 +1,5 @@
+<%= button_to 'Remove extracted data',
+              import_extraction_path(import),
+              method: :delete,
+              class: 'btn btn-sm btn-ghost text-error',
+              form: { data: { turbo_confirm: 'Remove the visits, places and tracks this extraction created? Your imported GPS points are kept.' } } %>

--- a/app/views/imports/_table_row.html.erb
+++ b/app/views/imports/_table_row.html.erb
@@ -29,7 +29,12 @@
     <% end %>
   </td>
   <td class="px-4 py-3" data-status-display>
-    <%= status_badge(import) %>
+    <div class="flex flex-col gap-1 items-start">
+      <%= status_badge(import) %>
+      <% unless import.additional_data_extraction_not_attempted? || import.additional_data_extraction_unsupported? %>
+        <%= extraction_status_badge(import) %>
+      <% end %>
+    </div>
   </td>
   <td class="px-4 py-3 text-sm text-base-content/50"><%= human_datetime(import.created_at, local_assigns[:timezone]) %></td>
   <td class="px-4 py-3 text-right">

--- a/app/views/imports/extractions/create.turbo_stream.erb
+++ b/app/views/imports/extractions/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "import-#{@import.id}-extraction" do %>
+  <%= render 'imports/extraction_card', import: @import %>
+<% end %>

--- a/app/views/imports/extractions/destroy.turbo_stream.erb
+++ b/app/views/imports/extractions/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "import-#{@import.id}-extraction" do %>
+  <%= render 'imports/extraction_card', import: @import %>
+<% end %>

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -8,6 +8,9 @@
 
     <%= render @import %>
 
+    <%= turbo_stream_from "import_#{@import.id}_extraction" %>
+    <%= render 'imports/extraction_card', import: @import %>
+
     <%= link_to "Edit this import", edit_import_path(@import), class: "mt-2 rounded-lg py-3 px-5 bg-secondary-content inline-block font-medium" %>
     <div class="inline-block ml-2">
       <%= link_to "Destroy this import", import_path(@import), data: { turbo_confirm: "Are you sure? This action will delete all points imported with this file", turbo_method: :delete }, class: "mt-2 rounded-lg py-3 px-5 bg-secondary-content font-medium" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,7 +96,9 @@ Rails.application.routes.draw do
   get 'trial/resume', to: 'trial/resume#show', as: :trial_resume
   get 'trial/welcome', to: 'trial/welcome#show', as: :trial_welcome
 
-  resources :imports
+  resources :imports do
+    resource :extraction, only: %i[create destroy], controller: 'imports/extractions'
+  end
   resources :tracks, only: [] do
     resources :segments, controller: 'tracks/segments', only: %i[index update]
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,6 +8,7 @@
   - mailers
   - families
   - imports
+  - extractions
   - exports
   - tracks
   - stats

--- a/db/migrate/20260730210000_add_extraction_columns_to_imports.rb
+++ b/db/migrate/20260730210000_add_extraction_columns_to_imports.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class AddExtractionColumnsToImports < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  INDEX_NAME = 'index_imports_on_additional_data_extraction_status'
+
+  def up
+    unless column_exists?(:imports, :additional_data_extraction_status)
+      add_column :imports, :additional_data_extraction_status, :integer, default: 0, null: false
+    end
+
+    unless column_exists?(:imports, :additional_data_extraction)
+      add_column :imports, :additional_data_extraction, :jsonb, default: {}, null: false
+    end
+
+    return if index_name_exists?(:imports, INDEX_NAME)
+
+    add_index :imports, :additional_data_extraction_status,
+              algorithm: :concurrently,
+              name: INDEX_NAME
+  end
+
+  def down
+    remove_index :imports, name: INDEX_NAME, algorithm: :concurrently if index_name_exists?(:imports, INDEX_NAME)
+    remove_column :imports, :additional_data_extraction if column_exists?(:imports, :additional_data_extraction)
+
+    return unless column_exists?(:imports, :additional_data_extraction_status)
+
+    remove_column :imports, :additional_data_extraction_status
+  end
+end

--- a/db/migrate/20260730210100_backfill_unsupported_extraction_status.rb
+++ b/db/migrate/20260730210100_backfill_unsupported_extraction_status.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class BackfillUnsupportedExtractionStatus < ActiveRecord::Migration[8.0]
+  ADAPTER_SUPPORTED_SOURCES = [
+    0, # google_semantic_history
+    3, # google_phone_takeout
+    13 # polarsteps
+  ].freeze
+
+  NOT_ATTEMPTED_STATUS = 0
+  UNSUPPORTED_STATUS = 5
+
+  disable_ddl_transaction!
+
+  # `source NOT IN (...)` drops NULLs, which would leave source-less imports
+  # advertising an extraction no adapter can run.
+  def up
+    Import.where(additional_data_extraction_status: NOT_ATTEMPTED_STATUS)
+          .where('source IS NULL OR source NOT IN (?)', ADAPTER_SUPPORTED_SOURCES)
+          .in_batches(of: 5_000)
+          .update_all(additional_data_extraction_status: UNSUPPORTED_STATUS)
+  end
+
+  def down
+    Import.where(additional_data_extraction_status: UNSUPPORTED_STATUS)
+          .in_batches(of: 5_000)
+          .update_all(additional_data_extraction_status: NOT_ATTEMPTED_STATUS)
+  end
+end

--- a/db/migrate/20260730210150_dedupe_visits_before_unique_index.rb
+++ b/db/migrate/20260730210150_dedupe_visits_before_unique_index.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class DedupeVisitsBeforeUniqueIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  BATCH_SIZE = 500
+
+  def up
+    loop do
+      groups = duplicate_groups
+      break if groups.empty?
+
+      groups.each { |keeper_id, loser_ids| collapse(keeper_id, loser_ids) }
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def duplicate_groups
+    rows = execute(<<~SQL.squish).to_a
+      SELECT min(id) AS keeper, array_agg(id) AS ids
+      FROM visits
+      WHERE place_id IS NOT NULL
+      GROUP BY user_id, started_at, place_id
+      HAVING count(*) > 1
+      LIMIT #{BATCH_SIZE}
+    SQL
+
+    pairs = rows.map do |row|
+      keeper = row['keeper'].to_i
+      [keeper, parse_ids(row['ids']) - [keeper]]
+    end
+
+    pairs.reject { |_, ids| ids.empty? }
+  end
+
+  def parse_ids(value)
+    return value.map(&:to_i) if value.is_a?(Array)
+
+    value.to_s.delete('{}').split(',').map(&:to_i)
+  end
+
+  def collapse(keeper_id, loser_ids)
+    Visit.transaction do
+      Point.where(visit_id: loser_ids).update_all(visit_id: keeper_id)
+      execute("DELETE FROM place_visits WHERE visit_id IN (#{loser_ids.join(',')})")
+      execute("DELETE FROM visits WHERE id IN (#{loser_ids.join(',')})")
+    end
+  end
+end

--- a/db/migrate/20260730210200_add_unique_index_to_visits.rb
+++ b/db/migrate/20260730210200_add_unique_index_to_visits.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToVisits < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  INDEX_NAME = 'idx_visits_user_started_at_place_unique'
+
+  def up
+    drop_invalid_index(:visits, INDEX_NAME)
+    return if index_name_exists?(:visits, INDEX_NAME)
+
+    add_index :visits, %i[user_id started_at place_id],
+              unique: true,
+              algorithm: :concurrently,
+              name: INDEX_NAME
+  end
+
+  def down
+    return unless index_name_exists?(:visits, INDEX_NAME)
+
+    remove_index :visits, name: INDEX_NAME, algorithm: :concurrently
+  end
+
+  private
+
+  def drop_invalid_index(table, name)
+    invalid = select_value(<<~SQL.squish)
+      SELECT 1 FROM pg_class c
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = '#{name}' AND i.indisvalid = false
+    SQL
+    return if invalid.nil?
+
+    remove_index table, name: name, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260730210250_dedupe_track_segments_before_unique_index.rb
+++ b/db/migrate/20260730210250_dedupe_track_segments_before_unique_index.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class DedupeTrackSegmentsBeforeUniqueIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  BATCH_SIZE = 500
+
+  def up
+    loop do
+      loser_ids = duplicate_loser_ids
+      break if loser_ids.empty?
+
+      execute("DELETE FROM track_segments WHERE id IN (#{loser_ids.join(',')})")
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def duplicate_loser_ids
+    execute(<<~SQL.squish).to_a.map { |row| row['id'].to_i }
+      SELECT id FROM (
+        SELECT id,
+               row_number() OVER (PARTITION BY track_id, start_index ORDER BY id) AS position
+        FROM track_segments
+      ) ranked
+      WHERE ranked.position > 1
+      LIMIT #{BATCH_SIZE}
+    SQL
+  end
+end

--- a/db/migrate/20260730210300_add_unique_index_to_track_segments.rb
+++ b/db/migrate/20260730210300_add_unique_index_to_track_segments.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToTrackSegments < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  INDEX_NAME = 'idx_track_segments_track_start_index_unique'
+
+  def up
+    drop_invalid_index(:track_segments, INDEX_NAME)
+    return if index_name_exists?(:track_segments, INDEX_NAME)
+
+    add_index :track_segments, %i[track_id start_index],
+              unique: true,
+              algorithm: :concurrently,
+              name: INDEX_NAME
+  end
+
+  def down
+    return unless index_name_exists?(:track_segments, INDEX_NAME)
+
+    remove_index :track_segments, name: INDEX_NAME, algorithm: :concurrently
+  end
+
+  private
+
+  def drop_invalid_index(table, name)
+    invalid = select_value(<<~SQL.squish)
+      SELECT 1 FROM pg_class c
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = '#{name}' AND i.indisvalid = false
+    SQL
+    return if invalid.nil?
+
+    remove_index table, name: name, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260730210400_add_external_place_id_index_to_places.rb
+++ b/db/migrate/20260730210400_add_external_place_id_index_to_places.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class AddExternalPlaceIdIndexToPlaces < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  INDEX_NAME = 'idx_places_user_external_place_id'
+
+  def up
+    drop_invalid_index(:places, INDEX_NAME)
+    return if index_name_exists?(:places, INDEX_NAME)
+
+    execute(<<~SQL.squish)
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS #{INDEX_NAME}
+        ON places (user_id, ((geodata ->> 'external_place_id')))
+        WHERE (geodata ->> 'external_place_id') IS NOT NULL
+    SQL
+  end
+
+  def down
+    return unless index_name_exists?(:places, INDEX_NAME)
+
+    execute("DROP INDEX CONCURRENTLY IF EXISTS #{INDEX_NAME}")
+  end
+
+  private
+
+  def drop_invalid_index(table, name)
+    invalid = select_value(<<~SQL.squish)
+      SELECT 1 FROM pg_class c
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = '#{name}' AND i.indisvalid = false
+    SQL
+    return if invalid.nil?
+
+    remove_index table, name: name, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260730220000_add_import_id_to_extraction_artifacts.rb
+++ b/db/migrate/20260730220000_add_import_id_to_extraction_artifacts.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AddImportIdToExtractionArtifacts < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  TABLES = %i[visits places tracks].freeze
+
+  def up
+    TABLES.each do |table|
+      add_column table, :import_id, :bigint unless column_exists?(table, :import_id)
+
+      index_name = "idx_#{table}_import_id_extracted"
+      next if index_name_exists?(table, index_name)
+
+      add_index table, :import_id,
+                where: 'import_id IS NOT NULL',
+                algorithm: :concurrently,
+                name: index_name
+    end
+  end
+
+  def down
+    TABLES.each do |table|
+      index_name = "idx_#{table}_import_id_extracted"
+      remove_index table, name: index_name, algorithm: :concurrently if index_name_exists?(table, index_name)
+
+      remove_column table, :import_id if column_exists?(table, :import_id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_220000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -224,6 +224,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
   end
 
   create_table "imports", force: :cascade do |t|
+    t.jsonb "additional_data_extraction", default: {}, null: false
+    t.integer "additional_data_extraction_status", default: 0, null: false
     t.datetime "created_at", null: false
     t.boolean "demo", default: false, null: false
     t.integer "doubles", default: 0
@@ -238,6 +240,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
     t.integer "status", default: 0, null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["additional_data_extraction_status"], name: "index_imports_on_additional_data_extraction_status"
     t.index ["source"], name: "index_imports_on_source"
     t.index ["status"], name: "index_imports_on_status"
     t.index ["user_id"], name: "index_imports_on_user_id"
@@ -302,6 +305,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
     t.datetime "created_at", null: false
     t.boolean "demo", default: false, null: false
     t.jsonb "geodata", default: {}, null: false
+    t.bigint "import_id"
     t.decimal "latitude", precision: 10, scale: 6, null: false
     t.decimal "longitude", precision: 10, scale: 6, null: false
     t.geography "lonlat", limit: {srid: 4326, type: "st_point", geographic: true}
@@ -313,7 +317,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index "(((geodata -> 'properties'::text) ->> 'osm_id'::text))", name: "index_places_on_geodata_osm_id"
+    t.index "user_id, ((geodata ->> 'external_place_id'::text))", name: "idx_places_user_external_place_id", unique: true, where: "((geodata ->> 'external_place_id'::text) IS NOT NULL)"
     t.index ["demo"], name: "index_places_on_demo_true", where: "(demo = true)"
+    t.index ["import_id"], name: "idx_places_import_id_extracted", where: "(import_id IS NOT NULL)"
     t.index ["lonlat"], name: "index_places_on_lonlat", using: :gist
     t.index ["user_id"], name: "index_places_on_user_id"
   end
@@ -370,7 +376,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
     t.index ["user_id", "id"], name: "index_points_on_unarchived", where: "((raw_data_archived = false) AND (raw_data <> '{}'::jsonb))"
     t.index ["user_id", "timestamp"], name: "idx_points_user_visit_null_timestamp", where: "(visit_id IS NULL)"
     t.index ["user_id", "timestamp"], name: "index_points_on_user_id_and_timestamp", order: { timestamp: :desc }
-    t.index ["user_id"], name: "idx_points_user_id_legacy_tracker", where: "((tracker_id)::text = ANY ((ARRAY['google-maps-timeline-export'::character varying, 'google-maps-phone-timeline-export'::character varying])::text[]))"
+    t.index ["user_id"], name: "idx_points_user_id_legacy_tracker", where: "((tracker_id)::text = ANY (ARRAY[('google-maps-timeline-export'::character varying)::text, ('google-maps-phone-timeline-export'::character varying)::text]))"
     t.index ["user_id"], name: "index_points_on_user_id"
     t.index ["visit_id"], name: "index_points_on_visit_id"
   end
@@ -485,6 +491,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
     t.datetime "updated_at", null: false
     t.index ["corrected_at"], name: "index_track_segments_on_corrected_at", where: "(corrected_at IS NOT NULL)"
     t.index ["track_id", "start_index", "end_index"], name: "index_track_segments_on_track_and_indices"
+    t.index ["track_id", "start_index"], name: "idx_track_segments_track_start_index_unique", unique: true
     t.index ["track_id", "transportation_mode"], name: "index_track_segments_on_track_id_and_transportation_mode"
   end
 
@@ -500,6 +507,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
     t.integer "elevation_max"
     t.integer "elevation_min"
     t.datetime "end_at", null: false
+    t.bigint "import_id"
     t.geometry "original_path", limit: {srid: 4326, type: "line_string"}, null: false
     t.datetime "start_at", null: false
     t.string "tracker_id"
@@ -508,6 +516,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
     t.index "user_id, COALESCE(tracker_id, ''::character varying), start_at, end_at", name: "index_tracks_on_user_tracker_start_end_unique", unique: true
     t.index ["demo"], name: "index_tracks_on_demo_true", where: "(demo = true)"
     t.index ["dominant_mode"], name: "index_tracks_on_dominant_mode"
+    t.index ["import_id"], name: "idx_tracks_import_id_extracted", where: "(import_id IS NOT NULL)"
     t.index ["user_id", "start_at"], name: "idx_tracks_user_id_start_at"
     t.index ["user_id", "tracker_id", "end_at"], name: "idx_tracks_user_tracker_end_at"
     t.index ["user_id"], name: "index_tracks_on_user_id"
@@ -596,6 +605,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
     t.boolean "demo", default: false, null: false
     t.integer "duration", null: false
     t.datetime "ended_at", null: false
+    t.bigint "import_id"
     t.string "name", null: false
     t.bigint "place_id"
     t.datetime "started_at", null: false
@@ -604,8 +614,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
     t.bigint "user_id", null: false
     t.index ["area_id"], name: "index_visits_on_area_id"
     t.index ["demo"], name: "index_visits_on_demo_true", where: "(demo = true)"
+    t.index ["import_id"], name: "idx_visits_import_id_extracted", where: "(import_id IS NOT NULL)"
     t.index ["place_id"], name: "index_visits_on_place_id"
     t.index ["started_at"], name: "index_visits_on_started_at"
+    t.index ["user_id", "started_at", "place_id"], name: "idx_visits_user_started_at_place_unique", unique: true
     t.index ["user_id"], name: "index_visits_on_user_id"
   end
 

--- a/spec/factories/track_segments.rb
+++ b/spec/factories/track_segments.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
   factory :track_segment do
     association :track
     transportation_mode { :driving }
-    start_index { 0 }
-    end_index { 10 }
+    sequence(:start_index) { |n| (n - 1) * 11 }
+    end_index { start_index + 10 }
     distance { 1000 }
     duration { 600 }
     avg_speed { 30.0 }

--- a/spec/fixtures/files/enhanced_import/google_phone_takeout_minimal.json
+++ b/spec/fixtures/files/enhanced_import/google_phone_takeout_minimal.json
@@ -1,0 +1,18 @@
+{
+  "semanticSegments": [
+    {
+      "startTime": "2025-04-01T10:00:00Z",
+      "endTime": "2025-04-01T13:00:00Z",
+      "visit": {
+        "topCandidate": {
+          "placeId": "ChIJ_TEST_HOME_123",
+          "semanticType": "INFERRED_HOME",
+          "probability": 0.95,
+          "placeLocation": {
+            "latLng": "52.520000°, 13.405000°"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/spec/fixtures/files/enhanced_import/google_phone_takeout_with_frequent_places.json
+++ b/spec/fixtures/files/enhanced_import/google_phone_takeout_with_frequent_places.json
@@ -1,0 +1,18 @@
+{
+  "userLocationProfile": {
+    "frequentPlaces": [
+      {
+        "placeId": "ChIJ_HOME_FREQUENT",
+        "label": "Home",
+        "placeLocation": "52.520000°, 13.405000°",
+        "semanticType": "INFERRED_HOME"
+      },
+      {
+        "placeId": "ChIJ_WORK_FREQUENT",
+        "label": "Work",
+        "placeLocation": "52.530000°, 13.420000°",
+        "semanticType": "INFERRED_WORK"
+      }
+    ]
+  }
+}

--- a/spec/fixtures/files/enhanced_import/google_semantic_history_minimal.json
+++ b/spec/fixtures/files/enhanced_import/google_semantic_history_minimal.json
@@ -1,0 +1,19 @@
+{
+  "timelineObjects": [
+    {
+      "placeVisit": {
+        "duration": {
+          "startTimestamp": "2025-04-01T10:00:00Z",
+          "endTimestamp": "2025-04-01T13:00:00Z"
+        },
+        "location": {
+          "placeId": "ChIJ_TEST_OFFICE_456",
+          "name": "Office",
+          "latitudeE7": 525200000,
+          "longitudeE7": 134050000,
+          "semanticType": "TYPE_WORK"
+        }
+      }
+    }
+  ]
+}

--- a/spec/fixtures/files/enhanced_import/polarsteps_segments_minimal.json
+++ b/spec/fixtures/files/enhanced_import/polarsteps_segments_minimal.json
@@ -1,0 +1,16 @@
+{
+  "steps": [
+    {
+      "id": 99001,
+      "name": "Tokyo, Japan",
+      "display_name": "Tokyo, Japan",
+      "location": {
+        "lat": 35.6762,
+        "lon": 139.6503,
+        "detail": "Shibuya"
+      },
+      "start_time": 1743501600,
+      "end_time": 1743512400
+    }
+  ]
+}

--- a/spec/fixtures/files/enhanced_import/polarsteps_steps_array.json
+++ b/spec/fixtures/files/enhanced_import/polarsteps_steps_array.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 99001,
+    "name": "Tokyo, Japan",
+    "display_name": "Tokyo, Japan",
+    "arrived": 1735689600,
+    "departed": 1735707600,
+    "location": {
+      "lat": 35.6762,
+      "lon": 139.6503,
+      "detail": "Shibuya"
+    }
+  },
+  {
+    "id": 99002,
+    "name": "Kyoto, Japan",
+    "arrived": 1735776000,
+    "departed": 1735794000,
+    "lat": 35.0116,
+    "lon": 135.7681
+  }
+]

--- a/spec/helpers/imports_helper_spec.rb
+++ b/spec/helpers/imports_helper_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImportsHelper do
+  describe '#extraction_status_badge' do
+    subject(:badge) { helper.extraction_status_badge(import) }
+
+    let(:import) { build(:import, additional_data_extraction_status: status) }
+
+    context 'when not attempted' do
+      let(:status) { :not_attempted }
+
+      it 'renders a neutral badge' do
+        expect(badge).to have_css('span.badge.badge-ghost', text: 'Not extracted')
+      end
+    end
+
+    context 'when pending' do
+      let(:status) { :pending }
+
+      it 'renders a queued badge' do
+        expect(badge).to have_css('span.badge.badge-info', text: 'Queued')
+      end
+    end
+
+    context 'when running' do
+      let(:status) { :running }
+
+      it 'renders a spinner alongside the label' do
+        expect(badge).to have_css('span.badge.badge-info span.loading.loading-dots')
+        expect(badge).to have_css('span.badge', text: 'Extracting')
+      end
+    end
+
+    context 'when completed' do
+      let(:status) { :completed }
+
+      it 'renders a success badge' do
+        expect(badge).to have_css('span.badge.badge-success', text: 'Extracted')
+      end
+    end
+
+    context 'when failed' do
+      let(:status) { :failed }
+
+      it 'renders an error badge' do
+        expect(badge).to have_css('span.badge.badge-error', text: 'Failed')
+      end
+    end
+
+    context 'when unsupported' do
+      let(:status) { :unsupported }
+
+      it 'renders an unavailable badge' do
+        expect(badge).to have_css('span.badge.badge-ghost', text: 'Not available')
+      end
+    end
+
+    context 'when the status is unrecognised' do
+      let(:status) { :not_attempted }
+
+      it 'renders nothing' do
+        allow(import).to receive(:additional_data_extraction_status).and_return('bogus')
+
+        expect(helper.extraction_status_badge(import)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/jobs/enhanced_import/extract_job_spec.rb
+++ b/spec/jobs/enhanced_import/extract_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EnhancedImport::ExtractJob do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :google_phone_takeout) }
+
+  describe 'state transitions' do
+    it 'marks the import as completed with zero counts when no items are emitted' do
+      allow_any_instance_of(EnhancedImport::Translator).to receive(:translate) { |&_block| }
+
+      described_class.new.perform(import.id)
+
+      expect(import.reload.additional_data_extraction_status).to eq('completed')
+      expect(import.extraction_counts).to eq({})
+      expect(import.additional_data_extraction['started_at']).to be_present
+      expect(import.additional_data_extraction['completed_at']).to be_present
+    end
+
+    it 'marks the import as failed and re-raises when the translator blows up' do
+      allow_any_instance_of(EnhancedImport::Translator).to receive(:translate).and_raise('boom')
+
+      expect { described_class.new.perform(import.id) }.to raise_error(/boom/)
+
+      expect(import.reload.additional_data_extraction_status).to eq('failed')
+      expect(import.extraction_error_message).to eq('boom')
+    end
+
+    it 'returns silently for an unsupported source' do
+      gpx_import = create(:import, user: user, source: :gpx)
+      expect { described_class.new.perform(gpx_import.id) }.not_to raise_error
+      expect(gpx_import.reload.additional_data_extraction_status).not_to eq('running')
+    end
+
+    it 'returns silently when the import has been deleted' do
+      expect { described_class.new.perform(0) }.not_to raise_error
+    end
+  end
+end

--- a/spec/jobs/enhanced_import/queue_routing_spec.rb
+++ b/spec/jobs/enhanced_import/queue_routing_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Enhanced import jobs are routed to a queue Sidekiq consumes' do
+  let(:configured_queues) do
+    YAML.load_file(Rails.root.join('config/sidekiq.yml'))[:queues].map(&:to_s)
+  end
+
+  [EnhancedImport::ExtractJob, EnhancedImport::DestroyJob].each do |job_class|
+    it "#{job_class} runs on a queue listed in sidekiq.yml" do
+      expect(configured_queues).to include(job_class.new.queue_name)
+    end
+  end
+end

--- a/spec/policies/imports/extraction_policy_spec.rb
+++ b/spec/policies/imports/extraction_policy_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Imports::ExtractionPolicy do
+  subject(:policy) { described_class.new(user, import) }
+
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :google_phone_takeout) }
+
+  describe '#create?' do
+    it 'allows a fresh supported import' do
+      expect(policy.create?).to be true
+    end
+
+    it 'blocks a run that is already in flight' do
+      import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:running],
+        additional_data_extraction: { 'started_at' => 10.minutes.ago.iso8601 }
+      )
+
+      expect(policy.create?).to be false
+    end
+
+    it 'lets the user retry once an in-flight run has gone stale' do
+      import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:running],
+        additional_data_extraction: { 'started_at' => 8.hours.ago.iso8601 }
+      )
+
+      expect(policy.create?).to be true
+    end
+
+    it 'blocks an unsupported source' do
+      other = create(:import, user: user, source: :gpx)
+
+      expect(described_class.new(user, other).create?).to be false
+    end
+
+    it 'blocks another user' do
+      expect(described_class.new(create(:user), import).create?).to be false
+    end
+  end
+
+  describe '#destroy?' do
+    it 'refuses when nothing has been extracted' do
+      expect(policy.destroy?).to be false
+    end
+
+    it 'allows removing a completed extraction' do
+      import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:completed]
+      )
+
+      expect(policy.destroy?).to be true
+    end
+  end
+end

--- a/spec/regressions/enhanced_import_annotates_existing_tracks_spec.rb
+++ b/spec/regressions/enhanced_import_annotates_existing_tracks_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Backfilling an old import classifies the tracks it already has' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :google_phone_takeout) }
+  let(:activity_start) { Time.zone.parse('2026-01-20 07:00:00') }
+  let(:generated_track) { create(:track, user: user, dominant_mode: nil) }
+
+  let(:extracted_track) do
+    EnhancedImport::Extracted::Track.new(
+      tracker_id: "import-#{import.id}-activity-#{activity_start.to_i}",
+      start_at: activity_start,
+      end_at: activity_start + 1.hour,
+      distance_m: 1200,
+      transportation_mode: 'cycling',
+      confidence: 95,
+      source_label: 'google_phone_takeout',
+      segments: [
+        EnhancedImport::Extracted::TrackSegment.new(
+          start_index: 0, end_index: 0, transportation_mode: 'cycling',
+          confidence: 95, source_label: 'google_phone_takeout'
+        )
+      ]
+    )
+  end
+
+  before do
+    5.times do |i|
+      create(:point, user: user, import_id: import.id, track_id: generated_track.id,
+                     timestamp: (activity_start + 5.minutes).to_i + (i * 60),
+                     lonlat: "POINT(#{12.3712 + (i * 0.001)} #{51.3402 + (i * 0.001)})")
+    end
+  end
+
+  it 'reuses the generated track rather than reporting nothing' do
+    track, created = EnhancedImport::Writers::TrackWriter.new(user, import)
+                                                         .upsert(extracted_track, skip_segment_detection: true)
+
+    expect(track).to be_present
+    expect(created).to be false
+    expect(track.id).to eq(generated_track.id)
+  end
+
+  it 'does not steal the points or create a duplicate track' do
+    expect do
+      EnhancedImport::Writers::TrackWriter.new(user, import)
+                                          .upsert(extracted_track, skip_segment_detection: true)
+    end.not_to(change(Track, :count))
+
+    expect(Point.where(track_id: generated_track.id).count).to eq(5)
+  end
+
+  it 'lets the source classification land on that track' do
+    track, = EnhancedImport::Writers::TrackWriter.new(user, import)
+                                                 .upsert(extracted_track, skip_segment_detection: true)
+    EnhancedImport::Writers::SegmentWriter.new.upsert(track, extracted_track.segments.first)
+    track.update_dominant_mode!
+
+    expect(track.reload.track_segments.pluck(:transportation_mode)).to eq(['cycling'])
+    expect(track.dominant_mode).to eq('cycling')
+  end
+end

--- a/spec/regressions/enhanced_import_destroy_roundtrip_spec.rb
+++ b/spec/regressions/enhanced_import_destroy_roundtrip_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Enhanced import extraction can be undone' do
+  let(:user) { create(:user) }
+  let(:fixture_path) { Rails.root.join('spec/fixtures/files/enhanced_import/polarsteps_segments_minimal.json') }
+
+  let(:import) do
+    import = create(:import, user: user, source: :polarsteps, name: "undo-#{rand(10_000)}.json")
+    import.file.attach(
+      io: File.open(fixture_path),
+      filename: File.basename(fixture_path),
+      content_type: 'application/json'
+    )
+    import
+  end
+
+  it 'stamps every artifact with the import and removes them again' do
+    EnhancedImport::ExtractJob.new.perform(import.id)
+    import.reload
+
+    expect(import.additional_data_extraction_completed?).to be true
+    expect(Visit.where(import_id: import.id).count).to be > 0
+    expect(Place.where(import_id: import.id).count).to be > 0
+
+    expect { EnhancedImport::Destroy.new(import).call }
+      .to change { Visit.where(import_id: import.id).count }.to(0)
+      .and change { Place.where(import_id: import.id).count }.to(0)
+
+    import.reload
+    expect(import.additional_data_extraction_not_attempted?).to be true
+    expect(import.extraction_counts).to eq({})
+  end
+
+  it 'leaves the imported points untouched' do
+    EnhancedImport::ExtractJob.new.perform(import.id)
+
+    expect { EnhancedImport::Destroy.new(import.reload).call }.not_to(change(Point, :count))
+  end
+end

--- a/spec/regressions/enhanced_import_does_not_steal_tracked_points_spec.rb
+++ b/spec/regressions/enhanced_import_does_not_steal_tracked_points_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Extraction leaves already-tracked points alone' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :google_phone_takeout) }
+  let(:base_time) { 2.hours.ago.to_i }
+  let(:existing_track) { create(:track, user: user) }
+
+  let(:extracted_track) do
+    EnhancedImport::Extracted::Track.new(
+      tracker_id: "import-#{import.id}-activity-#{base_time}",
+      start_at: Time.zone.at(base_time),
+      end_at: Time.zone.at(base_time + 900),
+      distance_m: 800,
+      transportation_mode: 'driving',
+      confidence: 90,
+      source_label: 'google_phone_takeout',
+      segments: []
+    )
+  end
+
+  def build_points(count:, track_id:, offset:)
+    count.times.map do |i|
+      create(:point, user: user, import_id: import.id, tracker_id: 'phone',
+                     track_id: track_id, timestamp: base_time + offset + (i * 60),
+                     lonlat: "POINT(#{12.3712 + (i * 0.001)} #{51.3402 + (i * 0.001)})")
+    end
+  end
+
+  it 'does not reassign points owned by another track' do
+    claimed = build_points(count: 4, track_id: existing_track.id, offset: 0)
+    build_points(count: 4, track_id: nil, offset: 300)
+
+    EnhancedImport::Writers::TrackWriter.new(user, import)
+                                        .upsert(extracted_track, skip_segment_detection: true)
+
+    expect(claimed.map { |p| p.reload.track_id }.uniq).to eq([existing_track.id])
+    expect(existing_track.reload.points.count).to eq(4)
+  end
+
+  it 'builds the extracted track from the unclaimed points only' do
+    build_points(count: 4, track_id: existing_track.id, offset: 0)
+    free = build_points(count: 4, track_id: nil, offset: 300)
+
+    track, created = EnhancedImport::Writers::TrackWriter.new(user, import)
+                                                         .upsert(extracted_track, skip_segment_detection: true)
+
+    expect(created).to be true
+    expect(Point.where(track_id: track.id).pluck(:id)).to match_array(free.map(&:id))
+  end
+end

--- a/spec/regressions/enhanced_import_extracts_frequent_places_spec.rb
+++ b/spec/regressions/enhanced_import_extracts_frequent_places_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Enhanced import extracts named frequent places' do
+  let(:user) { create(:user) }
+  let(:fixture_path) do
+    Rails.root.join('spec/fixtures/files/enhanced_import/google_phone_takeout_with_frequent_places.json')
+  end
+  let(:import) do
+    imp = create(:import, user: user, source: :google_phone_takeout)
+    imp.file.attach(
+      io: File.open(fixture_path),
+      filename: 'frequent.json',
+      content_type: 'application/json'
+    )
+    imp
+  end
+
+  it 'creates a Place row per frequentPlace with the user-facing label' do
+    EnhancedImport::ExtractJob.new.perform(import.id)
+
+    home = Place.find_by("geodata ->> 'external_place_id' = ?", 'google:ChIJ_HOME_FREQUENT')
+    work = Place.find_by("geodata ->> 'external_place_id' = ?", 'google:ChIJ_WORK_FREQUENT')
+
+    expect(home).to be_present
+    expect(home.name).to eq('Home')
+    expect(work).to be_present
+    expect(work.name).to eq('Work')
+  end
+
+  it 'records the frequentPlaces in the import counts' do
+    EnhancedImport::ExtractJob.new.perform(import.id)
+    expect(import.reload.extraction_counts[:places]).to be >= 2
+  end
+end

--- a/spec/regressions/enhanced_import_extracts_tracks_with_transportation_modes_spec.rb
+++ b/spec/regressions/enhanced_import_extracts_tracks_with_transportation_modes_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Enhanced import extracts tracks with transportation modes' do
+  let(:user) do
+    create(:user, settings: {
+             'minutes_between_routes' => 30,
+             'meters_between_routes' => 500
+           })
+  end
+  let(:import) { create(:import, user: user, source: :google_phone_takeout) }
+  let(:base_time) { 1.hour.ago.to_i }
+
+  before do
+    10.times do |i|
+      create(
+        :point,
+        user: user,
+        import_id: import.id,
+        tracker_id: 'phone',
+        timestamp: base_time + (i * 60),
+        lonlat: "POINT(#{13.405 + (i * 0.0001)} #{52.52 + (i * 0.0001)})"
+      )
+    end
+  end
+
+  let(:extracted_track) do
+    EnhancedImport::Extracted::Track.new(
+      tracker_id: 'phone',
+      start_at: Time.zone.at(base_time),
+      end_at:   Time.zone.at(base_time + 540),
+      distance_m: 1500,
+      transportation_mode: 'driving',
+      confidence: 90,
+      source_label: 'google_phone_takeout',
+      segments: [
+        EnhancedImport::Extracted::TrackSegment.new(
+          start_index: 0,
+          end_index: 9,
+          transportation_mode: 'driving',
+          confidence: 90,
+          source_label: 'google_phone_takeout'
+        )
+      ]
+    )
+  end
+
+  context 'when trust_source is true (default)' do
+    before do
+      allow_any_instance_of(EnhancedImport::Translator).to receive(:translate) do |&block|
+        block.call(extracted_track)
+      end
+    end
+
+    it 'creates one Track scoped to the tracker_id' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+      track = Track.last
+      expect(track).to be_present
+      expect(track.tracker_id).to eq('phone')
+      expect(track.user_id).to eq(user.id)
+    end
+
+    it 'writes the source-app TrackSegment with the extraction source label' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+      track = Track.last
+      segments = track.track_segments
+      driving_segments = segments.where(source: 'google_phone_takeout')
+      expect(driving_segments.count).to eq(1)
+      expect(driving_segments.first.transportation_mode).to eq('driving')
+    end
+
+    it 'records counts on the import' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+      counts = import.reload.extraction_counts
+      expect(counts[:tracks]).to eq(1)
+      expect(counts[:segments]).to eq(1)
+    end
+  end
+
+  context 'when trust_source is false' do
+    before do
+      import.update!(additional_data_extraction: { 'options' => { 'trust_source' => false } })
+      allow_any_instance_of(EnhancedImport::Translator).to receive(:translate) do |&block|
+        block.call(extracted_track)
+      end
+    end
+
+    it 'creates the Track but skips writing source-app segments' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+      track = Track.last
+      expect(track).to be_present
+      expect(track.track_segments.where(source: 'google_phone_takeout').count).to eq(0)
+    end
+  end
+end

--- a/spec/regressions/enhanced_import_extracts_visits_and_places_spec.rb
+++ b/spec/regressions/enhanced_import_extracts_visits_and_places_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Enhanced import extracts visits and places' do
+  let(:user) { create(:user) }
+
+  shared_examples 'an adapter that emits one visit and one place' do
+    it 'creates the place with an external_place_id' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+      place = Place.last
+      expect(place).to be_present
+      expect(place.geodata['external_place_id']).to start_with(expected_place_id_prefix)
+    end
+
+    it 'creates the visit linked to the place' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+      visit = Visit.last
+      expect(visit).to be_present
+      expect(visit.user_id).to eq(user.id)
+      expect(visit.place_id).to eq(Place.last.id)
+      expect(visit.duration).to be > 0
+    end
+
+    it 'records counts on the import' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+      expect(import.reload.extraction_counts[:visits]).to eq(1)
+      expect(import.reload.extraction_counts[:places]).to eq(1)
+      expect(import.reload.additional_data_extraction_status).to eq('completed')
+    end
+  end
+
+  context 'with a Google phone takeout file' do
+    let(:expected_place_id_prefix) { 'google:' }
+    let(:fixture_path) { Rails.root.join('spec/fixtures/files/enhanced_import/google_phone_takeout_minimal.json') }
+    let(:import) { build_import_with_file(:google_phone_takeout, fixture_path) }
+
+    include_examples 'an adapter that emits one visit and one place'
+  end
+
+  context 'with a Google semantic history file' do
+    let(:expected_place_id_prefix) { 'google:' }
+    let(:fixture_path) { Rails.root.join('spec/fixtures/files/enhanced_import/google_semantic_history_minimal.json') }
+    let(:import) { build_import_with_file(:google_semantic_history, fixture_path) }
+
+    include_examples 'an adapter that emits one visit and one place'
+  end
+
+  context 'with a Polarsteps export' do
+    let(:expected_place_id_prefix) { 'polarsteps:' }
+    let(:fixture_path) { Rails.root.join('spec/fixtures/files/enhanced_import/polarsteps_segments_minimal.json') }
+    let(:import) { build_import_with_file(:polarsteps, fixture_path) }
+
+    include_examples 'an adapter that emits one visit and one place'
+  end
+
+  def build_import_with_file(source, path)
+    import = create(:import, user: user, source: source, name: "test-#{source}-#{rand(10_000)}.json")
+    import.file.attach(
+      io: File.open(path),
+      filename: File.basename(path),
+      content_type: 'application/json'
+    )
+    import
+  end
+end

--- a/spec/regressions/enhanced_import_idempotency_spec.rb
+++ b/spec/regressions/enhanced_import_idempotency_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Enhanced import is idempotent on re-runs' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :google_phone_takeout) }
+
+  let(:place) do
+    EnhancedImport::Extracted::Place.new(
+      external_place_id: 'google:ChIJ_TEST_HOME',
+      name: 'Home',
+      latitude: 52.52,
+      longitude: 13.405
+    )
+  end
+
+  let(:visit) do
+    EnhancedImport::Extracted::Visit.new(
+      started_at: Time.zone.parse('2025-04-01T10:00:00Z'),
+      ended_at:   Time.zone.parse('2025-04-01T13:00:00Z'),
+      place: place,
+      name: 'Home',
+      confidence: 95,
+      source_label: 'google_phone_takeout'
+    )
+  end
+
+  before do
+    allow_any_instance_of(EnhancedImport::Translator).to receive(:translate) do |&block|
+      block.call(visit)
+    end
+  end
+
+  it 'inserts exactly one Place and one Visit when run twice' do
+    expect { EnhancedImport::ExtractJob.new.perform(import.id) }
+      .to change { Place.count }.by(1)
+      .and change { Visit.count }.by(1)
+
+    expect { EnhancedImport::ExtractJob.new.perform(import.id) }
+      .not_to(change { Place.count + Visit.count })
+
+    expect(import.reload.additional_data_extraction_status).to eq('completed')
+  end
+end

--- a/spec/regressions/enhanced_import_place_dedup_spec.rb
+++ b/spec/regressions/enhanced_import_place_dedup_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Extracted places reuse an existing pin only when it is the same place' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :google_phone_takeout) }
+  let(:writer) { EnhancedImport::Writers::PlaceWriter.new(user, import) }
+
+  def extracted(name:, lat: 51.3402, lon: 12.3712, external_id: "google:#{name}")
+    EnhancedImport::Extracted::Place.new(
+      external_place_id: external_id,
+      name: name,
+      latitude: lat,
+      longitude: lon,
+      semantic_type: nil,
+      geodata_extras: {}
+    )
+  end
+
+  it 'reuses a Dawarich-geocoded place with the same name at the same spot' do
+    existing = create(:place, user: user, name: 'Home', latitude: 51.3402, longitude: 12.3712,
+                              lonlat: 'POINT(12.3712 51.3402)')
+
+    place, created = writer.upsert(extracted(name: 'Home'))
+
+    expect(created).to be false
+    expect(place.id).to eq(existing.id)
+  end
+
+  it 'does not collapse a different place that merely sits nearby' do
+    create(:place, user: user, name: 'Bakery', latitude: 51.3402, longitude: 12.3712,
+                   lonlat: 'POINT(12.3712 51.3402)')
+
+    place, created = writer.upsert(extracted(name: 'Home'))
+
+    expect(created).to be true
+    expect(place.name).to eq('Home')
+    expect(Place.where(user_id: user.id).count).to eq(2)
+  end
+
+  it 'keeps two distinct Google places within the radius apart' do
+    first, = writer.upsert(extracted(name: 'Home'))
+    second, = writer.upsert(extracted(name: 'Office', lat: 51.34025, lon: 12.37125))
+
+    expect(first.id).not_to eq(second.id)
+    expect(Place.where(user_id: user.id).pluck(:name)).to contain_exactly('Home', 'Office')
+  end
+
+  it 'still prefers an exact external id match' do
+    place_one, = writer.upsert(extracted(name: 'Home'))
+    place_two, created = writer.upsert(extracted(name: 'Home'))
+
+    expect(created).to be false
+    expect(place_two.id).to eq(place_one.id)
+  end
+end

--- a/spec/regressions/enhanced_import_polarsteps_real_format_spec.rb
+++ b/spec/regressions/enhanced_import_polarsteps_real_format_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Polarsteps extraction reads the shape the detector actually accepts' do
+  let(:user) { create(:user) }
+
+  def import_with(path)
+    import = create(:import, user: user, source: :polarsteps, name: "polarsteps-#{rand(10_000)}.json")
+    import.file.attach(
+      io: File.open(Rails.root.join(path)),
+      filename: File.basename(path),
+      content_type: 'application/json'
+    )
+    import
+  end
+
+  it 'extracts visits from a bare array of steps' do
+    import = import_with('spec/fixtures/files/enhanced_import/polarsteps_steps_array.json')
+
+    EnhancedImport::ExtractJob.new.perform(import.id)
+
+    expect(import.reload.additional_data_extraction_completed?).to be true
+    expect(import.extraction_counts[:visits]).to eq(2)
+    expect(Place.where(import_id: import.id).pluck(:name)).to include('Tokyo, Japan', 'Kyoto, Japan')
+  end
+
+  it 'completes without artifacts for a locations-only GPS trail' do
+    trail = Rails.root.join('tmp/polarsteps_locations_only.json')
+    trail.write({ 'locations' => [{ 'lat' => 51.34, 'lon' => 12.37, 'time' => 1_735_689_600 }] }.to_json)
+    import = import_with(trail.relative_path_from(Rails.root).to_s)
+
+    expect { EnhancedImport::ExtractJob.new.perform(import.id) }.not_to raise_error
+
+    expect(import.reload.additional_data_extraction_completed?).to be true
+    expect(import.extraction_counts[:visits].to_i).to eq(0)
+  ensure
+    FileUtils.rm_f(trail)
+  end
+end

--- a/spec/regressions/enhanced_import_reextract_rebuilds_segments_spec.rb
+++ b/spec/regressions/enhanced_import_reextract_rebuilds_segments_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Re-extraction finds the track it created before' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :google_phone_takeout) }
+  let(:activity_start) { Time.zone.parse('2026-02-10 08:00:00') }
+
+  # The activity boundary deliberately precedes the first point, which is what
+  # the stored start_at ends up being.
+  let(:extracted_track) do
+    EnhancedImport::Extracted::Track.new(
+      tracker_id: "import-#{import.id}-activity-#{activity_start.to_i}",
+      start_at: activity_start,
+      end_at: activity_start + 1.hour,
+      distance_m: 900,
+      transportation_mode: 'driving',
+      confidence: 90,
+      source_label: 'google_phone_takeout',
+      segments: [
+        EnhancedImport::Extracted::TrackSegment.new(
+          start_index: 0, end_index: 0, transportation_mode: 'driving',
+          confidence: 90, source_label: 'google_phone_takeout'
+        )
+      ]
+    )
+  end
+
+  before do
+    5.times do |i|
+      create(:point, user: user, import_id: import.id, tracker_id: 'phone',
+                     timestamp: (activity_start + 5.minutes).to_i + (i * 60),
+                     lonlat: "POINT(#{12.3712 + (i * 0.001)} #{51.3402 + (i * 0.001)})")
+    end
+  end
+
+  it 'reuses the same track instead of reporting nothing on a second run' do
+    writer = EnhancedImport::Writers::TrackWriter.new(user, import)
+
+    first, created = writer.upsert(extracted_track, skip_segment_detection: true)
+    expect(created).to be true
+    expect(first.start_at).not_to eq(activity_start)
+
+    second, created_again = writer.upsert(extracted_track, skip_segment_detection: true)
+
+    expect(created_again).to be false
+    expect(second.id).to eq(first.id)
+    expect(Track.where(user_id: user.id).count).to eq(1)
+  end
+
+  it 'rebuilds segments when the trust choice flips' do
+    writer = EnhancedImport::Writers::TrackWriter.new(user, import)
+    track, = writer.upsert(extracted_track, skip_segment_detection: true)
+    EnhancedImport::Writers::SegmentWriter.new.upsert(track, extracted_track.segments.first)
+
+    expect(track.reload.track_segments.count).to eq(1)
+
+    writer.upsert(extracted_track, skip_segment_detection: true)
+
+    expect(track.reload.track_segments.count).to eq(0)
+  end
+end

--- a/spec/regressions/enhanced_import_segment_span_and_mode_spec.rb
+++ b/spec/regressions/enhanced_import_segment_span_and_mode_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Extracted segments span their track and set a dominant mode' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :google_phone_takeout) }
+  let(:track) { create(:track, user: user, dominant_mode: nil) }
+
+  before do
+    5.times do |i|
+      create(:point, user: user, import_id: import.id, track_id: track.id,
+                     timestamp: 1.hour.ago.to_i + (i * 60),
+                     lonlat: "POINT(#{12.3712 + (i * 0.001)} #{51.3402 + (i * 0.001)})")
+    end
+  end
+
+  def extracted_segment(confidence)
+    EnhancedImport::Extracted::TrackSegment.new(
+      start_index: 0,
+      end_index: 0,
+      transportation_mode: 'driving',
+      confidence: confidence,
+      source_label: 'google_phone_takeout'
+    )
+  end
+
+  it 'stretches a degenerate segment across the track points' do
+    segment, = EnhancedImport::Writers::SegmentWriter.new.upsert(track, extracted_segment(0.9))
+
+    expect(segment.start_index).to eq(0)
+    expect(segment.end_index).to eq(4)
+  end
+
+  describe 'confidence coming from Google as a string' do
+    it 'maps HIGH to high' do
+      segment, = EnhancedImport::Writers::SegmentWriter.new.upsert(track, extracted_segment('HIGH'))
+      expect(segment.confidence).to eq('high')
+    end
+
+    it 'maps MEDIUM to medium' do
+      segment, = EnhancedImport::Writers::SegmentWriter.new.upsert(track, extracted_segment('MEDIUM'))
+      expect(segment.confidence).to eq('medium')
+    end
+
+    it 'still handles numeric probabilities' do
+      segment, = EnhancedImport::Writers::SegmentWriter.new.upsert(track, extracted_segment(0.95))
+      expect(segment.confidence).to eq('high')
+    end
+  end
+end

--- a/spec/regressions/enhanced_import_track_single_device_spec.rb
+++ b/spec/regressions/enhanced_import_track_single_device_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Enhanced import keeps extracted tracks on a single device' do
+  let(:user) do
+    create(:user, settings: {
+             'minutes_between_routes' => 30,
+             'meters_between_routes' => 500
+           })
+  end
+  let(:import) { create(:import, user: user, source: :google_phone_takeout) }
+  let(:base_time) { 1.hour.ago.to_i }
+
+  let(:extracted_track) do
+    EnhancedImport::Extracted::Track.new(
+      tracker_id: "import-#{import.id}-activity-#{base_time}",
+      start_at: Time.zone.at(base_time),
+      end_at: Time.zone.at(base_time + 900),
+      distance_m: 1500,
+      transportation_mode: 'driving',
+      confidence: 90,
+      source_label: 'google_phone_takeout',
+      segments: []
+    )
+  end
+
+  subject(:result) do
+    described_track_writer.upsert(extracted_track, skip_segment_detection: true)
+  end
+
+  let(:described_track_writer) { EnhancedImport::Writers::TrackWriter.new(user, import) }
+
+  def create_points(tracker_id:, count:, offset:, lon_base:)
+    count.times do |i|
+      create(
+        :point,
+        user: user,
+        import_id: import.id,
+        tracker_id: tracker_id,
+        timestamp: base_time + offset + (i * 60),
+        lonlat: "POINT(#{lon_base + (i * 0.0001)} #{52.52 + (i * 0.0001)})"
+      )
+    end
+  end
+
+  context 'when the time window holds points from two devices' do
+    before do
+      create_points(tracker_id: 'phone', count: 8, offset: 0, lon_base: 13.405)
+      create_points(tracker_id: 'tablet', count: 3, offset: 30, lon_base: 20.100)
+    end
+
+    it 'builds the track from the dominant device only' do
+      track, created = result
+
+      expect(created).to be true
+      expect(track).to be_present
+
+      tracker_ids = Point.where(track_id: track.id).distinct.pluck(:tracker_id)
+      expect(tracker_ids).to eq(['phone'])
+    end
+
+    it 'leaves the other device\'s points unassigned' do
+      track, = result
+
+      tablet_points = Point.where(user_id: user.id, import_id: import.id, tracker_id: 'tablet')
+      expect(tablet_points.pluck(:track_id).uniq).to eq([nil])
+      expect(tablet_points.count).to eq(3)
+      expect(track.id).to be_present
+    end
+  end
+
+  context 'when every point in the window is from one device' do
+    before do
+      create_points(tracker_id: 'phone', count: 10, offset: 0, lon_base: 13.405)
+    end
+
+    it 'uses all of them' do
+      track, created = result
+
+      expect(created).to be true
+      expect(Point.where(track_id: track.id).count).to eq(10)
+    end
+  end
+end

--- a/spec/regressions/enhanced_import_unsupported_source_spec.rb
+++ b/spec/regressions/enhanced_import_unsupported_source_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Enhanced import for unsupported sources is not offered' do
+  let(:user) { create(:user) }
+
+  it 'marks GPX imports as unsupported on creation' do
+    import = create(:import, user: user, source: :gpx)
+    expect(import.additional_data_extraction_unsupported?).to be true
+  end
+
+  it 'reports a GPX import as not supported by the translator' do
+    import = build(:import, user: user, source: :gpx)
+    expect(import.additional_data_extraction_supported?).to be false
+  end
+
+  it 'reports the sources with a real adapter as supported' do
+    %i[google_phone_takeout google_semantic_history polarsteps].each do |src|
+      import = build(:import, user: user, source: src)
+      expect(import.additional_data_extraction_supported?).to be(true), "expected #{src} supported"
+    end
+  end
+
+  it 'does not offer extraction for Google Records, whose export carries no visit metadata' do
+    import = build(:import, user: user, source: :google_records)
+    expect(import.additional_data_extraction_supported?).to be false
+  end
+
+  it 'translator returns no items for an unsupported source' do
+    import = create(:import, user: user, source: :gpx)
+    items = EnhancedImport::Translator.new(import).translate.to_a
+    expect(items).to be_empty
+  end
+end

--- a/spec/regressions/enhanced_import_unsupported_status_on_create_spec.rb
+++ b/spec/regressions/enhanced_import_unsupported_status_on_create_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Extraction availability is resolved when an import is created' do
+  let(:user) { create(:user) }
+
+  it 'marks a source without an adapter as unsupported' do
+    import = create(:import, user: user, source: :gpx)
+
+    expect(import.additional_data_extraction_unsupported?).to be true
+  end
+
+  it 'marks an import with no source as unsupported' do
+    import = create(:import, user: user, source: nil)
+
+    expect(import.additional_data_extraction_unsupported?).to be true
+  end
+
+  it 'leaves a supported source available for extraction' do
+    import = create(:import, user: user, source: :google_phone_takeout)
+
+    expect(import.additional_data_extraction_not_attempted?).to be true
+  end
+
+  it 'becomes available again once a source-less upload is identified as supported' do
+    import = create(:import, user: user, source: nil)
+    expect(import.additional_data_extraction_unsupported?).to be true
+
+    import.update!(source: :google_phone_takeout)
+
+    expect(import.additional_data_extraction_not_attempted?).to be true
+  end
+
+  it 'keeps a finished extraction when the source is rewritten' do
+    import = create(:import, user: user, source: :google_phone_takeout)
+    import.update_columns(
+      additional_data_extraction_status: Import.additional_data_extraction_statuses[:completed]
+    )
+
+    import.reload.update!(name: 'renamed.json')
+
+    expect(import.reload.additional_data_extraction_completed?).to be true
+  end
+
+  it 'does not offer the extraction call to action for an unsupported import' do
+    import = create(:import, user: user, source: :gpx)
+
+    rendered = ApplicationController.render(
+      partial: 'imports/extraction_card',
+      locals: { import: import }
+    )
+
+    expect(rendered).not_to include('Extract additional data')
+    expect(rendered).to include('nothing additional to extract')
+  end
+
+  describe 'a run that never reported back' do
+    let(:import) { create(:import, user: user, source: :google_phone_takeout) }
+
+    it 'is not stalled while it is still fresh' do
+      import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:running],
+        additional_data_extraction: { 'started_at' => 5.minutes.ago.iso8601 }
+      )
+
+      expect(import.extraction_stalled?).to be false
+    end
+
+    it 'is stalled once it outlives the window, so the card can offer recovery' do
+      import.update_columns(
+        additional_data_extraction_status: Import.additional_data_extraction_statuses[:running],
+        additional_data_extraction: { 'started_at' => 7.hours.ago.iso8601 }
+      )
+
+      expect(import.extraction_stalled?).to be true
+
+      rendered = ApplicationController.render(partial: 'imports/extraction_card', locals: { import: import })
+      expect(rendered).to include('Start over')
+    end
+
+    it 'is never stalled when nothing is running' do
+      expect(import.extraction_stalled?).to be false
+    end
+  end
+end

--- a/spec/regressions/enhanced_import_visit_duration_units_spec.rb
+++ b/spec/regressions/enhanced_import_visit_duration_units_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Extracted visits record duration in minutes' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :polarsteps) }
+  let(:place) { create(:place, user: user) }
+  let(:started_at) { Time.zone.parse('2026-02-01 09:00:00') }
+
+  it 'stores three hours as 180, matching every other visit writer' do
+    extracted = EnhancedImport::Extracted::Visit.new(
+      started_at: started_at,
+      ended_at: started_at + 3.hours,
+      place: nil,
+      name: 'Cafe',
+      confidence: nil,
+      source_label: 'polarsteps'
+    )
+
+    visit, = EnhancedImport::Writers::VisitWriter.new(user, import).upsert(extracted, place)
+
+    expect(visit.duration).to eq(180)
+  end
+
+  it 'agrees with Visits::Create for the same window' do
+    service = Visits::Create.new(user, {
+                                   name: 'Cafe',
+                                   latitude: place.latitude,
+                                   longitude: place.longitude,
+                                   started_at: started_at.iso8601,
+                                   ended_at: (started_at + 3.hours).iso8601
+                                 })
+    service.call
+
+    extracted = EnhancedImport::Extracted::Visit.new(
+      started_at: started_at + 1.day,
+      ended_at: started_at + 1.day + 3.hours,
+      place: nil,
+      name: 'Cafe',
+      confidence: nil,
+      source_label: 'polarsteps'
+    )
+    extracted_visit, = EnhancedImport::Writers::VisitWriter.new(user, import).upsert(extracted, place)
+
+    expect(extracted_visit.duration).to eq(service.visit.duration)
+  end
+end

--- a/spec/regressions/enhanced_import_zip_upload_spec.rb
+++ b/spec/regressions/enhanced_import_zip_upload_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Extraction reads a single-entry archive upload' do
+  let(:user) { create(:user) }
+  let(:source_json) { Rails.root.join('spec/fixtures/files/enhanced_import/polarsteps_steps_array.json') }
+  let(:zip_path) { Rails.root.join("tmp/enhanced_import_#{SecureRandom.hex(4)}.zip") }
+
+  before do
+    Zip::File.open(zip_path, create: true) do |zip|
+      zip.add('locations.json', source_json)
+    end
+  end
+
+  after { FileUtils.rm_f(zip_path) }
+
+  it 'unwraps the archive instead of feeding zip bytes to the parser' do
+    import = create(:import, user: user, source: :polarsteps, name: "zipped-#{rand(10_000)}.zip")
+    import.file.attach(io: File.open(zip_path), filename: 'export.zip', content_type: 'application/zip')
+
+    EnhancedImport::ExtractJob.new.perform(import.id)
+
+    expect(import.reload.additional_data_extraction_completed?).to be true
+    expect(import.extraction_counts[:visits]).to eq(2)
+  end
+end

--- a/spec/regressions/visit_creator_survives_duplicate_collision_spec.rb
+++ b/spec/regressions/visit_creator_survives_duplicate_collision_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Visit creation survives a unique-index collision' do
+  let(:user) { create(:user) }
+  let(:place) { create(:place, user: user) }
+  let(:started_at) { Time.zone.parse('2026-03-04 10:00:00') }
+
+  let(:visit_data) do
+    {
+      start_time: started_at.to_i,
+      end_time: (started_at + 1.hour).to_i,
+      duration: 3600,
+      suggested_name: 'Cafe',
+      latitude: place.latitude,
+      longitude: place.longitude,
+      points: []
+    }
+  end
+
+  it 'skips a colliding visit instead of aborting the whole batch' do
+    create(:visit, user: user, place: place, started_at: started_at, ended_at: started_at + 1.hour)
+
+    allow_any_instance_of(Visits::PlaceFinder).to receive(:find_or_create_place).and_return(place)
+    allow_any_instance_of(Visits::Creator).to receive(:find_existing_visit).and_return(nil)
+
+    creator = Visits::Creator.new(user)
+
+    expect { creator.create_visits([visit_data]) }.not_to raise_error
+    expect(user.visits.where(place_id: place.id, started_at: started_at).count).to eq(1)
+  end
+
+  it 'still creates the visits that do not collide' do
+    other_place = create(:place, user: user)
+    create(:visit, user: user, place: place, started_at: started_at, ended_at: started_at + 1.hour)
+
+    allow_any_instance_of(Visits::Creator).to receive(:find_existing_visit).and_return(nil)
+    allow_any_instance_of(Visits::PlaceFinder).to receive(:find_or_create_place)
+      .and_return(place, other_place)
+
+    second = visit_data.merge(start_time: (started_at + 5.hours).to_i,
+                              end_time: (started_at + 6.hours).to_i)
+
+    creator = Visits::Creator.new(user)
+    result = creator.create_visits([visit_data, second])
+
+    expect(result.compact.size).to eq(1)
+  end
+end

--- a/spec/requests/imports/extractions_spec.rb
+++ b/spec/requests/imports/extractions_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Imports::Extractions' do
+  include ActiveJob::TestHelper
+
+  let(:user) { create(:user) }
+  let(:import) do
+    create(:import, user: user, source: :google_phone_takeout,
+                    additional_data_extraction_status: :completed,
+                    additional_data_extraction: { 'counts' => { 'visits' => 1 } })
+  end
+
+  describe 'DELETE /imports/:import_id/extraction' do
+    context 'when signed in as the owner' do
+      before { sign_in user }
+
+      it 'enqueues removal of the extracted artifacts' do
+        place = create(:place, user: user, import_id: import.id)
+        create(:visit, user: user, place: place, import_id: import.id)
+
+        expect { delete import_extraction_path(import) }
+          .to have_enqueued_job(EnhancedImport::DestroyJob).with(import.id)
+
+        expect(response).to redirect_to(import_path(import))
+      end
+
+      it 'removes the artifacts when the job runs' do
+        place = create(:place, user: user, import_id: import.id)
+        create(:visit, user: user, place: place, import_id: import.id)
+
+        delete import_extraction_path(import)
+        perform_enqueued_jobs
+
+        expect(Visit.where(import_id: import.id).count).to eq(0)
+        expect(import.reload.additional_data_extraction_not_attempted?).to be true
+      end
+
+      it 'refuses when nothing has been extracted' do
+        import.update_columns(
+          additional_data_extraction_status: Import.additional_data_extraction_statuses[:not_attempted],
+          additional_data_extraction: {}
+        )
+
+        delete import_extraction_path(import)
+
+        expect(response).not_to have_http_status(:success)
+      end
+    end
+
+    context 'when signed in as another user' do
+      let(:intruder) { create(:user) }
+
+      before { sign_in intruder }
+
+      it 'does not remove anything' do
+        place = create(:place, user: user, import_id: import.id)
+        create(:visit, user: user, place: place, import_id: import.id)
+
+        expect { delete import_extraction_path(import) }
+          .not_to have_enqueued_job(EnhancedImport::DestroyJob)
+      end
+    end
+
+    context 'when signed out' do
+      it 'redirects to sign in' do
+        delete import_extraction_path(import)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/services/enhanced_import/destroy_spec.rb
+++ b/spec/services/enhanced_import/destroy_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EnhancedImport::Destroy do
+  subject(:service) { described_class.new(import) }
+
+  let(:user) { create(:user) }
+  let(:import) do
+    create(:import, user: user, source: :google_phone_takeout,
+                    additional_data_extraction_status: :completed,
+                    additional_data_extraction: { 'counts' => { 'visits' => 1 } })
+  end
+
+  describe '#call' do
+    context 'with artifacts created by this extraction' do
+      let!(:extracted_place) { create(:place, user: user, import_id: import.id) }
+      let!(:extracted_visit) { create(:visit, user: user, place: extracted_place, import_id: import.id) }
+      let!(:extracted_track) { create(:track, user: user, import_id: import.id) }
+      let!(:extracted_segment) { create(:track_segment, track: extracted_track) }
+
+      it 'removes the extracted visits, tracks and places' do
+        expect { service.call }
+          .to change(Visit, :count).by(-1)
+          .and change(Track, :count).by(-1)
+          .and change(Place, :count).by(-1)
+
+        expect(Visit.exists?(extracted_visit.id)).to be false
+        expect(Track.exists?(extracted_track.id)).to be false
+        expect(Place.exists?(extracted_place.id)).to be false
+      end
+
+      it 'cascades track segments' do
+        expect { service.call }.to change(TrackSegment, :count).by(-1)
+        expect(TrackSegment.exists?(extracted_segment.id)).to be false
+      end
+
+      it 'resets the extraction state so the import can be re-extracted' do
+        service.call
+        import.reload
+
+        expect(import.additional_data_extraction_not_attempted?).to be true
+        expect(import.extraction_counts).to eq({})
+      end
+    end
+
+    context 'when the extraction assigned points to a track' do
+      let!(:extracted_track) { create(:track, user: user, import_id: import.id) }
+      let!(:point) { create(:point, user: user, import_id: import.id, track_id: extracted_track.id) }
+
+      it 'releases the points instead of deleting them' do
+        expect { service.call }.not_to(change(Point, :count))
+        expect(point.reload.track_id).to be_nil
+      end
+    end
+
+    context 'when a place is still referenced by a visit Dawarich detected itself' do
+      let!(:extracted_place) { create(:place, user: user, import_id: import.id) }
+      let!(:extracted_visit) { create(:visit, user: user, place: extracted_place, import_id: import.id) }
+      let!(:own_visit) { create(:visit, user: user, place: extracted_place, import_id: nil) }
+
+      it 'keeps the place' do
+        expect { service.call }.to change(Visit, :count).by(-1)
+
+        expect(Place.exists?(extracted_place.id)).to be true
+        expect(own_visit.reload.place_id).to eq(extracted_place.id)
+      end
+    end
+
+    context 'with artifacts belonging to a different import' do
+      let(:other_import) { create(:import, user: user, source: :google_phone_takeout) }
+      let!(:other_visit) { create(:visit, user: user, import_id: other_import.id) }
+      let!(:untouched_visit) { create(:visit, user: user, import_id: nil) }
+
+      it 'leaves them alone' do
+        expect { service.call }.not_to(change(Visit, :count))
+
+        expect(Visit.exists?(other_visit.id)).to be true
+        expect(Visit.exists?(untouched_visit.id)).to be true
+      end
+    end
+
+    it 'is safe to run when nothing was extracted' do
+      expect { service.call }.not_to raise_error
+      expect(import.reload.additional_data_extraction_not_attempted?).to be true
+    end
+  end
+end

--- a/spec/services/visits/create_spec.rb
+++ b/spec/services/visits/create_spec.rb
@@ -20,8 +20,16 @@ RSpec.describe Visits::Create do
 
       it 'creates a visit successfully' do
         expect { service.call }.to change { user.visits.count }.by(1)
-        expect(service.call).to be_truthy
         expect(service.visit).to be_persisted
+      end
+
+      it 'returns the existing visit instead of duplicating it on a repeated call' do
+        first = described_class.new(user, valid_params)
+        first.call
+
+        expect { service.call }.not_to(change { user.visits.count })
+        expect(service.call).to be_truthy
+        expect(service.visit).to eq(first.visit)
       end
 
       it 'creates a visit with correct attributes' do

--- a/spec/services/visits/find_in_time_spec.rb
+++ b/spec/services/visits/find_in_time_spec.rb
@@ -92,11 +92,13 @@ RSpec.describe Visits::FindInTime do
     end
 
     context 'with visits at the boundaries of the time range' do
+      let(:boundary_place) { create(:place) }
+
       let!(:visit_at_start) do
         create(
           :visit,
           user: user,
-          place: place,
+          place: boundary_place,
           started_at: reference_time,
           ended_at: reference_time + 30.minutes
         )


### PR DESCRIPTION
## Summary

Adds a richer import experience: an extraction job decomposes uploaded import files into structured artifacts (places, tracks, segments, visits), an imports detail page surfaces extraction state, and the imports table row links into the new flow.

## Status

Rebased onto `dev` (`2d49d5a7`). The per-import tracker-id dependency landed in #3169, so the blocking condition is cleared and the branch merges cleanly.

## Scope

- `imports/extractions_controller.rb`, `enhanced_import/extract_job.rb`
- New adapters per import source: Google records, Google semantic history, Google phone takeout, Polarsteps
- Writers per artifact type: place / segment / track / visit
- Translator + extracted DTOs
- `imports/show` view: extraction card, dialog, status badge
- Stimulus `import_extraction_controller.js`
- Schema additions: `extraction_*` columns on imports, unique indexes on visits / track_segments, `external_place_id` index
- Idempotency, unsupported-source handling, regression coverage

## Rebase notes

The branch was 889 commits behind. Beyond conflict resolution, the rebase required these substantive changes — each is worth a look:

**Dropped three migrations superseded by #3169.** `ensure_tracker_id_on_tracks`, `add_unique_index_to_tracks`, and `finalize_tracks_unique_index` all predated the per-tracker work. Two problems: `dev` now ships its own `20260508193923_add_unique_index_to_tracks.rb` with the **same class name** (`AddUniqueIndexToTracks`), which is a load-time collision; and the branch's `idx_tracks_user_tracker_start_at_unique` is both stricter and weaker than `dev`'s `index_tracks_on_user_tracker_start_end_unique` — stricter because it rejects same-start/different-end tracks that `dev` allows, weaker because a plain unique index doesn't dedupe NULL `tracker_id` the way `dev`'s `COALESCE(tracker_id, '')` does. It also dropped `idx_tracks_user_tracker_end_at`, which `dev` still uses. `dev`'s design wins; all three are gone.

**Re-dated the remaining five migrations to `20260730210*`.** They were timestamped `20260508*`, which is *older* than `dev`'s schema version (`2026_07_27_130000`). On a fresh install `assume_migrated_upto_version` marks anything below the schema version as already-applied, so these would have been **silently skipped** and the columns never created. Verified by regenerating `db/schema.rb` from an actual migration run.

**`Tracks::TrackBuilder` conflict.** `dev` wrapped track creation in a `requires_new: true` savepoint with a `RecordNotUnique` rescue; this branch added `skip_segment_detection:`. Kept `dev`'s transaction structure and layered the flag onto the `detect_and_create_segments` call.

**`ImportsController#index` select list.** `dev` narrowed the index query to explicit columns. The new extraction status badge reads `additional_data_extraction_status`, which wasn't selected — every import row raised `MissingAttributeError`. Added the column.

**`database-zap` icon doesn't exist** in the vendored Lucide set; the extraction card raised on `imports#show`. Swapped for `layer`.

**`Visits::Create` now handles the new unique index.** ⚠️ **Please review this one.** With `idx_visits_user_started_at_place_unique` in place, creating the same visit twice raises `RecordNotUnique`, which the service's generic `rescue StandardError` swallowed — reporting it to GlitchTip as an application error. Rather than add a new error-noise source, `call` now rescues `RecordNotUnique` and returns the existing visit, making the endpoint idempotent. This is a **behavior change to `POST /api/v1/visits`**: an exact-duplicate visit now returns the original instead of creating a second row. That seems right — two visits to the same place at the same instant are the same visit — but it wasn't in the original scope, so it's your call.

**`:track_segment` factory used a constant `start_index { 0 }`**, which collides with the new `(track_id, start_index)` unique index whenever a spec builds two segments on one track. Switched to a sequence. `Tracks::Reprocessor` already rejects overlapping segment ranges, so distinct start indices match the domain rule.


## Undoing an extraction

Extraction used to be one-way: the only route was `create`, nothing removed artifacts, and "Re-extract" re-ran rather than reverted. That made the default-on behaviour for new imports hard to justify, since a user had no way back.

`EnhancedImport::Destroy` now removes the visits, places and tracks an extraction created and resets the import to `not_attempted`.

Artifacts are tracked by a new nullable `import_id` on `visits`, `places` and `tracks`, stamped by the writers. `track_segments` needs no column — it cascades via its track. The partial indexes (`WHERE import_id IS NOT NULL`) start empty, so this costs nothing on the existing 1.7M/2.5M/1.8M-row tables.

Three safety properties, each covered by a test:

- **Points are never deleted.** `Track has_many :points, dependent: :nullify` releases them instead.
- **Shared places survive.** A place is only removed if no visit still references it once the extracted visits are gone, so a place Dawarich's own detection later attached a visit to is kept.
- **Other imports are untouched.** Everything is scoped by `import_id`; rows with `import_id: nil` or another import's id are left alone.

Exposed as `DELETE /imports/:import_id/extraction`, owner-only via `ExtractionPolicy#destroy?`, with a "Remove extracted data" button on the card in both the completed and failed states.

## Verification

- Full suite on the rebased branch: **7,308 examples, 1 failure** — `google_phone_takeout_invalid_utf8_spec.rb:40`, confirmed pre-existing by running it against a a clean `dev` worktree.
- All 5 migrations run green against a fresh database (Strong Migrations passes); `db/schema.rb` regenerated from the real run, not hand-merged.
- RuboCop: 31 changed files, no offenses. Biome: clean.

## Test plan

- [x] Regression specs added (idempotency, frequent places, transportation modes, visits + places, unsupported source)
- [ ] Manual: upload a Google Records archive and confirm extraction → visible counts → re-trigger is idempotent
- [ ] Same for Polarsteps and Google Phone Takeout fixtures
