### PR TITLE
Real-time place suggestions + orphan cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,31 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.7.9] - Unreleased
 
+### ⚠️ Upgrade notes
+
+- **Visit detection no longer fan-outs candidate places.** Previously, every detected visit persisted up to 25 reverse-geocoded "possible place" rows. Now each visit owns exactly one Place (named synchronously from Photon at creation time). Alternative suggestions are available live via `GET /api/v1/visits/:id/possible_places` and the new `POST /api/v1/visits/:id/select_place` endpoint. Existing pre-rollout candidate rows can be cleaned up with the new `bin/rails dawarich:cleanup_suggested_places` task. The `place_visits` table is preserved for one release and will be dropped in a follow-up after operators verify the drain completed.
+- **Web timeline picker** (the radio-list under "Needs review" for suggested visits) still reads from the legacy `place_visits` association in this release. After running the cleanup rake task, that list will show only the visit's main place. A follow-up release will switch the timeline picker to use real-time Photon suggestions via the new endpoints. Mobile clients consuming the JSON API see the new behavior immediately.
+- **Two one-time operator tasks** ship in this release. Run after deploy:
+  1. `bin/rails dawarich:backfill_place_names` — names any remaining legacy `Place::DEFAULT_NAME` rows.
+  2. `bin/rails dawarich:cleanup_suggested_places` — drains orphan suggested-place rows.
+  Self-hosters can run them on their own schedule; both are safe to re-run.
+
 ### Added
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
+- `POST /api/v1/visits/:id/select_place` — assigns a Photon candidate to a visit, lazy-creating the Place row in the user's catalogue. Returns the materialized Place.
+- Visit self-cleanup: when a visit's `place_id` changes or the visit is destroyed, the previous Place is deleted automatically if it has no notes, no tags, and no other referring visits.
+
+### Changed
+
+- Visit detection no longer creates 25 candidate Places per visit. Each visit now has exactly one Place, named synchronously from Photon at creation time.
+- `GET /api/v1/visits/:id/possible_places` returns real-time Photon suggestions instead of pre-persisted candidates. The currently-assigned place is prepended to the list with its `id`; suggestions below have `id: null` and round-trip via the new `select_place` endpoint.
+- `GET /api/v1/places/nearby` and `POST /api/v1/places/nearby` now include `id` (always `null` for Photon results), `source`, and `geodata` keys in each item (additive — existing consumers unaffected).
+- `Place#has_many :visits` is now `dependent: :nullify` (was `:destroy`). Deleting a Place leaves its visits intact with `place_id = nil`, preventing accidental visit loss.
+
+### Removed
+
+- `place_name_fetching_job` daily cron entry. Place naming now happens synchronously during visit detection — no nightly catch-up needed.
 
 ## [1.7.8] - 2026-05-16
 

--- a/app/controllers/api/v1/visits/possible_places_controller.rb
+++ b/app/controllers/api/v1/visits/possible_places_controller.rb
@@ -3,12 +3,43 @@
 class Api::V1::Visits::PossiblePlacesController < ApiController
   def index
     visit = current_api_user.visits.find(params[:id])
-    possible_places = visit.suggested_places.map do |place|
-      Api::PlaceSerializer.new(place).call
-    end
-
-    render json: possible_places
+    lat, lon = visit.center
+    suggestions = Places::NearbySearch.new(latitude: lat, longitude: lon, cache: true).call
+    suggestions = prepend_current_place(visit, suggestions)
+    render json: suggestions
   rescue ActiveRecord::RecordNotFound
     render json: { error: 'Visit not found' }, status: :not_found
+  end
+
+  private
+
+  def prepend_current_place(visit, suggestions)
+    return suggestions unless visit.place
+
+    current = serialize_existing_place(visit.place)
+    filtered = if current[:osm_id].present?
+                 suggestions.reject { |s| s[:osm_id] == current[:osm_id] }
+               else
+                 suggestions
+               end
+
+    [current] + filtered
+  end
+
+  def serialize_existing_place(place)
+    {
+      id: place.id,
+      name: place.name,
+      latitude: place.lat,
+      longitude: place.lon,
+      osm_id: place.osm_id,
+      osm_type: place.osm_type,
+      osm_key: place.osm_key,
+      osm_value: place.osm_value,
+      city: place.city,
+      country: place.country,
+      source: place.source,
+      geodata: place.geodata
+    }
   end
 end

--- a/app/controllers/api/v1/visits/select_place_controller.rb
+++ b/app/controllers/api/v1/visits/select_place_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Api::V1::Visits::SelectPlaceController < ApiController
+  def create
+    visit = current_api_user.visits.find(params[:id])
+    place = Visits::SelectPlace.new(user: current_api_user, visit: visit, photon: photon_params).call
+    render json: serialize_place(place), status: :created
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Visit not found' }, status: :not_found
+  rescue ActiveRecord::RecordInvalid, ActionController::ParameterMissing => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
+  private
+
+  def photon_params
+    params.require(:photon).permit(
+      :name, :latitude, :longitude,
+      :osm_id, :osm_type, :osm_key, :osm_value,
+      :city, :country, :street, :housenumber, :postcode,
+      geodata: {}
+    ).tap do |p|
+      raise ActionController::ParameterMissing, :name      if p[:name].blank?
+      raise ActionController::ParameterMissing, :latitude  if p[:latitude].blank?
+      raise ActionController::ParameterMissing, :longitude if p[:longitude].blank?
+    end
+  end
+
+  def serialize_place(place)
+    {
+      id: place.id,
+      name: place.name,
+      latitude: place.lat,
+      longitude: place.lon,
+      source: place.source,
+      note: place.note,
+      icon: place.tags.first&.icon,
+      color: place.tags.first&.color,
+      visits_count: place.visits.size,
+      created_at: place.created_at,
+      tags: place.tags.map do |tag|
+        {
+          id: tag.id,
+          name: tag.name,
+          icon: tag.icon,
+          color: tag.color,
+          privacy_radius_meters: tag.privacy_radius_meters
+        }
+      end
+    }
+  end
+end

--- a/app/jobs/places/orphan_cleanup_job.rb
+++ b/app/jobs/places/orphan_cleanup_job.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class Places::OrphanCleanupJob < ApplicationJob
+  queue_as :default
+  BATCH = 500
+
+  def perform(user_id)
+    user = User.find_by(id: user_id)
+    return unless user
+
+    total = 0
+    loop do
+      deleted = delete_batch(user)
+      break if deleted.zero?
+
+      total += deleted
+      Rails.logger.info("[OrphanCleanup] user=#{user.id} batch=#{deleted} total=#{total}")
+      sleep 0.05
+    end
+  end
+
+  private
+
+  def delete_batch(user)
+    conn = Place.connection
+    deleted = 0
+
+    conn.transaction do
+      victim_ids = conn.exec_query(victims_sql, 'OrphanCleanup victims', victim_binds(user.id)).rows.map { |r| r[0] }
+      break if victim_ids.empty?
+
+      conn.exec_delete(
+        "DELETE FROM place_visits WHERE place_id IN (#{victim_ids.join(',')})",
+        'OrphanCleanup place_visits'
+      )
+      deleted = conn.exec_delete(
+        "DELETE FROM places WHERE id IN (#{victim_ids.join(',')})",
+        'OrphanCleanup places'
+      )
+    end
+
+    deleted
+  end
+
+  def victims_sql
+    <<~SQL.squish
+      SELECT p.id
+      FROM places p
+      LEFT JOIN visits v   ON v.place_id = p.id
+      LEFT JOIN taggings t ON t.taggable_id = p.id AND t.taggable_type = 'Place'
+      WHERE p.user_id = $1
+        AND p.source = #{Place.sources[:photon]}
+        AND (p.note IS NULL OR p.note = '')
+        AND v.id IS NULL
+        AND t.id IS NULL
+      LIMIT #{BATCH}
+    SQL
+  end
+
+  def victim_binds(user_id)
+    [ActiveRecord::Relation::QueryAttribute.new('user_id', user_id, ActiveRecord::Type::Integer.new)]
+  end
+end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -8,7 +8,7 @@ class Place < ApplicationRecord
   DEFAULT_NAME = 'Suggested place'
 
   belongs_to :user, optional: true # Optional until Stage 2 NOT NULL
-  has_many :visits, dependent: :destroy
+  has_many :visits, dependent: :nullify
   has_many :place_visits, dependent: :destroy
   has_many :suggested_visits, -> { distinct }, through: :place_visits, source: :visit
 

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -8,6 +8,9 @@ class Visit < ApplicationRecord
   has_many :place_visits, dependent: :destroy
   has_many :suggested_places, through: :place_visits, source: :place
 
+  after_commit :cleanup_old_place_if_orphan, on: :update
+  after_destroy_commit :cleanup_place_if_orphan
+
   validates :started_at, :ended_at, :duration, :name, :status, presence: true
 
   validates :ended_at, comparison: { greater_than: :started_at }
@@ -45,6 +48,8 @@ class Visit < ApplicationRecord
     end
   end
 
+  private
+
   def center_from_points
     return [0, 0] if points.empty?
 
@@ -53,5 +58,18 @@ class Visit < ApplicationRecord
     count = points.size.to_f
 
     [lat_sum / count, lon_sum / count]
+  end
+
+  def cleanup_old_place_if_orphan
+    old_id, = previous_changes['place_id']
+    return unless old_id
+
+    Places::DeleteIfOrphan.call(old_id)
+  end
+
+  def cleanup_place_if_orphan
+    return unless place_id
+
+    Places::DeleteIfOrphan.call(place_id)
   end
 end

--- a/app/services/places/delete_if_orphan.rb
+++ b/app/services/places/delete_if_orphan.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Places
+  class DeleteIfOrphan
+    def self.call(place_id)
+      new(place_id).call
+    end
+
+    def initialize(place_id)
+      @place_id = place_id
+    end
+
+    def call
+      place = Place.find_by(id: @place_id)
+      return false unless place
+      return false unless place.photon?
+      return false if place.note.present?
+      return false if Visit.where(place_id: @place_id).exists?
+      return false if Tagging.where(taggable_id: @place_id, taggable_type: 'Place').exists?
+
+      place.delete
+      true
+    rescue ActiveRecord::InvalidForeignKey => e
+      Rails.logger.warn("[DeleteIfOrphan] place=#{@place_id} #{e.message}")
+      false
+    end
+  end
+end

