### PR TITLE
fix: reconcile overlapping tracks + reabsorb late-arriving points (#2463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Tracks no longer split into overlapping segments when location points arrive out of order (e.g. delayed or batched uploads from Colota / OwnTracks). Late-arriving points whose timestamps fall inside an existing track's window are absorbed back into that track, and any tracks that already overlap for the same device are merged automatically on the next real-time generation run. Existing overlapping tracks from earlier versions can be cleaned up via Settings → Recalculate tracks & stats. #2463
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.7.9] - Unreleased
 
+### ⚠️ Upgrade notes
+
+- **Existing overlapping tracks** from before this release will not auto-merge — clean them up via **Settings → Recalculate tracks & stats** after upgrading. New tracks from this release onward stay consistent automatically. #2463
+
 ### Added
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
 ### Fixed
 
-- Tracks no longer split into overlapping segments when location points arrive out of order (e.g. delayed or batched uploads from Colota / OwnTracks). Late-arriving points whose timestamps fall inside an existing track's window are absorbed back into that track, and any tracks that already overlap for the same device are merged automatically on the next real-time generation run. Existing overlapping tracks from earlier versions can be cleaned up via Settings → Recalculate tracks & stats. #2463
+- Tracks no longer split into overlapping segments when location points arrive out of order (e.g. delayed or batched uploads from Colota / OwnTracks). Late-arriving points whose timestamps fall inside an existing track's window are absorbed back into that track, and any tracks that already overlap for the same device are merged automatically on the next real-time generation run. #2463
 
 ## [1.7.8] - 2026-05-16
 

--- a/app/services/tracks/boundary_detector.rb
+++ b/app/services/tracks/boundary_detector.rb
@@ -7,6 +7,7 @@ class Tracks::BoundaryDetector
   include Tracks::TrackBuilder
 
   ORPHAN_REABSORPTION_FRESHNESS_BUFFER = 60.seconds
+  ORPHAN_REABSORPTION_LOOKBACK = 6.hours
 
   attr_reader :user
 
@@ -26,7 +27,10 @@ class Tracks::BoundaryDetector
   end
 
   def reabsorb_orphan_points
-    user.tracks.find_each.sum { |track| absorb_orphans_into(track) }
+    user.tracks
+        .where('end_at >= ?', ORPHAN_REABSORPTION_LOOKBACK.ago)
+        .find_each
+        .sum { |track| absorb_orphans_into(track) }
   end
 
   private
@@ -35,25 +39,37 @@ class Tracks::BoundaryDetector
     orphan_ids = orphan_point_ids_for(track)
     return 0 if orphan_ids.empty?
 
-    Point.where(id: orphan_ids).update_all(track_id: track.id)
+    succeeded = false
+    ActiveRecord::Base.transaction(requires_new: true) do
+      Point.where(id: orphan_ids).update_all(track_id: track.id)
 
-    bounds = Point.where(track_id: track.id).pick(Arel.sql('MIN(timestamp), MAX(timestamp)'))
-    return orphan_ids.size if bounds.nil?
+      bounds = Point.where(track_id: track.id).pick(Arel.sql('MIN(timestamp), MAX(timestamp)'))
+      raise ActiveRecord::Rollback if bounds.nil?
 
-    new_start = Time.zone.at(bounds[0])
-    new_end = Time.zone.at(bounds[1])
+      new_start = Time.zone.at(bounds[0])
+      new_end = Time.zone.at(bounds[1])
 
-    if track.start_at != new_start || track.end_at != new_end
-      track.update!(start_at: new_start, end_at: new_end)
-    else
-      track.recalculate_path_and_distance!
+      if track.start_at != new_start || track.end_at != new_end
+        track.update!(start_at: new_start, end_at: new_end)
+      else
+        track.recalculate_path_and_distance!
+      end
+
+      succeeded = true
     end
 
