### PR TITLE
Fix Insights top visited locations underreporting days

### DIFF
--- a/app/helpers/insights_helper.rb
+++ b/app/helpers/insights_helper.rb
@@ -88,19 +88,20 @@ module InsightsHelper
   end
 
   def format_location_time(minutes)
-    return '0 min' if minutes.nil? || minutes.to_i.zero?
+    total_minutes = minutes.to_i
+    return '0 min' if minutes.nil? || total_minutes.zero?
 
-    duration = ActiveSupport::Duration.build(minutes.to_i * 60)
-    parts = duration.parts
-
-    days = parts[:days] || 0
-    hours = parts[:hours] || 0
-    mins = parts[:minutes] || 0
-
+    # ActiveSupport::Duration#parts decomposes into months/weeks/days/etc., so
+    # `parts[:days]` only returns the day component within a month (max ~6) and
+    # silently truncates large totals (e.g. 133 actual days renders as "4 days").
+    # Compute the total day/hour count directly from the minutes input instead.
+    days = total_minutes / 1440
     return "#{days} #{'day'.pluralize(days)}" if days >= 1
+
+    hours = total_minutes / 60
     return "#{hours} #{'hour'.pluralize(hours)}" if hours >= 1
 
-    "#{mins} min"
+    "#{total_minutes} min"
   end
 
   def first_time_visits_from_digest(digest)

--- a/spec/helpers/insights_helper_spec.rb
+++ b/spec/helpers/insights_helper_spec.rb
@@ -160,4 +160,48 @@ RSpec.describe InsightsHelper, type: :helper do
       expect(indices).to eq(indices.sort)
     end
   end
+
+  describe '#format_location_time' do
+    it 'returns "0 min" for nil' do
+      expect(helper.format_location_time(nil)).to eq('0 min')
+    end
+
+    it 'returns "0 min" for zero' do
+      expect(helper.format_location_time(0)).to eq('0 min')
+    end
+
+    it 'returns minutes for sub-hour durations' do
+      expect(helper.format_location_time(30)).to eq('30 min')
+    end
+
+    it 'returns hours for sub-day durations' do
+      expect(helper.format_location_time(120)).to eq('2 hours')
+    end
+
+    it 'returns singular hour' do
+      expect(helper.format_location_time(60)).to eq('1 hour')
+    end
+
+    it 'returns total days for single-day durations' do
+      expect(helper.format_location_time(1440)).to eq('1 day')
+    end
+
+    it 'returns total days for multi-day durations' do
+      expect(helper.format_location_time(2 * 1440)).to eq('2 days')
+    end
+
+    # Regression: ActiveSupport::Duration#parts decomposes into months/weeks/days,
+    # so parts[:days] only returns the day-remainder (max ~6). The previous
+    # implementation reported "4 days" for 191_741 minutes (≈133 days), which
+    # silently underreports time spent at top locations.
+    it 'returns the total day count for durations spanning months' do
+      # 133 days = 191_520 minutes
+      expect(helper.format_location_time(133 * 1440)).to eq('133 days')
+    end
+
+    it 'returns the total day count for durations spanning years' do
+      # 400 days = 576_000 minutes — clearly across a year boundary
+      expect(helper.format_location_time(400 * 1440)).to eq('400 days')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`InsightsHelper#format_location_time` reads `ActiveSupport::Duration.build(seconds).parts[:days]`, but `Duration#parts` decomposes durations into months/weeks/days/etc., so `parts[:days]` only returns the day **remainder** within a month (max ~6). Large totals are silently truncated.

For example, a home location with `SUM(duration) = 191_741` minutes (≈133 days) is rendered as **"4 days"** in the *Top Visited Locations* card on the Insights page.

## Root cause

```ruby
duration = ActiveSupport::Duration.build(minutes.to_i * 60)
parts    = duration.parts
days     = parts[:days] || 0   # ← only the day component, not the total
```

`ActiveSupport::Duration.build(191_741 * 60).inspect` returns `"4 months, 1 week, 4 days, 9 hours, 44 minutes, and 36 seconds"`, so `parts[:days]` is `4`.

## Fix

Compute the total day/hour count directly from the input minutes (`total_minutes / 1440` and `total_minutes / 60`) instead of relying on `Duration#parts`.

## Verification

New specs in `spec/helpers/insights_helper_spec.rb` cover:
- `nil` and `0` → `"0 min"`
- sub-hour → `"30 min"`
- single hour → `"1 hour"` / multi-hour → `"2 hours"`
- single day → `"1 day"` / multi-day → `"2 days"`
- multi-month regression → `133 * 1440` minutes returns `"133 days"` (was `"4 days"`)
- multi-year regression → `400 * 1440` minutes returns `"400 days"`

## Test plan

- [ ] \`bundle exec rspec spec/helpers/insights_helper_spec.rb\`
- [ ] Visit \`/insights\` and confirm *Top Visited Locations* shows correct totals for locations with multi-month durations