--- a/app/services/places/delete_if_orphan.rb
+++ b/app/services/places/delete_if_orphan.rb
@@ -18,10 +18,13 @@ module Places
       return false if Visit.where(place_id: @place_id).exists?
       return false if Tagging.where(taggable_id: @place_id, taggable_type: 'Place').exists?
 
-      place.delete
+      Place.transaction do
+        PlaceVisit.where(place_id: @place_id).delete_all
+        place.delete
+      end
       true
     rescue ActiveRecord::InvalidForeignKey => e
-      Rails.logger.warn("[DeleteIfOrphan] place=#{@place_id} #{e.message}")
+      Rails.logger.warn("[DeleteIfOrphan] place=#{@place_id} FK race: #{e.message}")
       false
     end
   end

--- a/app/services/places/name_fetcher.rb
+++ b/app/services/places/name_fetcher.rb
@@ -2,22 +2,43 @@
 
 module Places
   class NameFetcher
+    def self.lookup_attrs(lat, lon)
+      return nil unless DawarichSettings.reverse_geocoding_enabled?
+
+      result = Geocoder.search([lat, lon], units: :km, limit: 1, distance_sort: true).first
+      return nil if result.blank?
+
+      properties = result.data&.dig('properties')
+      return nil if properties.blank?
+
+      name = ::Visits::Names::Builder.build_from_properties(properties)
+
+      { name: name, city: properties['city'], country: properties['country'], geodata: result.data }
+    rescue StandardError => e
+      ExceptionReporter.call(e, "NameFetcher.lookup_attrs failed for #{lat},#{lon}")
+      nil
+    end
+
     def initialize(place)
       @place = place
     end
 
     def call
-      geodata = Geocoder.search([place.lat, place.lon], units: :km, limit: 1, distance_sort: true).first
+      result = Geocoder.search([place.lat, place.lon], units: :km, limit: 1, distance_sort: true).first
+      return nil if result.blank?
 
-      return if geodata.blank?
+      properties = result.data&.dig('properties')
+      return nil if properties.blank?
 
-      properties = geodata.data&.dig('properties')
-      return if properties.blank?
+      name = ::Visits::Names::Builder.build_from_properties(properties)
 
       ActiveRecord::Base.transaction do
-        update_place_name(properties, geodata)
-        update_visits_name(properties)
-
+        place.name = name if name.present?
+        place.city = properties['city'] if properties['city'].present?
+        place.country = properties['country'] if properties['country'].present?
+        place.geodata = result.data if DawarichSettings.store_geodata?
+        place.save!
+        place.visits.where(name: Place::DEFAULT_NAME).update_all(name: name) if name.present?
         place
       end
     rescue StandardError => e
@@ -29,22 +50,5 @@ module Places
     private
 
     attr_reader :place
-
-    def update_place_name(properties, geodata)
-      built_name = ::Visits::Names::Builder.build_from_properties(properties)
-      place.name = built_name if built_name.present?
-      place.city = properties['city'] if properties['city'].present?
-      place.country = properties['country'] if properties['country'].present?
-      place.geodata = geodata.data if DawarichSettings.store_geodata?
-
-      place.save!
-    end
-
-    def update_visits_name(properties)
-      built_name = ::Visits::Names::Builder.build_from_properties(properties)
-      return if built_name.blank?
-
-      place.visits.where(name: Place::DEFAULT_NAME).update_all(name: built_name)
-    end
   end
 end

--- a/app/services/places/nearby_search.rb
+++ b/app/services/places/nearby_search.rb
@@ -4,45 +4,55 @@ module Places
   class NearbySearch
     RADIUS_KM = 0.5
     MAX_RESULTS = 10
+    CACHE_TTL = 1.hour
+    GRID_PRECISION = 4
 
-    def initialize(latitude:, longitude:, radius: RADIUS_KM, limit: MAX_RESULTS)
-      @latitude = latitude
-      @longitude = longitude
+    def initialize(latitude:, longitude:, radius: RADIUS_KM, limit: MAX_RESULTS, cache: false)
+      @latitude = latitude.to_f
+      @longitude = longitude.to_f
       @radius = radius
       @limit = limit
+      @cache = cache
     end
 
     def call
       return [] unless reverse_geocoding_enabled?
+      return [] if @latitude.zero? && @longitude.zero?
 
-      results = Geocoder.search(
-        [latitude, longitude],
-        limit: limit,
-        distance_sort: true,
-        radius: radius,
-        units: :km
-      )
-
-      format_results(results)
-    rescue StandardError => e
-      Rails.logger.error("Nearby places search error: #{e.message}")
-      []
+      @cache ? Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) { fetch_and_format } : fetch_and_format
     end
 
     private
-
-    attr_reader :latitude, :longitude, :radius, :limit
 
     def reverse_geocoding_enabled?
       DawarichSettings.reverse_geocoding_enabled?
     end
 
+    def cache_key
+      "places_nearby:#{@latitude.round(GRID_PRECISION)},#{@longitude.round(GRID_PRECISION)},r=#{@radius},l=#{@limit}"
+    end
+
+    def fetch_and_format
+      results = Geocoder.search(
+        [@latitude, @longitude],
+        limit: @limit,
+        distance_sort: true,
+        radius: @radius,
+        units: :km
+      )
+      format_results(results)
+    rescue StandardError => e
+      ExceptionReporter.call(e, "NearbySearch failed for #{@latitude},#{@longitude}")
+      []
+    end
+
     def format_results(results)
       results.map do |result|
         properties = result.data['properties'] || {}
-        coordinates = result.data.dig('geometry', 'coordinates') || [longitude, latitude]
+        coordinates = result.data.dig('geometry', 'coordinates') || [@longitude, @latitude]
 
         {
+          id: nil,
           name: extract_name(result.data),
           latitude: coordinates[1],
           longitude: coordinates[0],
@@ -54,14 +64,15 @@ module Places
           country: properties['country'],
           street: properties['street'],
           housenumber: properties['housenumber'],
-          postcode: properties['postcode']
+          postcode: properties['postcode'],
+          source: 'photon',
+          geodata: result.data
         }
       end
     end
 
     def extract_name(data)
       properties = data['properties'] || {}
-
       properties['name'] ||
         [properties['street'], properties['housenumber']].compact.join(' ').presence ||
         properties['city'] ||

--- a/app/services/visits/create.rb
+++ b/app/services/visits/create.rb
@@ -85,25 +85,6 @@ module Visits
         status: params[:status].presence || :confirmed
       )
 
-      attach_suggested_places(@visit) if @visit.suggested?
-
-      @visit
-    end
-
-    def attach_suggested_places(visit)
-      lat = visit.place.latitude
-      lon = visit.place.longitude
-      candidates = user.places
-                       .where(
-                         'ST_DWithin(lonlat::geography, ' \
-                         'ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, 100)',
-                         lon, lat
-                       )
-                       .limit(8)
-      candidates.each { |p| visit.suggested_places << p unless visit.suggested_places.include?(p) }
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
-      ExceptionReporter.call(e, "Failed to attach suggested places: #{e.message}")
-
       @visit
     end
   end

--- a/app/services/visits/creator.rb
+++ b/app/services/visits/creator.rb
@@ -11,45 +11,25 @@ module Visits
 
     def create_visits(visits)
       visits.map do |visit_data|
-        # Check for existing visits at this location
         existing_visit = find_existing_visit(visit_data)
         next nil if existing_visit
 
-        # Variables to store data outside the transaction
-        visit_instance = nil
-        place_data = nil
-
-        # First transaction to create the visit
         ActiveRecord::Base.transaction do
-          # Try to find matching area
           area = find_matching_area(visit_data)
-
-          # Only find/create place if no area was found
-          place_data = PlaceFinder.new(user).find_or_create_place(visit_data) unless area
-
-          main_place = place_data&.dig(:main_place)
+          main_place = area ? nil : PlaceFinder.new(user).find_or_create_place(visit_data)
 
           visit_instance = Visit.create!(
-            user: user,
-            area: area,
-            place: main_place,
+            user: user, area: area, place: main_place,
             started_at: Time.zone.at(visit_data[:start_time]),
-            ended_at: Time.zone.at(visit_data[:end_time]),
-            duration: visit_data[:duration] / 60, # Convert to minutes
-            name: generate_visit_name(area, main_place, visit_data[:suggested_name]),
-            status: :suggested
+            ended_at:   Time.zone.at(visit_data[:end_time]),
+            duration:   visit_data[:duration] / 60,
+            name:       generate_visit_name(area, main_place, visit_data[:suggested_name]),
+            status:     :suggested
           )
 
           Point.where(id: visit_data[:points].map(&:id)).update_all(visit_id: visit_instance.id)
+          visit_instance
         end
-
-        # Associate suggested places outside the main transaction
-        # to avoid deadlocks when multiple processes run simultaneously
-        if place_data&.dig(:suggested_places).present?
-          associate_suggested_places(visit_instance, place_data[:suggested_places])
-        end
-
-        visit_instance
       end.compact
     end
 
@@ -83,25 +63,6 @@ module Visits
       end
 
       nil
-    end
-
-    # Create place_visits records directly to avoid deadlocks
-    def associate_suggested_places(visit, suggested_places)
-      existing_place_ids = visit.place_visits.pluck(:place_id)
-
-      # Only create associations that don't already exist
-      place_ids_to_add = suggested_places.map(&:id) - existing_place_ids
-
-      # Skip if there's nothing to add
-      return if place_ids_to_add.empty?
-
-      # Batch create place_visit records
-      place_visits_attrs = place_ids_to_add.map do |place_id|
-        { visit_id: visit.id, place_id: place_id, created_at: Time.current, updated_at: Time.current }
-      end
-
-      # Use insert_all for efficient bulk insertion without callbacks
-      PlaceVisit.insert_all(place_visits_attrs) if place_visits_attrs.any?
     end
 
     def find_matching_area(visit_data)

--- a/app/services/visits/place_finder.rb
+++ b/app/services/visits/place_finder.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 module Visits
-  # Finds or creates places for visits
   class PlaceFinder
-    attr_reader :user
+    SIMILARITY_RADIUS = 50
 
-    SEARCH_RADIUS = 100 # meters
-    SIMILARITY_RADIUS = 50 # meters
-    MAX_SUGGESTED_PLACES = 25
+    attr_reader :user
 
     def initialize(user)
       @user = user
