### PR TITLE
fix: real-time family location updates (#2733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Family members' positions now update in real time on the map as they arrive, instead of only refreshing every 60 seconds. (#2733)
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/app/services/points/live_broadcaster.rb
+++ b/app/services/points/live_broadcaster.rb
@@ -1,15 +1,5 @@
 # frozen_string_literal: true
 
-# Broadcasts newly created points to PointsChannel for live map updates.
-#
-# Since all point creation uses upsert_all (which bypasses ActiveRecord callbacks),
-# this service manually broadcasts to PointsChannel after points are created.
-#
-# Used by real-time point creation services:
-# - OwnTracks::PointCreator
-# - Overland::PointsCreator
-# - Points::Create
-#
 class Points::LiveBroadcaster
   attr_reader :user_id, :upserted_results, :payloads
 
@@ -23,26 +13,59 @@ class Points::LiveBroadcaster
     return if upserted_results.empty?
 
     user = User.find_by(id: user_id)
-    return unless user&.safe_settings&.live_map_enabled
+    return unless user
+
+    live_map = user.safe_settings&.live_map_enabled
+    family = family_sharing?(user)
+    return unless live_map || family
 
     payloads_by_timestamp = payloads.index_by { |p| p[:timestamp].to_i }
 
     upserted_results.each do |result|
       payload = payloads_by_timestamp[result['timestamp'].to_i] || {}
-
-      PointsChannel.broadcast_to(
-        user,
-        [
-          result['latitude'].to_f,
-          result['longitude'].to_f,
-          payload[:battery].to_s,
-          payload[:altitude].to_s,
-          result['timestamp'].to_s,
-          payload[:velocity].to_s,
-          result['id'].to_s,
-          '' # country_name not yet available (async geocoding)
-        ]
-      )
+      broadcast_points(user, result, payload) if live_map
+      broadcast_family(user, result) if family
     end
+  end
+
+  private
+
+  def family_sharing?(user)
+    DawarichSettings.family_feature_enabled? &&
+      user.in_family? &&
+      user.family_sharing_enabled?
+  end
+
+  def broadcast_points(user, result, payload)
+    PointsChannel.broadcast_to(
+      user,
+      [
+        result['latitude'].to_f,
+        result['longitude'].to_f,
+        payload[:battery].to_s,
+        payload[:altitude].to_s,
+        result['timestamp'].to_s,
+        payload[:velocity].to_s,
+        result['id'].to_s,
+        ''
+      ]
+    )
+  end
+
+  def broadcast_family(user, result)
+    timestamp = result['timestamp'].to_i
+
+    FamilyLocationsChannel.broadcast_to(
+      user.family,
+      {
+        user_id: user.id,
+        email: user.email,
+        email_initial: user.email.first.upcase,
+        latitude: result['latitude'].to_f,
+        longitude: result['longitude'].to_f,
+        timestamp: timestamp,
+        updated_at: Time.zone.at(timestamp).iso8601
+      }
+    )
   end
 end

--- a/spec/regressions/family_realtime_broadcast_via_upsert_path_spec.rb
+++ b/spec/regressions/family_realtime_broadcast_via_upsert_path_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Family realtime broadcast survives upsert_all ingest path' do
+  let(:family) { create(:family) }
+  let(:owner) { family.creator }
+  let(:sharer) { create(:user) }
+
+  before do
+    allow(DawarichSettings).to receive(:family_feature_enabled?).and_return(true)
+    create(:family_membership, family: family, user: owner, role: :owner)
+    create(:family_membership, family: family, user: sharer, role: :member)
+    sharer.update_family_location_sharing!(true, duration: 'permanent')
+    sharer.settings['live_map_enabled'] = true
+    sharer.save!
+  end
+
+  let(:owntracks_payload) do
+    {
+      '_type' => 'location',
+      'lat' => 52.6,
+      'lon' => 13.6,
+      'tst' => Time.zone.local(2026, 5, 20, 12, 0, 0).to_i,
+      'batt' => 80,
+      'acc' => 10
+    }
+  end
+
+  it 'broadcasts to FamilyLocationsChannel when a point arrives via OwnTracks::PointCreator' do
+    expect do
+      OwnTracks::PointCreator.new(ActionController::Parameters.new(owntracks_payload).permit!, sharer.id).call
+    end.to have_broadcasted_to(family).from_channel(FamilyLocationsChannel)
+  end
+
+  it 'carries the sharing user identity, coordinates, and timestamp in the broadcast payload' do
+    broadcasts = []
+    allow(FamilyLocationsChannel).to receive(:broadcast_to) do |target, payload|
+      broadcasts << [target, payload]
+    end
+
+    OwnTracks::PointCreator.new(ActionController::Parameters.new(owntracks_payload).permit!, sharer.id).call
+
+    expect(broadcasts.length).to eq(1)
+    target, payload = broadcasts.first
+    expect(target).to eq(family)
+    expect(payload).to include(
+      user_id: sharer.id,
+      email: sharer.email,
+      email_initial: sharer.email.first.upcase,
+      latitude: 52.6,
+      longitude: 13.6,
+      timestamp: owntracks_payload['tst']
+    )
+  end
+
+  it 'does not broadcast to FamilyLocationsChannel when the sharer has disabled family sharing' do
+    sharer.update_family_location_sharing!(false)
+
+    expect do
+      OwnTracks::PointCreator.new(ActionController::Parameters.new(owntracks_payload).permit!, sharer.id).call
+    end.not_to have_broadcasted_to(family).from_channel(FamilyLocationsChannel)
+  end
+end

--- a/spec/services/points/live_broadcaster_spec.rb
+++ b/spec/services/points/live_broadcaster_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Points::LiveBroadcaster do
         user.save!
       end
 
-      it 'does not broadcast' do
+      it 'does not broadcast to PointsChannel' do
         expect(PointsChannel).not_to receive(:broadcast_to)
 
         described_class.new(user.id, upserted_results, payloads).call
@@ -50,6 +50,7 @@ RSpec.describe Points::LiveBroadcaster do
     context 'when upserted_results is empty' do
       it 'does not broadcast' do
         expect(PointsChannel).not_to receive(:broadcast_to)
+        expect(FamilyLocationsChannel).not_to receive(:broadcast_to)
 
         described_class.new(user.id, [], payloads).call
       end
@@ -58,6 +59,7 @@ RSpec.describe Points::LiveBroadcaster do
     context 'when user does not exist' do
       it 'does not broadcast' do
         expect(PointsChannel).not_to receive(:broadcast_to)
+        expect(FamilyLocationsChannel).not_to receive(:broadcast_to)
 
         described_class.new(-1, upserted_results, payloads).call
       end
@@ -103,6 +105,106 @@ RSpec.describe Points::LiveBroadcaster do
           user,
           [52.52, 13.405, '', '', '1700000000', '', '1', '']
         )
