### PR TITLE
Follow-ups to #2745: async place naming, advisory-lock dedup, SelectPlace input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### ⚠️ Upgrade notes
 
 - **Existing overlapping tracks** from before this release will not auto-merge — clean them up via **Settings → Recalculate tracks & stats** after upgrading. New tracks from this release onward stay consistent automatically. #2463
-- **Visit detection no longer fan-outs candidate places.** Previously, every detected visit persisted up to 25 reverse-geocoded "possible place" rows. Now each visit owns exactly one Place (named synchronously from Photon at creation time). Alternative suggestions are available live via `GET /api/v1/visits/:id/possible_places` and the new `POST /api/v1/visits/:id/select_place` endpoint. Existing pre-rollout candidate rows can be cleaned up with the new `bin/rails dawarich:cleanup_suggested_places` task. The `place_visits` table is preserved for one release and will be dropped in a follow-up after operators verify the drain completed.
+- **Visit detection no longer fan-outs candidate places.** Previously, every detected visit persisted up to 25 reverse-geocoded "possible place" rows. Now each visit owns exactly one Place, created with a default name and enriched by an enqueued `Places::NameFetchingJob` (so visit detection itself never blocks on Photon). Alternative suggestions are available live via `GET /api/v1/visits/:id/possible_places` and the new `POST /api/v1/visits/:id/select_place` endpoint. Existing pre-rollout candidate rows can be cleaned up with the new `bin/rails dawarich:cleanup_suggested_places` task. The `place_visits` table is preserved for one release and will be dropped in a follow-up after operators verify the drain completed.
 - **Web timeline picker** (the radio-list under "Needs review" for suggested visits) still reads from the legacy `place_visits` association in this release. After running the cleanup rake task, that list will show only the visit's main place. A follow-up release will switch the timeline picker to use real-time Photon suggestions via the new endpoints. Mobile clients consuming the JSON API see the new behavior immediately.
 - **Two one-time operator tasks** ship in this release. Run after deploy:
   1. `bin/rails dawarich:backfill_place_names` — names any remaining legacy `Place::DEFAULT_NAME` rows.
@@ -26,17 +26,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Visit detection no longer creates 25 candidate Places per visit. Each visit now has exactly one Place, named synchronously from Photon at creation time.
+- Visit detection no longer creates 25 candidate Places per visit. Each visit now has exactly one Place, named asynchronously via `Places::NameFetchingJob` so the detection pipeline never waits on Photon.
 - `GET /api/v1/visits/:id/possible_places` returns real-time Photon suggestions instead of pre-persisted candidates. The currently-assigned place is prepended to the list with its `id`; suggestions below have `id: null` and round-trip via the new `select_place` endpoint.
 - `GET /api/v1/places/nearby` and `POST /api/v1/places/nearby` now include `id` (always `null` for Photon results), `source`, and `geodata` keys in each item (additive — existing consumers unaffected).
 - `Place#has_many :visits` is now `dependent: :nullify` (was `:destroy`). Deleting a Place leaves its visits intact with `place_id = nil`, preventing accidental visit loss.
 
 ### Removed
 
-- `place_name_fetching_job` daily cron entry. Place naming now happens synchronously during visit detection — no nightly catch-up needed.
+- `place_name_fetching_job` daily cron entry. Place naming now happens per-place asynchronously when each Place is created — no nightly catch-up needed.
 
 ### Fixed
 