@@ -17,234 +14,36 @@ module Visits
       lat = visit_data[:center_lat]
       lon = visit_data[:center_lon]
 
-      # First check if there's an existing place
-      existing_place = find_existing_place(lat, lon, visit_data[:suggested_name])
+      existing = find_existing_place(lat, lon, visit_data[:suggested_name])
+      return existing if existing
 
-      # If we found an exact match, return it
-      if existing_place
-        return {
-          main_place: existing_place,
-          suggested_places: find_suggested_places(lat, lon)
-        }
-      end
-
-      # Get potential places from all sources
-      potential_places = collect_potential_places(visit_data)
-
-      # Find or create the main place
-      main_place = select_or_create_main_place(potential_places, lat, lon, visit_data[:suggested_name])
-
-      # Get suggested places including our main place
-      all_suggested_places = potential_places.presence || [main_place]
-
-      {
-        main_place: main_place,
-        suggested_places: all_suggested_places.uniq(&:name).first(MAX_SUGGESTED_PLACES)
-      }
+      create_default_place(lat, lon, visit_data[:suggested_name])
     end
 
     private
 
-    # Step 1: Find existing place
     def find_existing_place(lat, lon, name)
-      existing_by_location = user.places.near([lat, lon], SIMILARITY_RADIUS, :m).first
-      return existing_by_location if existing_by_location
+      by_location = user.places.near([lat, lon], SIMILARITY_RADIUS, :m).first
+      return by_location if by_location
 
       return nil if name.blank?
 
-      user.places.where(name: name)
-          .near([lat, lon], SEARCH_RADIUS, :m)
-          .first
+      user.places.where(name: name).near([lat, lon], SIMILARITY_RADIUS * 2, :m).first
     end
 
-    # Step 2: Collect potential places from all sources
-    def collect_potential_places(visit_data)
-      lat = visit_data[:center_lat]
-      lon = visit_data[:center_lon]
-
-      # Get places from points' geodata
-      places_from_points = extract_places_from_points(visit_data[:points])
-
-      # Combine and deduplicate by name
-      combined_places = []
-
-      # Add API places first (usually better quality)
-      reverse_geocoded_places(lat, lon).each do |api_place|
-        combined_places << api_place unless place_name_exists?(combined_places, api_place.name)
-      end
-
-      # Add places from points if name doesn't already exist
-      places_from_points.each do |point_place|
-        combined_places << point_place unless place_name_exists?(combined_places, point_place.name)
-      end
-
-      combined_places
-    end
-
-    # Step 3: Extract places from points
-    def extract_places_from_points(points)
-      return [] if points.blank?
-
-      # Filter points with geodata
-      points_with_geodata = points.select { |point| point.geodata.present? }
-      return [] if points_with_geodata.empty?
-
-      # Process each point to create or find places
-      places = []
-
-      points_with_geodata.each do |point|
-        place = create_place_from_point(point)
-        places << place if place
-      end
-
-      places.uniq(&:name)
-    end
-
-    # Step 4: Create place from point
-    def create_place_from_point(point)
-      return nil unless point.geodata.is_a?(Hash)
-
-      properties = point.geodata['properties'] || {}
-      return nil if properties.blank?
-
-      name = build_place_name(properties)
-      return nil if name == Place::DEFAULT_NAME
-
-      existing = user.places.where(name: name)
-                     .near([point.lat, point.lon], SIMILARITY_RADIUS, :m)
-                     .first
-
-      return existing if existing
-
-      place = user.places.build(
-        name: name,
-        lonlat: "POINT(#{point.lon} #{point.lat})",
-        latitude: point.lat,
-        longitude: point.lon,
-        city: properties['city'],
-        country: properties['country'],
-        geodata: point.geodata,
-        source: :photon
-      )
-
-      place.save!
-      place
-    rescue ActiveRecord::RecordInvalid
-      nil
-    end
-
-    # Step 5: Fetch places from API
-    def reverse_geocoded_places(lat, lon)
-      # Get broader search results from Geocoder
-      geocoder_results = Geocoder.search([lat, lon], units: :km, limit: 20, distance_sort: true)
-      return [] if geocoder_results.blank?
-
-      places = []
-
-      geocoder_results.each do |result|
-        place = create_place_from_api_result(result)
-        places << place if place
-      end
-
-      places
-    rescue StandardError => e
-      Rails.logger.error("Reverse geocoding error in PlaceFinder: #{e.message}")
-      ExceptionReporter.call(e)
-      []
-    end
-
-    # Step 6: Create place from API result
-    def create_place_from_api_result(result)
-      return nil unless result && result.data.is_a?(Hash)
-
-      properties = result.data['properties'] || {}
-      return nil if properties.blank?
-
-      name = build_place_name(properties)
-      return nil if name == Place::DEFAULT_NAME
-
-      existing = user.places.where(name: name)
-                     .near([result.latitude, result.longitude], SIMILARITY_RADIUS, :m)
-                     .first
-
-      return existing if existing
-
-      place = user.places.build(
-        name: name,
-        lonlat: "POINT(#{result.longitude} #{result.latitude})",
-        latitude: result.latitude,
-        longitude: result.longitude,
-        city: properties['city'],
-        country: properties['country'],
-        geodata: result.data,
-        source: :photon
-      )
-
-      place.save!
-      place
-    rescue ActiveRecord::RecordInvalid
-      nil
-    end
-
-    # Step 7: Select or create main place
-    def select_or_create_main_place(potential_places, lat, lon, suggested_name)
-      return create_default_place(lat, lon, suggested_name) if potential_places.blank?
-
-      # Choose the closest place as the main one
-      sorted_places = potential_places.sort_by do |place|
-        place.distance_to([lat, lon], :m)
-      end
-
-      sorted_places.first
-    end
-
-    # Step 8: Create default place when no other options
     def create_default_place(lat, lon, suggested_name)
-      name = suggested_name.presence || Place::DEFAULT_NAME
+      attrs = Places::NameFetcher.lookup_attrs(lat, lon) || {}
 
