### PR TITLE
Match area-only visits in bounding box queries (#2420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ scrape_configs:
 - Points with no reverse-geocoding result (ocean, wilderness) are now marked as attempted instead of being re-queued every nightly run; use "Start Reverse Geocoding" to retry after switching providers. #2271
 - Activity detection now falls back to displacement when the tracker reports 0 m/s, so OwnTracks Significant Change mode and similar low-power setups stop misclassifying real movement as stationary. Run **Map v2 → Settings → Recalculate tracks & stats** to apply to existing tracks. #2390
 - Redis no longer balloons (multi-GB) when browsing photos with Immich or Photoprism connected. Photo thumbnails are no longer copied into the server-side Redis cache; the browser caches them directly via `Cache-Control` instead. #1609
+- Drag-selecting a region on the map now includes visits attached to your saved Areas (Home, Work, etc.), instead of silently dropping area-only visits from the visit tray. #2420
 
 ## [1.7.6] - 2026-05-09
 

--- a/app/services/visits/find_within_bounding_box.rb
+++ b/app/services/visits/find_within_bounding_box.rb
@@ -11,16 +11,22 @@ module Visits
       @ne_lng = params[:ne_lng].to_f
     end
 
+    PLACE_INSIDE = 'places.lonlat IS NOT NULL AND ' \
+                   'ST_Contains(ST_MakeEnvelope(?, ?, ?, ?, 4326), ' \
+                   'ST_SetSRID(places.lonlat::geometry, 4326))'
+
+    AREA_INSIDE = 'areas.id IS NOT NULL AND ' \
+                  'ST_Contains(ST_MakeEnvelope(?, ?, ?, ?, 4326), ' \
+                  'ST_SetSRID(ST_MakePoint(areas.longitude, areas.latitude), 4326))'
+
     def call
       user.scoped_visits
           .includes(:place, :area)
-          .joins(:place)
+          .left_outer_joins(:place, :area)
           .where(
-            'ST_Contains(ST_MakeEnvelope(?, ?, ?, ?, 4326), ST_SetSRID(places.lonlat::geometry, 4326))',
-            sw_lng,
-            sw_lat,
-            ne_lng,
-            ne_lat
+            "(#{PLACE_INSIDE}) OR (#{AREA_INSIDE})",
+            sw_lng, sw_lat, ne_lng, ne_lat,
+            sw_lng, sw_lat, ne_lng, ne_lat
           )
           .order(started_at: :desc)
     end

--- a/app/services/visits/find_within_bounding_box.rb
+++ b/app/services/visits/find_within_bounding_box.rb
@@ -3,14 +3,6 @@
 module Visits
   # Finds visits in a selected area on the map
   class FindWithinBoundingBox
-    def initialize(user, params)
-      @user = user
-      @sw_lat = params[:sw_lat].to_f
-      @sw_lng = params[:sw_lng].to_f
-      @ne_lat = params[:ne_lat].to_f
-      @ne_lng = params[:ne_lng].to_f
-    end
-
     PLACE_INSIDE = 'places.lonlat IS NOT NULL AND ' \
                    'ST_Contains(ST_MakeEnvelope(?, ?, ?, ?, 4326), ' \
                    'ST_SetSRID(places.lonlat::geometry, 4326))'
@@ -19,10 +11,19 @@ module Visits
                   'ST_Contains(ST_MakeEnvelope(?, ?, ?, ?, 4326), ' \
                   'ST_SetSRID(ST_MakePoint(areas.longitude, areas.latitude), 4326))'
 
+    def initialize(user, params)
+      @user = user
+      @sw_lat = params[:sw_lat].to_f
+      @sw_lng = params[:sw_lng].to_f
+      @ne_lat = params[:ne_lat].to_f
+      @ne_lng = params[:ne_lng].to_f
+    end
+
     def call
       user.scoped_visits
-          .includes(:place, :area)
           .left_outer_joins(:place, :area)
+          .includes(:place, :area)
+          .references(:place, :area)
           .where(
             "(#{PLACE_INSIDE}) OR (#{AREA_INSIDE})",
             sw_lng, sw_lat, ne_lng, ne_lat,

--- a/spec/regressions/visits_in_area_includes_area_only_visits_spec.rb
+++ b/spec/regressions/visits_in_area_includes_area_only_visits_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Map Select Area returns visits attached only to an Area' do
+  let(:user) { create(:user) }
+
+  let(:envelope_params) do
+    {
+      sw_lat: '52.4', sw_lng: '13.5',
+      ne_lat: '52.5', ne_lng: '13.6'
+    }
+  end
+
+  let!(:area_inside) do
+    create(:area, user: user, latitude: 52.437, longitude: 13.539, radius: 100)
+  end
+
+  let!(:area_outside) do
+    create(:area, user: user, latitude: 50.0, longitude: 10.0, radius: 100)
+  end
+
+  let!(:place_inside) do
+    create(:place, latitude: 52.450, longitude: 13.550)
+  end
+
+  let!(:area_only_visit) do
+    create(:visit, user: user, area: area_inside, place: nil,
+                   started_at: 2.hours.ago, ended_at: 1.hour.ago)
+  end
+
+  let!(:place_only_visit) do
+    create(:visit, user: user, area: nil, place: place_inside,
+                   started_at: 4.hours.ago, ended_at: 3.hours.ago)
+  end
+
+  let!(:visit_outside_envelope) do
+    create(:visit, user: user, area: area_outside, place: nil,
+                   started_at: 6.hours.ago, ended_at: 5.hours.ago)
+  end
+
+  subject(:result) { Visits::FindWithinBoundingBox.new(user, envelope_params).call }
+
+  it 'includes visits whose Area centroid falls inside the envelope' do
+    expect(result).to include(area_only_visit)
+  end
+
+  it 'still includes visits whose Place falls inside the envelope' do
+    expect(result).to include(place_only_visit)
+  end
+
+  it 'excludes visits whose Area centroid falls outside the envelope' do
+    expect(result).not_to include(visit_outside_envelope)
+  end
+end


### PR DESCRIPTION
## Summary

Fixes [#2420](https://github.com/Freika/dawarich/issues/2420) — visits at user-defined Areas (with no associated Place) couldn't be selected from a map bounding-box query.

## Root cause

`Visits::FindWithinBoundingBox` joined `:place` only, so visits with no `Place` (area-only visits) were excluded.

## Fix

Switch `joins(:place)` → `left_outer_joins(:place, :area)` and match either `places.lonlat` inside the envelope OR `ST_MakePoint(areas.longitude, areas.latitude)` inside the envelope.

## Test plan

- [x] Regression: `spec/regressions/visits_in_area_includes_area_only_visits_spec.rb`
- [ ] Drag-select a region containing area-only visits and confirm they appear

Closes #2420