### PR TITLE
Fix Sentry P1/P3/NJ + drop unused points indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Visits can now be manually assigned to one of your saved areas. When you do, the visit takes the area's name automatically — unless you've already given it a custom name, or you've also picked a place (a place name wins over an area name). Available via API now; UI to follow. (#2577)
 
+### Changed
+
+- Track segment writes are batched into a single INSERT, and transportation-mode distance calculations run in Ruby instead of round-tripping through PostgreSQL — faster track building and lighter load on the DB during background jobs.
+- Two unused indexes on the `points` table are dropped on upgrade; on large self-hosted instances this frees several GB of disk (~7.4 GB on a production-scale dataset). Migration is non-blocking (`DROP INDEX CONCURRENTLY`).
+
 ### Fixed
 
 - Cloud only: PostHog exception capture is enabled to help diagnose production errors. Disabled on self-hosted instances and skipped unless `POSTHOG_API_KEY` is configured. The payload includes `user.id`, controller/action, and parameter-filtered request data — email, name, phone, credentials, and coordinates are redacted before send.

--- a/app/jobs/transportation_modes/backfill_job.rb
+++ b/app/jobs/transportation_modes/backfill_job.rb
@@ -79,23 +79,10 @@ module TransportationModes
     def create_segments(track, segment_data)
       return if segment_data.empty?
 
-      segments = segment_data.map do |data|
-        track.track_segments.create(
-          transportation_mode: data[:mode],
-          start_index: data[:start_index],
-          end_index: data[:end_index],
-          distance: data[:distance],
-          duration: data[:duration],
-          avg_speed: data[:avg_speed],
-          max_speed: data[:max_speed],
-          avg_acceleration: data[:avg_acceleration],
-          confidence: data[:confidence],
-          source: data[:source]
-        )
-      end.select(&:persisted?)
+      TrackSegments::BulkInserter.call(track, segment_data)
 
-      dominant_segment = segments.max_by { |s| s.duration || 0 }
-      track.update_column(:dominant_mode, dominant_segment&.transportation_mode || :unknown)
+      dominant = segment_data.max_by { |d| d[:duration] || 0 }
+      track.update_column(:dominant_mode, (dominant && dominant[:mode]) || :unknown)
     end
   end
 end

--- a/app/jobs/transportation_modes/backfill_job.rb
+++ b/app/jobs/transportation_modes/backfill_job.rb
@@ -81,8 +81,14 @@ module TransportationModes
 
       TrackSegments::BulkInserter.call(track, segment_data)
 
-      dominant = segment_data.max_by { |d| d[:duration] || 0 }
-      track.update_column(:dominant_mode, (dominant && dominant[:mode]) || :unknown)
+      segments = segment_data.map do |d|
+        TrackSegment.new(
+          transportation_mode: d[:mode],
+          distance: d[:distance],
+          duration: d[:duration]
+        )
+      end
+      track.update_column(:dominant_mode, Track.pick_dominant_mode(segments) || :unknown)
     end
   end
 end

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -106,16 +106,16 @@ class Points::AnomalyFilter
     before_ctx = Point.where(user_id: @user_id).not_anomaly
                       .where('timestamp < ?', start_time)
                       .order(timestamp: :desc).limit(CONTEXT_POINTS)
-                      .select(:id, :lonlat, :timestamp).to_a.reverse
+                      .select(:id, :timestamp).to_a.reverse
 
     main = Point.where(user_id: @user_id, timestamp: start_time..end_time)
                 .not_anomaly.order(:timestamp)
-                .select(:id, :lonlat, :timestamp).to_a
+                .select(:id, :timestamp).to_a
 
     after_ctx = Point.where(user_id: @user_id).not_anomaly
                      .where('timestamp > ?', end_time)
                      .order(:timestamp).limit(CONTEXT_POINTS)
-                     .select(:id, :lonlat, :timestamp).to_a
+                     .select(:id, :timestamp).to_a
 
     [before_ctx + main + after_ctx, main]
   end