-      place = user.places.build(
-        name: name,
-        lonlat: "POINT(#{lon} #{lat})",
-        latitude: lat,
+      user.places.create!(
+        name:      attrs[:name].presence || suggested_name.presence || Place::DEFAULT_NAME,
+        city:      attrs[:city],
+        country:   attrs[:country],
+        geodata:   DawarichSettings.store_geodata? ? (attrs[:geodata] || {}) : {},
+        latitude:  lat,
         longitude: lon,
-        source: :manual
+        lonlat:    "POINT(#{lon} #{lat})",
+        source:    :photon
       )
-
-      place.save!
-      place
-    end
-
-    # Step 9: Find suggested places
-    def find_suggested_places(lat, lon)
-      user.places
-          .near([lat, lon], SEARCH_RADIUS, :m)
-          .with_distance([lat, lon], :m)
-          .limit(MAX_SUGGESTED_PLACES)
-    end
-
-    # Helper methods
-
-    def build_place_name(properties)
-      # First try building with our name builder
-      built_name = Visits::Names::Builder.build_from_properties(properties)
-      return built_name if built_name.present?
-
-      # Try using the instance-based approach as a fallback
-      features = [{ 'properties' => properties }]
-      feature_type = properties['type'] || properties['osm_value']
-      name = properties['name']
-
-      if feature_type.present? && name.present?
-        built_name = Visits::Names::Builder.new(features, feature_type, name).call
-        return built_name if built_name.present?
-      end
-
-      # Fallback to the default name if all else fails
-      Place::DEFAULT_NAME
-    end
-
-    def place_name_exists?(places, name)
-      places.any? { |place| place.name == name }
     end
   end
 end

--- a/app/services/visits/select_place.rb
+++ b/app/services/visits/select_place.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Visits
+  class SelectPlace
+    PROXIMITY_METERS = 50
+
+    def initialize(user:, visit:, photon:)
+      @user = user
+      @visit = visit
+      @photon = photon.respond_to?(:with_indifferent_access) ? photon.with_indifferent_access : photon
+    end
+
+    def call
+      place = find_by_osm_id || find_by_name_and_proximity || create_place
+      @visit.update!(place_id: place.id, name: place.name)
+      place
+    end
+
+    private
+
+    def find_by_osm_id
+      osm_id = @photon[:osm_id]
+      return nil if osm_id.blank?
+
+      @user.places
+           .where("(geodata->'properties'->>'osm_id')::bigint = ?", osm_id.to_i)
+           .first
+    end
+
+    def find_by_name_and_proximity
+      name = @photon[:name]
+      lat = @photon[:latitude].to_f
+      lon = @photon[:longitude].to_f
+      return nil if name.blank?
+
+      @user.places
+           .where(name: name)
+           .where(
+             'ST_DWithin(lonlat::geography, ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)',
+             lon, lat, PROXIMITY_METERS
+           )
+           .first
+    end
+
+    def create_place
+      lat = @photon[:latitude].to_f
+      lon = @photon[:longitude].to_f
+
+      @user.places.create!(
+        name: @photon[:name],
+        latitude: lat,
+        longitude: lon,
+        lonlat: "POINT(#{lon} #{lat})",
+        city: @photon[:city],
+        country: @photon[:country],
+        geodata: DawarichSettings.store_geodata? ? (@photon[:geodata] || {}) : {},
+        source: :photon
+      )
+    end
+  end
+end

--- a/app/services/visits/select_place.rb
+++ b/app/services/visits/select_place.rb
@@ -23,7 +23,7 @@ module Visits
       return nil if osm_id.blank?
 
       @user.places
-           .where("(geodata->'properties'->>'osm_id')::bigint = ?", osm_id.to_i)
+           .where("geodata->'properties'->>'osm_id' = ?", osm_id.to_s)
            .first
     end
 

--- a/app/views/map/timeline_feeds/_suggested_picker.html.erb
+++ b/app/views/map/timeline_feeds/_suggested_picker.html.erb
@@ -55,6 +55,12 @@
         </li>
       <% end %>
     </ul>
+
+    <% if visible.size <= 1 && overflow.empty? %>
+      <p class="suggested-picker__note" data-testid="visit-no-alternatives">
+        No alternative suggestions yet. Confirm or decline this place, or edit it from the visit detail.
+      </p>
+    <% end %>
   <% end %>
 
   <%= button_to 'Decline', visit_path(entry[:visit_id], visit: { status: :declined }),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,6 +278,7 @@ Rails.application.routes.draw do
       end
       resources :visits, only: %i[index show create update destroy] do
         get 'possible_places', to: 'visits/possible_places#index', on: :member
+        post 'select_place', to: 'visits/select_place#create', on: :member
         collection do
           post 'merge', to: 'visits#merge'
           post 'bulk_update', to: 'visits#bulk_update'

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -30,11 +30,6 @@ cache_preheating_job:
   class: "Cache::PreheatingJob"
   queue: default
 
-place_name_fetching_job:
-  cron: "30 0 * * *" # every day at 00:30
-  class: "Places::BulkNameFetchingJob"
-  queue: places
-
 daily_track_generation_job:
   cron: "0 */12 * * *" # every 12 hours (real-time generation handles most cases)
   class: "Tracks::DailyGenerationJob"

--- a/lib/tasks/dawarich_places.rake
+++ b/lib/tasks/dawarich_places.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+namespace :dawarich do
+  desc 'One-time orphan suggested-place cleanup for all users'
+  task cleanup_suggested_places: :environment do
+    User.in_batches(of: 100).each_with_index do |batch, i|
+      batch.pluck(:id).each_with_index do |uid, j|
+        Places::OrphanCleanupJob.set(wait: ((i * 100 + j) * 0.1).seconds).perform_later(uid)
+      end
+    end
+    Rails.logger.info('[dawarich:cleanup_suggested_places] enqueued')
+  end
+
+  desc 'One-time backfill of legacy Place::DEFAULT_NAME rows'
+  task backfill_place_names: :environment do
+    Places::BulkNameFetchingJob.perform_later
+    Rails.logger.info('[dawarich:backfill_place_names] enqueued')
+  end
+end

--- a/spec/jobs/places/orphan_cleanup_job_spec.rb
+++ b/spec/jobs/places/orphan_cleanup_job_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Places::OrphanCleanupJob, type: :job do
+  let(:user)  { create(:user) }
+  let(:other) { create(:user) }
+
+  describe '#perform' do
+    it 'deletes orphan photon places for the given user only' do
+      orphan       = create(:place, user: user,  source: :photon)
+      chosen       = create(:place, user: user,  source: :photon)
+      manual       = create(:place, user: user,  source: :manual)
+      noted        = create(:place, user: user,  source: :photon, note: 'mine')
+      tagged       = create(:place, user: user,  source: :photon)
+      other_orphan = create(:place, user: other, source: :photon)
+
+      tag = create(:tag, user: user)
+      tagged.tags << tag
+
+      create(:visit, user: user, place: chosen, area: nil)
+
+      described_class.new.perform(user.id)
+
+      expect(Place.exists?(orphan.id)).to be(false)
+      expect(Place.exists?(chosen.id)).to be(true)
+      expect(Place.exists?(manual.id)).to be(true)
+      expect(Place.exists?(noted.id)).to be(true)
+      expect(Place.exists?(tagged.id)).to be(true)
+      expect(Place.exists?(other_orphan.id)).to be(true)
+    end
+
+    it 'is idempotent on second run' do
+      orphan = create(:place, user: user, source: :photon)
+      described_class.new.perform(user.id)
+      expect { described_class.new.perform(user.id) }.not_to raise_error
+      expect(Place.exists?(orphan.id)).to be(false)
+    end
+
+    it 'deletes place_visits rows referencing orphan places' do
+      manual_place = create(:place, user: user, source: :manual)
+      orphan       = create(:place, user: user, source: :photon)
+      visit        = create(:visit, user: user, area: nil, place: manual_place)
+      PlaceVisit.create!(place: orphan, visit: visit)
+
+      described_class.new.perform(user.id)
+
+      expect(PlaceVisit.exists?(place_id: orphan.id)).to be(false)
+      expect(Place.exists?(orphan.id)).to be(false)
+    end
+
+    it 'no-ops for unknown user' do
+      expect { described_class.new.perform(0) }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/tasks/dawarich_places_rake_spec.rb
+++ b/spec/lib/tasks/dawarich_places_rake_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'dawarich places rake tasks' do
+  before(:all) do
+    Rails.application.load_tasks if Rake::Task.tasks.none? { |t| t.name == 'dawarich:cleanup_suggested_places' }
+  end
+
+  after do
+    Rake::Task['dawarich:cleanup_suggested_places'].reenable
+    Rake::Task['dawarich:backfill_place_names'].reenable
+  end
+
+  describe 'dawarich:cleanup_suggested_places' do
+    it 'enqueues OrphanCleanupJob for each user' do
+      create(:user)
+      create(:user)
+      ActiveJob::Base.queue_adapter = :test
+      ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+      expected_count = User.count
+
+      Rake::Task['dawarich:cleanup_suggested_places'].invoke
+
+      expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count do |j|
+        j[:job] == Places::OrphanCleanupJob
+      end).to eq(expected_count)
+    end
+  end
+
+  describe 'dawarich:backfill_place_names' do
+    it 'enqueues BulkNameFetchingJob once' do
+      ActiveJob::Base.queue_adapter = :test
+      ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+
+      Rake::Task['dawarich:backfill_place_names'].invoke
+
+      expect(ActiveJob::Base.queue_adapter.enqueued_jobs.count { |j| j[:job] == Places::BulkNameFetchingJob }).to eq(1)
+    end
+  end
+end

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -4,9 +4,22 @@ require 'rails_helper'
 
 RSpec.describe Place, type: :model do
   describe 'associations' do
-    it { is_expected.to have_many(:visits).dependent(:destroy) }
+    it { is_expected.to have_many(:visits).dependent(:nullify) }
     it { is_expected.to have_many(:place_visits).dependent(:destroy) }
     it { is_expected.to have_many(:suggested_visits).through(:place_visits) }
+  end
+
+  describe 'destroying a place' do
+    it 'nullifies place_id on associated visits, does not delete them' do
+      user = create(:user)
+      place = create(:place, user: user)
+      visit = create(:visit, user: user, place: place, area: nil)
+
+      place.destroy!
+
+      expect(Visit.exists?(visit.id)).to be(true)
+      expect(visit.reload.place_id).to be_nil
+    end
   end
 
   describe 'validations' do

--- a/spec/models/visit_orphan_spec.rb
+++ b/spec/models/visit_orphan_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe Visit, type: :model do
   let(:user) { create(:user) }
 
   describe 'associations' do
-    it 'is destroyed when associated place is destroyed' do
+    it 'is nullified (place_id set to NULL) when associated place is destroyed' do
       place = create(:place, user: user)
-      create(:visit, user: user, place: place)
-      expect { place.destroy }.to change(Visit, :count).by(-1)
+      visit = create(:visit, user: user, place: place)
+
+      expect { place.destroy }.not_to change(Visit, :count)
+      expect(visit.reload.place_id).to be_nil
     end
 
     it 'is destroyed when associated area is destroyed' do

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -28,4 +28,36 @@ RSpec.describe Visit, type: :model do
   describe 'factory' do
     it { expect(build(:visit)).to be_valid }
   end
+
+  describe 'self-cleanup callbacks' do
+    let(:user)      { create(:user) }
+    let(:old_place) { create(:place, user: user, source: :photon) }
+    let(:new_place) { create(:place, user: user, source: :photon) }
+    let!(:visit)    { create(:visit, user: user, place: old_place, area: nil) }
+
+    describe 'after_commit on: :update' do
+      it 'deletes the previous place when place_id changes and old place is orphan' do
+        expect { visit.update!(place: new_place) }
+          .to change { Place.exists?(old_place.id) }.from(true).to(false)
+      end
+
+      it 'does not delete the place when an unrelated attribute changes' do
+        expect { visit.update!(name: 'Renamed') }
+          .not_to(change { Place.exists?(old_place.id) })
+      end
+    end
+
+    describe 'after_destroy_commit' do
+      it 'deletes the visit place when it becomes orphan' do
+        expect { visit.destroy! }
+          .to change { Place.exists?(old_place.id) }.from(true).to(false)
+      end
+
+      it 'is a no-op when visit had no place' do
+        orphan_visit = create(:visit, user: user, place: nil, area: nil)
+
+        expect { orphan_visit.destroy! }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe Visit, type: :model do
         expect { visit.update!(name: 'Renamed') }
           .not_to(change { Place.exists?(old_place.id) })
       end
+
+      it 'keeps the old place when it is still referenced by another visit' do
+        create(:visit, user: user, place: old_place, area: nil)
+
+        expect { visit.update!(place: new_place) }
+          .not_to(change { Place.exists?(old_place.id) })
+      end
     end
 
     describe 'after_destroy_commit' do

--- a/spec/requests/api/v1/visits/possible_places_spec.rb
+++ b/spec/requests/api/v1/visits/possible_places_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe 'GET /api/v1/visits/:id/possible_places' do
     expect(body.first['id']).to eq(place.id)
   end
 
+  it 'prepends a manual current place (no osm_id) without false-positive dedup' do
+    allow_any_instance_of(Places::NearbySearch).to receive(:call).and_return(photon_hashes)
+
+    get "/api/v1/visits/#{visit.id}/possible_places", headers: headers
+
+    body = JSON.parse(response.body)
+    expect(body.first['id']).to eq(place.id)
+    expect(body.first['osm_id']).to be_nil
+    expect(body.size).to eq(2)
+  end
+
   it 'returns 404 when visit not found' do
     get '/api/v1/visits/999999999/possible_places', headers: headers
     expect(response).to have_http_status(:not_found)

--- a/spec/requests/api/v1/visits/possible_places_spec.rb
+++ b/spec/requests/api/v1/visits/possible_places_spec.rb
@@ -2,54 +2,57 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Api::V1::Visits::PossiblePlaces', type: :request do
+RSpec.describe 'GET /api/v1/visits/:id/possible_places' do
   let(:user) { create(:user) }
-  let(:api_key) { user.api_key }
-  let(:visit) { create(:visit, user:) }
-  let(:place) { create(:place) }
-  let!(:place_visit) { create(:place_visit, visit:, place:) }
-  let(:other_user) { create(:user) }
-  let(:other_visit) { create(:visit, user: other_user) }
+  let(:visit) { create(:visit, user: user, area: nil, place: place) }
+  let(:place) { create(:place, user: user, name: 'Current Place', latitude: 52.5126, longitude: 13.4012) }
+  let(:headers) { { 'Authorization' => "Bearer #{user.api_key}" } }
 