+- `POST /api/v1/visits/:id/select_place` now validates latitude is within [-90, 90] and longitude within [-180, 180], rejecting out-of-range coordinates with 422.
+- Concurrent `POST /api/v1/visits/:id/select_place` calls for the same Photon result are now serialized via a PG advisory lock keyed on `(user_id, osm_id|name+coords)`, preventing duplicate Place rows (skipped automatically when advisory locks are disabled, e.g. behind PgBouncer transaction-pool).
 - Self-hosted instances no longer return 500 on the Stats / Insights page when `JWT_SECRET_KEY` is unset. The internal "upgrade URL" helper is now a no-op on self-hosted, matching the existing guards in other call sites. The `/trial/upgrade` route, which had the same unguarded crash, now redirects self-hosted users to the home page. #2682
 - Imports table now shows how many points were skipped as duplicates (already in your timeline at the same coordinates and timestamp), and notifies you when an import completes without inserting any points because every row in the file was a duplicate. Previously these imports looked indistinguishable from empty files. (#2721)
 - Family members' positions now update in real time on the map as they arrive, instead of only refreshing every 60 seconds. (#2733)

--- a/app/controllers/api/v1/visits/select_place_controller.rb
+++ b/app/controllers/api/v1/visits/select_place_controller.rb
@@ -23,10 +23,18 @@ class Api::V1::Visits::SelectPlaceController < ApiController
       raise ActionController::ParameterMissing, :name      if p[:name].blank?
       raise ActionController::ParameterMissing, :latitude  if p[:latitude].blank?
       raise ActionController::ParameterMissing, :longitude if p[:longitude].blank?
+
+      lat = p[:latitude].to_f
+      lon = p[:longitude].to_f
+      raise ActionController::ParameterMissing, :latitude  unless lat.between?(-90, 90)
+      raise ActionController::ParameterMissing, :longitude unless lon.between?(-180, 180)
     end
   end
 
   def serialize_place(place)
+    tags = place.tags.to_a
+    first_tag = tags.first
+
     {
       id: place.id,
       name: place.name,
@@ -34,11 +42,11 @@ class Api::V1::Visits::SelectPlaceController < ApiController
       longitude: place.lon,
       source: place.source,
       note: place.note,
-      icon: place.tags.first&.icon,
-      color: place.tags.first&.color,
+      icon: first_tag&.icon,
+      color: first_tag&.color,
       visits_count: place.visits.size,
       created_at: place.created_at,
-      tags: place.tags.map do |tag|
+      tags: tags.map do |tag|
         {
           id: tag.id,
           name: tag.name,

--- a/app/jobs/places/orphan_cleanup_job.rb
+++ b/app/jobs/places/orphan_cleanup_job.rb
@@ -29,14 +29,8 @@ class Places::OrphanCleanupJob < ApplicationJob
       victim_ids = conn.exec_query(victims_sql, 'OrphanCleanup victims', victim_binds(user.id)).rows.map { |r| r[0] }
       break if victim_ids.empty?
 
-      conn.exec_delete(
-        "DELETE FROM place_visits WHERE place_id IN (#{victim_ids.join(',')})",
-        'OrphanCleanup place_visits'
-      )
-      deleted = conn.exec_delete(
-        "DELETE FROM places WHERE id IN (#{victim_ids.join(',')})",
-        'OrphanCleanup places'
-      )
+      PlaceVisit.where(place_id: victim_ids).delete_all
+      deleted = Place.where(id: victim_ids).delete_all
     end
 
     deleted

--- a/app/services/visits/place_finder.rb
+++ b/app/services/visits/place_finder.rb
@@ -32,18 +32,17 @@ module Visits
     end
 
     def create_default_place(lat, lon, suggested_name)
-      attrs = Places::NameFetcher.lookup_attrs(lat, lon) || {}
-
-      user.places.create!(
-        name:      attrs[:name].presence || suggested_name.presence || Place::DEFAULT_NAME,
-        city:      attrs[:city],
-        country:   attrs[:country],
-        geodata:   DawarichSettings.store_geodata? ? (attrs[:geodata] || {}) : {},
+      place = user.places.create!(
+        name:      suggested_name.presence || Place::DEFAULT_NAME,
+        geodata:   {},
         latitude:  lat,
         longitude: lon,
         lonlat:    "POINT(#{lon} #{lat})",
         source:    :photon
       )
+
+      Places::NameFetchingJob.perform_later(place.id) if DawarichSettings.reverse_geocoding_enabled?
+      place
     end
   end
 end

--- a/app/services/visits/select_place.rb
+++ b/app/services/visits/select_place.rb
@@ -2,6 +2,8 @@
 
 module Visits
   class SelectPlace
+    include AdvisoryLockable
+
     PROXIMITY_METERS = 50
 
     def initialize(user:, visit:, photon:)
@@ -11,12 +13,21 @@ module Visits
     end
 
     def call
-      place = find_by_osm_id || find_by_name_and_proximity || create_place
-      @visit.update!(place_id: place.id, name: place.name)
-      place
+      with_dedup_lock do
+        place = find_by_osm_id || find_by_name_and_proximity || create_place
+        @visit.update!(place_id: place.id, name: place.name)
+        place
+      end
     end
 
     private
+
+    def with_dedup_lock(&block)
+      return block.call unless advisory_locks_enabled?
+
+      ident = @photon[:osm_id].presence || "#{@photon[:name]}:#{@photon[:latitude]}:#{@photon[:longitude]}"
+      ActiveRecord::Base.with_advisory_lock("select_place:#{@user.id}:#{ident}", &block)
+    end
 
     def find_by_osm_id
       osm_id = @photon[:osm_id]

--- a/lib/tasks/dawarich_places.rake
+++ b/lib/tasks/dawarich_places.rake
@@ -9,6 +9,11 @@ namespace :dawarich do
       end
     end
     Rails.logger.info('[dawarich:cleanup_suggested_places] enqueued')
+    Rails.logger.info(<<~MSG)
+      [dawarich:cleanup_suggested_places] To verify the drain is complete, run:
+        bin/rails runner 'puts Place.where(source: :photon, note: [nil, ""]).where.missing(:visits, :taggings).count'
+      A return value of 0 means all orphan suggested places have been deleted and it is safe to schedule the place_visits drop.
+    MSG
   end
 
   desc 'One-time backfill of legacy Place::DEFAULT_NAME rows'

--- a/spec/services/visits/place_finder_spec.rb
+++ b/spec/services/visits/place_finder_spec.rb
@@ -23,36 +23,24 @@ RSpec.describe Visits::PlaceFinder do
 
   describe '#find_or_create_place' do
     it 'returns a Place (not a hash)' do
-      allow(Places::NameFetcher).to receive(:lookup_attrs).and_return(
-        { name: 'Café Bravo', city: 'Berlin', country: 'Germany', geodata: { 'properties' => {} } }
-      )
-
       result = described_class.new(user).find_or_create_place(visit_data)
 
       expect(result).to be_a(Place)
-      expect(result.name).to eq('Café Bravo')
     end
 
     it 'creates exactly ONE place per call (no fan-out)' do
-      allow(Places::NameFetcher).to receive(:lookup_attrs).and_return(
-        { name: 'Café Bravo', city: 'Berlin', country: 'Germany', geodata: {} }
-      )
-
       expect { described_class.new(user).find_or_create_place(visit_data) }
         .to change { Place.count }.by(1)
     end
 
-    it 'falls back to Place::DEFAULT_NAME when Photon returns nothing' do
-      allow(Places::NameFetcher).to receive(:lookup_attrs).and_return(nil)
-
+    it 'creates the place with Place::DEFAULT_NAME when no suggested_name is given' do
       result = described_class.new(user).find_or_create_place(visit_data)
 
       expect(result.name).to eq(Place::DEFAULT_NAME)
       expect(result.source).to eq('photon')
     end
 
-    it 'uses suggested_name when Photon returns nothing and suggested_name is present' do
-      allow(Places::NameFetcher).to receive(:lookup_attrs).and_return(nil)
+    it 'uses suggested_name when present' do
       data = visit_data.merge(suggested_name: 'Home')
 
       expect(described_class.new(user).find_or_create_place(data).name).to eq('Home')
@@ -60,19 +48,28 @@ RSpec.describe Visits::PlaceFinder do
 
     it 'reuses an existing user place near the center' do
       existing = create(:place, user: user, latitude: 52.5126, longitude: 13.4012)
-      expect(Places::NameFetcher).not_to receive(:lookup_attrs)
 
+      expect { described_class.new(user).find_or_create_place(visit_data) }
+        .not_to have_enqueued_job(Places::NameFetchingJob)
       expect(described_class.new(user).find_or_create_place(visit_data)).to eq(existing)
     end
 
-    it 'does NOT persist geodata when store_geodata? is false' do
-      allow(Places::NameFetcher).to receive(:lookup_attrs).and_return(
-        { name: 'Café Bravo', city: 'Berlin', country: 'Germany',
-          geodata: { 'properties' => { 'osm_id' => 1 } } }
-      )
-
+    it 'never persists geodata at creation (filled by Places::NameFetchingJob)' do
       result = described_class.new(user).find_or_create_place(visit_data)
+
       expect(result.geodata).to eq({})
+    end
+
+    it 'enqueues Places::NameFetchingJob for the new place when reverse geocoding is enabled' do
+      expect { described_class.new(user).find_or_create_place(visit_data) }
+        .to have_enqueued_job(Places::NameFetchingJob).with(an_instance_of(Integer))
+    end
+
+    it 'does not enqueue Places::NameFetchingJob when reverse geocoding is disabled' do
+      allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(false)
+
+      expect { described_class.new(user).find_or_create_place(visit_data) }
+        .not_to have_enqueued_job(Places::NameFetchingJob)
     end
   end
 end


### PR DESCRIPTION
## Summary

Follow-ups identified in the review of #2745 (after it was merged). Each item below addresses one finding without changing the merged behavior contract — the public API surface is unchanged; only the implementation is tightened.

## What changes

**Perf**
- `Visits::PlaceFinder#create_default_place` no longer calls `Places::NameFetcher.lookup_attrs` inline. It creates the Place with a default name and enqueues `Places::NameFetchingJob`, so the visit-detection Sidekiq job never stalls on a slow Photon. Visible name lands on the next `:places` queue tick.
- `Api::V1::Visits::SelectPlaceController#serialize_place` reads `place.tags` once instead of three times (`first` × 2 + `map`), dropping 3 SQLs per response to 1.

**Correctness**
- `Api::V1::Visits::SelectPlaceController#photon_params` now rejects latitude outside `[-90, 90]` and longitude outside `[-180, 180]` with `422`. Previously they were silently stored verbatim.
- `Visits::SelectPlace#call` is wrapped in a PG advisory lock keyed on `(user_id, osm_id | name+coords)`. Two concurrent `POST /select_place` calls for the same Photon result now serialize instead of producing duplicate `Place` rows. No-op when advisory locks are disabled (PgBouncer transaction-pool); falls back to the original behavior.

**Hygiene**
- `Places::OrphanCleanupJob#delete_batch` replaces `exec_delete("DELETE FROM ... WHERE id IN (#{victim_ids.join(',')})")` with `Model.where(id: victim_ids).delete_all`. IDs were DB-sourced so no injection today, but the pattern was fragile.
- `lib/tasks/dawarich_places.rake#cleanup_suggested_places` now prints a `bin/rails runner '…'` one-liner so operators can confirm the orphan drain is complete before scheduling the `place_visits` drop.

**Docs**
- CHANGELOG: corrected "named synchronously from Photon" to "named asynchronously via `Places::NameFetchingJob`" in two places, plus new `Fixed` entries for the lat/lon validation and the advisory-lock dedup.
- `place_finder_spec` updated to match the new async-naming contract (verifies `NameFetchingJob` enqueue; drops sync-name expectations).

## Test plan

- [x] RuboCop: clean on all 5 modified Ruby/rake files
- [x] RSpec: 23 examples / 0 failures across `place_finder_spec`, `select_place_spec`, `select_place_controller_spec`, `orphan_cleanup_job_spec`, `dawarich_places_rake_spec`
- [ ] Manual: enqueue a visit-detection job with Photon unreachable and confirm detection completes immediately, name lands later via the `:places` queue (recommended pre-merge sanity check on staging)

## Out of scope

- The web timeline picker degradation (`_suggested_picker.html.erb`) — already partially mitigated by `fed9f157` (the merged review-response commit on #2745 added a one-line note). Full real-time rewire remains a planned follow-up release.
- Dropping `place_visits` — still deferred per the original PR plan.