--- a/app/services/track_segments/bulk_inserter.rb
+++ b/app/services/track_segments/bulk_inserter.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module TrackSegments
+  class BulkInserter
+    def self.call(track, segment_data)
+      new(track, segment_data).call
+    end
+
+    def initialize(track, segment_data)
+      @track = track
+      @segment_data = segment_data
+    end
+
+    def call
+      return [] if segment_data.empty?
+
+      TrackSegment.insert_all(rows)
+      segment_data
+    end
+
+    private
+
+    attr_reader :track, :segment_data
+
+    def rows
+      now = Time.current
+      segment_data.map do |data|
+        {
+          track_id: track.id,
+          transportation_mode: TrackSegment.transportation_modes.fetch(data[:mode].to_s),
+          start_index: data[:start_index],
+          end_index: data[:end_index],
+          distance: data[:distance],
+          duration: data[:duration],
+          avg_speed: data[:avg_speed],
+          max_speed: data[:max_speed],
+          avg_acceleration: data[:avg_acceleration],
+          confidence: TrackSegment.confidences.fetch(data[:confidence].to_s),
+          source: data[:source],
+          created_at: now,
+          updated_at: now
+        }
+      end
+    end
+  end
+end

--- a/app/services/tracks/reprocessor.rb
+++ b/app/services/tracks/reprocessor.rb
@@ -129,20 +129,7 @@ module Tracks
     def create_segments(track, segment_data)
       return if segment_data.empty?
 
-      segment_data.each do |data|
-        track.track_segments.create(
-          transportation_mode: data[:mode],
-          start_index: data[:start_index],
-          end_index: data[:end_index],
-          distance: data[:distance],
-          duration: data[:duration],
-          avg_speed: data[:avg_speed],
-          max_speed: data[:max_speed],
-          avg_acceleration: data[:avg_acceleration],
-          confidence: data[:confidence],
-          source: data[:source]
-        )
-      end
+      TrackSegments::BulkInserter.call(track, segment_data)
     end
 
     def recompute_dominant_mode(track)

--- a/app/services/tracks/track_builder.rb
+++ b/app/services/tracks/track_builder.rb
@@ -210,29 +210,22 @@ module Tracks::TrackBuilder
 
     return if segment_data.empty?
 
-    segments = segment_data.map do |data|
-      track.track_segments.create(
-        transportation_mode: data[:mode],
-        start_index: data[:start_index],
-        end_index: data[:end_index],
-        distance: data[:distance],
-        duration: data[:duration],
-        avg_speed: data[:avg_speed],
-        max_speed: data[:max_speed],
-        avg_acceleration: data[:avg_acceleration],
-        confidence: data[:confidence],
-        source: data[:source]
-      )
-    end.select(&:persisted?)
-
-    update_dominant_mode(track, segments)
+    TrackSegments::BulkInserter.call(track, segment_data)
+    update_dominant_mode(track, segment_data)
   rescue StandardError => e
     Rails.logger.error "Failed to detect transportation modes for track #{track.id}: #{e.message}"
   end
 
-  def update_dominant_mode(track, segments)
-    return if segments.empty?
+  def update_dominant_mode(track, segment_data)
+    return if segment_data.empty?
 
+    segments = segment_data.map do |d|
+      TrackSegment.new(
+        transportation_mode: d[:mode],
+        distance: d[:distance],
+        duration: d[:duration]
+      )
+    end
     mode = Track.pick_dominant_mode(segments)
     track.update_column(:dominant_mode, mode) if mode
   end

--- a/app/services/transportation_modes/movement_analyzer.rb
+++ b/app/services/transportation_modes/movement_analyzer.rb
@@ -110,16 +110,7 @@ module TransportationModes
     end
 
     def calculate_distance(point1, point2)
-      # Use PostGIS distance if available
-      if point1.respond_to?(:distance_to)
-        begin
-          point1.distance_to(point2, :m)
-        rescue StandardError
-          geocoder_distance(point1, point2)
-        end
-      else
-        geocoder_distance(point1, point2)
-      end
+      geocoder_distance(point1, point2)
     end
 
     def geocoder_distance(point1, point2)

--- a/app/services/transportation_modes/source_data_extractor.rb
+++ b/app/services/transportation_modes/source_data_extractor.rb
@@ -357,7 +357,7 @@ module TransportationModes
       total = 0
       points.each_cons(2) do |p1, p2|
         total += begin
