### PR TITLE
Treat stored zero velocity as 'unknown' and fall back to displacement (#2390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ scrape_configs:
 - 500 error on the imports page. #2683
 - Insights weekly pattern now refreshes after monthly stats change, instead of showing a stale snapshot until the next monthly digest job runs. #2478
 - Points with no reverse-geocoding result (ocean, wilderness) are now marked as attempted instead of being re-queued every nightly run; use "Start Reverse Geocoding" to retry after switching providers. #2271
+- Activity detection now falls back to displacement when the tracker reports 0 m/s, so OwnTracks Significant Change mode and similar low-power setups stop misclassifying real movement as stationary. Run **Map v2 → Settings → Recalculate tracks & stats** to apply to existing tracks. #2390
 
 ## [1.7.6] - 2026-05-09
 

--- a/app/services/transportation_modes/movement_analyzer.rb
+++ b/app/services/transportation_modes/movement_analyzer.rb
@@ -149,7 +149,7 @@ module TransportationModes
       # Prefer stored velocity from GPS
       if point2.velocity.present?
         stored_speed = point2.velocity.to_f
-        return stored_speed if stored_speed >= 0
+        return stored_speed if stored_speed.positive?
       end
 
       # Calculate from distance and time

--- a/spec/regressions/movement_analyzer_zero_stored_velocity_spec.rb
+++ b/spec/regressions/movement_analyzer_zero_stored_velocity_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'MovementAnalyzer falls back to displacement when stored velocity is zero' do
+  let(:user) { create(:user) }
+  let(:track) { create(:track, user: user) }
+
+  it 'classifies a moving sequence with stored velocity 0 as non-stationary' do
+    points = (0..10).map do |i|
+      build(:point,
+            user: user,
+            timestamp: 1000 + (i * 60),
+            velocity: '0',
+            lonlat: "POINT(#{13.404954 + (i * 0.01)} 52.520008)")
+    end
+
+    segments = TransportationModes::MovementAnalyzer.new(track, points).call
+
+    expect(segments).not_to be_empty
+    expect(segments.map { |s| s[:avg_speed] }.max).to be > 0
+    expect(segments.map { |s| s[:mode] }.any? { |m| m != :stationary }).to be(true)
+  end
+
+  it 'still reports zero speed when both stored velocity is 0 and points are co-located' do
+    same_lonlat = 'POINT(13.404954 52.520008)'
+    points = (0..5).map do |i|
+      build(:point,
+            user: user,
+            timestamp: 1000 + (i * 60),
+            velocity: '0',
+            lonlat: same_lonlat)
+    end
+
+    segments = TransportationModes::MovementAnalyzer.new(track, points).call
+
+    expect(segments.map { |s| s[:avg_speed] }).to all(eq(0))
+  end
+
+  it 'still trusts a positive stored velocity over displacement' do
+    points = (0..10).map do |i|
+      build(:point,
+            user: user,
+            timestamp: 1000 + (i * 60),
+            velocity: '1.4',
+            lonlat: "POINT(13.404954 #{52.520008 + (i * 0.0001)})")
+    end
+
+    segments = TransportationModes::MovementAnalyzer.new(track, points).call
+
+    expect(segments.first[:mode]).to eq(:walking)
+  end
+end


### PR DESCRIPTION
## Summary

Fixes [#2390](https://github.com/Freika/dawarich/issues/2390) — phones that report stored speed = 0 while moving were classified 'stationary' on routes the user clearly walked or drove.

## Root cause

`MovementAnalyzer` short-circuited on `stored_speed >= 0`, accepting tracker-reported 0 verbatim.

## Fix

Change the guard to `stored_speed.positive?` so a stored 0 falls through to the existing displacement-based fallback. Genuinely stationary devices still get speed 0 (displacement is also 0); tracker-reported 0 with non-trivial displacement now produces a useful number.

## Test plan

- [x] Regression: `spec/regressions/movement_analyzer_zero_stored_velocity_spec.rb`
- [ ] Replay a known-broken route from the affected reporter and confirm transportation classification

Closes #2390