-  describe 'GET /api/v1/visits/:id/possible_places' do
-    context 'when visit belongs to the user' do
-      it 'returns a list of suggested places for the visit' do
-        get "/api/v1/visits/#{visit.id}/possible_places", params: { api_key: }
+  before do
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+    Rails.cache.clear
+  end
 
-        expect(response).to have_http_status(:ok)
-        json_response = JSON.parse(response.body)
-        expect(json_response).to be_an(Array)
-        expect(json_response.size).to eq(1)
-        expect(json_response.first['id']).to eq(place.id)
-      end
-    end
+  let(:photon_hashes) do
+    [{
+      id: nil, name: 'Café Bravo', latitude: 52.5126, longitude: 13.4012,
+      osm_id: 1_234_567, source: 'photon', geodata: { 'properties' => { 'osm_id' => 1_234_567 } }
+    }]
+  end
 
-    context 'when visit does not exist' do
-      it 'returns a not found error' do
-        get '/api/v1/visits/999999/possible_places', headers: { 'Authorization' => "Bearer #{api_key}" }
+  it 'returns Photon hashes prepended with the current place' do
+    allow_any_instance_of(Places::NearbySearch).to receive(:call).and_return(photon_hashes)
 
-        expect(response).to have_http_status(:not_found)
-        json_response = JSON.parse(response.body)
-        expect(json_response['error']).to eq('Visit not found')
-      end
-    end
+    get "/api/v1/visits/#{visit.id}/possible_places", headers: headers
 
-    context 'when visit does not belong to the user' do
-      it 'returns a not found error' do
-        get "/api/v1/visits/#{other_visit.id}/possible_places", params: { api_key: }
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body.first['id']).to eq(place.id)
+    expect(body.first['name']).to eq('Current Place')
+    expect(body.last['id']).to be_nil
+    expect(body.last['name']).to eq('Café Bravo')
+  end
 
-        expect(response).to have_http_status(:not_found)
-        json_response = JSON.parse(response.body)
-        expect(json_response['error']).to eq('Visit not found')
-      end
-    end
+  it 'deduplicates the current place by osm_id when Photon also returns it' do
+    place.update!(geodata: { 'properties' => { 'osm_id' => 1_234_567 } })
+    allow_any_instance_of(Places::NearbySearch).to receive(:call).and_return(photon_hashes)
 
-    context 'when no api key is provided' do
-      it 'returns unauthorized error' do
-        get "/api/v1/visits/#{visit.id}/possible_places"
+    get "/api/v1/visits/#{visit.id}/possible_places", headers: headers
 
-        expect(response).to have_http_status(:unauthorized)
-      end
-    end
+    body = JSON.parse(response.body)
+    expect(body.count { |p| p['osm_id'] == 1_234_567 }).to eq(1)
+    expect(body.first['id']).to eq(place.id)
+  end
+
+  it 'returns 404 when visit not found' do
+    get '/api/v1/visits/999999999/possible_places', headers: headers
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'does NOT create any DB rows during the request' do
+    allow_any_instance_of(Places::NearbySearch).to receive(:call).and_return(photon_hashes)
+    visit_id = visit.id
+    expect { get "/api/v1/visits/#{visit_id}/possible_places", headers: headers }
+      .not_to(change { Place.count })
   end
 end

--- a/spec/requests/api/v1/visits/select_place_controller_spec.rb
+++ b/spec/requests/api/v1/visits/select_place_controller_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'POST /api/v1/visits/:id/select_place' do
+  let(:user)  { create(:user) }
+  let(:other) { create(:user) }
+  let(:visit) { create(:visit, user: user, area: nil, place: nil) }
+  let(:headers) { { 'Authorization' => "Bearer #{user.api_key}" } }
+
+  before { allow(DawarichSettings).to receive(:store_geodata?).and_return(true) }
+
+  let(:photon_payload) do
+    {
+      photon: {
+        name: 'Café Bravo',
+        latitude: 52.5126,
+        longitude: 13.4012,
+        osm_id: 1_234_567,
+        city: 'Berlin',
+        country: 'Germany',
+        geodata: { 'properties' => { 'osm_id' => 1_234_567 } }
+      }
+    }
+  end
+
+  it 'creates a place and assigns it to the visit (201)' do
+    post "/api/v1/visits/#{visit.id}/select_place", params: photon_payload, headers: headers, as: :json
+
+    expect(response).to have_http_status(:created)
+    body = JSON.parse(response.body)
+    expect(body['name']).to eq('Café Bravo')
+    expect(body['id']).to eq(visit.reload.place_id)
+  end
+
+  it 'returns 404 for a visit not owned by current user' do
+    other_visit = create(:visit, user: other, area: nil)
+    post "/api/v1/visits/#{other_visit.id}/select_place", params: photon_payload, headers: headers, as: :json
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'returns 422 when name is missing' do
+    payload = photon_payload.deep_dup
+    payload[:photon].delete(:name)
+    post "/api/v1/visits/#{visit.id}/select_place", params: payload, headers: headers, as: :json
+
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+end

--- a/spec/services/places/delete_if_orphan_spec.rb
+++ b/spec/services/places/delete_if_orphan_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe Places::DeleteIfOrphan do
       expect(Place.exists?(place.id)).to be(true)
     end
 
+    it 'deletes the place and cascading place_visits rows even when residual ones exist' do
+      place = create(:place, user: user, source: :photon)
+      visit = create(:visit, user: user, area: nil, place: create(:place, user: user, source: :manual))
+      PlaceVisit.create!(place: place, visit: visit)
+
+      expect(described_class.call(place.id)).to be(true)
+      expect(Place.exists?(place.id)).to be(false)
+      expect(PlaceVisit.exists?(place_id: place.id)).to be(false)
+    end
+
     it 'logs and returns false on InvalidForeignKey' do
       place = create(:place, user: user, source: :photon)
       allow_any_instance_of(Place).to receive(:delete).and_raise(ActiveRecord::InvalidForeignKey, 'fk')

--- a/spec/services/places/delete_if_orphan_spec.rb
+++ b/spec/services/places/delete_if_orphan_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Places::DeleteIfOrphan do
+  let(:user) { create(:user) }
+
+  describe '.call' do
+    it 'deletes a photon place with no visit, no note, no tags' do
+      place = create(:place, user: user, source: :photon, note: nil)
+
+      expect(described_class.call(place.id)).to be(true)
+      expect(Place.exists?(place.id)).to be(false)
+    end
+
+    it 'returns false when place does not exist' do
+      expect(described_class.call(99_999_999)).to be(false)
+    end
+
+    it 'keeps non-photon (manual) places' do
+      place = create(:place, user: user, source: :manual)
+
+      expect(described_class.call(place.id)).to be(false)
+      expect(Place.exists?(place.id)).to be(true)
+    end
+
+    it 'keeps places with a note' do
+      place = create(:place, user: user, source: :photon, note: 'mine')
+
+      expect(described_class.call(place.id)).to be(false)
+      expect(Place.exists?(place.id)).to be(true)
+    end
+
+    it 'keeps places referenced by any visit' do
+      place = create(:place, user: user, source: :photon)
+      create(:visit, user: user, place: place, area: nil)
+
+      expect(described_class.call(place.id)).to be(false)
+      expect(Place.exists?(place.id)).to be(true)
+    end
+
+    it 'keeps places with tags' do
+      place = create(:place, user: user, source: :photon)
+      tag = create(:tag, user: user)
+      place.tags << tag
+
+      expect(described_class.call(place.id)).to be(false)
+      expect(Place.exists?(place.id)).to be(true)
+    end
+
+    it 'logs and returns false on InvalidForeignKey' do
+      place = create(:place, user: user, source: :photon)
+      allow_any_instance_of(Place).to receive(:delete).and_raise(ActiveRecord::InvalidForeignKey, 'fk')
+
+      expect(Rails.logger).to receive(:warn).with(/DeleteIfOrphan/)
+      expect(described_class.call(place.id)).to be(false)
+    end
+  end
+end

--- a/spec/services/places/name_fetcher_spec.rb
+++ b/spec/services/places/name_fetcher_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Places::NameFetcher do
     end
 
     before do
+      allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
       allow(Geocoder).to receive(:search).and_return([geocoder_result])
     end
 
@@ -217,6 +218,64 @@ RSpec.describe Places::NameFetcher do
         expect(place.city).to be_nil
         expect(place.country).to be_nil
       end
+    end
+  end
+
+  describe '.lookup_attrs' do
+    let(:lat) { 52.5126 }
+    let(:lon) { 13.4012 }
+
+    let(:photon_result) do
+      double(
+        'photon_result',
+        data: {
+          'properties' => {
+            'name' => 'Café Bravo', 'city' => 'Berlin', 'country' => 'Germany',
+            'osm_key' => 'amenity', 'osm_value' => 'cafe', 'type' => 'house'
+          },
+          'geometry' => { 'coordinates' => [lon, lat] }
+        }
+      )
+    end
+
+    before do
+      allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+    end
+
+    it 'returns name/city/country/geodata hash when Photon resolves' do
+      allow(Geocoder).to receive(:search).and_return([photon_result])
+
+      attrs = described_class.lookup_attrs(lat, lon)
+
+      expect(attrs).to include(name: be_present, city: 'Berlin', country: 'Germany')
+      expect(attrs[:geodata]).to eq(photon_result.data)
+    end
+
+    it 'returns nil when reverse geocoding is disabled' do
+      allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(false)
+
+      expect(described_class.lookup_attrs(lat, lon)).to be_nil
+    end
+
+    it 'returns nil when Photon returns no results' do
+      allow(Geocoder).to receive(:search).and_return([])
+
+      expect(described_class.lookup_attrs(lat, lon)).to be_nil
+    end
+
+    it 'returns nil when properties are blank' do
+      empty = double('photon_result', data: { 'properties' => {} })
+      allow(Geocoder).to receive(:search).and_return([empty])
+
+      expect(described_class.lookup_attrs(lat, lon)).to be_nil
+    end
+
+    it 'rescues StandardError and returns nil' do
+      allow(Geocoder).to receive(:search).and_raise(StandardError, 'photon down')
+      allow(ExceptionReporter).to receive(:call)
+
+      expect(described_class.lookup_attrs(lat, lon)).to be_nil
+      expect(ExceptionReporter).to have_received(:call)
     end
   end
 end