+
+        described_class.new(user.id, upserted_results, payloads).call
+      end
+    end
+
+    context 'family location broadcast' do
+      let(:family) { create(:family) }
+      let(:user) { family.creator }
+
+      before do
+        allow(DawarichSettings).to receive(:family_feature_enabled?).and_return(true)
+        create(:family_membership, family: family, user: user, role: :owner)
+        user.update_family_location_sharing!(true, duration: 'permanent')
+      end
+
+      context 'when family sharing is enabled' do
+        it 'broadcasts to FamilyLocationsChannel with the user payload' do
+          expect(FamilyLocationsChannel).to receive(:broadcast_to).with(
+            family,
+            hash_including(
+              user_id: user.id,
+              email: user.email,
+              email_initial: user.email.first.upcase,
+              latitude: 52.52,
+              longitude: 13.405,
+              timestamp: 1_700_000_000
+            )
+          )
+
+          described_class.new(user.id, upserted_results, payloads).call
+        end
+
+        it 'broadcasts even when live_map_enabled is false' do
+          user.settings['live_map_enabled'] = false
+          user.save!
+
+          expect(PointsChannel).not_to receive(:broadcast_to)
+          expect(FamilyLocationsChannel).to receive(:broadcast_to)
+
+          described_class.new(user.id, upserted_results, payloads).call
+        end
+
+        it 'broadcasts to both channels when live_map_enabled and family sharing are both on' do
+          user.settings['live_map_enabled'] = true
+          user.save!
+
+          expect(PointsChannel).to receive(:broadcast_to)
+          expect(FamilyLocationsChannel).to receive(:broadcast_to)
+
+          described_class.new(user.id, upserted_results, payloads).call
+        end
+
+        it 'emits one family broadcast per upserted point' do
+          multi_results = [
+            { 'id' => 1, 'timestamp' => 1_700_000_000, 'latitude' => 52.52, 'longitude' => 13.405 },
+            { 'id' => 2, 'timestamp' => 1_700_000_060, 'latitude' => 52.53, 'longitude' => 13.41 }
+          ]
+          multi_payloads = [
+            { timestamp: 1_700_000_000, battery: 85, altitude: 100, velocity: '5.0' },
+            { timestamp: 1_700_000_060, battery: 80, altitude: 110, velocity: '10.0' }
+          ]
+
+          expect(FamilyLocationsChannel).to receive(:broadcast_to).twice
+
+          described_class.new(user.id, multi_results, multi_payloads).call
+        end
+      end
+
+      context 'when family sharing is disabled' do
+        before { user.update_family_location_sharing!(false) }
+
+        it 'does not broadcast to FamilyLocationsChannel' do
+          expect(FamilyLocationsChannel).not_to receive(:broadcast_to)
+
+          described_class.new(user.id, upserted_results, payloads).call
+        end
+      end
+
+      context 'when family feature is disabled globally' do
+        before { allow(DawarichSettings).to receive(:family_feature_enabled?).and_return(false) }
+
+        it 'does not broadcast to FamilyLocationsChannel even when user sharing is enabled' do
+          expect(FamilyLocationsChannel).not_to receive(:broadcast_to)
+
+          described_class.new(user.id, upserted_results, payloads).call
+        end
+      end
+    end
+
+    context 'when user is not in a family' do
+      let(:user) { create(:user) }
+
+      before do
+        allow(DawarichSettings).to receive(:family_feature_enabled?).and_return(true)
+        user.settings['live_map_enabled'] = false
+        user.save!
+      end
+
+      it 'does not broadcast to FamilyLocationsChannel' do
+        expect(FamilyLocationsChannel).not_to receive(:broadcast_to)
 
         described_class.new(user.id, upserted_results, payloads).call
       end


