### PR TITLE
fix: exclude anomalies from bulk track recalculation (#2630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Anomaly-flagged GPS points are no longer included when "Recalculate tracks & stats" or "Re-evaluate past data" rebuilds tracks — anomalies now stay off the track line and out of `track_id` assignment, matching the behaviour of real-time track generation. #2630
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/app/controllers/api/v1/tracks/points_controller.rb
+++ b/app/controllers/api/v1/tracks/points_controller.rb
@@ -5,13 +5,14 @@ class Api::V1::Tracks::PointsController < ApiController
     track = current_api_user.tracks.find(params[:track_id])
 
     # First try to get points directly associated with the track
-    points = track.points.without_raw_data.includes(:country).order(timestamp: :asc)
+    points = track.points.not_anomaly.without_raw_data.includes(:country).order(timestamp: :asc)
     points = apply_plan_scope(points)
 
     # If no points are associated, fall back to fetching by time range
     # This handles tracks created before point association was implemented
     if points.empty?
       points = scoped_points
+               .not_anomaly
                .without_raw_data
                .includes(:country)
                .where(timestamp: track.start_at.to_i..track.end_at.to_i)

--- a/app/jobs/tracks/time_chunk_processor_job.rb
+++ b/app/jobs/tracks/time_chunk_processor_job.rb
@@ -61,6 +61,7 @@ class Tracks::TimeChunkProcessorJob < ApplicationJob
 
   def load_chunk_points
     relation = user.points
+                   .not_anomaly
                    .where(timestamp: chunk_data[:buffer_start_timestamp]..chunk_data[:buffer_end_timestamp])
                    .order(:timestamp)
     relation = relation.where(track_id: nil) if chunk_data[:untracked_only]

--- a/spec/regressions/anomaly_points_excluded_from_bulk_track_generation_spec.rb
+++ b/spec/regressions/anomaly_points_excluded_from_bulk_track_generation_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Anomaly-flagged points are excluded from bulk track generation' do
+  let(:user) do
+    create(:user, settings: {
+             'minutes_between_routes' => 30,
+             'meters_between_routes' => 500
+           })
+  end
+
+  let(:chunk_start) { Time.zone.local(2026, 1, 1, 12, 0, 0).to_i }
+  let(:chunk_end)   { Time.zone.local(2026, 1, 1, 12, 30, 0).to_i }
+
+  let!(:clean_point_a) do
+    create(:point, user: user, timestamp: chunk_start + 60,
+                   latitude: 52.5200, longitude: 13.4050,
+                   lonlat: 'POINT(13.4050 52.5200)', anomaly: false)
+  end
+
+  let!(:anomaly_point) do
+    create(:point, user: user, timestamp: chunk_start + 120,
+                   latitude: 52.5201, longitude: 13.4060,
+                   lonlat: 'POINT(13.4060 52.5201)', anomaly: true)
+  end
+
+  let!(:clean_point_b) do
+    create(:point, user: user, timestamp: chunk_start + 180,
+                   latitude: 52.5202, longitude: 13.4070,
+                   lonlat: 'POINT(13.4070 52.5202)', anomaly: false)
+  end
+
+  let(:chunk_data) do
+    {
+      chunk_id: 'spec-chunk',
+      start_timestamp: chunk_start,
+      end_timestamp: chunk_end,
+      buffer_start_timestamp: chunk_start,
+      buffer_end_timestamp: chunk_end,
+      untracked_only: false
+    }
+  end
+
+  before do
+    session_manager = instance_double(Tracks::SessionManager, session_exists?: true, session_id: 'spec-session')
+    allow(session_manager).to receive(:increment_completed_chunks)
+    allow(session_manager).to receive(:increment_tracks_created)
+    allow(session_manager).to receive(:mark_failed)
+    allow(Tracks::SessionManager).to receive(:new).and_return(session_manager)
+  end
+
+  it 'does not assign track_id to anomaly points and omits their coords from track.original_path' do
+    Tracks::TimeChunkProcessorJob.new.perform(user.id, 'spec-session', chunk_data)
+
+    track = user.tracks.reload.first
+    expect(track).to be_present
+
+    aggregate_failures do
+      expect(clean_point_a.reload.track_id).to eq(track.id)
+      expect(clean_point_b.reload.track_id).to eq(track.id)
+      expect(anomaly_point.reload.track_id).to be_nil
+
+      path_coords = track.original_path.points.map { |p| [p.x.round(4), p.y.round(4)] }
+      expect(path_coords).to contain_exactly([13.4050, 52.5200], [13.4070, 52.5202])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Real-time track generation already filters anomaly points, but the bulk path (`Recalculate tracks & stats` → `Tracks::TimeChunkProcessorJob`) did not. Result: GPS spikes that the user had already flagged got dragged back onto the track line every time tracks were rebuilt.

- `Tracks::TimeChunkProcessorJob#load_chunk_points` applies `.not_anomaly` to the chunk relation.
- `Api::V1::Tracks::PointsController#index` applies `.not_anomaly` to both the direct `track.points` lookup AND the time-range fallback, so legacy tracks (created before per-point `track_id` association) also stop returning anomalies in the polyline payload.

Fixes #2630

## Test plan

- [x] Regression spec under `spec/regressions/anomaly_points_excluded_from_bulk_track_generation_spec.rb`
- [ ] User with seeded anomaly points → click Recalculate tracks & stats → confirm track polyline does not snap to anomalies
- [ ] Re-evaluate past data on same user → same result