### PR TITLE
fix: surface skipped duplicates on imports (#2721)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Imports table now shows how many points were skipped as duplicates (already in your timeline at the same coordinates and timestamp), and notifies you when an import completes without inserting any points because every row in the file was a duplicate. Previously these imports looked indistinguishable from empty files. (#2721)
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/app/services/imports/bulk_insertable.rb
+++ b/app/services/imports/bulk_insertable.rb
@@ -18,11 +18,21 @@ module Imports
         on_duplicate: :skip
       )
 
-      result.length
+      inserted = result.length
+      skipped  = unique_batch.length - inserted
+      record_batch_counters(unique_batch.length, skipped)
+
+      inserted
     rescue StandardError => e
       on_bulk_insert_error(e)
       create_import_error_notification("Failed to process #{importer_name} data: #{e.message}")
       0
+    end
+
+    def record_batch_counters(attempted, skipped)
+      counters = { raw_points: attempted }
+      counters[:doubles] = skipped if skipped.positive?
+      Import.update_counters(import.id, counters)
     end
 
     def create_import_error_notification(message)

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -11,7 +11,7 @@ class Imports::Create
   end
 
   def call
-    import.update!(status: :processing)
+    import.update!(status: :processing, raw_points: 0, doubles: 0)
     broadcast_status_update
 
     temp_file_path = Imports::SecureFileDownloader.new(import.file).download_to_temp_file
@@ -37,6 +37,7 @@ class Imports::Create
     schedule_visit_suggesting(user.id, import)
     schedule_track_generation(user.id, import)
     update_import_points_count(import)
+    notify_if_all_skipped(import)
   rescue StandardError => e
     return if import.destroyed?
 
@@ -89,6 +90,21 @@ class Imports::Create
 
   def update_import_points_count(import)
     Import::UpdatePointsCountJob.perform_later(import.id)
+  end
+
+  def notify_if_all_skipped(import)
+    import.reload
+    return unless import.doubles.to_i.positive? && import.points.count.zero?
+
+    Notification.create!(
+      user_id: import.user_id,
+      title: 'Import completed with no new points',
+      content: "Your file #{import.name} contained #{import.raw_points} points, all of which " \
+               'already exist in your timeline at the same coordinates and timestamps. ' \
+               'Nothing was imported. If this was unexpected, delete the existing points ' \
+               'for that date range and re-import.',
+      kind: :info
+    )
   end
 
   def filter_anomalies(user, import)

--- a/app/views/imports/_table_row.html.erb
+++ b/app/views/imports/_table_row.html.erb
@@ -21,6 +21,12 @@
   <td class="px-4 py-3 text-sm"><%= number_to_human_size(import.file&.byte_size) || 'N/A' %></td>
   <td class="px-4 py-3 text-right tabular-nums font-medium" data-points-count>
     <%= number_with_delimiter import.processed %>
+    <% if import.doubles.to_i.positive? %>
+      <div class="text-xs font-normal text-base-content/60 mt-0.5"
+           title="Points at coordinates and timestamps that already exist in your timeline were skipped to avoid duplicates.">
+        <%= number_with_delimiter(import.doubles) %> already imported
+      </div>
+    <% end %>
   </td>
   <td class="px-4 py-3" data-status-display>
     <%= status_badge(import) %>