--- a/spec/services/places/nearby_search_spec.rb
+++ b/spec/services/places/nearby_search_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'geocoder/results/photon'
+
+RSpec.describe Places::NearbySearch do
+  before do
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+  end
+
+  let(:lat) { 52.5126 }
+  let(:lon) { 13.4012 }
+
+  let(:photon_result) do
+    instance_double(
+      Geocoder::Result::Photon,
+      data: {
+        'properties' => {
+          'osm_id' => 1_234_567, 'osm_type' => 'N', 'osm_key' => 'amenity',
+          'osm_value' => 'cafe', 'name' => 'Café Bravo', 'city' => 'Berlin',
+          'country' => 'Germany', 'street' => 'Bergmannstraße', 'housenumber' => '1',
+          'postcode' => '10961'
+        },
+        'geometry' => { 'coordinates' => [lon, lat], 'type' => 'Point' }
+      }
+    )
+  end
+
+  describe '#call' do
+    it 'returns hashes with id, source, geodata keys' do
+      allow(Geocoder).to receive(:search).and_return([photon_result])
+
+      result = described_class.new(latitude: lat, longitude: lon).call
+
+      expect(result.first).to include(
+        id: nil,
+        name: 'Café Bravo',
+        source: 'photon',
+        osm_id: 1_234_567
+      )
+      expect(result.first[:geodata]).to eq(photon_result.data)
+    end
+
+    it 'returns [] when reverse geocoding is disabled' do
+      allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(false)
+
+      expect(described_class.new(latitude: lat, longitude: lon).call).to eq([])
+    end
+
+    it 'returns [] when coordinates are zero (degenerate visit)' do
+      expect(Geocoder).not_to receive(:search)
+
+      expect(described_class.new(latitude: 0.0, longitude: 0.0).call).to eq([])
+    end
+
+    it 'rescues Geocoder errors and returns []' do
+      allow(Geocoder).to receive(:search).and_raise(StandardError, 'photon down')
+      allow(ExceptionReporter).to receive(:call)
+
+      expect(described_class.new(latitude: lat, longitude: lon).call).to eq([])
+      expect(ExceptionReporter).to have_received(:call)
+    end
+
+    context 'with cache: true' do
+      before { Rails.cache.clear }
+
+      it 'hits Geocoder only once for repeated calls within TTL' do
+        allow(Geocoder).to receive(:search).and_return([photon_result])
+
+        described_class.new(latitude: lat, longitude: lon, cache: true).call
+        described_class.new(latitude: lat, longitude: lon, cache: true).call
+
+        expect(Geocoder).to have_received(:search).once
+      end
+    end
+
+    context 'with cache: false (default)' do
+      it 'hits Geocoder on every call' do
+        allow(Geocoder).to receive(:search).and_return([photon_result])
+
+        described_class.new(latitude: lat, longitude: lon).call
+        described_class.new(latitude: lat, longitude: lon).call
+
+        expect(Geocoder).to have_received(:search).twice
+      end
+    end
+  end
+end

--- a/spec/services/visits/create_spec.rb
+++ b/spec/services/visits/create_spec.rb
@@ -203,6 +203,24 @@ RSpec.describe Visits::Create do
       end
     end
 
+    describe 'no suggested_places attachment on manual visit creation' do
+      let(:user)  { create(:user) }
+      let(:place) { create(:place, user: user, latitude: 52.5126, longitude: 13.4012) }
+      let(:other) { create(:place, user: user, latitude: 52.5127, longitude: 13.4013) }
+
+      it 'does not create PlaceVisit rows when API creates a visit' do
+        place
+        other
+        params = {
+          latitude: 52.5126, longitude: 13.4012,
+          name: 'Test', started_at: 1.hour.ago.iso8601, ended_at: Time.current.iso8601,
+          status: 'suggested'
+        }
+
+        expect { described_class.new(user, params).call }.not_to(change { PlaceVisit.count })
+      end
+    end
+
     context 'edge cases' do
       context 'when name is not provided but defaults are used' do
         let(:params) { valid_params.merge(name: '') }

--- a/spec/services/visits/creator_spec.rb
+++ b/spec/services/visits/creator_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Visits::Creator do
 
       before do
         allow(Visits::PlaceFinder).to receive(:new).with(user).and_return(place_finder)
-        allow(place_finder).to receive(:find_or_create_place).and_return({ main_place: place, suggested_places: [] })
+        allow(place_finder).to receive(:find_or_create_place).and_return(place)
       end
 
       it 'creates a new visit because existing visit location is determined by area (far away)' do
@@ -267,7 +267,7 @@ longitude: -73.9000)
 
       before do
         allow(Visits::PlaceFinder).to receive(:new).with(user).and_return(place_finder)
-        allow(place_finder).to receive(:find_or_create_place).and_return({ main_place: place, suggested_places: [] })
+        allow(place_finder).to receive(:find_or_create_place).and_return(place)
       end
 
       it 'creates a new suggested visit' do
@@ -323,19 +323,11 @@ longitude: -73.9000)
 
     context 'when matching a place' do
       let(:place) { create(:place, name: 'Test Place') }
-      let(:suggested_place1) { create(:place, name: 'Suggested Place 1') }
-      let(:suggested_place2) { create(:place, name: 'Suggested Place 2') }
       let(:place_finder) { instance_double(Visits::PlaceFinder) }
-      let(:place_data) do
-        {
-          main_place: place,
-          suggested_places: [suggested_place1, suggested_place2]
-        }
-      end
 
       before do
         allow(Visits::PlaceFinder).to receive(:new).with(user).and_return(place_finder)
-        allow(place_finder).to receive(:find_or_create_place).and_return(place_data)
+        allow(place_finder).to receive(:find_or_create_place).and_return(place)
       end
 
       it 'creates a visit associated with the place' do
@@ -347,36 +339,6 @@ longitude: -73.9000)
         expect(visit.area).to be_nil
         expect(visit.place).to eq(place)
         expect(visit.name).to eq(place.name)
-      end
-
-      it 'associates suggested places with the visit' do
-        visits = subject.create_visits([visit_data])
-        visit = visits.first
-
-        # Check for place_visits associations
-        expect(visit.place_visits.count).to eq(2)
-        expect(visit.place_visits.pluck(:place_id)).to contain_exactly(
-          suggested_place1.id,
-          suggested_place2.id
-        )
-        expect(visit.suggested_places).to contain_exactly(suggested_place1, suggested_place2)
-      end
-
-      it 'does not create duplicate place_visit associations' do
-        # Create an existing association
-        visit = create(:visit, user: user, place: place)
-        create(:place_visit, visit: visit, place: suggested_place1)
-
-        allow(Visit).to receive(:create!).and_return(visit)
-
-        # Only one new association should be created
-        expect do
-          subject.create_visits([visit_data])
-        end.to change(PlaceVisit, :count).by(1)
-        expect(visit.place_visits.pluck(:place_id)).to contain_exactly(
-          suggested_place1.id,
-          suggested_place2.id
-        )
       end
     end
 
@@ -426,10 +388,8 @@ longitude: -73.9000)
 
       before do
         allow(Visits::PlaceFinder).to receive(:new).with(user).and_return(place_finder)
-        allow(place_finder).to receive(:find_or_create_place)
-          .with(visit_data).and_return({ main_place: place1, suggested_places: [] })
-        allow(place_finder).to receive(:find_or_create_place)
-          .with(visit_data2).and_return({ main_place: place2, suggested_places: [] })
+        allow(place_finder).to receive(:find_or_create_place).with(visit_data).and_return(place1)
+        allow(place_finder).to receive(:find_or_create_place).with(visit_data2).and_return(place2)
       end
 
       it 'creates multiple visits' do
@@ -512,6 +472,26 @@ longitude: -73.9000)
 
       result = subject.send(:near_area?, center, area)
       expect(result).to be false
+    end
+  end
+
+  describe 'no PlaceVisit fan-out' do
+    let(:user) { create(:user) }
+
+    it 'creates exactly one Place per detected visit (no PlaceVisit rows)' do
+      allow(Places::NameFetcher).to receive(:lookup_attrs).and_return(
+        { name: 'Café Bravo', city: 'Berlin', country: 'Germany', geodata: {} }
+      )
+      points = [create(:point, user: user, timestamp: 1.hour.ago.to_i)]
+      visit_data = [{
+        center_lat: 52.5126, center_lon: 13.4012,
+        suggested_name: nil, points: points,
+        start_time: 1.hour.ago.to_i, end_time: Time.current.to_i, duration: 3600
+      }]
+
+      expect { described_class.new(user).create_visits(visit_data) }
+        .to change { Place.count }.by(1)
+        .and change { PlaceVisit.count }.by(0)
     end
   end
 end

--- a/spec/services/visits/place_finder_spec.rb
+++ b/spec/services/visits/place_finder_spec.rb
@@ -4,380 +4,75 @@ require 'rails_helper'
 
 RSpec.describe Visits::PlaceFinder do
   let(:user) { create(:user) }
-  let(:latitude) { 40.7128 }
-  let(:longitude) { -74.0060 }
+  let(:visit_data) do
+    {
+      center_lat: 52.5126,
+      center_lon: 13.4012,
+      suggested_name: nil,
+      points: [],
+      start_time: Time.zone.now.to_i,
+      end_time: (Time.zone.now + 1.hour).to_i,
+      duration: 3600
+    }
+  end
 
-  subject { described_class.new(user) }
+  before do
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+    allow(DawarichSettings).to receive(:store_geodata?).and_return(false)
+  end
 
   describe '#find_or_create_place' do
-    let(:visit_data) do
-      {
-        center_lat: latitude,
-        center_lon: longitude,
-        suggested_name: 'Test Place',
-        points: []
-      }
+    it 'returns a Place (not a hash)' do
+      allow(Places::NameFetcher).to receive(:lookup_attrs).and_return(
+        { name: 'Café Bravo', city: 'Berlin', country: 'Germany', geodata: { 'properties' => {} } }
+      )
+
+      result = described_class.new(user).find_or_create_place(visit_data)
+
+      expect(result).to be_a(Place)
+      expect(result.name).to eq('Café Bravo')
     end
 
