### PR TITLE
Rebind anomalies layer state on toggle, hydration, and date change (#2568)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix support of FIT files from Garmin Connect. #2686
+- The Anomalies map layer no longer requires manually toggling off and on after a page reload or timeframe change. The toggle state is restored on reload, and the layer refetches anomalies for the active date range. #2568
 
 ## [1.7.7] - 2026-05-09
 

--- a/app/javascript/controllers/maps/maplibre/routes_manager.js
+++ b/app/javascript/controllers/maps/maplibre/routes_manager.js
@@ -13,6 +13,7 @@ export class RoutesManager {
     this.map = controller.map
     this.layerManager = controller.layerManager
     this.settings = controller.settings
+    this._anomaliesFetchId = 0
   }
 
   /**
@@ -536,49 +537,52 @@ export class RoutesManager {
     SettingsManager.updateSetting("pointsVisible", visible)
   }
 
-  /**
-   * Toggle anomalies layer
-   * Fetches anomaly points from backend on first enable (lazy-load pattern)
-   */
   async toggleAnomalies(event) {
     const enabled = event.target.checked
     SettingsManager.updateSetting("anomaliesEnabled", enabled)
+    await this.refreshAnomalies({ enabled })
+  }
+
+  async refreshAnomalies({ enabled }) {
+    const anomaliesLayer = this.layerManager.getLayer("anomalies")
+    if (!anomaliesLayer) return
+
+    if (!enabled) {
+      anomaliesLayer.hide()
+      return
+    }
+
+    const fetchId = ++this._anomaliesFetchId
+    this.controller.showProgress()
+    this.controller.updateLoadingCounts({
+      counts: { anomalies: 0 },
+      isComplete: false,
+    })
 
     try {
-      const anomaliesLayer = this.layerManager.getLayer("anomalies")
-      if (!anomaliesLayer) return
+      const startDate = this.controller.startDateValue
+      const endDate = this.controller.endDateValue
+      const geoJSON = await anomaliesLayer.fetchAnomalies({
+        start_at: startDate,
+        end_at: endDate,
+      })
 
-      if (enabled) {
-        if (anomaliesLayer.data?.features?.length > 0) {
-          anomaliesLayer.show()
-        } else {
-          // Fetch anomaly points from backend (lazy-load)
-          this.controller.showProgress()
-          this.controller.updateLoadingCounts({
-            counts: { anomalies: 0 },
-            isComplete: false,
-          })
+      if (fetchId !== this._anomaliesFetchId) return
 
-          const startDate = this.controller.startDateValue
-          const endDate = this.controller.endDateValue
-          const geoJSON = await anomaliesLayer.fetchAnomalies({
-            start_at: startDate,
-            end_at: endDate,
-          })
+      this.controller.updateLoadingCounts({
+        counts: { anomalies: geoJSON.features.length },
+        isComplete: true,
+      })
 
-          this.controller.updateLoadingCounts({
-            counts: { anomalies: geoJSON.features.length },
-            isComplete: true,
-          })
-
-          anomaliesLayer.update(geoJSON)
-          anomaliesLayer.show()
-        }
-      } else {
-        anomaliesLayer.hide()
-      }
+      anomaliesLayer.update(geoJSON)
+      anomaliesLayer.show()
     } catch (error) {
-      console.error("Failed to toggle anomalies layer:", error)
+      if (fetchId !== this._anomaliesFetchId) return
+      console.error("Failed to refresh anomalies layer:", error)
+      this.controller.updateLoadingCounts({
+        counts: { anomalies: 0 },
+        isComplete: true,
+      })
       Toast.error("Failed to load anomalies")
     }
   }

--- a/app/javascript/controllers/maps/maplibre/settings_manager.js
+++ b/app/javascript/controllers/maps/maplibre/settings_manager.js
@@ -64,6 +64,7 @@ export class SettingsController {
       familyToggle: "familyEnabled",
       speedColoredToggle: "speedColoredRoutes",
       tracksToggle: "tracksEnabled",
+      anomaliesToggle: "anomaliesEnabled",
     }
 
     // Gated layer toggles that Lite users cannot persist

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -329,6 +329,9 @@ export default class extends Controller {
       if (this.settings?.familyEnabled) {
         this.loadFamilyMembers()
       }
+      if (this.settings?.anomaliesEnabled) {
+        this.routesManager.refreshAnomalies({ enabled: true })
+      }
     })
 
     // Show family members list immediately (doesn't depend on layer)
@@ -452,7 +455,11 @@ export default class extends Controller {
     this.endDateValue = end
 
     this._clearDayHighlight?.()
-    this.loadMapData()
+    this.loadMapData().then(() => {
+      if (this.settings?.anomaliesEnabled) {
+        this.routesManager.refreshAnomalies({ enabled: true })
+      }
+    })
     this.refreshTimelineFeedIfActive?.()
     this.debouncedLoadFamilyHistory?.()
   }


### PR DESCRIPTION
## Summary

Fixes [#2568](https://github.com/Freika/dawarich/issues/2568) — the anomalies toggle on Maps v2 didn't refresh the layer when the date range changed or after a fresh page-load hydration.

## Fix

Extract a single `refreshAnomalies({ enabled })` helper on `RoutesManager` that fetches with the controller's current `startDateValue`/`endDateValue` and shows-or-hides the layer; route all three trigger paths through it (toggle click, page-load hydration, date change). Also add `anomaliesToggle: 'anomaliesEnabled'` to `syncToggleStates`'s `toggleMap`.

## Test plan

- [ ] Toggle anomalies on, change date range — layer refreshes with new data
- [ ] Reload while toggle is on — layer hydrates with current range
- [ ] Toggle off — layer disappears

Closes #2568