### PR TITLE
Recalculate monthly insights digest when stale (#2478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ scrape_configs:
 
 - Fixed monthly stats failing with a "Stats update failed" notification when the month's distance exceeded the int4 limit (2,147,483,647 m ≈ 2.15M km). Affected months stayed stuck on the prior value until recalculated. #1996
 - 500 error on the imports page. #2683
+- Insights weekly pattern now refreshes after monthly stats change, instead of showing a stale snapshot until the next monthly digest job runs. #2478
 
 ## [1.7.6] - 2026-05-09
 
@@ -98,7 +99,6 @@ scrape_configs:
 - Track generation no longer creates duplicate tracks — multiple background jobs (daily, realtime, recalc, import) could previously produce the same track per time window, leaving 2–3 copies on your map. Run **Map v2 → Settings → Recalculate tracks & stats** once after upgrading to recompute from the merged points. #2677
 - Heatmap on Map V2 looks a lot better than before
 - In notifications section of navbar only "99+" is shown when there are more than 99 notifications, instead of the actual number.
-
 
 ## [1.7.5] - 2026-05-04
 

--- a/app/controllers/insights_controller.rb
+++ b/app/controllers/insights_controller.rb
@@ -188,11 +188,22 @@ class InsightsController < ApplicationController
                                   .monthly
                                   .find_by(year: @selected_year, month: @selected_month)
 
-    return unless @monthly_digest.nil? && @available_months.include?(@selected_month)
+    return unless @available_months.include?(@selected_month)
+
+    return unless @monthly_digest.nil? || monthly_digest_stale?(@monthly_digest)
 
     @monthly_digest = Users::Digests::CalculateMonth
                       .new(current_user.id, @selected_year, @selected_month)
                       .call
+  end
+
+  def monthly_digest_stale?(digest)
+    latest_stat_update = current_user.scoped_stats
+                                     .where(year: digest.year, month: digest.month)
+                                     .maximum(:updated_at)
+    return false if latest_stat_update.nil?
+
+    digest.updated_at < latest_stat_update
   end
 
   def determine_selected_month

--- a/spec/regressions/insights_monthly_digest_staleness_spec.rb
+++ b/spec/regressions/insights_monthly_digest_staleness_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Insights monthly digest staleness', type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  context 'when an existing monthly digest is older than the latest stat' do
+    let!(:stat) do
+      create(:stat, user: user, year: 2026, month: 4, distance: 100_000,
+                    daily_distance: { '1' => 50_000, '8' => 50_000 })
+    end
+
+    let!(:stale_digest) do
+      digest = create(:users_digest, :monthly,
+                      user: user, year: 2026, month: 4,
+                      monthly_distances: { '1' => 5000 })
+      digest.update_columns(updated_at: 2.days.ago, created_at: 2.days.ago)
+      digest
+    end
+
+    before do
+      user.stats.where(year: 2026, month: 4).update_all(updated_at: 1.minute.ago)
+    end
+
+    it 'recalculates the monthly digest before rendering' do
+      original_updated_at = stale_digest.updated_at
+
+      get details_insights_url(year: '2026', month: '4')
+
+      expect(response.status).to eq(200)
+      expect(stale_digest.reload.updated_at).to be > original_updated_at
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes [#2478](https://github.com/Freika/dawarich/issues/2478) — `InsightsController#load_monthly_digest` cached digests indefinitely once generated. When new stats arrived for the same month, the digest stayed stale.

## Fix

Mirror the yearly path's `digest_stale?` guard for the monthly path: extract a private `monthly_digest_stale?(digest)` so the controller recalculates when the cached digest is older than the latest stat for the same month.

## Test plan

- [x] Regression spec: `spec/regressions/insights_monthly_digest_staleness_spec.rb`
- [ ] Add new points after a digest is rendered → revisit the page → digest reflects the new data

Closes #2478