### PR TITLE
feat: optional OIDC PKCE support (#2282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
+- OIDC PKCE support for sign-in. Set `OIDC_PKCE_ENABLED=true` when your OIDC client (e.g., Pocket ID) enforces PKCE. Defaults to off so existing providers keep working. #2282
 
 ## [1.7.8] - 2026-05-16
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'oidc_config'
+
 Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
@@ -280,44 +282,21 @@ Devise.setup do |config|
     end
   end
 
-  # Self-hosted version: only OpenID Connect (when env vars present)
-  # Generic OpenID Connect provider (Authelia, Authentik, Keycloak, etc.)
-  # Supports both discovery mode (preferred) and manual endpoint configuration
-  if SELF_HOSTED && ENV['OIDC_CLIENT_ID'].present? && ENV['OIDC_CLIENT_SECRET'].present?
-    oidc_config = {
-      name: :openid_connect,
-      scope: %i[openid email profile],
-      response_type: :code,
-      client_options: {
-        identifier: ENV['OIDC_CLIENT_ID'],
-        secret: ENV['OIDC_CLIENT_SECRET'],
-        redirect_uri: ENV.fetch('OIDC_REDIRECT_URI', "#{ENV.fetch('APPLICATION_URL', 'http://localhost:3000')}/users/auth/openid_connect/callback")
-      }
-    }
+  if SELF_HOSTED && OidcConfig.enabled?
+    oidc_config = OidcConfig.build
 
-    # Use OIDC discovery if issuer is provided (recommended for Authelia, Authentik, Keycloak)
-    if ENV['OIDC_ISSUER'].present?
-      oidc_config[:issuer] = ENV['OIDC_ISSUER']
-      oidc_config[:discovery] = true
-      Rails.logger.info "OIDC: Discovery mode enabled with issuer: #{ENV['OIDC_ISSUER']}"
-    # Otherwise use manual endpoint configuration
-    elsif ENV['OIDC_HOST'].present?
-      oidc_config[:client_options].merge!(
-        {
-          host: ENV['OIDC_HOST'],
-          scheme: ENV.fetch('OIDC_SCHEME', 'https'),
-          port: ENV.fetch('OIDC_PORT', 443).to_i,
-          authorization_endpoint: ENV.fetch('OIDC_AUTHORIZATION_ENDPOINT', '/authorize'),
-          token_endpoint: ENV.fetch('OIDC_TOKEN_ENDPOINT', '/token'),
-          userinfo_endpoint: ENV.fetch('OIDC_USERINFO_ENDPOINT', '/userinfo')
-        }
-      )
-      Rails.logger.info "OIDC: Manual mode enabled with host: #{ENV['OIDC_SCHEME']}://#{ENV['OIDC_HOST']}:#{ENV.fetch(
-        'OIDC_PORT', 443
-      )}"
+    if oidc_config[:discovery]
+      Rails.logger.info "OIDC: Discovery mode enabled with issuer: #{oidc_config[:issuer]}"
+    elsif oidc_config[:client_options][:host]
+      host = oidc_config[:client_options][:host]
+      scheme = oidc_config[:client_options][:scheme]
+      port = oidc_config[:client_options][:port]
+      Rails.logger.info "OIDC: Manual mode enabled with host: #{scheme}://#{host}:#{port}"
     end
 
-    Rails.logger.info "OIDC: Client ID: #{ENV['OIDC_CLIENT_ID']}, Redirect URI: #{oidc_config[:client_options][:redirect_uri]}"
+    Rails.logger.info "OIDC: PKCE #{oidc_config[:pkce] ? 'enabled' : 'disabled'}"
+    Rails.logger.info "OIDC: Client ID: #{oidc_config[:client_options][:identifier]}, " \
+                      "Redirect URI: #{oidc_config[:client_options][:redirect_uri]}"
     config.omniauth :openid_connect, oidc_config
   else
     Rails.logger.warn 'OIDC: Not configured (missing OIDC_CLIENT_ID or OIDC_CLIENT_SECRET)'

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -177,6 +177,14 @@ ALLOW_EMAIL_PASSWORD_REGISTRATION=false
 # Set to 'false' to enforce OIDC-only sign-in and hide the email/password form
 ALLOW_EMAIL_PASSWORD_LOGIN=true
 
