### PR TITLE
fix: speed-color editor modal misses Stimulus controller (#2120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Map v2 speed-color gradient editor: saving the gradient now actually recolors the routes and persists the scale (#2120)
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/app/javascript/controllers/maps/maplibre/routes_manager.js
+++ b/app/javascript/controllers/maps/maplibre/routes_manager.js
@@ -70,7 +70,7 @@ export class RoutesManager {
     let modal = document.getElementById("speed-color-editor-modal")
     if (!modal) {
       modal = this.createSpeedColorEditorModal(currentScale)
-      document.body.appendChild(modal)
+      this.controller.element.appendChild(modal)
     } else {
       const controller =
         this.controller.application.getControllerForElementAndIdentifier(


### PR DESCRIPTION
## Summary

Map v2's speed-color gradient editor was appending its modal to `document.body`, which put it outside the map Stimulus controller's element. Saving the gradient relies on `getControllerForElementAndIdentifier(this.controller.element, …)` — when the modal lives outside that subtree, the lookup returns `null` silently and the save handler never runs. Result: route colors don't update, scale doesn't persist.

Append the modal to `this.controller.element` instead.

Fixes #2120

## Test plan

- [ ] Map v2 → routes layer → open speed-color editor
- [ ] Edit gradient, click Save → confirm routes recolor immediately
- [ ] Reload page → confirm new scale persisted