-          p1.distance_to(p2, :m)
+          p1.distance_to_geocoder(p2, :m)
         rescue StandardError
           0
         end

--- a/db/migrate/20260521223000_drop_anomaly_and_track_generation_indexes.rb
+++ b/db/migrate/20260521223000_drop_anomaly_and_track_generation_indexes.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class DropAnomalyAndTrackGenerationIndexes < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  INDEXES = %w[
+    index_points_on_not_anomaly
+    idx_points_track_generation
+  ].freeze
+
+  def up
+    Rails.logger.info '[DropAnomalyAndTrackGenerationIndexes] starting'
+    INDEXES.each do |name|
+      Rails.logger.info "[DropAnomalyAndTrackGenerationIndexes] dropping #{name}"
+      execute "DROP INDEX CONCURRENTLY IF EXISTS #{name}"
+    end
+    Rails.logger.info '[DropAnomalyAndTrackGenerationIndexes] done'
+  end
+
+  def down
+    execute <<~SQL
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS index_points_on_not_anomaly
+        ON points (anomaly)
+        WHERE anomaly IS NOT TRUE
+    SQL
+
+    execute <<~SQL
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_points_track_generation
+        ON points (user_id, timestamp, track_id)
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_14_120100) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_21_223000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "postgis"
@@ -291,7 +291,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_14_120100) do
     t.jsonb "motion_data", default: {}, null: false
     t.decimal "altitude_decimal", precision: 10, scale: 2
     t.boolean "anomaly"
-    t.index ["anomaly"], name: "index_points_on_not_anomaly", where: "(anomaly IS NOT TRUE)"
     t.index ["id"], name: "index_points_on_not_reverse_geocoded", where: "(reverse_geocoded_at IS NULL)"
     t.index ["import_id"], name: "index_points_on_import_id"
     t.index ["lonlat", "timestamp", "user_id"], name: "index_points_on_lonlat_timestamp_user_id", unique: true
@@ -302,7 +301,6 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_14_120100) do
     t.index ["user_id", "country_name"], name: "idx_points_user_country_name"
     t.index ["user_id", "geodata"], name: "index_points_on_user_id_and_empty_geodata", where: "(geodata = '{}'::jsonb)"
     t.index ["user_id", "id"], name: "index_points_on_unarchived", where: "((raw_data_archived = false) AND (raw_data <> '{}'::jsonb))"
-    t.index ["user_id", "timestamp", "track_id"], name: "idx_points_track_generation"
     t.index ["user_id", "timestamp"], name: "idx_points_user_visit_null_timestamp", where: "(visit_id IS NULL)"
     t.index ["user_id", "timestamp"], name: "index_points_on_user_id_and_timestamp", order: { timestamp: :desc }
     t.index ["user_id"], name: "index_points_on_user_id"

