### PR TITLE
fix: include anomalies in Map v2 Select Area for bulk delete (#2476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Map v2 **Select Area** now includes anomaly points, so the "Delete points" button can bulk-delete them instead of forcing one-by-one deletion via My Data → Points (#2476)
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -14,6 +14,8 @@ class Api::V1::PointsController < ApiController
 
     points = if ActiveModel::Type::Boolean.new.cast(params[:anomalies_only])
                scoped_points.anomaly
+             elsif ActiveModel::Type::Boolean.new.cast(params[:include_anomalies])
+               scoped_points
              else
                scoped_points.not_anomaly
              end

--- a/app/javascript/maps_maplibre/services/api_client.js
+++ b/app/javascript/maps_maplibre/services/api_client.js
@@ -561,6 +561,7 @@ export class ApiClient {
       max_longitude: max_longitude.toString(),
       min_latitude: min_latitude.toString(),
       max_latitude: max_latitude.toString(),
+      include_anomalies: "true",
       per_page: "10000", // Get all points in area (up to 10k)
     })
 

--- a/spec/regressions/points_api_bbox_includes_anomalies_spec.rb
+++ b/spec/regressions/points_api_bbox_includes_anomalies_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/points anomaly filtering inside a bounding box', type: :request do
+  let(:user) { create(:user) }
+  let(:now)  { Time.zone.now }
+
+  let!(:normal_point) do
+    create(:point,
+           user: user,
+           timestamp: now.to_i,
+           latitude: 52.5,
+           longitude: 13.4,
+           lonlat: 'POINT(13.4 52.5)',
+           anomaly: false)
+  end
+
+  let!(:anomaly_point) do
+    create(:point,
+           user: user,
+           timestamp: now.to_i + 60,
+           latitude: 52.51,
+           longitude: 13.41,
+           lonlat: 'POINT(13.41 52.51)',
+           anomaly: true)
+  end
+
+  let(:bbox_params) do
+    'min_longitude=13.0&max_longitude=14.0&min_latitude=52.0&max_latitude=53.0'
+  end
+
+  let(:time_params) do
+    "start_at=#{(now - 1.hour).to_i}&end_at=#{(now + 1.hour).to_i}"
+  end
+
+  def fetch_ids(extra_params = '')
+    get "/api/v1/points?api_key=#{user.api_key}&#{time_params}&#{bbox_params}&#{extra_params}"
+    expect(response).to have_http_status(:ok)
+    JSON.parse(response.body).map { |p| p['id'] }
+  end
+
+  it 'defaults to non-anomaly points only' do
+    expect(fetch_ids).to contain_exactly(normal_point.id)
+  end
+
+  it 'returns only anomaly points when anomalies_only=true' do
+    expect(fetch_ids('anomalies_only=true')).to contain_exactly(anomaly_point.id)
+  end
+
+  it 'returns both normal and anomaly points when include_anomalies=true' do
+    expect(fetch_ids('include_anomalies=true'))
+      .to contain_exactly(normal_point.id, anomaly_point.id)
+  end
+
+  it 'gives anomalies_only precedence when both flags are set' do
+    expect(fetch_ids('anomalies_only=true&include_anomalies=true'))
+      .to contain_exactly(anomaly_point.id)
+  end
+end


### PR DESCRIPTION
## Summary

`PointsController#index` defaulted to `scoped_points.not_anomaly`, which silently excluded anomaly-flagged points from the bbox query that powers Map v2's Select Area. So when a user drew a polygon around a cluster of GPS spikes and hit Delete N Points, the anomalies weren't in the selection — they could only be deleted one at a time from My Data → Points.

- API: opt-in `include_anomalies=true` param on `Api::V1::PointsController#index`. Preserves the default (`.not_anomaly`) and the existing `anomalies_only` branch.
- Client: Map v2 bbox query passes `include_anomalies=true` so anomaly points appear in the selection and the bulk-delete action covers them.

Anomaly-only views (the "show anomalies" toggle) still use `anomalies_only`, unchanged.

Fixes #2476

## Test plan

- [x] Regression spec under `spec/regressions/points_api_bbox_includes_anomalies_spec.rb`
- [ ] Map v2 → seed anomaly points → Select Area around them → confirm count includes anomalies → Delete N Points → confirm gone
- [ ] My Data → Points → confirm normal points view still hides anomalies (no default change)