-    orphan_ids.size
+    succeeded ? orphan_ids.size : 0
   rescue ActiveRecord::RecordNotUnique
     Rails.logger.warn(
       'event=tracks.reabsorb_orphan_points_failed reason=unique_violation ' \
-      "user_id=#{user.id} track_id=#{track.id}"
+      "user_id=#{user.id} track_id=#{track.id} orphan_ids=#{orphan_ids.join(',')}"
+    )
+    0
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.warn(
+      'event=tracks.reabsorb_orphan_points_failed reason=invalid ' \
+      "user_id=#{user.id} track_id=#{track.id} orphan_ids=#{orphan_ids.join(',')} " \
+      "error=#{e.message}"
     )
     0
   end

--- a/app/services/tracks/boundary_detector.rb
+++ b/app/services/tracks/boundary_detector.rb
@@ -6,26 +6,67 @@ class Tracks::BoundaryDetector
   include Tracks::Segmentation
   include Tracks::TrackBuilder
 
+  ORPHAN_REABSORPTION_FRESHNESS_BUFFER = 60.seconds
+
   attr_reader :user
 
   def initialize(user)
     @user = user
   end
 
-  # Main method to resolve cross-chunk tracks
   def resolve_cross_chunk_tracks
     boundary_candidates = find_boundary_track_candidates
-    return 0 if boundary_candidates.empty?
 
     resolved_count = 0
     boundary_candidates.each do |group|
       resolved_count += 1 if merge_boundary_tracks(group)
     end
 
-    resolved_count
+    resolved_count + reabsorb_orphan_points
+  end
+
+  def reabsorb_orphan_points
+    user.tracks.find_each.sum { |track| absorb_orphans_into(track) }
   end
 
   private
+
+  def absorb_orphans_into(track)
+    orphan_ids = orphan_point_ids_for(track)
+    return 0 if orphan_ids.empty?
+
+    Point.where(id: orphan_ids).update_all(track_id: track.id)
+
+    bounds = Point.where(track_id: track.id).pick(Arel.sql('MIN(timestamp), MAX(timestamp)'))
+    return orphan_ids.size if bounds.nil?
+
+    new_start = Time.zone.at(bounds[0])
+    new_end = Time.zone.at(bounds[1])
+
+    if track.start_at != new_start || track.end_at != new_end
+      track.update!(start_at: new_start, end_at: new_end)
+    else
+      track.recalculate_path_and_distance!
+    end
+
+    orphan_ids.size
+  rescue ActiveRecord::RecordNotUnique
+    Rails.logger.warn(
+      'event=tracks.reabsorb_orphan_points_failed reason=unique_violation ' \
+      "user_id=#{user.id} track_id=#{track.id}"
+    )
+    0
+  end
+
+  def orphan_point_ids_for(track)
+    Point.where(user_id: user.id)
+         .where('COALESCE(tracker_id, ?) = COALESCE(?, ?)', '', track.tracker_id, '')
+         .where(track_id: nil)
+         .where('anomaly IS NOT TRUE')
+         .where(timestamp: track.start_at.to_i..track.end_at.to_i)
+         .where(created_at: ...ORPHAN_REABSORPTION_FRESHNESS_BUFFER.ago)
+         .pluck(:id)
+  end
 
   def find_boundary_track_candidates
     recent_tracks = user.tracks
@@ -68,7 +109,8 @@ class Tracks::BoundaryDetector
     conditions = recent_tracks.flat_map do |track|
       [
         ['end_at BETWEEN ? AND ?', track.start_at - window, track.start_at],
-        ['start_at BETWEEN ? AND ?', track.end_at, track.end_at + window]
+        ['start_at BETWEEN ? AND ?', track.end_at, track.end_at + window],
+        ['start_at <= ? AND end_at >= ?', track.end_at, track.start_at]
       ]
     end
 
@@ -105,11 +147,11 @@ class Tracks::BoundaryDetector
       candidate_start = candidate.start_at.to_i
       candidate_end = candidate.end_at.to_i
 