-    context 'when an existing place is found' do
-      let!(:existing_place) do
-        create(:place, user: user, latitude: latitude, longitude: longitude, lonlat: "POINT(#{longitude} #{latitude})")
-      end
+    it 'creates exactly ONE place per call (no fan-out)' do
+      allow(Places::NameFetcher).to receive(:lookup_attrs).and_return(
+        { name: 'Café Bravo', city: 'Berlin', country: 'Germany', geodata: {} }
+      )
 
-      it 'returns the existing place as main_place' do
-        result = subject.find_or_create_place(visit_data)
-
-        expect(result).to be_a(Hash)
-        expect(result[:main_place]).to eq(existing_place)
-      end
-
-      it 'includes suggested places in the result' do
-        result = subject.find_or_create_place(visit_data)
-
-        expect(result[:suggested_places]).to respond_to(:each)
-        expect(result[:suggested_places]).to include(existing_place)
-      end
-
-      it 'finds an existing place by name within search radius' do
-        # Place is outside the global proximity radius (50m) but within the name search radius (100m)
-        offset = 0.0006 # ~67m offset
-        similar_named_place = create(:place,
-                                     user: user,
-                                     name: 'Test Place',
-                                     latitude: latitude + offset,
-                                     longitude: longitude + offset,
-                                     lonlat: "POINT(#{longitude + offset} #{latitude + offset})")
-
-        modified_visit_data = visit_data.merge(
-          suggested_name: 'Test Place',
-          center_lat: latitude + offset + 0.0001,
-          center_lon: longitude + offset + 0.0001
-        )
-
-        result = subject.find_or_create_place(modified_visit_data)
-
-        expect(result[:main_place]).to eq(similar_named_place)
-      end
+      expect { described_class.new(user).find_or_create_place(visit_data) }
+        .to change { Place.count }.by(1)
     end
 
-    context 'with places from points data' do
-      let(:point_with_geodata) do
-        build_stubbed(:point,
-                      lonlat: "POINT(#{longitude} #{latitude})",
-                      geodata: {
-                        'properties' => {
-                          'name' => 'POI from Point',
-                          'city' => 'New York',
-                          'country' => 'USA'
-                        }
-                      })
-      end
+    it 'falls back to Place::DEFAULT_NAME when Photon returns nothing' do
+      allow(Places::NameFetcher).to receive(:lookup_attrs).and_return(nil)
 
-      let(:visit_data_with_points) do
-        visit_data.merge(points: [point_with_geodata])
-      end
+      result = described_class.new(user).find_or_create_place(visit_data)
 
-      before do
-        allow(Geocoder).to receive(:search).and_return([])
-      end
-
-      it 'extracts and creates places from point geodata' do
-        expect do
-          result = subject.find_or_create_place(visit_data_with_points)
-          expect(result[:main_place].name).to include('POI from Point')
-        end.to change(Place, :count).by(1)
-      end
+      expect(result.name).to eq(Place::DEFAULT_NAME)
+      expect(result.source).to eq('photon')
     end
 
-    context 'when no existing place is found' do
-      let(:geocoder_result) do
-        double(
-          data: {
-            'properties' => {
-              'name' => 'Test Location',
-              'street' => 'Test Street',
-              'city' => 'Test City',
-              'country' => 'Test Country'
-            }
-          },
-          latitude: latitude,
-          longitude: longitude
-        )
-      end
+    it 'uses suggested_name when Photon returns nothing and suggested_name is present' do
+      allow(Places::NameFetcher).to receive(:lookup_attrs).and_return(nil)
+      data = visit_data.merge(suggested_name: 'Home')
 
-      let(:other_geocoder_result) do
-        double(
-          data: {
-            'properties' => {
-              'name' => 'Other Location',
-              'street' => 'Other Street',
-              'city' => 'Test City',
-              'country' => 'Test Country'
-            }
-          },
-          latitude: latitude + 0.001,
-          longitude: longitude + 0.001
-        )
-      end
-
-      before do
-        allow(Geocoder).to receive(:search).and_return([geocoder_result, other_geocoder_result])
-      end
-
-      it 'creates a new place with geocoded data' do
-        expect do
-          result = subject.find_or_create_place(visit_data)
-          expect(result[:main_place].name).to include('Test Location')
-        end.to change(Place, :count).by(2)
-
-        place = Place.find_by(name: 'Test Location, Test Street, Test City')
-
-        expect(place.city).to eq('Test City')
-        expect(place.country).to eq('Test Country')
-        expect(place.source).to eq('photon')
-      end
-
-      it 'returns both main place and suggested places' do
-        result = subject.find_or_create_place(visit_data)
-
-        expect(result[:main_place].name).to include('Test Location')
-        expect(result[:suggested_places].length).to eq(2)
-
-        expect(result[:suggested_places].map(&:name)).to include(
-          'Test Location, Test Street, Test City',
-          'Other Location, Other Street, Test City'
-        )
-      end
-
-      context 'when geocoding returns no results' do
-        before do
-          allow(Geocoder).to receive(:search).and_return([])
-        end
-
-        it 'creates a place with the suggested name' do
-          expect do
-            result = subject.find_or_create_place(visit_data)
-            expect(result[:main_place].name).to eq('Test Place')
-          end.to change(Place, :count).by(1)
-
-          place = Place.last
-          expect(place.name).to eq('Test Place')
-          expect(place.source).to eq('manual')
-        end
-
-        it 'returns the created place as both main and the only suggested place' do
-          result = subject.find_or_create_place(visit_data)
-
-          expect(result[:main_place].name).to eq('Test Place')
-          expect(result[:suggested_places]).to eq([result[:main_place]])
-        end
-
-        it 'falls back to default name when suggested name is missing' do
-          visit_data_without_name = visit_data.merge(suggested_name: nil)
-
-          result = subject.find_or_create_place(visit_data_without_name)
-
-          expect(result[:main_place].name).to eq(Place::DEFAULT_NAME)
-        end
-      end
+      expect(described_class.new(user).find_or_create_place(data).name).to eq('Home')
     end
 
-    context 'with multiple potential places' do
-      let!(:place1) { create(:place, user: user, name: 'Place 1', latitude: latitude, longitude: longitude) }
-      let!(:place2) do
-        create(:place, user: user, name: 'Place 2', latitude: latitude + 0.0005, longitude: longitude + 0.0005)
-      end
-      let!(:place3) do
-        create(:place, user: user, name: 'Place 3', latitude: latitude + 0.001, longitude: longitude + 0.001)
-      end
+    it 'reuses an existing user place near the center' do
+      existing = create(:place, user: user, latitude: 52.5126, longitude: 13.4012)
+      expect(Places::NameFetcher).not_to receive(:lookup_attrs)
 
-      it 'selects the closest place as main_place' do
-        result = subject.find_or_create_place(visit_data)
-
-        expect(result[:main_place]).to eq(place1)
-      end
-
-      it 'includes nearby places as suggested_places' do
-        result = subject.find_or_create_place(visit_data)
-
-        expect(result[:suggested_places]).to include(place1, place2)
-        # place3 might be outside the search radius depending on the constants defined
-      end
-
-      it 'may include places with the same name' do
-        create(:place, user: user, name: 'Place 1', latitude: latitude + 0.0002, longitude: longitude + 0.0002)
-
-        result = subject.find_or_create_place(visit_data)
-
-        names = result[:suggested_places].map(&:name)
-        expect(names.count('Place 1')).to be >= 1
-      end
+      expect(described_class.new(user).find_or_create_place(visit_data)).to eq(existing)
     end
 
-    context 'with API place creation failures' do
-      let(:invalid_geocoder_result) do
-        double(
-          data: {
-            'properties' => {
-              # Missing required fields
-            }
-          },
-          latitude: latitude,
-          longitude: longitude
-        )
-      end
+    it 'does NOT persist geodata when store_geodata? is false' do
+      allow(Places::NameFetcher).to receive(:lookup_attrs).and_return(
+        { name: 'Café Bravo', city: 'Berlin', country: 'Germany',
+          geodata: { 'properties' => { 'osm_id' => 1 } } }
+      )
 
