### PR TITLE
Address 1.7.8 review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.7.8] - Unreleased
+## [1.7.8] - 2026-05-10
+
+### ⚠️ Upgrade notes
+
+- **Self-hosters running OIDC-only sign-in:** the `ALLOW_EMAIL_PASSWORD_REGISTRATION` env var no longer doubles as a login gate. Email/password sign-in is now controlled by the new `ALLOW_EMAIL_PASSWORD_LOGIN` env var (defaults to `true`). To preserve OIDC-only sign-in after upgrade, set `ALLOW_EMAIL_PASSWORD_LOGIN=false`.
+- **Visit detection rewrite:** the next nightly run after upgrade will produce different suggested visits. Confirmed visits and named places are preserved; only suggestions change.
 
 ### Changed
 
@@ -19,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix support of FIT files from Garmin Connect. #2686
 - The Anomalies map layer no longer requires manually toggling off and on after a page reload or timeframe change. The toggle state is restored on reload, and the layer refetches anomalies for the active date range. #2568
-- Email/password login is now shown alongside the OIDC button on self-hosted instances by default, instead of being hidden whenever OIDC is configured. Operators who want to enforce OIDC-only sign-in can set `ALLOW_EMAIL_PASSWORD_LOGIN=false`. #2495
+- Email/password login is now shown alongside the OIDC button on self-hosted instances by default, instead of being hidden whenever OIDC is configured. Operators who want to enforce OIDC-only sign-in can set `ALLOW_EMAIL_PASSWORD_LOGIN=false`. See the upgrade note above. #2495
 - Suggested visits at residential addresses are no longer stuck on the placeholder name "Suggested place" indefinitely. The nightly place-naming job now assembles a name from street, house number, city, and state when the geocoder response has no top-level place name — matching how new visits are named at creation time. (#1711)
 - Photos imported from Immich now display at the correct time on Map v2 and import with the correct UTC timestamp, regardless of the host server's timezone or the photo's capture timezone. Previously, photos taken outside the server's timezone could appear up to 24 hours off. Existing imports keep their old timestamps; re-run the Immich import to fix already-imported photos. The photos API now also exposes a `capturedAt` field with the canonical UTC instant alongside the existing `localDateTime` key. #2253
 - Confirmed and declined visits inside an area or assigned to a place are no longer reverted to "suggested" — and any name you gave them is no longer overwritten — by the nightly visit-recompute job. (#2048, #2484)

--- a/app/controllers/settings/visits_controller.rb
+++ b/app/controllers/settings/visits_controller.rb
@@ -6,7 +6,7 @@ class Settings::VisitsController < ApplicationController
   def show; end
 
   def update
-    merged = current_user.safe_settings.settings.merge(coerced_settings_params)
+    merged = (current_user.settings || {}).merge(coerced_settings_params)
     current_user.update!(settings: merged)
 
     redirect_to settings_visits_path, notice: 'Visit detection settings updated'

--- a/app/jobs/visits/full_history_redetect_job.rb
+++ b/app/jobs/visits/full_history_redetect_job.rb
@@ -42,8 +42,18 @@ class Visits::FullHistoryRedetectJob < ApplicationJob
     Visit.where(id: visit_ids).find_each(&:destroy)
 
     months = monthly_ranges(min_ts, max_ts)
-    visits_created = months.sum do |range_start, range_end|
-      Visits::SmartDetect.new(user, start_at: range_start, end_at: range_end).call.size
+    visits_created = 0
+    months_failed = []
+
+    months.each do |range_start, range_end|
+      visits_created += Visits::SmartDetect.new(user, start_at: range_start, end_at: range_end).call.size
+    rescue StandardError => e
+      months_failed << [range_start, range_end]
+      Rails.logger.error(
+        "[Visits::FullHistoryRedetectJob month_failed] user_id=#{user.id} " \
+        "range=#{range_start}..#{range_end} class=#{e.class} message=#{e.message}"
+      )
+      ExceptionReporter.call(e)
     end
 
     places_deleted = cleanup_orphan_places(user, candidate_place_ids)
@@ -53,11 +63,19 @@ class Visits::FullHistoryRedetectJob < ApplicationJob
     duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).to_i
     Rails.logger.info(
       "[Visits::FullHistoryRedetectJob done] user_id=#{user.id} " \
-      "visits_created=#{visits_created} places_deleted=#{places_deleted} duration_ms=#{duration_ms}"
+      "visits_created=#{visits_created} places_deleted=#{places_deleted} " \
+      "months_processed=#{months.size - months_failed.size}/#{months.size} duration_ms=#{duration_ms}"
     )
 
-    notify!(user, kind: :info, title: 'Visit re-detection complete',
-                  content: "#{visits_created} visits across #{months.size} months.")
+    if months_failed.empty?
+      notify!(user, kind: :info, title: 'Visit re-detection complete',
+                    content: "#{visits_created} visits across #{months.size} months.")
+    else
+      ok_months = months.size - months_failed.size
+      notify!(user, kind: :warning, title: 'Visit re-detection partially complete',
+                    content: "#{visits_created} visits across #{ok_months} of #{months.size} months. " \
+                             "#{months_failed.size} month(s) failed; re-run after the cooldown to retry.")
+    end
   rescue StandardError => e
     Rails.logger.error(
       "[Visits::FullHistoryRedetectJob error] user_id=#{user_id} " \

--- a/app/services/visits/smart_detect.rb
+++ b/app/services/visits/smart_detect.rb
@@ -107,7 +107,9 @@ module Visits
 
     def build_visit_hashes(clusters)
       all_point_ids = clusters.flat_map { |c| c[:point_ids] }.select(&:positive?)
-      points_by_id = Point.where(id: all_point_ids).index_by(&:id)
+      points_by_id = Point.where(id: all_point_ids)
+                          .select(:id, :lonlat, :timestamp, :accuracy, :geodata)
+                          .index_by(&:id)
 
       clusters.filter_map do |cluster|
         cluster_points = cluster[:point_ids].filter_map { |id| points_by_id[id] }.sort_by(&:timestamp)

--- a/app/views/settings/visits/_redetect_panel.html.erb
+++ b/app/views/settings/visits/_redetect_panel.html.erb
@@ -7,6 +7,9 @@
       Replaces all suggested visits across your entire history with fresh detections using the settings above.
       Confirmed visits and the places you've named are preserved. This usually takes a few minutes.
     </p>
+    <% if current_user.respond_to?(:plan_restricted?) && current_user.plan_restricted? %>
+      <p class="text-xs opacity-70">On the Lite plan, re-detection covers your visible 12-month window only.</p>
+    <% end %>
 
     <%= button_to visits_redetections_path,
                   method: :post,

--- a/spec/jobs/visits/full_history_redetect_job_spec.rb
+++ b/spec/jobs/visits/full_history_redetect_job_spec.rb
@@ -75,12 +75,45 @@ RSpec.describe Visits::FullHistoryRedetectJob, type: :job do
   end
 
   describe 'failure handling' do
-    it 'reports the error, notifies the user, and re-raises' do
+    it 'reports each failing month, sends a warning notification, and does not re-raise when SmartDetect fails' do
       allow_any_instance_of(Visits::SmartDetect).to receive(:call).and_raise(StandardError, 'boom')
-      expect(ExceptionReporter).to receive(:call).with(instance_of(StandardError))
+      expect(ExceptionReporter).to receive(:call).with(instance_of(StandardError)).at_least(:once)
 
-      expect { described_class.new.perform(user.id) }.to raise_error(StandardError, /boom/)
+      expect { described_class.new.perform(user.id) }.not_to raise_error
 
+      expect(user.notifications.where(kind: :warning)).to exist
+      expect(user.reload.visits_redetected_at).to be_present
+    end
+
+    it 'continues across months, completing successful ones when one month fails' do
+      jan_ts = Time.utc(2024, 1, 15, 12, 0).to_i
+      feb_ts = Time.utc(2024, 2, 15, 12, 0).to_i
+      [jan_ts, feb_ts].each do |ts|
+        3.times do |i|
+          create(:point, user: user,
+                         latitude: 52.5, longitude: 13.4, lonlat: 'POINT(13.4 52.5)',
+                         timestamp: ts + i * 60, accuracy: 10, visit_id: nil)
+        end
+      end
+
+      call_count = 0
+      allow_any_instance_of(Visits::SmartDetect).to receive(:call) do
+        call_count += 1
+        call_count == 1 ? raise(StandardError, 'transient') : []
+      end
+
+      expect { described_class.new.perform(user.id) }.not_to raise_error
+
+      warning = user.notifications.where(kind: :warning).last
+      expect(warning).to be_present
+      expect(warning.content).to match(/1 month\(s\) failed/)
+    end
+
+    it 'wraps the rest of perform in the outer rescue so non-month errors still notify and re-raise' do
+      allow(User).to receive(:find).and_call_original
+      allow_any_instance_of(User).to receive(:points).and_raise(StandardError, 'db down')
+
+      expect { described_class.new.perform(user.id) }.to raise_error(StandardError, /db down/)
       expect(user.notifications.where(kind: :error)).to exist
     end
   end

--- a/spec/regressions/visits_settings_update_persists_only_modified_keys_spec.rb
+++ b/spec/regressions/visits_settings_update_persists_only_modified_keys_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Settings::Visits update persists only the modified keys', type: :request do
+  let(:user) { create(:user, settings: { 'timezone' => 'Europe/Berlin' }) }
+
+  before { sign_in user }
+
+  it 'does not balloon users.settings with the full DEFAULT_VALUES hash' do
+    patch settings_visits_path, params: { settings: { visit_radius_meters: 75 } }
+
+    persisted_keys = user.reload.settings.keys.sort
+    expect(persisted_keys).to contain_exactly('timezone', 'visit_radius_meters')
+    expect(user.settings['visit_radius_meters']).to eq(75)
+    expect(user.settings['timezone']).to eq('Europe/Berlin')
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to #2693 addressing review findings without expanding the release scope.

- **`Settings::VisitsController#update`** now merges into raw `current_user.settings` instead of `safe_settings.settings` — saving visit settings no longer persists the entire `DEFAULT_VALUES` hash (~30 keys) into `users.settings`, which would have frozen current defaults for those users.
- **`Visits::FullHistoryRedetectJob`** rescues `SmartDetect` failures per month, finishes remaining months, and sends a `:warning` notification listing the failed-month count. Previously a transient mid-loop failure left the user with all suggested visits destroyed and re-detection aborted.
- **`Visits::SmartDetect#build_visit_hashes`** loads only the columns the cluster code actually uses (`:id, :lonlat, :timestamp, :accuracy, :geodata`) on the per-cluster `Point.where(id: ...)` fetch — bounded memory under `MAX_CANDIDATE_POINTS=100_000`.
- **Redetect panel** notes the 12-month coverage caveat for Lite users (the SmartDetect plan clamp already applied; the UI copy didn't reflect it).
- **CHANGELOG**: real release date `2026-05-10`, promoted the OIDC env-var change (`ALLOW_EMAIL_PASSWORD_LOGIN` now controls login independently of `ALLOW_EMAIL_PASSWORD_REGISTRATION`) to a prominent ⚠️ Upgrade note, and added a heads-up that the DBSCAN rewrite produces different suggested visits on the first post-upgrade nightly run (confirmed visits and named places stay).

## Test plan

- [x] `bundle exec rspec spec/jobs/visits/full_history_redetect_job_spec.rb` — 7 examples, 0 failures (existing failure-handling spec updated to match the new partial-success behavior; added partial-failure-across-months spec; added non-month-error spec to confirm the outer rescue still re-raises)
- [x] `bundle exec rspec spec/regressions/visits_settings_update_persists_only_modified_keys_spec.rb` — passes (asserts only modified keys are persisted)
- [x] `bundle exec rspec spec/services/visits/smart_detect_spec.rb spec/services/visits/dbscan_clusterer_spec.rb spec/requests/settings/visits_spec.rb` — all green
- [x] `bundle exec rubocop` on changed files — clean
- [ ] Manual QA: trigger redetect with `SmartDetect` stubbed to raise on a single month; confirm warning notification renders and `visits_redetected_at` is set