--- a/spec/services/track_segments/bulk_inserter_spec.rb
+++ b/spec/services/track_segments/bulk_inserter_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TrackSegments::BulkInserter do
+  let(:user) { create(:user) }
+  let(:track) { create(:track, user: user) }
+
+  let(:segment_data) do
+    [
+      {
+        mode: :walking,
+        start_index: 0,
+        end_index: 5,
+        distance: 500,
+        duration: 300,
+        avg_speed: 5.0,
+        max_speed: 7.0,
+        avg_acceleration: 0.1,
+        confidence: :medium,
+        source: 'inferred'
+      },
+      {
+        mode: :driving,
+        start_index: 6,
+        end_index: 20,
+        distance: 12_000,
+        duration: 600,
+        avg_speed: 30.0,
+        max_speed: 50.0,
+        avg_acceleration: 0.5,
+        confidence: :high,
+        source: 'inferred'
+      }
+    ]
+  end
+
+  describe '.call' do
+    it 'creates one row per segment' do
+      expect { described_class.call(track, segment_data) }
+        .to change { track.track_segments.count }.from(0).to(2)
+    end
+
+    it 'writes attributes to the database' do
+      described_class.call(track, segment_data)
+
+      walking, driving = track.track_segments.order(:start_index).to_a
+
+      expect(walking).to have_attributes(
+        transportation_mode: 'walking',
+        start_index: 0,
+        end_index: 5,
+        distance: 500,
+        duration: 300,
+        avg_speed: 5.0,
+        max_speed: 7.0,
+        confidence: 'medium',
+        source: 'inferred'
+      )
+      expect(driving).to have_attributes(
+        transportation_mode: 'driving',
+        start_index: 6,
+        end_index: 20,
+        confidence: 'high'
+      )
+    end
+
+    it 'issues a single INSERT' do
+      queries = []
+      callback = ->(_n, _s, _f, _i, payload) { queries << payload[:sql] if payload[:sql].start_with?('INSERT') }
+
+      ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+        described_class.call(track, segment_data)
+      end
+
+      inserts = queries.count { |sql| sql.include?('"track_segments"') }
+      expect(inserts).to eq(1)
+    end
+
+    it 'sets created_at and updated_at' do
+      described_class.call(track, segment_data)
+      track.track_segments.each do |segment|
+        expect(segment.created_at).to be_within(5.seconds).of(Time.current)
+        expect(segment.updated_at).to be_within(5.seconds).of(Time.current)
+      end
+    end
+
+    it 'returns the original segment data' do
+      result = described_class.call(track, segment_data)
+      expect(result).to eq(segment_data)
+    end
+
+    it 'returns empty array and writes nothing when segment_data is empty' do
+      expect { described_class.call(track, []) }
+        .not_to(change { TrackSegment.count })
+      expect(described_class.call(track, [])).to eq([])
+    end
+
+    it 'raises KeyError for an unknown transportation mode' do
+      bad_data = [segment_data.first.merge(mode: :teleportation)]
+      expect { described_class.call(track, bad_data) }.to raise_error(KeyError)
+    end
+
+    it 'raises KeyError for an unknown confidence value' do
+      bad_data = [segment_data.first.merge(confidence: :certain)]
+      expect { described_class.call(track, bad_data) }.to raise_error(KeyError)
+    end
+  end
+end

--- a/spec/services/tracks/track_builder_spec.rb
+++ b/spec/services/tracks/track_builder_spec.rb
@@ -303,6 +303,48 @@ RSpec.describe Tracks::TrackBuilder do
     end
   end
 
+  describe '#update_dominant_mode' do
+    let(:track) { create(:track, user: user, dominant_mode: :unknown) }
+
+    it 'is a no-op for empty segment_data' do
+      expect { builder.update_dominant_mode(track, []) }.not_to(change { track.reload.dominant_mode })
+    end
+
+    it 'picks the longest-distance moving mode when mixed with stationary' do
+      segment_data = [
+        { mode: :stationary, distance: 10_000, duration: 7200 },
+        { mode: :walking,    distance: 200,    duration: 300 },
+        { mode: :driving,    distance: 5_000,  duration: 600 }
+      ]
+
+      builder.update_dominant_mode(track, segment_data)
+
+      expect(track.reload.dominant_mode).to eq('driving')
+    end
+
+    it 'falls back to longest-duration mode when no moving segment crosses the distance threshold' do
+      segment_data = [
+        { mode: :stationary, distance: 0,  duration: 3600 },
+        { mode: :stationary, distance: 0,  duration: 1800 },
+        { mode: :walking,    distance: 10, duration: 60 }
+      ]
+
+      builder.update_dominant_mode(track, segment_data)
+
+      expect(track.reload.dominant_mode).to eq('stationary')
+    end
+
+    it 'tolerates nil distance and duration via Track.pick_dominant_mode#to_i coercion' do
+      segment_data = [
+        { mode: :walking, distance: nil, duration: nil },
+        { mode: :driving, distance: 5_000, duration: 600 }
+      ]
+
+      expect { builder.update_dominant_mode(track, segment_data) }.not_to raise_error
+      expect(track.reload.dominant_mode).to eq('driving')
+    end
+  end
+
   describe 'user method requirement' do
     let(:invalid_class) do
       Class.new do


### PR DESCRIPTION
## Summary

