### PR TITLE
fix: Map v2 'Apply Settings' button does nothing (#2680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Map v2 settings panel: "Apply Settings" now actually saves your changes. Points rendering mode, speed-colored routes, live mode, and fog-of-war toggles all persist on click and reload. #2680
+- Map v2 settings panel: "Apply Settings" now actually saves your changes. Points rendering mode, speed-colored routes, live mode, and fog-of-war toggles all persist on click and reload. Apply/Reset buttons moved above the Transportation Mode section so they sit inside the outer form. #2680
 
 ## [1.7.8] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Map v2 settings panel: "Apply Settings" now actually saves your changes. Points rendering mode, speed-colored routes, live mode, and fog-of-war toggles all persist on click and reload. #2680
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/app/views/map/maplibre/_settings_panel.html.erb
+++ b/app/views/map/maplibre/_settings_panel.html.erb
@@ -596,6 +596,75 @@
 
           <div class="divider"></div>
 
+          <!-- Points Rendering Mode -->
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text font-medium">Points Rendering Mode</span>
+            </label>
+            <div class="flex flex-col gap-2">
+              <label class="label cursor-pointer justify-start gap-3 py-1">
+                <input type="radio"
+                       name="pointsRenderingMode"
+                       value="raw"
+                       class="radio radio-primary radio-sm"
+                       checked />
+                <span class="label-text">Raw (all points)</span>
+              </label>
+              <label class="label cursor-pointer justify-start gap-3 py-1">
+                <input type="radio"
+                       name="pointsRenderingMode"
+                       value="simplified"
+                       class="radio radio-primary radio-sm" />
+                <span class="label-text">Simplified (reduced points)</span>
+              </label>
+            </div>
+          </div>
+
+          <div class="divider"></div>
+
+          <!-- Speed-Colored Routes -->
+          <div class="form-control">
+            <label class="label cursor-pointer justify-start gap-3">
+              <input type="checkbox"
+                     name="speedColoredRoutes"
+                     class="toggle toggle-primary" />
+              <span class="label-text font-medium">Speed-Colored Routes</span>
+            </label>
+            <p class="text-sm text-base-content/60 mt-1">Color routes by speed</p>
+          </div>
+
+          <div class="divider"></div>
+
+          <!-- Live Mode -->
+          <div class="form-control">
+            <label class="label cursor-pointer justify-start gap-3">
+              <input type="checkbox"
+                     class="toggle toggle-primary"
+                     data-action="change->maps--maplibre-realtime#toggleLiveMode"
+                     data-maps--maplibre-realtime-target="liveModeToggle" />
+              <span class="label-text font-medium">Live Mode</span>
+            </label>
+            <p class="text-sm text-base-content/60 mt-1">Show new points in real-time</p>
+          </div>
+
+          <div class="divider"></div>
+
+          <!-- Update Button -->
+          <button type="submit" class="btn btn-sm btn-primary btn-block">
+            <%= icon 'save' %>
+            Apply Settings
+          </button>
+
+          <!-- Reset Settings -->
+          <button type="button"
+                  class="btn btn-sm btn-outline btn-block"
+                  data-action="click->maps--maplibre#resetSettings">
+            <%= icon 'rotate-ccw' %>
+            Reset to Defaults
+          </button>
+
+          <div class="divider"></div>
+
           <!-- Transportation Mode Detection Thresholds -->
           <details class="collapse collapse-arrow bg-base-200 rounded-lg">
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
@@ -930,6 +999,11 @@
               </div>
 
               <div class="mt-4 pt-4 border-t border-base-300">
+                <%# button_to renders a nested <form>. The HTML5 parser implicitly closes
+                    the outer <form data-action="submit->maps--maplibre#updateAdvancedSettings">
+                    here, so any controls placed inside this <details> or after this
+                    block are orphaned from outer-form submission. Keep the outer
+                    submit button BEFORE the Transportation Mode <details>. %>
                 <%= button_to 'Re-classify my history',
                               tracks_recalculation_path,
                               method: :post,
@@ -944,75 +1018,6 @@
               </div>
             </div>
           </details>
-
-          <div class="divider"></div>
-
-          <!-- Points Rendering Mode -->
-          <div class="form-control w-full">
-            <label class="label">
-              <span class="label-text font-medium">Points Rendering Mode</span>
-            </label>
-            <div class="flex flex-col gap-2">
-              <label class="label cursor-pointer justify-start gap-3 py-1">
-                <input type="radio"
-                       name="pointsRenderingMode"
-                       value="raw"
-                       class="radio radio-primary radio-sm"
-                       checked />
-                <span class="label-text">Raw (all points)</span>
-              </label>
-              <label class="label cursor-pointer justify-start gap-3 py-1">
-                <input type="radio"
-                       name="pointsRenderingMode"
-                       value="simplified"
-                       class="radio radio-primary radio-sm" />
-                <span class="label-text">Simplified (reduced points)</span>
-              </label>
-            </div>
-          </div>
-
-          <div class="divider"></div>
-
-          <!-- Speed-Colored Routes -->
-          <div class="form-control">
-            <label class="label cursor-pointer justify-start gap-3">
-              <input type="checkbox"
-                     name="speedColoredRoutes"
-                     class="toggle toggle-primary" />
-              <span class="label-text font-medium">Speed-Colored Routes</span>
-            </label>
-            <p class="text-sm text-base-content/60 mt-1">Color routes by speed</p>
-          </div>
-
-          <div class="divider"></div>
-
-          <!-- Live Mode -->
-          <div class="form-control">
-            <label class="label cursor-pointer justify-start gap-3">
-              <input type="checkbox"
-                     class="toggle toggle-primary"
-                     data-action="change->maps--maplibre-realtime#toggleLiveMode"
-                     data-maps--maplibre-realtime-target="liveModeToggle" />
-              <span class="label-text font-medium">Live Mode</span>
-            </label>
-            <p class="text-sm text-base-content/60 mt-1">Show new points in real-time</p>
-          </div>
-
-          <div class="divider"></div>
-
-          <!-- Update Button -->
-          <button type="submit" class="btn btn-sm btn-primary btn-block">
-            <%= icon 'save' %>
-            Apply Settings
-          </button>
-
-          <!-- Reset Settings -->
-          <button type="button"
-                  class="btn btn-sm btn-outline btn-block"
-                  data-action="click->maps--maplibre#resetSettings">
-            <%= icon 'rotate-ccw' %>
-            Reset to Defaults
-          </button>
         </form>
       </div>
 


### PR DESCRIPTION
## Summary

Map v2 settings form has a `button_to "Re-classify my history"` nested inside the Transportation Mode `<details>`. `button_to` renders a `<form>`, and the HTML5 parser implicitly closes any outer `<form>` at the start of a nested one. So the outer form (`data-action="submit->maps--maplibre#updateAdvancedSettings"`) was silently being closed at that `button_to` — and every control placed *after* it (Points Rendering Mode, Speed-Colored Routes, Live Mode, the Apply Settings submit button itself) was orphaned. Clicking Apply Settings literally did nothing.

Move all of those controls + Apply/Reset buttons above the Transportation Mode `<details>` so they live inside the outer form's actual DOM boundary. Add an inline comment by the `button_to` so a future edit doesn't reintroduce the regression.

Fixes #2680

## Test plan

- [ ] Map v2 → settings panel → toggle Speed-Colored Routes, switch Points Rendering Mode → click Apply Settings → confirm changes take effect
- [ ] Reload → confirm changes persisted
- [ ] Re-classify my history still works (nested button_to unaffected)