-      # Check if tracks are temporally adjacent
-      next unless (candidate_start - track_end_time).abs <= time_window ||
+      ranges_overlap = candidate_start <= track_end_time && candidate_end >= track_start_time
+      next unless ranges_overlap ||
+                  (candidate_start - track_end_time).abs <= time_window ||
                   (track_start_time - candidate_end).abs <= time_window
 
-      # Check if they're spatially connected
       connected << candidate if tracks_spatially_connected?(track, candidate)
     end
 
@@ -120,7 +162,8 @@ class Tracks::BoundaryDetector
   def tracks_spatially_connected?(track1, track2)
     return false unless track1.points.exists? && track2.points.exists?
 
-    # Get endpoints of both tracks
+    return true if track1.tracker_id.present? && track1.tracker_id == track2.tracker_id
+
     track1_start = track1.points.order(:timestamp).first
     track1_end = track1.points.order(:timestamp).last
     track2_start = track2.points.order(:timestamp).first
@@ -154,10 +197,7 @@ class Tracks::BoundaryDetector
   def valid_boundary_group?(group)
     return false if group.size < 2
 
-    # Check that tracks are sequential in time
     sorted_tracks = group.sort_by(&:start_at)
-
-    # Ensure no large time gaps that would indicate separate journeys
     max_gap = 1.hour.to_i
 
     sorted_tracks.each_cons(2) do |track1, track2|

--- a/app/services/tracks/incremental_generator.rb
+++ b/app/services/tracks/incremental_generator.rb
@@ -31,7 +31,6 @@ class Tracks::IncrementalGenerator
   def call
     Tracks::PerUserLock.with_user_lock(user.id) do
       segments = fetch_untracked_segments
-      return if segments.empty?
 
       segments.each do |segment|
         next if segment[:points].size < 2
@@ -44,6 +43,8 @@ class Tracks::IncrementalGenerator
 
         merge_with_recent_track(track) if track
       end
+
+      Tracks::BoundaryDetector.new(user).resolve_cross_chunk_tracks
     end
   end
 

--- a/spec/regressions/realtime_tracks_with_late_arrival_points_spec.rb
+++ b/spec/regressions/realtime_tracks_with_late_arrival_points_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe 'Real-time track generation with late-arriving GPS points' do
       expect(user.tracks.count).to eq(1)
       expect(existing_track.reload.points.count).to eq(4)
     end
+
+    it 'recalculates distance and path to include the absorbed point' do
+      pre_distance = existing_track.distance
+      pre_path = existing_track.original_path.to_s
+
+      generator.call
+
+      existing_track.reload
+      expect(existing_track.distance).to be > 0
+      expect(existing_track.distance).not_to eq(pre_distance)
+      expect(existing_track.original_path).to be_present
+      expect(existing_track.original_path.to_s).not_to eq(pre_path)
+    end
   end
 
   context 'when late points sandwiched between batches form a new track inside an existing window' do