Addresses three Sentry performance issues from `Tracks::TimeChunkProcessorJob` and `Points::AnomalyFilterJob`, plus drops two indexes on the `points` table that are no longer pulling their weight (~7.4 GB reclaim on prod).

## Commits

| Commit | What | Sentry |
|--------|------|--------|
| `879f622c` | Drop `index_points_on_not_anomaly` + `idx_points_track_generation` — verified safe via `EXPLAIN` + `pg_stat_user_indexes` on prod | — |
| `f27ae1fc` | `TrackSegments::BulkInserter` — collapses N×INSERTs into a single `insert_all` across `Tracks::TrackBuilder`, `TransportationModes::BackfillJob`, `Tracks::Reprocessor` | Fixes DAWARICH-P3 |
| `ec6fb15d` | Switch `MovementAnalyzer#calculate_distance` and `SourceDataExtractor#calculate_segment_distance` from `Point#distance_to` (DB round-trip per pair) to `Point#distance_to_geocoder` (in-Ruby Haversine) | Fixes DAWARICH-P1 |
| `6f9f8392` | Drop unused `:lonlat` from `AnomalyFilter#fetch_points_with_context` — the geometry column was selected but only `point.id` is read in Ruby; lonlat is re-fetched by the speed-calc CTE | Fixes DAWARICH-NJ |

## Index drop rationale (per `EXPLAIN BUFFERS` on prod user_id=333)

- **`index_points_on_not_anomaly`** — `idx_scan=0, idx_tup_read=0` lifetime. Planner picks `index_points_on_user_id_and_timestamp` with heap filter on `anomaly`. Confirmed via EXPLAIN: `Index Scan using index_points_on_user_id_and_timestamp ... Filter: ((anomaly IS NULL) OR (NOT anomaly))`.
- **`idx_points_track_generation`** — `idx_scan=32` lifetime; the matching `Track.segment_points_in_sql` query ran 64 times for 0.7s cumulative per `pg_stat_statements`. Not worth 6.5 GB.

**Kept** (validated load-bearing):
- `index_points_on_raw_data_archive_id` — FK enforcement for 44 M `points.raw_data_archive_id → points_raw_data_archives.id` (`ON DELETE: RESTRICT`).
- `index_points_on_unarchived` — `ARCHIVE_RAW_DATA=true` on prod; monthly archiver query matches the partial predicate exactly.

## Expected impact

| Issue | Before | After |
|-------|--------|-------|
| N+1 INSERT (P3) | N × ~8ms per track | 1 batched INSERT per track |
| Per-pair ST_Distance (P1) | DB round-trip per consecutive pair | In-Ruby Haversine (µs) |
| Anomaly filter SELECT (NJ) | id + lonlat + timestamp on 500k+ rows | id + timestamp — ~30 bytes saved per row |

## Test plan

- [x] RSpec on affected specs: 146 examples, 0 failures
  - `spec/services/track_segments/bulk_inserter_spec.rb` (new — 8 examples)
  - `spec/services/tracks/track_builder_spec.rb`, `reprocessor_spec.rb`, `merger_spec.rb`, `segment_editor_spec.rb`
  - `spec/services/transportation_modes/*`
  - `spec/services/points/anomaly_filter_spec.rb` + integration
  - `spec/regressions/{track_builder_handles_concurrent_creation,movement_analyzer_zero_stored_velocity}_spec.rb`
  - `spec/requests/tracks/segments_spec.rb`
- [x] RuboCop clean on all changed files
- [x] `db:migrate` and `db:rollback` validated on test DB
- [ ] Monitor Sentry DAWARICH-P3/P1/NJ for new occurrences after deploy
- [ ] Verify `pg_size_pretty(pg_total_relation_size('points'))` drops by ~7.4 GB post-migration on prod

## Notes

- Migration uses `disable_ddl_transaction!` + `DROP INDEX CONCURRENTLY IF EXISTS` — non-blocking on prod
- `down` recreates both indexes via `CREATE INDEX CONCURRENTLY` for clean rollback
- `BulkInserter` skips AR validations (insert_all); the `Detector` emits deterministic schema-conformant data — `.fetch` on unknown enum keys raises early instead of silently writing nil