--- a/spec/regressions/imports_surface_skipped_duplicates_spec.rb
+++ b/spec/regressions/imports_surface_skipped_duplicates_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Imports surface skipped duplicates' do
+  let(:user) { create(:user) }
+  let(:file_path) { Rails.root.join('spec/fixtures/files/gpx/gpx_track_single_segment.gpx') }
+
+  def build_import_with(file_path, name:, source: :gpx)
+    import = create(:import, user: user, name: name, source: source, skip_background_processing: true)
+    import.file.attach(
+      io: File.open(file_path, 'rb'),
+      filename: name,
+      content_type: 'application/gpx+xml'
+    )
+    import
+  end
+
+  context 'with no pre-existing points' do
+    it 'imports normally and leaves doubles at zero' do
+      import = build_import_with(file_path, name: 'happy_path.gpx')
+
+      expect { Imports::Create.new(user, import).call }
+        .to change { import.reload.points.count }.from(0).to(10)
+
+      expect(import.doubles).to eq(0)
+      expect(import.raw_points).to eq(10)
+      expect(user.notifications.count).to eq(0)
+    end
+  end
+
+  context 'when every point in the file already exists in the timeline' do
+    before do
+      reader = Nokogiri::XML(File.read(file_path))
+      reader.remove_namespaces!
+      reader.xpath('//trkpt').each do |node|
+        lon = node['lon']
+        lat = node['lat']
+        ts  = Time.zone.parse(node.at_xpath('time').text).to_i
+        Point.create!(user: user, lonlat: "POINT(#{lon} #{lat})", timestamp: ts, raw_data: { seeded: true })
+      end
+    end
+
+    it 'inserts no points, records every row as a duplicate, and notifies the user' do
+      import = build_import_with(file_path, name: 'all_duplicates.gpx')
+
+      Imports::Create.new(user, import).call
+
+      import.reload
+      expect(import.points.count).to eq(0)
+      expect(import.raw_points).to eq(10)
+      expect(import.doubles).to eq(10)
+      expect(import.status).to eq('completed')
+
+      notification = user.notifications.order(:created_at).last
+      expect(notification).not_to be_nil
+      expect(notification.kind).to eq('info')
+      expect(notification.title).to eq('Import completed with no new points')
+      expect(notification.content).to include('all_duplicates.gpx')
+      expect(notification.content).to include('10 points')
+    end
+  end
+
+  context 'when some points already exist and some are new' do
+    before do
+      reader = Nokogiri::XML(File.read(file_path))
+      reader.remove_namespaces!
+      reader.xpath('//trkpt').first(4).each do |node|
+        lon = node['lon']
+        lat = node['lat']
+        ts  = Time.zone.parse(node.at_xpath('time').text).to_i
+        Point.create!(user: user, lonlat: "POINT(#{lon} #{lat})", timestamp: ts, raw_data: { seeded: true })
+      end
+    end
+
+    it 'inserts only the new points, records the rest as duplicates, and does not notify' do
+      import = build_import_with(file_path, name: 'partial_overlap.gpx')
+
+      Imports::Create.new(user, import).call
+
+      import.reload
+      expect(import.points.count).to eq(6)
+      expect(import.raw_points).to eq(10)
+      expect(import.doubles).to eq(4)
+      expect(user.notifications.where(title: 'Import completed with no new points')).to be_empty
+    end
+  end
+
+  context 'when an import is retried after a prior partial run' do
+    it 'resets raw_points and doubles when processing starts' do
+      import = build_import_with(file_path, name: 'retry.gpx')
+      import.update_columns(raw_points: 999, doubles: 555)
+
+      Imports::Create.new(user, import).call
+
+      import.reload
+      expect(import.raw_points).to eq(10)
+      expect(import.doubles).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Bulk import silently skipped rows that already existed in the user's timeline at the same coordinates/timestamp (`on_duplicate: :skip`), and the UI showed identical state to an empty-file import. Users had no way to tell whether their import had worked, was empty, or was a duplicate-only run.

- Count rows skipped by `bulk_insert` and write them to `import.doubles`; track attempted rows in `import.raw_points`.
- If every row in the file was a duplicate, raise an info notification explaining what happened and what to do.
- Render "\<N\> already imported" under the processed count in the Imports table.

Fixes #2721

## Test plan

- [x] Regression spec covers happy-path, all-duplicates, and partial-overlap
- [ ] Import a GPX file twice → second import shows "N already imported" + info notification
- [ ] Import a new GPX file → no duplicate indicator, no notification