+# OIDC PKCE (Proof Key for Code Exchange)
+# Enable PKCE for the authorization code flow. Required when your OIDC client
+# enforces PKCE (e.g., Pocket ID with PKCE enabled). Uses the S256 code
+# challenge method.
+# Default: false (preserves the previous behavior for providers that don't
+# advertise PKCE support)
+# OIDC_PKCE_ENABLED=true
+
 # Option 2: Manual Endpoint Configuration (if discovery is not supported)
 # Use this if your provider doesn't support OIDC discovery
 # OIDC_CLIENT_ID=

--- a/lib/oidc_config.rb
+++ b/lib/oidc_config.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module OidcConfig
+  DEFAULT_AUTHORIZATION_ENDPOINT = '/authorize'
+  DEFAULT_TOKEN_ENDPOINT = '/token'
+  DEFAULT_USERINFO_ENDPOINT = '/userinfo'
+  DEFAULT_PORT = 443
+  DEFAULT_SCHEME = 'https'
+
+  def self.enabled?(env = ENV)
+    env['OIDC_CLIENT_ID'].to_s.strip != '' && env['OIDC_CLIENT_SECRET'].to_s.strip != ''
+  end
+
+  def self.build(env = ENV)
+    return nil unless enabled?(env)
+
+    config = {
+      name: :openid_connect,
+      scope: %i[openid email profile],
+      response_type: :code,
+      pkce: pkce_enabled?(env),
+      client_options: {
+        identifier: env['OIDC_CLIENT_ID'],
+        secret: env['OIDC_CLIENT_SECRET'],
+        redirect_uri: redirect_uri(env)
+      }
+    }
+
+    if env['OIDC_ISSUER'].to_s.strip != ''
+      config[:issuer] = env['OIDC_ISSUER']
+      config[:discovery] = true
+    elsif env['OIDC_HOST'].to_s.strip != ''
+      config[:client_options].merge!(manual_endpoints(env))
+    end
+
+    config
+  end
+
+  def self.pkce_enabled?(env = ENV)
+    env['OIDC_PKCE_ENABLED'].to_s.strip.downcase == 'true'
+  end
+
+  def self.redirect_uri(env)
+    env.fetch('OIDC_REDIRECT_URI') do
+      base = env.fetch('APPLICATION_URL', 'http://localhost:3000')
+      "#{base}/users/auth/openid_connect/callback"
+    end
+  end
+  private_class_method :redirect_uri
+
+  def self.manual_endpoints(env)
+    {
+      host: env['OIDC_HOST'],
+      scheme: env.fetch('OIDC_SCHEME', DEFAULT_SCHEME),
+      port: env.fetch('OIDC_PORT', DEFAULT_PORT).to_i,
+      authorization_endpoint: env.fetch('OIDC_AUTHORIZATION_ENDPOINT', DEFAULT_AUTHORIZATION_ENDPOINT),
+      token_endpoint: env.fetch('OIDC_TOKEN_ENDPOINT', DEFAULT_TOKEN_ENDPOINT),
+      userinfo_endpoint: env.fetch('OIDC_USERINFO_ENDPOINT', DEFAULT_USERINFO_ENDPOINT)
+    }
+  end
+  private_class_method :manual_endpoints
+end

