### PR TITLE
fix: handle flat-record FIT files from Garmin Connect

### DIFF
--- a/app/services/fit/importer.rb
+++ b/app/services/fit/importer.rb
@@ -35,23 +35,16 @@ class Fit::Importer
 
     points_data = []
 
-    activity.sessions.each do |session|
-      sport = session.sport&.to_s
-      activity_type = map_activity_type(sport)
+    each_record(activity) do |record, activity_type|
+      next if record.position_lat.nil? || record.position_long.nil?
 
-      session.laps.each do |lap|
-        lap.records.each do |record|
-          next if record.position_lat.nil? || record.position_long.nil?
+      points_data << build_point(record, activity_type)
 
-          points_data << build_point(record, activity_type)
+      next unless points_data.size >= BATCH_SIZE
 
-          next unless points_data.size >= BATCH_SIZE
-
-          inserted = bulk_insert_points(points_data)
-          broadcast_import_progress(import, inserted)
-          points_data = []
-        end
-      end
+      inserted = bulk_insert_points(points_data)
+      broadcast_import_progress(import, inserted)
+      points_data = []
     end
 
     if points_data.any?
@@ -63,6 +56,36 @@ class Fit::Importer
   end
 
   private
+
+  # Iterates all trackpoint records in the activity, yielding each with its activity type.
+  #
+  # FIT files from different sources use different structures:
+  #   - Standard: sessions → laps → records
+  #   - Garmin Connect exports: sessions have no laps; activity-level laps have no records;
+  #     all records are stored flat on the activity object
+  #
+  # This method tries each structure in order so that Garmin Connect FIT files
+  # (and any other flat-record variants) import correctly.
+  def each_record(activity, &block)
+    activity_type = map_activity_type(activity.sessions.first&.sport&.to_s)
+
+    records_via_sessions = activity.sessions.flat_map { |s| s.laps.flat_map(&:records) }
+    if records_via_sessions.any?
+      activity.sessions.each do |session|
+        type = map_activity_type(session.sport&.to_s)
+        session.laps.each { |lap| lap.records.each { |r| block.call(r, type) } }
+      end
+      return
+    end
+
+    records_via_laps = activity.laps.flat_map(&:records)
+    if records_via_laps.any?
+      activity.laps.each { |lap| lap.records.each { |r| block.call(r, activity_type) } }
+      return
+    end
+
+    activity.records.each { |r| block.call(r, activity_type) }
+  end
 
   def build_point(record, activity_type)
     lat = record.position_lat

--- a/spec/services/fit/importer_spec.rb
+++ b/spec/services/fit/importer_spec.rb
@@ -73,6 +73,35 @@ RSpec.describe Fit::Importer do
       end
     end
 
+    context 'with flat-record FIT file (sessions may have no laps, as observed with Garmin Connect exports)' do
+      let(:flat_fit_fixture_path) do
+        path = Rails.root.join('tmp', "test_flat_#{SecureRandom.hex(4)}.fit").to_s
+        generate_flat_record_fit_fixture(path)
+        path
+      end
+
+      after { File.delete(flat_fit_fixture_path) if File.exist?(flat_fit_fixture_path) }
+
+      before do
+        described_class.new(import, user.id, flat_fit_fixture_path).call
+      end
+
+      it 'imports points when sessions may have no laps and records are flat on the activity' do
+        expect(user.points.count).to eq(3)
+      end
+
+      it 'parses coordinates correctly' do
+        point = user.points.order(:timestamp).first
+        expect(point.lat).to be_within(0.0001).of(52.5200)
+        expect(point.lon).to be_within(0.0001).of(13.4050)
+      end
+
+      it 'maps activity type from session sport' do
+        point = user.points.order(:timestamp).first
+        expect(point.raw_data['activity_type']).to eq('cycling')
+      end
+    end
+
     context 'with ActiveStorage file (nil file_path)' do
       let(:temp_path) { fit_fixture_path }
       let(:downloader) { instance_double(Imports::SecureFileDownloader, download_to_temp_file: temp_path) }

--- a/spec/support/fit_fixture_helper.rb
+++ b/spec/support/fit_fixture_helper.rb
@@ -1,6 +1,34 @@
 # frozen_string_literal: true
 
 module FitFixtureHelper
+  # Generates a FIT fixture where sessions may have no laps and all
+  # trackpoint records are stored flat on the activity object.
+  # Observed with FIT files exported from Garmin Connect.
+  def generate_flat_record_fit_fixture(path)
+    require 'fit4ruby'
+
+    ts = Time.utc(2024, 6, 15, 10, 30, 0)
+    a = Fit4Ruby::Activity.new
+    a.total_timer_time = 180.0
+    a.new_device_info({ timestamp: ts, device_index: 0, manufacturer: 'garmin',
+                        garmin_product: 'fenix3', serial_number: 123_456_789 })
+    3.times do |i|
+      a.new_record({ timestamp: ts + (i * 60), position_lat: 52.52 + i * 0.001,
+                     position_long: 13.405 + i * 0.001, altitude: (34 + i).to_f,
+                     speed: 5.0 + i * 0.5, heart_rate: 140 + i * 5,
+                     cadence: 80 + i, distance: 100.0 * (i + 1) })
+    end
+    a.new_session({ timestamp: ts + 180, sport: 'cycling', sub_sport: 'generic',
+                    start_time: ts, total_timer_time: 180.0, total_elapsed_time: 180.0,
+                    total_distance: 300.0, total_ascent: 2, total_descent: 0,
+                    avg_speed: 5.5, max_speed: 6.0,
+                    avg_heart_rate: 147, max_heart_rate: 150,
+                    avg_cadence: 81, max_cadence: 82,
+                    nec_lat: 52.522, nec_long: 13.407,
+                    swc_lat: 52.520, swc_long: 13.405 })
+    Fit4Ruby.write(path, a)
+  end
+
   def generate_fit_fixture(path)
     require 'fit4ruby'
 


### PR DESCRIPTION
Fixes #2686

## Problem

`Fit::Importer` only traverses `sessions → laps → records`. FIT files exported from Garmin Connect may have sessions with no laps — activity-level laps may also have no records — so all trackpoint records are stored flat on the activity object. This causes imports to silently produce 0 points.

Verified with `fit4ruby` on a real Garmin Connect FIT file:

```ruby
activity.sessions.first.laps.count  # => 0
activity.laps.count                 # => 13
activity.laps.first.records.count   # => 0
activity.records.count              # => 7338  ← all points are here
```

## Fix

Extract a private `each_record` helper that tries three structures in order:

1. `sessions → laps → records` (standard — existing behaviour preserved)
2. `activity.laps → records`
3. `activity.records` flat (Garmin Connect)

## Tests

Added a fixture generator (`generate_flat_record_fit_fixture`) that produces a FIT file where sessions have no laps, and a spec context that verifies all three points are imported correctly.