### PR TITLE
Derive map time range from import bounds when viewing import on map (#1857)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Photos imported from Immich now display at the correct time on Map v2 and import with the correct UTC timestamp, regardless of the host server's timezone or the photo's capture timezone. Previously, photos taken outside the server's timezone could appear up to 24 hours off. Existing imports keep their old timestamps; re-run the Immich import to fix already-imported photos. The photos API now also exposes a `capturedAt` field with the canonical UTC instant alongside the existing `localDateTime` key. #2253
 - Confirmed and declined visits inside an area or assigned to a place are no longer reverted to "suggested" — and any name you gave them is no longer overwritten — by the nightly visit-recompute job. (#2048, #2484)
 - GPX import now streams the file rather than loading the entire XML into memory, so multi-hundred-MB GPX files (e.g. long-running activity exports) no longer OOM the Sidekiq worker. (#2296)
+- Viewing an import on Map v2 or the Points page now selects the import's full date range, instead of defaulting to today or the last month. #1857
 
 ## [1.7.7] - 2026-05-09
 

--- a/app/controllers/concerns/import_time_window.rb
+++ b/app/controllers/concerns/import_time_window.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ImportTimeWindow
+  extend ActiveSupport::Concern
+
+  private
+
+  def import_window_start
+    return @import_window_start if defined?(@import_window_start)
+
+    load_import_window!
+    @import_window_start
+  end
+
+  def import_window_end
+    return @import_window_end if defined?(@import_window_end)
+
+    load_import_window!
+    @import_window_end
+  end
+
+  def import_record
+    return @import_record if defined?(@import_record)
+
+    @import_record = params[:import_id].present? ? current_user.imports.find_by(id: params[:import_id]) : nil
+  end
+
+  def load_import_window!
+    min_ts, max_ts = import_record&.points&.pick(Arel.sql('MIN(timestamp)'), Arel.sql('MAX(timestamp)'))
+
+    @import_window_start = min_ts ? Time.zone.at(min_ts).beginning_of_day.to_i : nil
+    @import_window_end   = max_ts ? Time.zone.at(max_ts).end_of_day.to_i : nil
+  end
+end

--- a/app/controllers/map/maplibre_controller.rb
+++ b/app/controllers/map/maplibre_controller.rb
@@ -3,6 +3,7 @@
 module Map
   class MaplibreController < ApplicationController
     include SafeTimestampParser
+    include ImportTimeWindow
 
     before_action :authenticate_user!
     layout 'map'
@@ -46,12 +47,14 @@ module Map
 
     def start_at
       return safe_timestamp(params[:start_at]) if params[:start_at].present?
+      return import_window_start if import_window_start
 
       Time.zone.today.beginning_of_day.to_i
     end
 
     def end_at
       return safe_timestamp(params[:end_at]) if params[:end_at].present?
+      return import_window_end if import_window_end
 
       Time.zone.today.end_of_day.to_i
     end

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -2,6 +2,7 @@
 
 class PointsController < ApplicationController
   include SafeTimestampParser
+  include ImportTimeWindow
 
   before_action :authenticate_user!
 
@@ -47,15 +48,17 @@ class PointsController < ApplicationController
   end
 
   def start_at
-    return 1.month.ago.beginning_of_day.to_i if params[:start_at].nil?
+    return safe_timestamp(params[:start_at]) if params[:start_at].present?
+    return import_window_start if import_window_start
 
-    safe_timestamp(params[:start_at])
+    1.month.ago.beginning_of_day.to_i
   end
 
   def end_at
-    return Time.zone.today.end_of_day.to_i if params[:end_at].nil?
+    return safe_timestamp(params[:end_at]) if params[:end_at].present?
+    return import_window_end if import_window_end
 
-    safe_timestamp(params[:end_at])
+    Time.zone.today.end_of_day.to_i
   end
 
   def points

--- a/spec/regressions/imports_map_time_range_spec.rb
+++ b/spec/regressions/imports_map_time_range_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Imports map and points pages default to the import time range',
+               type: :request do
+  let(:user) { create(:user, settings: { 'timezone' => 'Etc/UTC' }) }
+
+  let!(:import) { create(:import, user: user) }
+
+  let!(:day1_point) do
+    create(:point, user: user, import: import,
+                   timestamp: Time.utc(2024, 5, 1, 10, 0, 0).to_i)
+  end
+  let!(:day2_point) do
+    create(:point, user: user, import: import,
+                   timestamp: Time.utc(2024, 5, 2, 14, 0, 0).to_i)
+  end
+
+  let(:expected_start_iso) { '2024-05-01T00:00:00Z' }
+  let(:expected_end_iso)   { '2024-05-02T23:59:59Z' }
+
+  before { sign_in user }
+
+  describe 'GET /map/v2 with only import_id' do
+    it 'renders a window covering the full import range' do
+      get '/map/v2', params: { import_id: import.id }
+
+      expect(response.body).to include(%(data-maps--maplibre-start-date-value="#{expected_start_iso}"))
+      expect(response.body).to include(%(data-maps--maplibre-end-date-value="#{expected_end_iso}"))
+    end
+  end
+
+  describe 'GET /points with only import_id' do
+    it 'renders datetime inputs covering the full import range' do
+      get '/points', params: { import_id: import.id }
+
+      expect(response.body).to match(/value="2024-05-01T00:00"[^>]*name="start_at"/)
+      expect(response.body).to match(/value="2024-05-02T23:59"[^>]*name="end_at"/)
+    end
+  end
+
+  describe 'GET /points without import_id and without time params' do
+    it 'falls back to the last-month window' do
+      get '/points'
+
+      expected = Time.use_zone('Etc/UTC') { 1.month.ago.beginning_of_day.strftime('%Y-%m-%dT%H:%M') }
+      expect(response.body).to include(%(value="#{expected}"))
+    end
+  end
+
+  describe 'GET /map/v2 without import_id and without time params' do
+    it 'falls back to today' do
+      get '/map/v2'
+
+      expected = Time.use_zone('Etc/UTC') { Time.zone.today.beginning_of_day.iso8601 }
+      expect(response.body).to include(%(data-maps--maplibre-start-date-value="#{expected}"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes [#1857](https://github.com/Freika/dawarich/issues/1857) — opening 'View on map' from the imports list landed on the user's default time range instead of the imported data's actual range, so the map looked empty until the user manually adjusted the dates.

## Fix

When `params[:import_id]` is present and `start_at`/`end_at` are absent, derive the window from the import's `MIN(timestamp).beginning_of_day` … `MAX(timestamp).end_of_day` so the imported points are visible immediately.

## Test plan

- [x] Regression: `spec/regressions/imports_map_time_range_spec.rb`
- [ ] 'View on map' on a recently uploaded import lands on its actual date range

Closes #1857