### PR TITLE
Fix Stats page 500 after deleting an import (nil toponyms)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `select_place` validates lat/lon bounds (422 on out-of-range) and serializes concurrent calls via PG advisory lock to prevent duplicate Places.
 - `select_place` dedups by name + 50 m proximity instead of `geodata` JSONB, working regardless of `STORE_GEODATA`.
 - Self-hosted instances no longer 500 on Stats/Insights when `JWT_SECRET_KEY` is unset; `/trial/upgrade` now redirects home. #2682
+- Stats page no longer 500s after deleting an import or recalculating a month with no points. #2682
 - Imports table shows duplicate-skip counts and notifies when an import is all duplicates. #2721
 - Family members' positions update in real time instead of every 60 s. #2733
 - Immich/Photoprism photos reappear after a transient empty response (no more 30-minute hidden window). #1071, #784

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.7.10] - Unreleased
+
+### Fixed
+
+- Stats page no longer 500s after deleting an import or recalculating a month with no points. #2682
+
 ## [1.7.9] - Unreleased
 
 ### ⚠️ Upgrade notes
@@ -33,7 +39,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `select_place` validates lat/lon bounds (422 on out-of-range) and serializes concurrent calls via PG advisory lock to prevent duplicate Places.
 - `select_place` dedups by name + 50 m proximity instead of `geodata` JSONB, working regardless of `STORE_GEODATA`.
 - Self-hosted instances no longer 500 on Stats/Insights when `JWT_SECRET_KEY` is unset; `/trial/upgrade` now redirects home. #2682
-- Stats page no longer 500s after deleting an import or recalculating a month with no points. #2682
 - Imports table shows duplicate-skip counts and notifies when an import is all duplicates. #2721
 - Family members' positions update in real time instead of every 60 s. #2733
 - Immich/Photoprism photos reappear after a transient empty response (no more 30-minute hidden window). #1071, #784

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -76,7 +76,7 @@ module StatsHelper
     cities = []
 
     year_stats.each do |stat|
-      toponyms = stat.toponyms.flatten
+      toponyms = stat.toponyms&.flatten || []
       toponyms.each do |t|
         city_names = (t['cities'] || []).filter_map { |c| c['city'] }
         cities.concat(city_names)
@@ -91,7 +91,7 @@ module StatsHelper
     grouped = Hash.new { |h, k| h[k] = [] }
 
     year_stats.each do |stat|
-      stat.toponyms.flatten.each do |toponym|
+      (stat.toponyms&.flatten || []).each do |toponym|
         country = normalize_country_name(toponym['country'])
         next if country.blank?
 

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -9,6 +9,10 @@ class Stat < ApplicationRecord
 
   before_create :generate_sharing_uuid
 
+  def toponyms
+    super || []
+  end
+
   def distance_by_day
     monthly_points = points_for_distance_query
     calculate_daily_distances(monthly_points)

--- a/app/services/stats/calculate_month.rb
+++ b/app/services/stats/calculate_month.rb
@@ -96,7 +96,7 @@ class Stats::CalculateMonth
     stat.update!(
       daily_distance: {},
       distance: 0,
-      toponyms: nil,
+      toponyms: [],
       h3_hex_ids: {}
     )
 

