### PR TITLE
Decouple email+password login from registration flag (#2495)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix support of FIT files from Garmin Connect. #2686
 - The Anomalies map layer no longer requires manually toggling off and on after a page reload or timeframe change. The toggle state is restored on reload, and the layer refetches anomalies for the active date range. #2568
+- Email/password login is now shown alongside the OIDC button on self-hosted instances by default, instead of being hidden whenever OIDC is configured. Operators who want to enforce OIDC-only sign-in can set `ALLOW_EMAIL_PASSWORD_LOGIN=false`. #2495
 
 ## [1.7.7] - 2026-05-09
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -13,6 +13,7 @@ class Users::SessionsController < Devise::SessionsController
 
   def check_otp_required
     return unless request.post?
+    return if DawarichSettings.oidc_enabled? && !ALLOW_EMAIL_PASSWORD_LOGIN
     return unless DawarichSettings.two_factor_available?
     return if params.dig(:user, :email).blank?
 
@@ -28,7 +29,7 @@ class Users::SessionsController < Devise::SessionsController
 
   def check_email_password_login_allowed
     return unless DawarichSettings.oidc_enabled?
-    return if DawarichSettings.registration_enabled?
+    return if ALLOW_EMAIL_PASSWORD_LOGIN
 
     redirect_to root_path, alert: 'Email/password login is disabled. Please use OIDC to sign in.'
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -164,7 +164,7 @@ module ApplicationHelper
   def email_password_login_enabled?
     return true unless DawarichSettings.oidc_enabled?
 
-    DawarichSettings.registration_enabled?
+    ALLOW_EMAIL_PASSWORD_LOGIN
   end
 
   def preferred_map_path(params = {})

--- a/config/initializers/01_constants.rb
+++ b/config/initializers/01_constants.rb
@@ -67,5 +67,7 @@ OIDC_AUTO_REGISTER = ENV.fetch('OIDC_AUTO_REGISTER', 'true') == 'true'
 # Email/password registration setting (default: false for self-hosted, true for cloud)
 ALLOW_EMAIL_PASSWORD_REGISTRATION = ENV.fetch('ALLOW_EMAIL_PASSWORD_REGISTRATION', 'false') == 'true'
 
+ALLOW_EMAIL_PASSWORD_LOGIN = ENV.fetch('ALLOW_EMAIL_PASSWORD_LOGIN', 'true') == 'true'
+
 # Raw data archival setting
 ARCHIVE_RAW_DATA = ENV.fetch('ARCHIVE_RAW_DATA', 'false') == 'true'

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -172,6 +172,11 @@ OIDC_AUTO_REGISTER=true
 # Set to 'true' to allow public email/password registration alongside OIDC
 ALLOW_EMAIL_PASSWORD_REGISTRATION=false
 
+# ALLOW_EMAIL_PASSWORD_LOGIN - Show the email/password login form when OIDC is enabled
+# Default: true (both OIDC and email/password login are offered side by side)
+# Set to 'false' to enforce OIDC-only sign-in and hide the email/password form
+ALLOW_EMAIL_PASSWORD_LOGIN=true
+
 # Option 2: Manual Endpoint Configuration (if discovery is not supported)
 # Use this if your provider doesn't support OIDC discovery
 # OIDC_CLIENT_ID=

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -385,8 +385,8 @@ RSpec.describe ApplicationHelper, type: :helper do
         allow(DawarichSettings).to receive(:oidc_enabled?).and_return(false)
       end
 
-      it 'returns true regardless of ALLOW_EMAIL_PASSWORD_REGISTRATION' do
-        stub_const('ALLOW_EMAIL_PASSWORD_REGISTRATION', false)
+      it 'returns true regardless of ALLOW_EMAIL_PASSWORD_LOGIN' do
+        stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', false)
 
         expect(helper.email_password_login_enabled?).to be true
       end
@@ -394,13 +394,11 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context 'in cloud mode with OAuth providers (GitHub/Google)' do
       before do
-        # Cloud mode: self_hosted? is false, so oidc_enabled? returns false
-        # even if there are OAuth providers configured
         allow(DawarichSettings).to receive(:oidc_enabled?).and_return(false)
       end
 
       it 'always returns true (OAuth is supplementary to email/password)' do
-        stub_const('ALLOW_EMAIL_PASSWORD_REGISTRATION', false)
+        stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', false)
 
         expect(helper.email_password_login_enabled?).to be true
       end
@@ -411,9 +409,9 @@ RSpec.describe ApplicationHelper, type: :helper do
         allow(DawarichSettings).to receive(:oidc_enabled?).and_return(true)
       end
 
-      context 'when ALLOW_EMAIL_PASSWORD_REGISTRATION is true' do
+      context 'when ALLOW_EMAIL_PASSWORD_LOGIN is true' do
         before do
-          stub_const('ALLOW_EMAIL_PASSWORD_REGISTRATION', true)
+          stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', true)
         end
 
         it 'returns true' do
@@ -421,9 +419,9 @@ RSpec.describe ApplicationHelper, type: :helper do
         end
       end
 
-      context 'when ALLOW_EMAIL_PASSWORD_REGISTRATION is false' do
+      context 'when ALLOW_EMAIL_PASSWORD_LOGIN is false' do
         before do
-          stub_const('ALLOW_EMAIL_PASSWORD_REGISTRATION', false)
+          stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', false)
         end
 
         it 'returns false (OIDC-only mode)' do

--- a/spec/regressions/email_password_login_visibility_spec.rb
+++ b/spec/regressions/email_password_login_visibility_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Email/password login visibility when OIDC is enabled', type: :helper do
+  describe '#email_password_login_enabled?' do
+    before { allow(DawarichSettings).to receive(:oidc_enabled?).and_return(true) }
+
+    context 'with the registration flag off' do
+      before { allow(DawarichSettings).to receive(:registration_enabled?).and_return(false) }
+
+      it 'still allows email/password login by default' do
+        stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', true)
+
+        expect(helper.email_password_login_enabled?).to be true
+      end
+
+      it 'is independent of the registration flag' do
+        stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', true)
+
+        expect(helper.email_password_login_enabled?).to be true
+        expect(DawarichSettings.registration_enabled?).to be false
+      end
+    end
+
+    context 'when an operator opts into OIDC-only login' do
+      before { allow(DawarichSettings).to receive(:registration_enabled?).and_return(true) }
+
+      it 'hides the email/password form when ALLOW_EMAIL_PASSWORD_LOGIN is false' do
+        stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', false)
+
+        expect(helper.email_password_login_enabled?).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe 'Users::Sessions', type: :request do
         allow(DawarichSettings).to receive(:oidc_enabled?).and_return(true)
       end
 
-      context 'when ALLOW_EMAIL_PASSWORD_REGISTRATION is true' do
+      context 'when ALLOW_EMAIL_PASSWORD_LOGIN is true' do
         before do
-          stub_const('ALLOW_EMAIL_PASSWORD_REGISTRATION', true)
+          stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', true)
         end
 
         it 'allows email/password login' do
@@ -52,9 +52,9 @@ RSpec.describe 'Users::Sessions', type: :request do
         end
       end
 
-      context 'when ALLOW_EMAIL_PASSWORD_REGISTRATION is false (OIDC-only mode)' do
+      context 'when ALLOW_EMAIL_PASSWORD_LOGIN is false (OIDC-only mode)' do
         before do
-          stub_const('ALLOW_EMAIL_PASSWORD_REGISTRATION', false)
+          stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', false)
         end
 
         it 'blocks email/password login' do
@@ -82,10 +82,10 @@ RSpec.describe 'Users::Sessions', type: :request do
   end
 
   describe 'GET /users/sign_in' do
-    context 'when OIDC is enabled and ALLOW_EMAIL_PASSWORD_REGISTRATION is false' do
+    context 'when OIDC is enabled and ALLOW_EMAIL_PASSWORD_LOGIN is false' do
       before do
         allow(DawarichSettings).to receive(:oidc_enabled?).and_return(true)
-        stub_const('ALLOW_EMAIL_PASSWORD_REGISTRATION', false)
+        stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', false)
       end
 
       it 'renders the login page (to show OIDC buttons)' do


### PR DESCRIPTION
## Summary

Fixes [#2495](https://github.com/Freika/dawarich/issues/2495) — OIDC-only deployments couldn't disable email+password login independently of self-registration. The login form was gated by the registration flag, conflating the two.

## Fix

Introduce a separate `ALLOW_EMAIL_PASSWORD_LOGIN` env var (default `true`), gate both the view and the sessions controller's POST blocker on it, and stop borrowing the registration flag.

The OTP precheck (`prepend_before_action :check_otp_required`) also short-circuits when login is disabled, so credential-verification side channels don't run in OIDC-only mode.

## Behavior

| `ALLOW_EMAIL_PASSWORD_LOGIN` | Behavior |
|---|---|
| `true` (default) | Email+password login form visible and POST works |
| `false` | Form hidden; POST redirects to `/` with an "Email/password login is disabled" alert |

Self-registration remains gated by its own flag (unchanged).

Cloud (Google/GitHub OAuth) is unaffected — the gate only fires for self-hosted OpenID Connect deployments (`oidc_enabled?` is false on Cloud).

## Test plan

- [x] Regression: `spec/regressions/email_password_login_visibility_spec.rb`
- [x] Request specs: `spec/requests/users/sessions_spec.rb`
- [ ] OIDC-only deployment with `ALLOW_EMAIL_PASSWORD_LOGIN=false` — only the OIDC button shows, direct POST redirects
- [ ] Default deployment unchanged

Closes #2495