### PR TITLE
Use ISO8601 timestamps for trip photo bounds and cover sub-day case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 **Hexagons** layer (Pro) — aggregates your points into colored H3 cells so dense areas pop out at a glance. Toggle from the map settings panel; resolution adapts to zoom. #2568
 
+### Fixed
+
+- Trip photos now appear on trips shorter than one day. Previously, the start and end timestamps were truncated to dates, so Immich and Photoprism received `takenAfter == takenBefore` and returned no photos. #2708
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/app/services/trips/photos.rb
+++ b/app/services/trips/photos.rb
@@ -25,8 +25,8 @@ class Trips::Photos
 
     photos = Photos::Search.new(
       user,
-      start_date: trip.started_at.to_date.to_s,
-      end_date: trip.ended_at.to_date.to_s
+      start_date: trip.started_at.iso8601,
+      end_date: trip.ended_at.iso8601
     ).call
 
     @photos = photos.map { |photo| photo_thumbnail(photo) }

--- a/spec/regressions/trip_photos_use_full_timestamps_for_sub_day_trips_spec.rb
+++ b/spec/regressions/trip_photos_use_full_timestamps_for_sub_day_trips_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Trip photos use full timestamps when searching for assets' do
+  let(:user) { instance_double('User') }
+
+  before do
+    allow(user).to receive(:immich_integration_configured?).and_return(true)
+    allow(user).to receive(:photoprism_integration_configured?).and_return(false)
+    allow(user).to receive(:api_key).and_return('test-api-key')
+  end
+
+  context 'when a trip spans hours within a single day' do
+    let(:started_at) { Time.utc(2024, 3, 29, 8, 0, 0) }
+    let(:ended_at)   { Time.utc(2024, 3, 29, 20, 0, 0) }
+    let(:trip)       { instance_double('Trip', started_at: started_at, ended_at: ended_at) }
+
+    it 'passes distinct ISO8601 datetime bounds to Photos::Search' do
+      photo_search = instance_double('Photos::Search', call: [])
+
+      expect(Photos::Search).to receive(:new) do |received_user, **kwargs|
+        expect(received_user).to eq(user)
+        expect(kwargs[:start_date]).to eq('2024-03-29T08:00:00Z')
+        expect(kwargs[:end_date]).to   eq('2024-03-29T20:00:00Z')
+        expect(kwargs[:start_date]).not_to eq(kwargs[:end_date]),
+                                           'sub-day trip bounds collapsed to the same value; downstream Immich/Photoprism ' \
+                                           'filtering will reject every photo because takenAfter == takenBefore'
+        photo_search
+      end
+
+      Trips::Photos.new(trip, user).call
+    end
+  end
+
+  context 'when a trip spans multiple days' do
+    let(:started_at) { Time.utc(2024, 3, 29, 8, 0, 0) }
+    let(:ended_at)   { Time.utc(2024, 4, 2, 20, 0, 0) }
+    let(:trip)       { instance_double('Trip', started_at: started_at, ended_at: ended_at) }
+
+    it 'still passes ISO8601 datetime bounds (no date-only truncation)' do
+      photo_search = instance_double('Photos::Search', call: [])
+
+      expect(Photos::Search).to receive(:new) do |_received_user, **kwargs|
+        expect(kwargs[:start_date]).to eq('2024-03-29T08:00:00Z')
+        expect(kwargs[:end_date]).to   eq('2024-04-02T20:00:00Z')
+        photo_search
+      end
+
+      Trips::Photos.new(trip, user).call
+    end
+  end
+end

--- a/spec/services/trips/photos_spec.rb
+++ b/spec/services/trips/photos_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Trips::Photos do
   let(:user) { instance_double('User') }
-  let(:trip) { instance_double('Trip', started_at: Date.new(2024, 1, 1), ended_at: Date.new(2024, 1, 7)) }
+  let(:started_at) { Time.utc(2024, 1, 1, 10, 0, 0) }
+  let(:ended_at) { Time.utc(2024, 1, 7, 18, 30, 0) }
+  let(:trip) { instance_double('Trip', started_at: started_at, ended_at: ended_at) }
   let(:service) { described_class.new(trip, user) }
 
   describe '#call' do
@@ -44,7 +46,7 @@ RSpec.describe Trips::Photos do
         allow(user).to receive(:api_key).and_return('test-api-key')
 
         allow(Photos::Search).to receive(:new)
-          .with(user, start_date: '2024-01-01', end_date: '2024-01-07')
+          .with(user, start_date: '2024-01-01T10:00:00Z', end_date: '2024-01-07T18:30:00Z')
           .and_return(photo_search)
         allow(photo_search).to receive(:call).and_return(raw_photos)
       end


### PR DESCRIPTION
## Summary
- Switch `Trips::Photos` to call `iso8601` on the trip bounds instead of `to_date.to_s`, so sub-day trips no longer collapse `takenAfter == takenBefore` and lose all Immich/Photoprism results.
- The production change is identical to the one proposed by @calebgab in #2718 — credit and approach belong to them. This PR exists to add the regression coverage and changelog entry their PR was missing.
- Rewrites the existing `spec/services/trips/photos_spec.rb` to use `Time.utc(...)` doubles (the old `Date.new(...)` doubles passed coincidentally because `Date#iso8601` returns date-only, so the stub never exercised the actual fix).
- New regression spec at `spec/regressions/trip_photos_use_full_timestamps_for_sub_day_trips_spec.rb` covers the sub-day case (08:00→20:00 on the same date) and the multi-day case. Verified failing before the fix and passing after.
- CHANGELOG entry under the existing \`## [1.7.9] - Unreleased\` → \`### Fixed\` referencing #2708.

## Relationship to #2718
@calebgab's PR also bundles an unrelated SMTP cert-verification change (\`lib/smtp_config.rb\` + spec). That belongs in a separate PR — keeping these fixes split makes each one independently reviewable, revertible, and shippable. This PR is the trip-photos half; the SMTP half stays in #2718 and can be merged on its own.

## Test plan
- [x] \`bundle exec rspec spec/services/trips/photos_spec.rb spec/regressions/trip_photos_use_full_timestamps_for_sub_day_trips_spec.rb\` — 4 examples, 0 failures
- [x] Verified the new regression spec fails when \`photos.rb\` reverts to \`to_date.to_s\` (red-green confirmed)
- [x] \`bundle exec rubocop\` clean on all changed Ruby files

Closes #2708.