-      before do
-        allow(Geocoder).to receive(:search).and_return([invalid_geocoder_result])
-      end
-
-      it 'gracefully handles errors in place creation' do
-        result = subject.find_or_create_place(visit_data)
-
-        # Should create the default place
-        expect(result[:main_place].name).to eq('Test Place')
-        expect(result[:main_place].source).to eq('manual')
-      end
-    end
-
-    context 'when Geocoder raises a network error' do
-      before do
-        allow(Geocoder).to receive(:search).and_raise(EOFError.new('end of file reached'))
-        allow(ExceptionReporter).to receive(:call)
-        allow(Rails.logger).to receive(:error)
-      end
-
-      it 'handles the error gracefully and continues' do
-        result = subject.find_or_create_place(visit_data)
-
-        # Should still return a result with a default place
-        expect(result[:main_place]).to be_a(Place)
-        expect(result[:main_place].name).to eq('Test Place')
-      end
-
-      it 'logs the error' do
-        subject.find_or_create_place(visit_data)
-        expect(Rails.logger).to have_received(:error).with(/Reverse geocoding error in PlaceFinder/)
-      end
-
-      it 'reports the exception' do
-        subject.find_or_create_place(visit_data)
-        expect(ExceptionReporter).to have_received(:call)
-      end
-    end
-  end
-
-  describe 'suggested places limit' do
-    it 'limits suggested places to MAX_SUGGESTED_PLACES' do
-      # Create more places than the limit, all within search radius
-      30.times do |i|
-        tiny_offset = i * 0.00001
-        create(:place,
-               user: user,
-               name: "Place #{i}",
-               latitude: latitude + tiny_offset,
-               longitude: longitude + tiny_offset,
-               lonlat: "POINT(#{longitude + tiny_offset} #{latitude + tiny_offset})")
-      end
-
-      visit_data = {
-        center_lat: latitude,
-        center_lon: longitude,
-        suggested_name: 'Test',
-        points: []
-      }
-
-      result = subject.find_or_create_place(visit_data)
-
-      expect(result[:suggested_places].size).to be <= described_class::MAX_SUGGESTED_PLACES
-    end
-  end
-
-  describe 'cross-user isolation (IDOR)' do
-    let(:user_a) { create(:user) }
-    let(:user_b) { create(:user) }
-
-    let(:lat) { 52.5200 }
-    let(:lon) { 13.4050 }
-
-    let!(:user_a_place) do
-      create(:place,
-             user: user_a,
-             name: "User A's Place",
-             latitude: lat,
-             longitude: lon,
-             lonlat: "POINT(#{lon} #{lat})")
-    end
-
-    let!(:user_a_nearby_place) do
-      offset = 0.0001
-      create(:place,
-             user: user_a,
-             name: "User A's Nearby Place",
-             latitude: lat + offset,
-             longitude: lon + offset,
-             lonlat: "POINT(#{lon + offset} #{lat + offset})")
-    end
-
-    let(:visit_data) do
-      {
-        center_lat: lat,
-        center_lon: lon,
-        suggested_name: 'New Place',
-        points: []
-      }
-    end
-
-    before do
-      allow(Geocoder).to receive(:search).and_return([])
-    end
-
-    it 'does not return any of user A\'s places to user B' do
-      finder = described_class.new(user_b)
-      result = finder.find_or_create_place(visit_data)
-
-      expect(result[:main_place]).not_to eq(user_a_place)
-      expect(result[:main_place].user_id).to eq(user_b.id)
-
-      expect(result[:suggested_places]).not_to include(user_a_place)
-      expect(result[:suggested_places]).not_to include(user_a_nearby_place)
-
-      foreign_user_ids = result[:suggested_places].map(&:user_id).uniq - [user_b.id]
-      expect(foreign_user_ids).to be_empty
-    end
-  end
-
-  describe 'private methods' do
-    context '#build_place_name' do
-      it 'combines name components correctly' do
-        properties = {
-          'name' => 'Coffee Shop',
-          'street' => 'Main St',
-          'housenumber' => '123',
-          'city' => 'New York'
-        }
-
-        name = subject.send(:build_place_name, properties)
-        expect(name).to eq('Coffee Shop, Main St, 123, New York')
-      end
-
-      it 'removes duplicate components' do
-        properties = {
-          'name' => 'Coffee Shop',
-          'street' => 'Coffee Shop', # Duplicate of name
-          'city' => 'New York'
-        }
-
-        name = subject.send(:build_place_name, properties)
-        expect(name).to eq('Coffee Shop, New York')
-      end
-
-      it 'returns default name when no components are available' do
-        properties = { 'other' => 'irrelevant' }
-
-        name = subject.send(:build_place_name, properties)
-        expect(name).to eq(Place::DEFAULT_NAME)
-      end
+      result = described_class.new(user).find_or_create_place(visit_data)
+      expect(result.geodata).to eq({})
     end
   end
 end

--- a/spec/services/visits/select_place_spec.rb
+++ b/spec/services/visits/select_place_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe Visits::SelectPlace do
       expect(user.places.count).to eq(1)
     end
 
+    it 'does not match another user\'s place with the same osm_id (isolation)' do
+      other = create(:user)
+      other_place = create(:place, user: other, name: 'Café Bravo')
+      other_place.update!(geodata: { 'properties' => { 'osm_id' => 1_234_567 } })
+
+      place = described_class.new(user: user, visit: visit, photon: photon_payload).call
+
+      expect(place.user).to eq(user)
+      expect(place.id).not_to eq(other_place.id)
+      expect(user.places.count).to eq(1)
+    end
+
     it 'reuses an existing place matched by name + 50m proximity' do
       existing = create(:place, user: user, name: 'Café Bravo', latitude: 52.5126, longitude: 13.4012)
 

--- a/spec/services/visits/select_place_spec.rb
+++ b/spec/services/visits/select_place_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Visits::SelectPlace do
+  let(:user)  { create(:user) }
+  let(:visit) { create(:visit, user: user, area: nil, place: nil) }
+
+  let(:photon_payload) do
+    {
+      name: 'Café Bravo',
+      latitude: 52.5126,
+      longitude: 13.4012,
+      osm_id: 1_234_567,
+      osm_type: 'N',
+      osm_key: 'amenity',
+      osm_value: 'cafe',
+      city: 'Berlin',
+      country: 'Germany',
+      geodata: { 'properties' => { 'osm_id' => 1_234_567, 'name' => 'Café Bravo' } }
+    }
+  end
+
+  before do
+    allow(DawarichSettings).to receive(:store_geodata?).and_return(true)
+  end
+
+  describe '#call' do
+    it 'creates a user-scoped Place when no match exists' do
+      place = described_class.new(user: user, visit: visit, photon: photon_payload).call
+
+      expect(place).to be_persisted
+      expect(place.user).to eq(user)
+      expect(place.name).to eq('Café Bravo')
+      expect(place.source).to eq('photon')
+      expect(visit.reload.place_id).to eq(place.id)
+      expect(visit.name).to eq('Café Bravo')
+    end
+
+    it 'reuses an existing place matched by osm_id' do
+      existing = create(:place, user: user, name: 'Different Name')
+      existing.update!(geodata: { 'properties' => { 'osm_id' => 1_234_567 } })
+
+      place = described_class.new(user: user, visit: visit, photon: photon_payload).call
+
+      expect(place.id).to eq(existing.id)
+      expect(user.places.count).to eq(1)
+    end
+
+    it 'reuses an existing place matched by name + 50m proximity' do
+      existing = create(:place, user: user, name: 'Café Bravo', latitude: 52.5126, longitude: 13.4012)
+
+      place = described_class.new(user: user, visit: visit, photon: photon_payload.except(:osm_id, :geodata)).call
+
+      expect(place.id).to eq(existing.id)
+      expect(user.places.count).to eq(1)
+    end
+
+    it 'is idempotent across repeated calls' do
+      first  = described_class.new(user: user, visit: visit, photon: photon_payload).call
+      second = described_class.new(user: user, visit: visit, photon: photon_payload).call
+
+      expect(first.id).to eq(second.id)
+      expect(user.places.count).to eq(1)
+    end
+
+    it 'does not persist geodata when store_geodata? is disabled' do
+      allow(DawarichSettings).to receive(:store_geodata?).and_return(false)
+
+      place = described_class.new(user: user, visit: visit, photon: photon_payload).call
+
+      expect(place.geodata).to eq({})
+    end
+  end
+end

--- a/spec/swagger/api/v1/visits_controller_spec.rb
+++ b/spec/swagger/api/v1/visits_controller_spec.rb
@@ -252,12 +252,18 @@ describe 'Visits API', type: :request do
                items: {
                  type: :object,
                  properties: {
-                   id: { type: :integer },
+                   id: { type: [:integer, 'null'] },
                    name: { type: :string },
                    latitude: { type: :number },
                    longitude: { type: :number },
-                   city: { type: :string },
-                   country: { type: :string }
+                   osm_id: { type: [:integer, :string, 'null'] },
+                   osm_type: { type: [:string, 'null'] },
+                   osm_key: { type: [:string, 'null'] },
+                   osm_value: { type: [:string, 'null'] },
+                   city: { type: [:string, 'null'] },
+                   country: { type: [:string, 'null'] },
+                   source: { type: :string },
+                   geodata: { type: :object }
                  }
                }
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -4820,17 +4820,44 @@ paths:
                   type: object
                   properties:
                     id:
-                      type: integer
+                      type:
+                      - integer
+                      - 'null'
                     name:
                       type: string
                     latitude:
                       type: number
                     longitude:
                       type: number
+                    osm_id:
+                      type:
+                      - integer
+                      - string
+                      - 'null'
+                    osm_type:
+                      type:
+                      - string
+                      - 'null'
+                    osm_key:
+                      type:
+                      - string
+                      - 'null'
+                    osm_value:
+                      type:
+                      - string
+                      - 'null'
                     city:
-                      type: string
+                      type:
+                      - string
+                      - 'null'
                     country:
+                      type:
+                      - string
+                      - 'null'
+                    source:
                       type: string
+                    geodata:
+                      type: object
         '404':
           description: visit not found
         '401':


### PR DESCRIPTION
## Summary

Stops persisting reverse-geocoded candidate places at visit detection. Serves possible places real-time from Photon via existing `Places::NearbySearch` (now with caching). Lazy-creates Place rows when the user picks one via `POST /api/v1/visits/:id/select_place`. Self-cleans orphans via Visit `after_commit` callbacks. Ships two one-shot operator rake tasks for historical cleanup.

Spec: `~/projects/dawarich/superpowers/specs/2026-05-19-realtime-place-suggestions-design.md`
Plan: `~/projects/dawarich/superpowers/plans/2026-05-20-realtime-place-suggestions.md`

## What's in this PR

- New `Visits::SelectPlace` service and `POST /api/v1/visits/:id/select_place` endpoint
- New `Places::DeleteIfOrphan` service + Visit self-cleanup callbacks
- New `Places::OrphanCleanupJob` and two operator rake tasks
- Extended `Places::NearbySearch` with caching + additive Photon keys
- Refactored `Places::NameFetcher` (added `lookup_attrs` class method)
- Slimmed `Visits::PlaceFinder` from 250 to 46 lines
- Removed `place_name_fetching_job` daily cron (naming now synchronous)
- `Place#has_many :visits` flipped from `:destroy` to `:nullify`
- 16 commits (15 implementation + 1 verification-phase fix)

## What's NOT in this PR (follow-up work)

- The server-rendered timeline picker (`_suggested_picker.html.erb`) still reads from `visit.suggested_places`. After running the cleanup rake task, the picker shows only the visit's main place. Follow-up release will rewire the web picker to the new real-time endpoints.
- `drop_table :place_visits` is deferred to Release N+1 after the operator verifies the drain completed.

## Operator runbook (post-merge)

1. Deploy this branch (already merged to `dev`, then rolled to production).
2. Run `bin/rails dawarich:backfill_place_names` (names legacy `Place::DEFAULT_NAME` rows).
3. Run `bin/rails dawarich:cleanup_suggested_places` (drains orphan suggested-place rows).
4. Monitor Sidekiq `default` and `places` queues for completion.
5. Once drained, plan the follow-on release that drops `place_visits`.

## Test plan

- [x] RSpec — 5606 examples, 0 new failures (4 pre-existing on `dev`, all in `backfill_user_id_on_places_spec.rb`, unrelated to this branch)
- [x] RuboCop clean on all 26 modified files
- [ ] Drain runbook tested on staging (manual)
- [ ] Web timeline picker degradation reviewed (cosmetic, follow-up tracked)