--- a/spec/regressions/stats_helper_handles_nil_toponyms_spec.rb
+++ b/spec/regressions/stats_helper_handles_nil_toponyms_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StatsHelper, type: :helper do
+  describe 'rendering /stats for a year that contains a reset month' do
+    let(:user) { create(:user) }
+
+    before do
+      create(:stat, user: user, year: 2025, month: 1, toponyms: [
+               { 'country' => 'Germany', 'cities' => [{ 'city' => 'Berlin' }] }
+             ])
+
+      reset_stat = build(:stat, user: user, year: 2025, month: 2, toponyms: nil)
+      reset_stat.save!(validate: false)
+      reset_stat.update_columns(toponyms: nil)
+    end
+
+    let(:year_stats) { Stat.where(user: user, year: 2025).order(:month) }
+
+    it 'returns [] from Stat#toponyms when the column is nil' do
+      reset_stat = year_stats.find_by(month: 2)
+      expect(reset_stat.read_attribute(:toponyms)).to be_nil
+      expect(reset_stat.toponyms).to eq([])
+    end
+
+    it 'does not raise when computing countries_and_cities_stat_for_year' do
+      expect do
+        helper.countries_and_cities_stat_for_year(2025, year_stats)
+      end.not_to raise_error
+    end
+
+    it 'still counts countries from months that have data' do
+      result = helper.countries_and_cities_stat_for_year(2025, year_stats)
+
+      expect(result[:countries_count]).to eq(1)
+      expect(result[:cities_count]).to eq(1)
+    end
+  end
+
+  describe 'Stats::CalculateMonth#reset_month_stats' do
+    let(:user) { create(:user) }
+
+    it 'writes an empty array to toponyms instead of nil' do
+      stat = create(:stat, user: user, year: 2025, month: 3, toponyms: [
+                      { 'country' => 'Germany', 'cities' => [{ 'city' => 'Berlin' }] }
+                    ])
+
+      Stats::CalculateMonth.new(user.id, 2025, 3).call
+
+      expect(stat.reload.read_attribute(:toponyms)).to eq([])
+    end
+  end
+end

--- a/spec/services/stats/calculate_month_spec.rb
+++ b/spec/services/stats/calculate_month_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Stats::CalculateMonth do
           stat.reload
           expect(stat.distance).to eq(0)
           expect(stat.daily_distance).to eq({})
-          expect(stat.toponyms).to be_nil
+          expect(stat.toponyms).to eq([])
           expect(stat.h3_hex_ids).to eq({})
         end
 


### PR DESCRIPTION
## Summary

Fixes #2682 — the Stats page still 500s on 1.7.9 after a user deletes an import (or otherwise resets a month that ends up with zero points).

The earlier fix tagged #2682 addressed an adjacent path (`JWT_SECRET_KEY`). The remaining crash comes from `Stats::CalculateMonth#reset_month_stats` writing `toponyms: nil` to the legacy `stats.toponyms` column (nullable, no default). Iterating year stats on `/stats` then hits `nil.flatten` at `app/helpers/stats_helper.rb:79`:

```
ActionView::Template::Error (undefined method 'flatten' for nil)
app/helpers/stats_helper.rb:79:in 'block in StatsHelper#collect_countries_and_cities'
```

## Changes

Defence in depth — three layers, any one of which is sufficient on its own:

1. **`app/models/stat.rb`** — override `Stat#toponyms` to return `[]` when the column is `nil`. Single point of coalescing; protects every existing call site (helpers, views, serializers) regardless of how the nil got into the DB.
2. **`app/services/stats/calculate_month.rb:99`** — stop writing `nil` on reset (`toponyms: nil` → `toponyms: []`). Prevents new occurrences.
3. **`app/helpers/stats_helper.rb:79, 94`** — defensive `stat.toponyms&.flatten || []`. Last line of defence against any nil that slips past via raw SQL or older data.

## Test plan

- [x] \`bundle exec rspec spec/helpers/stats_helper_spec.rb spec/services/stats/calculate_month_spec.rb spec/models/stat_spec.rb spec/regressions/stats_helper_handles_nil_toponyms_spec.rb\` — 65 examples, 0 failures
- [x] \`bundle exec rubocop\` on all modified files — no offences
- [x] New regression spec covers: model coalescing, helper not raising on a year with a reset month, country counts still correct from non-reset months, and \`CalculateMonth\` writing \`[]\` on reset
- [x] Existing \`calculate_month_spec.rb:26\` updated to assert \`eq([])\` instead of \`be_nil\` to match the new contract

## Notes

No data migration needed — the model reader coalesces transparently. Existing \`stats\` rows with \`toponyms IS NULL\` start behaving as if they held \`[]\`.

Closes #2682