--- a/spec/lib/oidc_config_spec.rb
+++ b/spec/lib/oidc_config_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OidcConfig do
+  let(:base_env) do
+    {
+      'OIDC_CLIENT_ID' => 'client-abc',
+      'OIDC_CLIENT_SECRET' => 'secret-xyz',
+      'APPLICATION_URL' => 'https://dawarich.example.com'
+    }
+  end
+
+  describe '.enabled?' do
+    it 'is true when client id and secret are both present' do
+      expect(described_class.enabled?(base_env)).to be true
+    end
+
+    it 'is false when client id is missing' do
+      expect(described_class.enabled?(base_env.merge('OIDC_CLIENT_ID' => ''))).to be false
+    end
+
+    it 'is false when client secret is missing' do
+      expect(described_class.enabled?(base_env.merge('OIDC_CLIENT_SECRET' => nil))).to be false
+    end
+  end
+
+  describe '.build' do
+    it 'returns nil when OIDC is not configured' do
+      expect(described_class.build({})).to be_nil
+    end
+
+    it 'builds a discovery-mode config when issuer is present' do
+      config = described_class.build(base_env.merge('OIDC_ISSUER' => 'https://auth.example.com'))
+
+      expect(config[:issuer]).to eq('https://auth.example.com')
+      expect(config[:discovery]).to be true
+      expect(config[:client_options]).not_to have_key(:host)
+    end
+
+    it 'builds a manual-mode config when host is present without issuer' do
+      env = base_env.merge(
+        'OIDC_HOST' => 'auth.example.com',
+        'OIDC_PORT' => '8443',
+        'OIDC_TOKEN_ENDPOINT' => '/custom/token'
+      )
+
+      config = described_class.build(env)
+
+      expect(config).not_to have_key(:discovery)
+      expect(config[:client_options][:host]).to eq('auth.example.com')
+      expect(config[:client_options][:port]).to eq(8443)
+      expect(config[:client_options][:token_endpoint]).to eq('/custom/token')
+      expect(config[:client_options][:authorization_endpoint]).to eq('/authorize')
+    end
+
+    it 'defaults the redirect URI from APPLICATION_URL' do
+      config = described_class.build(base_env)
+
+      expect(config[:client_options][:redirect_uri])
+        .to eq('https://dawarich.example.com/users/auth/openid_connect/callback')
+    end
+
+    it 'honors an explicit OIDC_REDIRECT_URI' do
+      env = base_env.merge('OIDC_REDIRECT_URI' => 'https://other.example.com/cb')
+
+      expect(described_class.build(env)[:client_options][:redirect_uri])
+        .to eq('https://other.example.com/cb')
+    end
+
+    context 'PKCE' do
+      it 'is disabled by default' do
+        expect(described_class.build(base_env)[:pkce]).to be false
+      end
+
+      it 'is enabled when OIDC_PKCE_ENABLED=true' do
+        expect(described_class.build(base_env.merge('OIDC_PKCE_ENABLED' => 'true'))[:pkce]).to be true
+      end
+
+      it 'accepts mixed case' do
+        expect(described_class.build(base_env.merge('OIDC_PKCE_ENABLED' => 'TRUE'))[:pkce]).to be true
+      end
+
+      it 'stays disabled for any non-true value' do
+        %w[false 1 yes off].each do |value|
+          built = described_class.build(base_env.merge('OIDC_PKCE_ENABLED' => value))
+          expect(built[:pkce]).to be(false), "expected pkce to be false when OIDC_PKCE_ENABLED=#{value.inspect}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Some OIDC providers (Pocket ID with PKCE on, hardened Authentik/Keycloak) require PKCE on the authorization code flow even for confidential clients. omniauth_openid_connect already supports it — we just need to surface the toggle.

- New env var `OIDC_PKCE_ENABLED` (default `false`)
- Extracted OIDC config building from `config/initializers/devise.rb` into `lib/OidcConfig` for testability — the initializer was getting unwieldy
- `OidcConfig.build` returns a hash including `pkce: true/false`, consumed directly by omniauth_openid_connect (S256 code challenge by default)
- Log line at boot shows "PKCE enabled/disabled" so users can confirm

Default OFF — no behavior change for existing deployments.

Fixes #2282

## Test plan

- [x] Spec for `OidcConfig` covers: enabled?, discovery mode, manual mode, PKCE on/off, redirect URI fallback
- [ ] Self-hosted with `OIDC_PKCE_ENABLED=true` + Pocket ID (PKCE-required) → sign-in succeeds, boot log says "PKCE enabled"
- [ ] Self-hosted without the var → behavior unchanged, boot log says "PKCE disabled"