### PR TITLE
Stop server-side photo thumbnail caching; use browser cache instead (#1609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ scrape_configs:
 - Insights weekly pattern now refreshes after monthly stats change, instead of showing a stale snapshot until the next monthly digest job runs. #2478
 - Points with no reverse-geocoding result (ocean, wilderness) are now marked as attempted instead of being re-queued every nightly run; use "Start Reverse Geocoding" to retry after switching providers. #2271
 - Activity detection now falls back to displacement when the tracker reports 0 m/s, so OwnTracks Significant Change mode and similar low-power setups stop misclassifying real movement as stationary. Run **Map v2 → Settings → Recalculate tracks & stats** to apply to existing tracks. #2390
+- Redis no longer balloons (multi-GB) when browsing photos with Immich or Photoprism connected. Photo thumbnails are no longer copied into the server-side Redis cache; the browser caches them directly via `Cache-Control` instead. #1609
 
 ## [1.7.6] - 2026-05-09
 

--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::PhotosController < ApiController
+  THUMBNAIL_BROWSER_CACHE_MAX_AGE = 30.minutes
+
   before_action :check_integration_configured, only: %i[index thumbnail]
   before_action :check_source, only: %i[thumbnail]
 
@@ -20,28 +22,19 @@ class Api::V1::PhotosController < ApiController
   end
 
   def thumbnail
-    response = fetch_cached_thumbnail(params[:source])
-    handle_thumbnail_response(response)
+    upstream = Photos::Thumbnail.new(current_api_user, params[:source], params[:id]).call
+    handle_thumbnail_response(upstream)
   end
 
   private
 
-  def fetch_cached_thumbnail(source)
-    cache_key = "photo_thumbnail_#{current_api_user.id}_#{source}_#{params[:id]}"
-    cached_response = Rails.cache.read(cache_key)
-    return cached_response if cached_response.present?
-
-    response = Photos::Thumbnail.new(current_api_user, source, params[:id]).call
-    Rails.cache.write(cache_key, response, expires_in: 30.minutes) if response.success?
-    response
-  end
-
-  def handle_thumbnail_response(response)
-    if response.success?
-      send_data(response.body, type: 'image/jpeg', disposition: 'inline', status: :ok)
+  def handle_thumbnail_response(upstream)
+    if upstream.success?
+      expires_in THUMBNAIL_BROWSER_CACHE_MAX_AGE, public: false
+      send_data(upstream.body, type: 'image/jpeg', disposition: 'inline', status: :ok)
     else
-      error_message = thumbnail_error(response)
-      render json: { error: error_message }, status: response.code
+      error_message = thumbnail_error(upstream)
+      render json: { error: error_message }, status: upstream.code
     end
   end
 

--- a/spec/regressions/photo_thumbnail_no_blob_cache_spec.rb
+++ b/spec/regressions/photo_thumbnail_no_blob_cache_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class ThumbnailFakeResponse
+  attr_reader :body, :code
+
+  def initialize(body)
+    @body = body
+    @code = 200
+  end
+
+  def success?
+    true
+  end
+end
+
+RSpec.describe 'Photo thumbnail does not cache binary blobs in Rails.cache', type: :request do
+  let(:user) { create(:user, :with_immich_integration) }
+  let(:photo_id) { 'asset-abc-123' }
+  let(:body) { 'X' * 100_000 }
+
+  before do
+    allow(HTTParty).to receive(:get).and_return(ThumbnailFakeResponse.new(body))
+    Rails.cache.clear
+  end
+
+  it 'never writes a photo_thumbnail_* entry into Rails.cache' do
+    expect(Rails.cache).not_to receive(:write)
+      .with(a_string_matching(/\Aphoto_thumbnail_/), anything, anything)
+
+    get "/api/v1/photos/#{photo_id}/thumbnail",
+        params: { api_key: user.api_key, source: 'immich' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body.bytesize).to eq(body.bytesize)
+  end
+
+  it 'sets a private Cache-Control header so browsers cache instead of Redis' do
+    get "/api/v1/photos/#{photo_id}/thumbnail",
+        params: { api_key: user.api_key, source: 'immich' }
+
+    cache_control = response.headers['Cache-Control']
+    expect(cache_control).to include('private')
+    expect(cache_control).to match(/max-age=\d+/)
+  end
+
+  it 'fetches upstream every request (no server-side memoization between calls)' do
+    expect(HTTParty).to receive(:get).twice.and_return(ThumbnailFakeResponse.new(body))
+
+    2.times do
+      get "/api/v1/photos/#{photo_id}/thumbnail",
+          params: { api_key: user.api_key, source: 'immich' }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes [#1609](https://github.com/Freika/dawarich/issues/1609) — Redis grew unboundedly because every Immich/PhotoPrism thumbnail blob was cached server-side per request.

## Fix

Remove the server-side blob cache and emit `Cache-Control: private, max-age=1800` instead. The user-perceived 'thumbnails don't refetch on every pan' behavior is preserved by shifting the cache to the browser, where it's correctly scoped per-user and per-tab.

## Test plan

- [x] Regression: `spec/regressions/photo_thumbnail_no_blob_cache_spec.rb`
- [ ] Confirm Redis no longer grows linearly with photo count
- [ ] Browser still serves cached thumbnails on subsequent pans within 30 min

Closes #1609