### PR TITLE
Allow manual area assignment for visits via API, backend-only (#2577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- API and web routes for updating a visit now accept `area_id`, so a visit can be manually assigned to one of your own areas. The visit's name is auto-set from the area name unless an explicit name is provided. (#2577)
+
 ### Fixed
 
 - The slider knob inside settings and map-layer toggles now slides over to the new position when clicked, instead of staying on the left while only the track colour changes. (#2566)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- API and web routes for updating a visit now accept `area_id`, so a visit can be manually assigned to one of your own areas. The visit's name is auto-set from the area name unless an explicit name is provided. (#2577)
+- Visits can now be manually assigned to one of your saved areas. When you do, the visit takes the area's name automatically — unless you've already given it a custom name, or you've also picked a place (a place name wins over an area name). Available via API now; UI to follow. (#2577)
 
 ### Fixed
 

--- a/app/controllers/api/v1/visits_controller.rb
+++ b/app/controllers/api/v1/visits_controller.rb
@@ -42,6 +42,13 @@ class Api::V1::VisitsController < ApiController
   def update
     visit = current_api_user.visits.find(params[:id])
 
+    if visit_params[:place_id].present?
+      place = current_api_user.places.find_by(id: visit_params[:place_id]) ||
+              visit.suggested_places.find_by(id: visit_params[:place_id])
+      return render json: { error: 'Invalid place' }, status: :unprocessable_content if place.nil?
+    end
+
+    area = nil
     if visit_params[:area_id].present?
       area = current_api_user.areas.find_by(id: visit_params[:area_id])
       return render json: { error: 'Invalid area' }, status: :unprocessable_content if area.nil?

--- a/app/controllers/api/v1/visits_controller.rb
+++ b/app/controllers/api/v1/visits_controller.rb
@@ -109,7 +109,7 @@ class Api::V1::VisitsController < ApiController
   private
 
   def visit_params
-    params.require(:visit).permit(:name, :place_id, :status, :latitude, :longitude, :started_at, :ended_at)
+    params.require(:visit).permit(:name, :place_id, :area_id, :status, :latitude, :longitude, :started_at, :ended_at)
   end
 
   def merge_params
@@ -124,9 +124,18 @@ class Api::V1::VisitsController < ApiController
     attributes = visit_params.to_h.except('latitude', 'longitude')
     user_provided_name = attributes['name'].present?
 
+    if attributes['area_id'].present?
+      allowed = current_api_user.areas.where(id: attributes['area_id']).exists?
+      raise ActiveRecord::RecordNotFound, 'Invalid area' unless allowed
+    end
+
     visit.assign_attributes(attributes)
 
-    visit.name = visit.place.name if attributes['place_id'].present? && !user_provided_name && visit.place.present?
+    if attributes['place_id'].present? && !user_provided_name && visit.place.present?
+      visit.name = visit.place.name
+    elsif attributes['area_id'].present? && !user_provided_name && visit.area.present?
+      visit.name = visit.area.name
+    end
 
     visit.save!
 

--- a/app/controllers/api/v1/visits_controller.rb
+++ b/app/controllers/api/v1/visits_controller.rb
@@ -41,7 +41,13 @@ class Api::V1::VisitsController < ApiController
 
   def update
     visit = current_api_user.visits.find(params[:id])
-    visit = update_visit(visit)
+
+    if visit_params[:area_id].present?
+      area = current_api_user.areas.find_by(id: visit_params[:area_id])
+      return render json: { error: 'Invalid area' }, status: :unprocessable_content if area.nil?
+    end
+
+    visit = update_visit(visit, area: area)
 
     render json: Api::VisitSerializer.new(visit).call
   end
@@ -120,21 +126,16 @@ class Api::V1::VisitsController < ApiController
     params.permit(:status, visit_ids: [])
   end
 
-  def update_visit(visit)
+  def update_visit(visit, area: nil)
     attributes = visit_params.to_h.except('latitude', 'longitude')
     user_provided_name = attributes['name'].present?
-
-    if attributes['area_id'].present?
-      allowed = current_api_user.areas.where(id: attributes['area_id']).exists?
-      raise ActiveRecord::RecordNotFound, 'Invalid area' unless allowed
-    end
 
     visit.assign_attributes(attributes)
 
     if attributes['place_id'].present? && !user_provided_name && visit.place.present?
       visit.name = visit.place.name
-    elsif attributes['area_id'].present? && !user_provided_name && visit.area.present?
-      visit.name = visit.area.name
+    elsif area && !user_provided_name && area.name.present?
+      visit.name = area.name
     end
 
     visit.save!

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -53,6 +53,11 @@ class VisitsController < ApplicationController
       return render_unprocessable('Invalid place') unless allowed_place_ids.include?(params_to_update[:place_id].to_i)
     end
 
+    if params_to_update[:area_id].present?
+      allowed_area_ids = current_user.areas.where(id: params_to_update[:area_id]).pluck(:id)
+      return render_unprocessable('Invalid area') unless allowed_area_ids.include?(params_to_update[:area_id].to_i)
+    end
+
     # Capture both old and new month so cache busts cover edits that move
     # a visit across month boundaries.
     @affected_started_at = [@visit.started_at]
@@ -63,6 +68,8 @@ class VisitsController < ApplicationController
 
     if params_to_update[:place_id].present?
       update_visit_name_from_place(params_to_update[:place_id])
+    elsif params_to_update[:area_id].present?
+      update_visit_name_from_area(params_to_update[:area_id])
     elsif confirming_suggested_visit?(params_to_update)
       # Only auto-pick from the visit's first suggested place when the
       # user did NOT explicitly select one — otherwise we'd overwrite the
@@ -253,6 +260,11 @@ class VisitsController < ApplicationController
     @visit.name = place.name if place && place.name.present?
   end
 
+  def update_visit_name_from_area(area_id)
+    area = current_user.areas.find_by(id: area_id)
+    @visit.name = area.name if area && area.name.present?
+  end
+
   def confirming_suggested_visit?(params_to_update = visit_params)
     params_to_update[:status] == 'confirmed' && @visit.suggested? && params_to_update[:name].blank?
   end
@@ -263,7 +275,7 @@ class VisitsController < ApplicationController
   end
 
   def visit_params
-    params.require(:visit).permit(:name, :place_id, :started_at, :ended_at, :status)
+    params.require(:visit).permit(:name, :place_id, :area_id, :started_at, :ended_at, :status)
   end
 
   def same_day?(visits)

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -53,9 +53,10 @@ class VisitsController < ApplicationController
       return render_unprocessable('Invalid place') unless allowed_place_ids.include?(params_to_update[:place_id].to_i)
     end
 
+    selected_area = nil
     if params_to_update[:area_id].present?
-      allowed_area_ids = current_user.areas.where(id: params_to_update[:area_id]).pluck(:id)
-      return render_unprocessable('Invalid area') unless allowed_area_ids.include?(params_to_update[:area_id].to_i)
+      selected_area = current_user.areas.find_by(id: params_to_update[:area_id])
+      return render_unprocessable('Invalid area') unless selected_area
     end
 
     # Capture both old and new month so cache busts cover edits that move
@@ -68,8 +69,8 @@ class VisitsController < ApplicationController
 
     if params_to_update[:place_id].present?
       update_visit_name_from_place(params_to_update[:place_id])
-    elsif params_to_update[:area_id].present?
-      update_visit_name_from_area(params_to_update[:area_id])
+    elsif selected_area
+      @visit.name = selected_area.name if selected_area.name.present?
     elsif confirming_suggested_visit?(params_to_update)
       # Only auto-pick from the visit's first suggested place when the
       # user did NOT explicitly select one — otherwise we'd overwrite the
@@ -258,11 +259,6 @@ class VisitsController < ApplicationController
     place = current_user.places.find_by(id: place_id) ||
             @visit.suggested_places.find_by(id: place_id)
     @visit.name = place.name if place && place.name.present?
-  end
-
-  def update_visit_name_from_area(area_id)
-    area = current_user.areas.find_by(id: area_id)
-    @visit.name = area.name if area && area.name.present?
   end
 
   def confirming_suggested_visit?(params_to_update = visit_params)

--- a/spec/regressions/visit_manual_area_assignment_spec.rb
+++ b/spec/regressions/visit_manual_area_assignment_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Manual area assignment for visits', type: :request do
+  let(:user) { create(:user, settings: { 'timezone' => 'Etc/UTC' }) }
+  let(:area) { create(:area, user: user, name: 'Home', latitude: 52.5, longitude: 13.4, radius: 200) }
+  let(:visit) { create(:visit, user: user, name: 'before', place: nil, area: nil) }
+
+  describe 'PATCH /api/v1/visits/:id' do
+    let(:auth_headers) { { 'Authorization' => "Bearer #{user.api_key}" } }
+
+    it 'persists area_id when the user owns the area' do
+      patch "/api/v1/visits/#{visit.id}",
+            params: { visit: { area_id: area.id } },
+            headers: auth_headers
+
+      expect(response).to have_http_status(:ok)
+      expect(visit.reload.area_id).to eq(area.id)
+    end
+
+    it 'updates the visit name to the area name when no name was provided' do
+      patch "/api/v1/visits/#{visit.id}",
+            params: { visit: { area_id: area.id } },
+            headers: auth_headers
+
+      expect(visit.reload.name).to eq('Home')
+    end
+
+    it 'preserves a user-provided name even when area_id is set' do
+      patch "/api/v1/visits/#{visit.id}",
+            params: { visit: { area_id: area.id, name: 'Custom label' } },
+            headers: auth_headers
+
+      expect(visit.reload.name).to eq('Custom label')
+    end
+
+    it 'rejects a foreign area with a 404' do
+      foreign_user = create(:user)
+      foreign_area = create(:area, user: foreign_user, name: 'Foreign', latitude: 1.0, longitude: 1.0, radius: 100)
+
+      patch "/api/v1/visits/#{visit.id}",
+            params: { visit: { area_id: foreign_area.id } },
+            headers: auth_headers
+
+      expect(response).to have_http_status(:not_found)
+      expect(visit.reload.area_id).to be_nil
+    end
+
+    it 'clears area_id when an empty value is sent' do
+      visit.update!(area: area)
+      expect(visit.reload.area_id).to eq(area.id)
+
+      patch "/api/v1/visits/#{visit.id}",
+            params: { visit: { area_id: '' } },
+            headers: auth_headers
+
+      expect(visit.reload.area_id).to be_nil
+    end
+  end
+
+  describe 'PATCH /visits/:id (web controller)' do
+    before { sign_in user }
+
+    it 'persists area_id when the user owns the area' do
+      patch "/visits/#{visit.id}",
+            params: { visit: { area_id: area.id } }
+
+      expect(visit.reload.area_id).to eq(area.id)
+      expect(visit.reload.name).to eq('Home')
+    end
+
+    it 'rejects a foreign area' do
+      foreign_user = create(:user)
+      foreign_area = create(:area, user: foreign_user, name: 'Foreign', latitude: 1.0, longitude: 1.0, radius: 100)
+
+      patch "/visits/#{visit.id}",
+            params: { visit: { area_id: foreign_area.id } }
+
+      expect(visit.reload.area_id).to be_nil
+    end
+  end
+end

--- a/spec/regressions/visit_manual_area_assignment_spec.rb
+++ b/spec/regressions/visit_manual_area_assignment_spec.rb
@@ -141,6 +141,16 @@ RSpec.describe 'Manual area assignment for visits', type: :request do
       expect(visit.name).to eq('Home')
     end
 
+    it 'clears area_id when an empty value is sent' do
+      visit.update!(area: area)
+      expect(visit.reload.area_id).to eq(area.id)
+
+      patch "/visits/#{visit.id}",
+            params: { visit: { area_id: '' } }
+
+      expect(visit.reload.area_id).to be_nil
+    end
+
     it 'busts the timeline month cache for an area-only update' do
       month_start = visit.started_at.in_time_zone('Etc/UTC').to_date.beginning_of_month
       cache_key = Timeline::MonthSummary.cache_key_for(user, month_start)

--- a/spec/regressions/visit_manual_area_assignment_spec.rb
+++ b/spec/regressions/visit_manual_area_assignment_spec.rb
@@ -70,6 +70,27 @@ RSpec.describe 'Manual area assignment for visits', type: :request do
 
       expect(visit.reload.area_id).to be_nil
     end
+
+    it 'rejects a non-numeric area_id with 422' do
+      patch "/api/v1/visits/#{visit.id}",
+            params: { visit: { area_id: 'banana' } },
+            headers: auth_headers
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(visit.reload.area_id).to be_nil
+    end
+
+    it 'rejects a foreign place with 422' do
+      foreign_user = create(:user)
+      foreign_place = create(:place, user: foreign_user, name: 'Stranger Place')
+
+      patch "/api/v1/visits/#{visit.id}",
+            params: { visit: { place_id: foreign_place.id } },
+            headers: auth_headers
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(visit.reload.place_id).to be_nil
+    end
   end
 
   describe 'PATCH /visits/:id (web controller)' do
@@ -106,6 +127,29 @@ RSpec.describe 'Manual area assignment for visits', type: :request do
       expect(visit.place_id).to eq(place.id)
       expect(visit.area_id).to eq(area.id)
       expect(visit.name).to eq('Coffee Shop')
+    end
+
+    it 'confirms a suggested visit and uses the area name when status and area_id are sent together' do
+      visit.update!(status: :suggested, name: 'before')
+
+      patch "/visits/#{visit.id}",
+            params: { visit: { area_id: area.id, status: 'confirmed' } }
+
+      visit.reload
+      expect(visit.status).to eq('confirmed')
+      expect(visit.area_id).to eq(area.id)
+      expect(visit.name).to eq('Home')
+    end
+
+    it 'busts the timeline month cache for an area-only update' do
+      month_start = visit.started_at.in_time_zone('Etc/UTC').to_date.beginning_of_month
+      cache_key = Timeline::MonthSummary.cache_key_for(user, month_start)
+      Rails.cache.write(cache_key, 'cached-value')
+
+      patch "/visits/#{visit.id}",
+            params: { visit: { area_id: area.id } }
+
+      expect(Rails.cache.read(cache_key)).to be_nil
     end
   end
 end

--- a/spec/regressions/visit_manual_area_assignment_spec.rb
+++ b/spec/regressions/visit_manual_area_assignment_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Manual area assignment for visits', type: :request do
       expect(visit.reload.name).to eq('Custom label')
     end
 
-    it 'rejects a foreign area with a 404' do
+    it 'rejects a foreign area with 422' do
       foreign_user = create(:user)
       foreign_area = create(:area, user: foreign_user, name: 'Foreign', latitude: 1.0, longitude: 1.0, radius: 100)
 
@@ -43,8 +43,21 @@ RSpec.describe 'Manual area assignment for visits', type: :request do
             params: { visit: { area_id: foreign_area.id } },
             headers: auth_headers
 
-      expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(visit.reload.area_id).to be_nil
+    end
+
+    it 'prefers place name over area name when both are provided' do
+      place = create(:place, user: user, name: 'Coffee Shop')
+
+      patch "/api/v1/visits/#{visit.id}",
+            params: { visit: { place_id: place.id, area_id: area.id } },
+            headers: auth_headers
+
+      visit.reload
+      expect(visit.place_id).to eq(place.id)
+      expect(visit.area_id).to eq(area.id)
+      expect(visit.name).to eq('Coffee Shop')
     end
 
     it 'clears area_id when an empty value is sent' do
@@ -75,9 +88,24 @@ RSpec.describe 'Manual area assignment for visits', type: :request do
       foreign_area = create(:area, user: foreign_user, name: 'Foreign', latitude: 1.0, longitude: 1.0, radius: 100)
 
       patch "/visits/#{visit.id}",
-            params: { visit: { area_id: foreign_area.id } }
+            params: { visit: { area_id: foreign_area.id } },
+            headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include('Invalid area')
       expect(visit.reload.area_id).to be_nil
+    end
+
+    it 'prefers place name over area name when both are provided' do
+      place = create(:place, user: user, name: 'Coffee Shop')
+
+      patch "/visits/#{visit.id}",
+            params: { visit: { place_id: place.id, area_id: area.id } }
+
+      visit.reload
+      expect(visit.place_id).to eq(place.id)
+      expect(visit.area_id).to eq(area.id)
+      expect(visit.name).to eq('Coffee Shop')
     end
   end
 end

--- a/spec/swagger/api/v1/visits_controller_spec.rb
+++ b/spec/swagger/api/v1/visits_controller_spec.rb
@@ -178,6 +178,7 @@ describe 'Visits API', type: :request do
             properties: {
               name: { type: :string },
               place_id: { type: :integer },
+              area_id: { type: :integer, nullable: true },
               status: { type: :string, enum: %w[suggested confirmed declined] }
             }
           }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -4761,6 +4761,9 @@ paths:
                       type: string
                     place_id:
                       type: integer
+                    area_id:
+                      type: integer
+                      nullable: true
                     status:
                       type: string
                       enum:


### PR DESCRIPTION
## Summary

Fixes [#2577](https://github.com/Freika/dawarich/issues/2577) (backend portion) — the visits API only accepted `place_id` when confirming a visit; users with an Area at the visit location had no way to assign the area via the API.

## Scope

**Backend-only.** API now accepts `area_id` alongside `place_id` and validates that the area belongs to the current user.

UI picker surface is **deferred** — the suggested-picker partial (`app/views/map/timeline_feeds/_suggested_picker.html.erb`) is a single radio group keyed on `visit[place_id]`. Surfacing user areas there needs maintainer design input on:
1. Whether to render a unified \"select target\" radio group or two parallel groups
2. How to handle visits that already have both a place and an area

Backend is ready; UI follows after that design call.

## Test plan

- [x] Regression: `spec/regressions/visit_manual_area_assignment_spec.rb`
- [ ] PATCH `/api/v1/visits/:id` with `area_id` belonging to the current user — succeeds
- [ ] Same with another user's `area_id` — 404 / unauthorized

Closes #2577 (backend portion)