### PR TITLE
fix: timeline day-click sets invalid Search end-time (#2624)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Clicking a day in the Timeline panel no longer puts the Search end-time into an invalid state; the time fields now match the minute precision of the date picker (#2624)
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/app/javascript/controllers/timeline_feed_controller.js
+++ b/app/javascript/controllers/timeline_feed_controller.js
@@ -293,8 +293,8 @@ export default class extends Controller {
 
     const startInput = document.querySelector('input[name="start_at"]')
     const endInput = document.querySelector('input[name="end_at"]')
-    if (startInput) startInput.value = startAtLocal
-    if (endInput) endInput.value = endAtLocal
+    if (startInput) startInput.value = `${date}T00:00`
+    if (endInput) endInput.value = `${date}T23:59`
 
     document.dispatchEvent(
       new CustomEvent("timeline-feed:date-navigated", {


### PR DESCRIPTION
## Summary

Clicking a day in the Timeline panel writes the new time range into the Search form's `start_at` / `end_at` inputs. Those inputs are `datetime-local` with minute precision, but the controller was writing full ISO strings (with seconds), which the inputs treat as invalid — the end-time field landed in a broken state.

Set the inputs to `YYYY-MM-DDT00:00` / `T23:59` to match field precision.

Fixes #2624

## Test plan

- [ ] Open Map v2 → Timeline panel
- [ ] Click any day → confirm `start_at` and `end_at` show as valid values
- [ ] Run Search → confirm range applied