### PR DESCRIPTION
## Summary

Family members' positions on the map only refreshed every 60 seconds because `Points::LiveBroadcaster` — which runs after every upsert from `OwnTracks::PointCreator`, `Overland::PointsCreator`, and `Points::Create` — only broadcast to `PointsChannel` (the live-map toggle) and never to `FamilyLocationsChannel`. Family sharing relied entirely on the polling endpoint.

- `LiveBroadcaster#call` now also broadcasts to `FamilyLocationsChannel` for each upserted point when: family feature is on globally, the user is in a family, and the user has sharing enabled.
- The two channels are independent: `live_map_enabled` gates `PointsChannel`; family sharing gates `FamilyLocationsChannel`. Either, both, or neither can run.
- Family payload mirrors the polling-endpoint shape (`user_id`, `email`, `email_initial`, `latitude`, `longitude`, `timestamp`, `updated_at` ISO8601) so the front-end consumes the same JSON.

Fixes #2733

## Test plan

- [x] Updated `spec/services/points/live_broadcaster_spec.rb` (independent gating, multi-point, feature flag, not-in-family)
- [x] Regression spec under `spec/regressions/family_realtime_broadcast_via_upsert_path_spec.rb`
- [ ] Two-account manual test: family member A reports a new point via OwnTracks; family member B sees pin move within ~1s (vs. waiting up to 60s)