### PR TITLE
Lock cross-tenant place_id isolation on POST /api/v1/visits

### DIFF
--- a/spec/regressions/visits_api_create_place_id_isolation_spec.rb
+++ b/spec/regressions/visits_api_create_place_id_isolation_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'POST /api/v1/visits ignores cross-tenant place_id', type: :request do
+  let(:owner) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:foreign_place) do
+    create(:place, user: other_user, name: 'Foreign secret', latitude: 48.8566, longitude: 2.3522)
+  end
+  let(:auth_headers) do
+    { 'Authorization' => "Bearer #{owner.api_key}", 'Content-Type' => 'application/json' }
+  end
+  let(:create_params) do
+    {
+      visit: {
+        name: 'Probe',
+        latitude: 52.5200,
+        longitude: 13.4050,
+        started_at: '2026-01-01T10:00:00Z',
+        ended_at: '2026-01-01T11:00:00Z',
+        place_id: foreign_place.id
+      }
+    }
+  end
+
+  it 'does not link the new visit to a foreign place_id' do
+    post '/api/v1/visits', params: create_params.to_json, headers: auth_headers
+
+    expect(response).to have_http_status(:ok)
+    visit = owner.visits.last
+    expect(visit.place_id).not_to eq(foreign_place.id)
+    expect(visit.place.user_id).to eq(owner.id)
+  end
+
+  it 'does not echo the foreign place coordinates in the create response' do
+    post '/api/v1/visits', params: create_params.to_json, headers: auth_headers
+
+    body = JSON.parse(response.body)
+    expect(body.dig('place', 'latitude')).not_to eq(foreign_place.latitude)
+    expect(body.dig('place', 'longitude')).not_to eq(foreign_place.longitude)
+    expect(body.dig('place', 'id')).not_to eq(foreign_place.id)
+  end
+
+  it 'creates the visit at the requested coordinates with a user-owned place' do
+    expect { post '/api/v1/visits', params: create_params.to_json, headers: auth_headers }
+      .to change { owner.visits.count }.by(1)
+
+    visit = owner.visits.last
+    expect(visit.place.latitude).to eq(52.5200)
+    expect(visit.place.longitude).to eq(13.4050)
+    expect(visit.place.user_id).to eq(owner.id)
+  end
+end


### PR DESCRIPTION
## Summary

Adds a regression spec asserting that `POST /api/v1/visits` does not link a new visit to a `place_id` belonging to another user.

## Audit finding

`Visits::Create` (`app/services/visits/create.rb`) ignores `params[:place_id]` entirely. It find-or-creates a place from `latitude` / `longitude`, scoped to the requesting user via:

- `find_existing_place` joins `visits ON places.id = visits.place_id` filtered by `visits.user = user` AND `places.user_id = user.id`
- `create_new_place` explicitly passes `user: user` to `Place.create!`

The `:place_id` permission in `visit_params` is dead on the create path — Rails accepts the field, the service never reads it. So **the create path is not vulnerable to the cross-tenant `place_id` leak class** that affects the update path.

## Why a spec if there's no fix

`Visits::Create` is small and the next refactor that decides to honor `place_id` (a plausible request) could re-introduce the bug if the author isn't thinking about ownership. This spec locks the property and fails fast in that future PR.

## What it asserts

Three behaviors with a `place_id` belonging to another user in the request body:

1. The created visit's persisted `place_id` is **not** the foreign id; the resulting `place.user_id == owner.id`.
2. The response body does **not** echo the foreign place's coordinates or id.
3. The visit is created at the requested lat/lon with a user-owned place.

## Verification

All 3 examples pass on unmodified `dev`. No production code change. No CHANGELOG entry (test-only, no user-perceivable behavior change).

## Out of scope (follow-ups)

- Splitting `visit_params` into separate `create_params` / `update_params` so the strong-params permit list reflects what each action actually consumes. Pure cosmetic — no security implication.

## Test plan

- [x] `bundle exec rspec spec/regressions/visits_api_create_place_id_isolation_spec.rb` → 3 examples, 0 failures
- [x] `bundle exec rubocop spec/regressions/visits_api_create_place_id_isolation_spec.rb` → no offenses