### PR TITLE
fix: guard upgrade-token paths on self-hosted (#2682)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Self-hosted instances no longer return 500 on the Stats / Insights page when `JWT_SECRET_KEY` is unset. The internal "upgrade URL" helper is now a no-op on self-hosted, matching the existing guards in other call sites. The `/trial/upgrade` route, which had the same unguarded crash, now redirects self-hosted users to the home page. #2682
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -94,6 +94,8 @@ class ApiController < ApplicationController
   end
 
   def upgrade_url_for(user)
+    return nil if DawarichSettings.self_hosted?
+
     "#{MANAGER_URL}/auth/dawarich?token=#{user.generate_subscription_token}"
   end
 

--- a/app/controllers/trial/upgrades_controller.rb
+++ b/app/controllers/trial/upgrades_controller.rb
@@ -3,6 +3,7 @@
 module Trial
   class UpgradesController < ApplicationController
     before_action :authenticate_user!
+    before_action :redirect_if_self_hosted
 
     def show
       token = current_user.generate_subscription_token(
@@ -19,6 +20,10 @@ module Trial
     end
 
     private
+
+    def redirect_if_self_hosted
+      redirect_to root_path if DawarichSettings.self_hosted?
+    end
 
     def sanitized_plan
       %w[pro lite].include?(params[:plan]) ? params[:plan] : nil

--- a/spec/regressions/insights_api_self_hosted_no_jwt_secret_spec.rb
+++ b/spec/regressions/insights_api_self_hosted_no_jwt_secret_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Insights API on self-hosted without JWT_SECRET_KEY', type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { { 'Authorization' => "Bearer #{user.api_key}" } }
+
+  before do
+    create(:stat, year: 2024, month: 1, user: user, daily_distance: { '1' => 1000 })
+
+    allow(DawarichSettings).to receive(:self_hosted?).and_return(true)
+
+    env_without_jwt = ENV.to_h.tap { |h| h.delete('JWT_SECRET_KEY') }
+    stub_const('ENV', env_without_jwt)
+  end
+
+  describe 'GET /api/v1/insights' do
+    it 'does not raise when JWT_SECRET_KEY is unset on self-hosted' do
+      get api_v1_insights_url, headers: headers
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns a nil upgradeUrl on self-hosted' do
+      get api_v1_insights_url, headers: headers
+
+      json = JSON.parse(response.body)
+      expect(json['upgradeUrl']).to be_nil
+    end
+  end
+
+  describe 'GET /api/v1/insights/details' do
+    it 'does not raise when JWT_SECRET_KEY is unset on self-hosted' do
+      get details_api_v1_insights_url, headers: headers
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET /trial/upgrade' do
+    it 'redirects self-hosted users away instead of generating a subscription token' do
+      sign_in(user)
+
+      get '/trial/upgrade', params: { plan: 'pro', interval: 'annual' }
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end

--- a/spec/requests/trial/upgrades_spec.rb
+++ b/spec/requests/trial/upgrades_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Trial::Upgrades', type: :request do
 
     before do
       stub_const('MANAGER_URL', 'https://manager.example.test')
+      allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
     end
 
     context 'when not signed in' do


### PR DESCRIPTION
## Summary

`generate_subscription_token` requires `JWT_SECRET_KEY`, which is unset on typical self-hosted instances. Two call sites still hit it unguarded:

- `ApiController#upgrade_url_for` ran on every Stats / Insights API response → 500 on the Stats / Insights page.
- `Trial::UpgradesController#show` / `#process_upgrade` generated a token unconditionally → 500 if anyone hit `/trial/upgrade`.

Match existing guards in other call sites:

- `ApiController#upgrade_url_for` returns `nil` on self-hosted; the JSON payload simply omits the field.
- `Trial::UpgradesController` gains a `before_action :redirect_if_self_hosted` that bounces self-hosted users to `root_path` before the token-generation path is reached.

Existing request spec needed `allow(DawarichSettings).to receive(:self_hosted?).and_return(false)` to keep the non-self-hosted code path under test.

Fixes #2682

## Test plan

- [x] Updated `spec/requests/trial/upgrades_spec.rb`
- [x] Regression spec under `spec/regressions/insights_api_self_hosted_no_jwt_secret_spec.rb`
- [ ] Self-hosted (no `JWT_SECRET_KEY`) → open Stats/Insights → no 500
- [ ] Self-hosted → visit `/trial/upgrade` → redirected to `/`
- [ ] Hosted (with `JWT_SECRET_KEY`) → both flows unchanged