### PR TITLE
fix: clean invalid points indexes in RemoveUnusedIndexes migration (#2124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Database migrations no longer crash with `Multiple indexes found on points columns` when upgrading from 0.36.x with orphan indexes left behind by failed `REINDEX CONCURRENTLY`. The `RemoveUnusedIndexes` migration now drops any invalid indexes on `points` before removing the unused ones. #2124
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Database migrations no longer crash with `Multiple indexes found on points columns` when upgrading from 0.36.x with orphan indexes left behind by failed `REINDEX CONCURRENTLY`. The `RemoveUnusedIndexes` migration now drops any invalid indexes on `points` before removing the unused ones. #2124
+- Database migrations no longer crash with `Multiple indexes found on points columns` when upgrading from 0.36.x with orphan indexes left behind by failed `REINDEX CONCURRENTLY`. The `RemoveUnusedIndexes` migration now drops any invalid indexes on `points` before removing the unused ones. The dropped indexes were intentionally removed in 0.37.0 after profiling and do not need to be recreated. #2124
 
 ## [1.7.8] - 2026-05-16
 

--- a/db/migrate/20251228000000_remove_unused_indexes.rb
+++ b/db/migrate/20251228000000_remove_unused_indexes.rb
@@ -3,7 +3,9 @@
 class RemoveUnusedIndexes < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
-  def change
+  def up
+    drop_invalid_indexes_on_points!
+
     remove_index :points, :geodata, algorithm: :concurrently, if_exists: true
     remove_index :points, %i[latitude longitude], algorithm: :concurrently, if_exists: true
     remove_index :points, :altitude, algorithm: :concurrently, if_exists: true
@@ -15,5 +17,22 @@ class RemoveUnusedIndexes < ActiveRecord::Migration[8.0]
     remove_index :points, :battery, algorithm: :concurrently, if_exists: true
     remove_index :points, :country, algorithm: :concurrently, if_exists: true
     remove_index :points, :external_track_id, algorithm: :concurrently, if_exists: true
+  end
+
+  def down; end
+
+  def drop_invalid_indexes_on_points!
+    invalid = connection.select_values(<<~SQL)
+      SELECT c.relname
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      JOIN pg_class t ON t.oid = i.indrelid
+      WHERE t.relname = 'points' AND NOT i.indisvalid
+    SQL
+
+    invalid.each do |name|
+      Rails.logger.info("Dropping invalid index on points: #{name}")
+      execute "DROP INDEX CONCURRENTLY IF EXISTS #{connection.quote_table_name(name)}"
+    end
   end
 end

--- a/db/migrate/20251228000000_remove_unused_indexes.rb
+++ b/db/migrate/20251228000000_remove_unused_indexes.rb
@@ -19,7 +19,9 @@ class RemoveUnusedIndexes < ActiveRecord::Migration[8.0]
     remove_index :points, :external_track_id, algorithm: :concurrently, if_exists: true
   end
 
-  def down; end
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 
   def drop_invalid_indexes_on_points!
     invalid = connection.select_values(<<~SQL)

--- a/spec/migrations/remove_unused_indexes_spec.rb
+++ b/spec/migrations/remove_unused_indexes_spec.rb
@@ -3,9 +3,7 @@
 require 'rails_helper'
 require Rails.root.join('db/migrate/20251228000000_remove_unused_indexes.rb')
 
-RSpec.describe RemoveUnusedIndexes do
-  self.use_transactional_tests = false
-
+RSpec.describe RemoveUnusedIndexes, :non_transactional do
   let(:connection) { ActiveRecord::Base.connection }
   let(:migration)  { described_class.new }
   let(:test_index_name) { 'tmp_test_orphan_points_idx' }

--- a/spec/migrations/remove_unused_indexes_spec.rb
+++ b/spec/migrations/remove_unused_indexes_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20251228000000_remove_unused_indexes.rb')
+
+RSpec.describe RemoveUnusedIndexes do
+  self.use_transactional_tests = false
+
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:migration)  { described_class.new }
+  let(:test_index_name) { 'tmp_test_orphan_points_idx' }
+
+  before do
+    connection.execute("DROP INDEX IF EXISTS #{test_index_name}")
+    connection.execute("CREATE INDEX #{test_index_name} ON points (city)")
+    connection.execute(<<~SQL)
+      UPDATE pg_index
+      SET indisvalid = false
+      WHERE indexrelid = '#{test_index_name}'::regclass
+    SQL
+  end
+
+  after do
+    connection.execute("DROP INDEX IF EXISTS #{test_index_name}")
+  end
+
+  describe '#drop_invalid_indexes_on_points!' do
+    it 'drops indexes on points that are marked indisvalid' do
+      migration.drop_invalid_indexes_on_points!
+
+      still_present = connection.select_value(
+        "SELECT 1 FROM pg_class WHERE relname = '#{test_index_name}'"
+      )
+      expect(still_present).to be_nil
+    end
+
+    it 'leaves valid indexes on points untouched' do
+      valid_before = points_valid_index_names
+
+      migration.drop_invalid_indexes_on_points!
+
+      expect(points_valid_index_names).to match_array(valid_before)
+    end
+
+    it 'is a no-op when there are no invalid indexes' do
+      connection.execute("DROP INDEX IF EXISTS #{test_index_name}")
+
+      expect { migration.drop_invalid_indexes_on_points! }.not_to raise_error
+    end
+  end
+
+  def points_valid_index_names
+    connection.select_values(<<~SQL)
+      SELECT c.relname
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      JOIN pg_class t ON t.oid = i.indrelid
+      WHERE t.relname = 'points' AND i.indisvalid
+    SQL
+  end
+end


### PR DESCRIPTION
## Summary

Upgrades from 0.36.x crash at the `RemoveUnusedIndexes` migration with `Multiple indexes found on points columns`. Root cause: a prior `REINDEX CONCURRENTLY` (or aborted `CREATE INDEX CONCURRENTLY`) leaves behind an INVALID duplicate index on `points`. When the migration then calls `remove_index :points, :geodata` etc., Rails sees two indexes on the same columns and bails.

- Convert the migration from `change` to `up`/`down` so we can do imperative cleanup.
- Add `drop_invalid_indexes_on_points!` that scans `pg_index` for indexes with `indrelid = 'points'` AND `NOT indisvalid` and drops each one with `DROP INDEX CONCURRENTLY IF EXISTS`.
- Run cleanup before the existing `remove_index` calls.

Idempotent and safe to re-run.

Fixes #2124

## Test plan

- [x] Migration spec under `spec/migrations/`
- [ ] On a DB with a seeded INVALID `index_points_on_user_id_ccnew`: run `db:migrate` → confirm the invalid index is dropped and migration completes
- [ ] On a clean DB: re-run the migration → no error