### PR TITLE
fix: don't cache empty photo search results (#1071, #784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Photos from Immich and Photoprism integrations now reappear on the map after a transient empty response from the upstream, instead of staying hidden for 30 minutes due to a cached empty result. (#1071, #784)
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::PhotosController < ApiController
   def index
     cache_key = "photos_#{current_api_user.id}_#{params[:start_date]}_#{params[:end_date]}"
     cached_photos = Rails.cache.read(cache_key)
-    return render json: cached_photos, status: :ok unless cached_photos.nil?
+    return render json: cached_photos, status: :ok if cached_photos.present?
 
     search = Photos::Search.new(current_api_user, start_date: params[:start_date], end_date: params[:end_date])
     @photos = search.call

--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::PhotosController < ApiController
 
     search = Photos::Search.new(current_api_user, start_date: params[:start_date], end_date: params[:end_date])
     @photos = search.call
-    Rails.cache.write(cache_key, @photos, expires_in: 30.minutes) if search.errors.blank?
+    Rails.cache.write(cache_key, @photos, expires_in: 30.minutes) if search.errors.blank? && @photos.present?
 
     render json: @photos, status: :ok
   rescue StandardError => e

--- a/spec/regressions/photos_empty_results_not_cached_spec.rb
+++ b/spec/regressions/photos_empty_results_not_cached_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Photos API caching of empty results', type: :request do
+  let(:user) { create(:user, :with_photoprism_integration) }
+  let(:start_date) { '2026-01-13T00:00:00.000+00:00' }
+  let(:end_date)   { '2026-01-20T23:59:59.999+00:00' }
+
+  let(:photo_data) do
+    [
+      {
+        'id' => 1,
+        'latitude' => 35.6762,
+        'longitude' => 139.6503,
+        'localDateTime' => '2024-01-01T00:00:00.000Z',
+        'originalFileName' => 'photo1.jpg',
+        'city' => 'Tokyo',
+        'state' => 'Tokyo',
+        'country' => 'Japan',
+        'type' => 'photo',
+        'source' => 'photoprism'
+      }
+    ]
+  end
+
+  before { Rails.cache.clear }
+
+  it 'returns fresh upstream photos after a prior empty result for the same range' do
+    allow_any_instance_of(Photos::Search).to receive(:errors).and_return([])
+
+    allow_any_instance_of(Photos::Search).to receive(:call).and_return([])
+    get '/api/v1/photos', params: { api_key: user.api_key, start_date: start_date, end_date: end_date }
+    expect(JSON.parse(response.body)).to eq([])
+
+    allow_any_instance_of(Photos::Search).to receive(:call).and_return(photo_data)
+    get '/api/v1/photos', params: { api_key: user.api_key, start_date: start_date, end_date: end_date }
+
+    expect(JSON.parse(response.body)).to eq(photo_data)
+  end
+
+  it 'still caches non-empty results for the configured TTL' do
+    allow_any_instance_of(Photos::Search).to receive(:errors).and_return([])
+    allow_any_instance_of(Photos::Search).to receive(:call).and_return(photo_data)
+
+    get '/api/v1/photos', params: { api_key: user.api_key, start_date: start_date, end_date: end_date }
+    expect(JSON.parse(response.body)).to eq(photo_data)
+
+    allow_any_instance_of(Photos::Search).to receive(:call).and_raise('upstream called despite warm cache')
+    get '/api/v1/photos', params: { api_key: user.api_key, start_date: start_date, end_date: end_date }
+
+    expect(JSON.parse(response.body)).to eq(photo_data)
+  end
+end

--- a/spec/requests/api/v1/photos_spec.rb
+++ b/spec/requests/api/v1/photos_spec.rb
@@ -71,6 +71,24 @@ RSpec.describe 'Api::V1::Photos', type: :request do
           get '/api/v1/photos', params: { api_key: user.api_key, start_date: start_date, end_date: end_date }
         end
       end
+
+      context 'when the upstream returns an empty array' do
+        let(:start_date) { '2024-01-01' }
+        let(:end_date) { '2024-01-02' }
+
+        before do
+          allow_any_instance_of(Photos::Search).to receive(:call).and_return([])
+          allow(Rails.cache).to receive(:read).and_return(nil)
+        end
+
+        it 'does not write the empty result to the cache' do
+          expect(Rails.cache).not_to receive(:write)
+
+          get '/api/v1/photos', params: { api_key: user.api_key, start_date: start_date, end_date: end_date }
+
+          expect(JSON.parse(response.body)).to eq([])
+        end
+      end
     end
 
     context 'when the integration is not configured' do


### PR DESCRIPTION
## Summary

`Api::V1::PhotosController#index` cached the search result for 30 minutes whenever `search.errors.blank?`. But an empty array also passes that check — so a transient empty response (slow Immich/Photoprism, upstream blip) poisoned the cache and photos stayed hidden on the map for up to 30 minutes.

Add `@photos.present?` to the cache-write guard so only non-empty results are cached.

Fixes #1071, #784

## Test plan

- [x] Regression spec covers: empty result not cached, non-empty result cached
- [ ] Manual: trigger transient empty (stop Immich → reload map → start Immich → reload) → photos reappear immediately