--- a/spec/regressions/realtime_tracks_with_late_arrival_points_spec.rb
+++ b/spec/regressions/realtime_tracks_with_late_arrival_points_spec.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Real-time track generation with late-arriving GPS points' do
+  let(:user) do
+    create(:user, settings: {
+             'minutes_between_routes' => 30,
+             'meters_between_routes' => 500
+           })
+  end
+  let(:generator) { Tracks::IncrementalGenerator.new(user) }
+  let(:tracker) { 'colota-device-1' }
+  let(:base_time) { 1.hour.ago.to_i }
+
+  def make_point(offset_seconds, lng:, lat:, track: nil, tracker_id: tracker, created_at: nil)
+    attrs = {
+      user: user,
+      timestamp: base_time + offset_seconds,
+      lonlat: "POINT(#{lng} #{lat})",
+      tracker_id: tracker_id,
+      track: track
+    }
+    attrs[:created_at] = created_at if created_at
+    create(:point, **attrs)
+  end
+
+  context 'when a single late point arrives inside an existing track time window' do
+    let!(:existing_track) do
+      create(:track, user: user, tracker_id: tracker,
+                     start_at: Time.zone.at(base_time),
+                     end_at: Time.zone.at(base_time + 30))
+    end
+
+    before do
+      make_point(0,  lng: -74.000, lat: 40.7128, track: existing_track)
+      make_point(15, lng: -74.001, lat: 40.7138, track: existing_track)
+      make_point(30, lng: -74.002, lat: 40.7148, track: existing_track)
+
+      make_point(10, lng: -74.0005, lat: 40.7133,
+                     track: nil,
+                     created_at: 2.minutes.ago)
+    end
+
+    it 'absorbs the orphan point into the existing track' do
+      generator.call
+
+      expect(user.tracks.count).to eq(1)
+      expect(existing_track.reload.points.count).to eq(4)
+    end
+  end
+
+  context 'when late points sandwiched between batches form a new track inside an existing window' do
+    let!(:existing_track) do
+      create(:track, user: user, tracker_id: tracker,
+                     start_at: Time.zone.at(base_time),
+                     end_at: Time.zone.at(base_time + 30))
+    end
+
+    before do
+      make_point(0,  lng: -74.000, lat: 40.7128, track: existing_track)
+      make_point(15, lng: -74.001, lat: 40.7138, track: existing_track)
+      make_point(30, lng: -74.002, lat: 40.7148, track: existing_track)
+
+      make_point(10, lng: -74.0005, lat: 40.7133, track: nil, created_at: 2.minutes.ago)
+      make_point(45, lng: -74.003,  lat: 40.7158, track: nil, created_at: 2.minutes.ago)
+      make_point(60, lng: -74.004,  lat: 40.7168, track: nil, created_at: 2.minutes.ago)
+      make_point(75, lng: -74.005,  lat: 40.7178, track: nil, created_at: 2.minutes.ago)
+    end
+
+    it 'produces a single track containing all points in timestamp order' do
+      generator.call
+
+      expect(user.tracks.count).to eq(1)
+      track = user.tracks.first
+      timestamps = track.points.order(:timestamp).pluck(:timestamp)
+      expect(timestamps).to eq([base_time, base_time + 10, base_time + 15, base_time + 30,
+                                base_time + 45, base_time + 60, base_time + 75])
+    end
+  end
+
+  context 'when late points straddle an existing track end boundary' do
+    let!(:existing_track) do
+      create(:track, user: user, tracker_id: tracker,
+                     start_at: Time.zone.at(base_time),
+                     end_at: Time.zone.at(base_time + 30))
+    end
+
+    before do
+      make_point(0,  lng: -74.000, lat: 40.7128, track: existing_track)
+      make_point(15, lng: -74.001, lat: 40.7138, track: existing_track)
+      make_point(30, lng: -74.002, lat: 40.7148, track: existing_track)
+
+      make_point(20, lng: -74.0015, lat: 40.7143, track: nil, created_at: 2.minutes.ago)
+      make_point(40, lng: -74.0025, lat: 40.7158, track: nil, created_at: 2.minutes.ago)
+      make_point(50, lng: -74.003,  lat: 40.7168, track: nil, created_at: 2.minutes.ago)
+    end
+
+    it 'merges the straddling late points with the existing track' do
+      generator.call
+
+      expect(user.tracks.count).to eq(1)
+      merged = user.tracks.first
+      expect(merged.points.count).to eq(6)
+      expect(merged.end_at.to_i).to eq(base_time + 50)
+    end
+  end
+
+  context 'when multiple overlapping tracks already exist for the same tracker' do
+    let!(:track_a) do
+      create(:track, user: user, tracker_id: tracker,
+                     start_at: Time.zone.at(base_time),
+                     end_at: Time.zone.at(base_time + 60))
+    end
+    let!(:track_b) do
+      create(:track, user: user, tracker_id: tracker,
+                     start_at: Time.zone.at(base_time + 20),
+                     end_at: Time.zone.at(base_time + 80))
+    end
+    let!(:track_c) do
+      create(:track, user: user, tracker_id: tracker,
+                     start_at: Time.zone.at(base_time + 50),
+                     end_at: Time.zone.at(base_time + 100))
+    end
+
+    before do
+      make_point(0,   lng: -74.000, lat: 40.7128, track: track_a)
+      make_point(30,  lng: -74.001, lat: 40.7138, track: track_a)
+      make_point(60,  lng: -74.002, lat: 40.7148, track: track_a)
+      make_point(20,  lng: -74.0008, lat: 40.7133, track: track_b)
+      make_point(50,  lng: -74.0015, lat: 40.7143, track: track_b)
+      make_point(80,  lng: -74.003,  lat: 40.7158, track: track_b)
+      make_point(50,  lng: -74.0016, lat: 40.7144, track: track_c)
+      make_point(70,  lng: -74.0025, lat: 40.7153, track: track_c)
+      make_point(100, lng: -74.0035, lat: 40.7163, track: track_c)
+    end
+
+    it 'reconciles all three into a single track' do
+      generator.call
+
+      expect(user.tracks.count).to eq(1)
+      merged = user.tracks.first
+      expect(merged.start_at.to_i).to eq(base_time)
+      expect(merged.end_at.to_i).to eq(base_time + 100)
+    end
+  end
+
+  context 'when overlapping tracks have the same tracker_id but spatially distant endpoints' do
+    let!(:track_a) do
+      create(:track, user: user, tracker_id: tracker,
+                     start_at: Time.zone.at(base_time),
+                     end_at: Time.zone.at(base_time + 30))
+    end
+    let!(:track_b) do
+      create(:track, user: user, tracker_id: tracker,
+                     start_at: Time.zone.at(base_time + 10),
+                     end_at: Time.zone.at(base_time + 40))
+    end
+
+    before do
+      make_point(0,  lng: -74.000, lat: 40.7128, track: track_a)
+      make_point(15, lng: -74.001, lat: 40.7138, track: track_a)
+      make_point(30, lng: -74.002, lat: 40.7148, track: track_a)
+      make_point(10, lng: -73.500, lat: 40.5000, track: track_b)
+      make_point(25, lng: -73.501, lat: 40.5010, track: track_b)
+      make_point(40, lng: -73.502, lat: 40.5020, track: track_b)
+    end
+
+    it 'merges them because tracker_id matches and time ranges overlap' do
+      generator.call
+
+      expect(user.tracks.count).to eq(1)
+    end
+  end
+
+  context 'when overlapping tracks belong to different trackers' do
+    let!(:track_a) do
+      create(:track, user: user, tracker_id: 'device-a',
+                     start_at: Time.zone.at(base_time),
+                     end_at: Time.zone.at(base_time + 30))
+    end
+    let!(:track_b) do
+      create(:track, user: user, tracker_id: 'device-b',
+                     start_at: Time.zone.at(base_time + 10),
+                     end_at: Time.zone.at(base_time + 40))
+    end
+
+    before do
+      make_point(0,  lng: -74.000, lat: 40.7128, track: track_a, tracker_id: 'device-a')
+      make_point(15, lng: -74.001, lat: 40.7138, track: track_a, tracker_id: 'device-a')
+      make_point(30, lng: -74.002, lat: 40.7148, track: track_a, tracker_id: 'device-a')
+      make_point(10, lng: -74.5,   lat: 40.50,   track: track_b, tracker_id: 'device-b')
+      make_point(25, lng: -74.501, lat: 40.501,  track: track_b, tracker_id: 'device-b')
+      make_point(40, lng: -74.502, lat: 40.502,  track: track_b, tracker_id: 'device-b')
+    end
+
+    it 'preserves both tracks because they belong to different devices' do
+      generator.call
+
+      expect(user.tracks.count).to eq(2)
+      expect(user.tracks.pluck(:tracker_id)).to contain_exactly('device-a', 'device-b')
+    end
+  end
+
+  context 'when an untracked point is too fresh (still inside the anomaly-filter race window)' do
+    let!(:existing_track) do
+      create(:track, user: user, tracker_id: tracker,
+                     start_at: Time.zone.at(base_time),
+                     end_at: Time.zone.at(base_time + 30))
+    end
+
+    before do
+      make_point(0,  lng: -74.000, lat: 40.7128, track: existing_track)
+      make_point(30, lng: -74.002, lat: 40.7148, track: existing_track)
+
+      make_point(15, lng: -74.001, lat: 40.7138,
+                     track: nil,
+                     created_at: 10.seconds.ago)
+    end
+
+    it 'leaves the fresh point untracked until anomaly detection completes' do
+      generator.call
+
+      expect(existing_track.reload.points.count).to eq(2)
+      expect(user.points.where(track_id: nil).count).to eq(1)
+    end
+  end
+
+  context 'when an untracked point is flagged as anomaly' do
+    let!(:existing_track) do
+      create(:track, user: user, tracker_id: tracker,
+                     start_at: Time.zone.at(base_time),
+                     end_at: Time.zone.at(base_time + 30))
+    end
+
+    before do
+      make_point(0,  lng: -74.000, lat: 40.7128, track: existing_track)
+      make_point(30, lng: -74.002, lat: 40.7148, track: existing_track)
+
+      anomaly = make_point(15, lng: -74.001, lat: 40.7138, track: nil, created_at: 2.minutes.ago)
+      anomaly.update_column(:anomaly, true)
+    end
+
+    it 'does not absorb the anomaly point' do
+      generator.call
+
+      expect(existing_track.reload.points.count).to eq(2)
+      expect(user.points.where(track_id: nil, anomaly: true).count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Out-of-order point uploads (delayed Colota / OwnTracks batches) produced two compounding regressions:

1. Late-arriving points whose timestamps fell inside an existing track's window were left orphaned (`track_id: nil`) because they didn't form a new segment.
2. `BoundaryDetector`'s adjacency check only matched gap-adjacent tracks; truly overlapping ranges were never considered for merge — so we ended up with multiple tracks claiming the same time window on the map.

### Changes

- `BoundaryDetector#resolve_cross_chunk_tracks` now always runs the orphan-reabsorption pass.
- New `#reabsorb_orphan_points`: for each user track, find orphan points (`track_id: nil`, `anomaly` not true, same `tracker_id`, timestamp within track window, created at least `ORPHAN_REABSORPTION_FRESHNESS_BUFFER` (60s) ago) and assign them to the track. Bump `start_at`/`end_at` if extended; otherwise recalc path/distance.
- Overlap query gains `start_at <= ? AND end_at >= ?` so overlapping ranges are detected.
- `tracks_temporally_and_spatially_close?` accepts range overlap, not just gap adjacency.
- `tracks_spatially_connected?` short-circuits to `true` for same-`tracker_id` tracks — same device + overlapping range = same journey.
- `IncrementalGenerator` runs `BoundaryDetector#resolve_cross_chunk_tracks` unconditionally at the end of each call (previously skipped when no new segments — exactly the case that left orphans pending).

Existing overlapping tracks from before this fix can be cleaned up via Settings → Recalculate tracks & stats.

Fixes #2463

## Test plan

- [x] Regression spec under `spec/regressions/realtime_tracks_with_late_arrival_points_spec.rb` (late arrival, overlap detection, freshness buffer)
- [ ] Soak test on staging: replay out-of-order OwnTracks payloads → confirm no overlapping tracks remain
- [ ] Recalculate tracks & stats on a user with known overlap from prior versions → confirm merge