### PR TITLE
Gate visit detection on real-point stationarity; tunable min duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Map v2 family member markers show name + last-seen datetime on hover.
 - Map v2 area info card exposes an **Edit** button that opens the area modal pre-filled — rename and resize existing areas without redrawing. Backed by a new `PATCH /areas/:id` route.
 - Map v2 selection tool: **Delete N Anomaly Points** button appears when the selection contains anomaly points, so you can clean up GPS noise without touching real points.
+- New **Minimum visit duration** setting under Settings → Visit detection (1–60 minutes, default 5). Raise it to ignore short drive-bys; lower it to catch brief errands. Replaces the hardcoded 3-minute floor that was the same for everyone in 1.7.8–1.7.9.
 
 ### Changed
 
@@ -22,6 +23,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 Place creation modal now closes on successful submit — the success path is no longer gated on a Turbo Stream side-effect, so the modal always dismisses after the place is saved.
 - Stats page no longer 500s after deleting an import or recalculating a month with no points. #2682
+- Visit detection no longer suggests stops at places you only drove past. Clusters where the device was moving faster than walking pace between real GPS points are rejected, so road centerlines on busy arterials stop showing up as "visits" to Kent Street / Leach Highway / etc. #2736 #2775
+- Visit detection requires real GPS points (not interpolated density-fill ghost points) to meet the minimum-points threshold, so a single drive between two real fixes can't be inflated into a visit. #2736
+- Smart density fill (`visit_density_fill_enabled`) actually fires now — its SQL parameters were swapped in 1.7.8 so the WHERE clauses contradicted each other and no synthetic points were ever generated.
 
 
 ## [1.7.9] - 2026-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Visit detection no longer suggests stops at places you only drove past. Clusters where the device was moving faster than walking pace between real GPS points are rejected, so road centerlines on busy arterials stop showing up as "visits" to Kent Street / Leach Highway / etc. #2736 #2775
 - Visit detection requires real GPS points (not interpolated density-fill ghost points) to meet the minimum-points threshold, so a single drive between two real fixes can't be inflated into a visit. #2736
 - Smart density fill (`visit_density_fill_enabled`) actually fires now — its SQL parameters were swapped in 1.7.8 so the WHERE clauses contradicted each other and no synthetic points were ever generated.
+- Visit detection now honors your **Visit time threshold** setting (`time_threshold_minutes`) when splitting same-location points into separate visits. Previously hardcoded to 30 minutes in the DBSCAN SQL regardless of the saved value.
 
 
 ## [1.7.9] - 2026-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### ⚠️ Upgrade notes
 
-- **Visit detection thresholds changed.** The hardcoded 3-minute minimum-visit floor used in 1.7.8/1.7.9 is replaced by a new user-configurable setting (**Settings → Visit detection → Minimum visit duration**) with a default of **5 minutes**. If you want the previous looser behavior — including 3-minute "did I really stop here?" suggestions — lower this setting after upgrade.
-- **Smart density fill now actually fires.** A parameter-binding bug in 1.7.8 disabled it silently for everyone. Users who left `visit_density_fill_enabled` on (the default) may see more visit suggestions on sparse-tracking days starting with the next nightly run; users on dense trackers will see no change. Turn the setting off in Settings → Visit detection if you don't want it.
+- Minimum visit duration default is now 5 min (was hardcoded 3 min). Lower it under **Settings → Visit detection** to keep shorter suggestions.
+- Smart density fill was a no-op in 1.7.8–1.7.9 due to a param bug; now active. Expect more visit suggestions on sparse-tracking days unless you turn it off.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Stats page no longer 500s after deleting an import or recalculating a month with no points. #2682
 - Visit detection no longer suggests stops at places you only drove past. Clusters where the device was moving faster than walking pace between real GPS points are rejected, so road centerlines on busy arterials stop showing up as "visits" to Kent Street / Leach Highway / etc. #2736 #2775
 - Visit detection requires real GPS points (not interpolated density-fill ghost points) to meet the minimum-points threshold, so a single drive between two real fixes can't be inflated into a visit. #2736
-- Smart density fill (`visit_density_fill_enabled`) actually fires now — its SQL parameters were swapped in 1.7.8 so the WHERE clauses contradicted each other and no synthetic points were ever generated.
-- Visit detection now honors your **Visit time threshold** setting (`time_threshold_minutes`) when splitting same-location points into separate visits. Previously hardcoded to 30 minutes in the DBSCAN SQL regardless of the saved value.
+- Smart density fill now works correctly — it was silently disabled in 1.7.8 and 1.7.9.
+- Visit detection now respects your **Visit time threshold** setting when deciding where one visit ends and the next begins. The setting was previously ignored and always treated as 30 minutes.
 
 
 ## [1.7.9] - 2026-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.7.10] - Unreleased
 
+### ⚠️ Upgrade notes
+
+- **Visit detection thresholds changed.** The hardcoded 3-minute minimum-visit floor used in 1.7.8/1.7.9 is replaced by a new user-configurable setting (**Settings → Visit detection → Minimum visit duration**) with a default of **5 minutes**. If you want the previous looser behavior — including 3-minute "did I really stop here?" suggestions — lower this setting after upgrade.
+- **Smart density fill now actually fires.** A parameter-binding bug in 1.7.8 disabled it silently for everyone. Users who left `visit_density_fill_enabled` on (the default) may see more visit suggestions on sparse-tracking days starting with the next nightly run; users on dense trackers will see no change. Turn the setting off in Settings → Visit detection if you don't want it.
+
 ### Added
 
 - Map v2 family member markers show name + last-seen datetime on hover.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### ⚠️ Upgrade notes
 
-- Minimum visit duration default is now 5 min (was hardcoded 3 min). Lower it under **Settings → Visit detection** to keep shorter suggestions.
-- Smart density fill was a no-op in 1.7.8–1.7.9 due to a param bug; now active. Expect more visit suggestions on sparse-tracking days unless you turn it off.
+- Stops shorter than 5 minutes are no longer suggested as visits by default. Change the threshold under **Settings → Visit detection** if you want shorter stops included.
+- Smart density fill now works correctly (it was broken in 1.7.8–1.7.9). You may see more visit suggestions, especially on days when your tracker recorded points unevenly.
 
 ### Added
 

--- a/app/controllers/settings/visits_controller.rb
+++ b/app/controllers/settings/visits_controller.rb
@@ -15,7 +15,8 @@ class Settings::VisitsController < ApplicationController
   private
 
   def settings_params
-    params.require(:settings).permit(:visit_radius_meters, :visit_min_points, :visit_density_fill_enabled)
+    params.require(:settings).permit(:visit_radius_meters, :visit_min_points,
+                                     :visit_min_duration_minutes, :visit_density_fill_enabled)
   end
 
   def coerced_settings_params
@@ -23,6 +24,9 @@ class Settings::VisitsController < ApplicationController
     coerced = {}
     coerced['visit_radius_meters'] = raw['visit_radius_meters'].to_i if raw.key?('visit_radius_meters')
     coerced['visit_min_points']    = raw['visit_min_points'].to_i    if raw.key?('visit_min_points')
+    if raw.key?('visit_min_duration_minutes')
+      coerced['visit_min_duration_minutes'] = raw['visit_min_duration_minutes'].to_i
+    end
     if raw.key?('visit_density_fill_enabled')
       coerced['visit_density_fill_enabled'] =
         ActiveModel::Type::Boolean.new.cast(raw['visit_density_fill_enabled'])

--- a/app/services/users/safe_settings.rb
+++ b/app/services/users/safe_settings.rb
@@ -56,6 +56,7 @@ class Users::SafeSettings
     'timezone' => ENV.fetch('TIME_ZONE', 'UTC'),
     'visit_radius_meters' => 100,
     'visit_min_points' => 3,
+    'visit_min_duration_minutes' => 5,
     'visit_density_fill_enabled' => true
   }.freeze
 
@@ -102,6 +103,7 @@ class Users::SafeSettings
       timezone: timezone,
       visit_radius_meters: visit_radius_meters,
       visit_min_points: visit_min_points,
+      visit_min_duration_minutes: visit_min_duration_minutes,
       visit_density_fill_enabled: visit_density_fill_enabled?
     }
   end
@@ -290,6 +292,11 @@ class Users::SafeSettings
 
   def visit_min_points
     settings['visit_min_points'].to_i.clamp(2, 20)
+  end
+
+  def visit_min_duration_minutes
+    raw = settings['visit_min_duration_minutes'] || DEFAULT_VALUES['visit_min_duration_minutes']
+    raw.to_i.clamp(1, 60)
   end
 
   def visit_density_fill_enabled?

--- a/app/services/users/safe_settings.rb
+++ b/app/services/users/safe_settings.rb
@@ -133,7 +133,7 @@ class Users::SafeSettings
   end
 
   def time_threshold_minutes
-    settings['time_threshold_minutes'].to_i
+    settings['time_threshold_minutes'].to_i.clamp(1, 1440)
   end
 
   def merge_threshold_minutes

--- a/app/services/visits/dbscan_clusterer.rb
+++ b/app/services/visits/dbscan_clusterer.rb
@@ -2,7 +2,6 @@
 
 module Visits
   class DbscanClusterer
-    MIN_DURATION_SECONDS = 180
     QUERY_TIMEOUT_MS = 30_000
     MAX_SYNTHETIC_PER_GAP = 200
     MAX_CANDIDATE_POINTS = 100_000
@@ -10,6 +9,7 @@ module Visits
     DENSITY_MAX_GAP_SECONDS = 12 * 3600
     DENSITY_MAX_DISTANCE_METERS = 50
     TIME_GAP_SECONDS = 30 * 60
+    STATIONARY_SPEED_MPS = 1.4
 
     attr_reader :user, :start_at, :end_at
 
@@ -90,6 +90,10 @@ module Visits
       user.safe_settings.visit_min_points
     end
 
+    def min_duration_seconds
+      user.safe_settings.visit_min_duration_minutes * 60
+    end
+
     def density_enabled?
       user.safe_settings.visit_density_fill_enabled?
     end
@@ -109,10 +113,11 @@ module Visits
     def dbscan_sql
       params = [
         user.id, start_at, end_at,
-        density_threshold_seconds, density_max_gap_seconds, density_max_distance_meters,
         MAX_SYNTHETIC_PER_GAP,
+        density_threshold_seconds, density_max_gap_seconds, density_max_distance_meters,
         eps_meters, min_points,
-        TIME_GAP_SECONDS, min_points, MIN_DURATION_SECONDS
+        TIME_GAP_SECONDS,
+        min_points, min_points, min_duration_seconds, STATIONARY_SPEED_MPS
       ]
       ActiveRecord::Base.sanitize_sql_array([<<-SQL.squish, *params])
         WITH candidate_points AS (
@@ -186,18 +191,50 @@ module Visits
           SELECT *,
             CONCAT(spatial_cluster, '-', SUM(new_segment) OVER (PARTITION BY spatial_cluster ORDER BY timestamp)) AS visit_id
           FROM gap_detection
+        ),
+        real_point_motion AS (
+          SELECT
+            visit_id,
+            id,
+            lonlat,
+            timestamp,
+            LAG(lonlat) OVER (PARTITION BY visit_id ORDER BY timestamp) AS prev_lonlat,
+            LAG(timestamp) OVER (PARTITION BY visit_id ORDER BY timestamp) AS prev_timestamp
+          FROM visit_groups
+          WHERE id > 0
+        ),
+        visit_motion AS (
+          SELECT
+            visit_id,
+            COUNT(*) AS real_point_count,
+            AVG(
+              CASE
+                WHEN prev_lonlat IS NULL OR (timestamp - prev_timestamp) <= 0 THEN NULL
+                ELSE ST_Distance(lonlat::geography, prev_lonlat::geography)::double precision
+                     / (timestamp - prev_timestamp)
+              END
+            ) AS avg_speed_mps
+          FROM real_point_motion
+          GROUP BY visit_id
         )
         SELECT
-          visit_id,
-          array_agg(id ORDER BY timestamp) AS point_ids,
-          MIN(timestamp) AS start_time,
-          MAX(timestamp) AS end_time,
-          COUNT(*) AS point_count
-        FROM visit_groups
-        GROUP BY visit_id
+          vg.visit_id,
+          array_agg(vg.id ORDER BY vg.timestamp) FILTER (WHERE vg.id > 0) AS point_ids,
+          MIN(vg.timestamp) FILTER (WHERE vg.id > 0) AS start_time,
+          MAX(vg.timestamp) FILTER (WHERE vg.id > 0) AS end_time,
+          COUNT(*) FILTER (WHERE vg.id > 0) AS point_count
+        FROM visit_groups vg
+        JOIN visit_motion vm USING (visit_id)
+        GROUP BY vg.visit_id, vm.real_point_count, vm.avg_speed_mps
         HAVING COUNT(*) >= ?
-          AND MAX(timestamp) - MIN(timestamp) >= ?
-        ORDER BY MIN(timestamp)
+          AND vm.real_point_count >= ?
+          AND COALESCE(
+                MAX(vg.timestamp) FILTER (WHERE vg.id > 0)
+                - MIN(vg.timestamp) FILTER (WHERE vg.id > 0),
+                0
+              ) >= ?
+          AND (vm.avg_speed_mps IS NULL OR vm.avg_speed_mps <= ?::double precision)
+        ORDER BY MIN(vg.timestamp) FILTER (WHERE vg.id > 0)
       SQL
     end
   end

--- a/app/services/visits/dbscan_clusterer.rb
+++ b/app/services/visits/dbscan_clusterer.rb
@@ -120,7 +120,7 @@ module Visits
         density_threshold_seconds, density_max_gap_seconds, density_max_distance_meters,
         eps_meters, min_points,
         time_gap_seconds,
-        min_points, min_points, min_duration_seconds, STATIONARY_SPEED_MPS
+        min_points, min_duration_seconds, STATIONARY_SPEED_MPS
       ]
       ActiveRecord::Base.sanitize_sql_array([<<-SQL.squish, *params])
         WITH candidate_points AS (
@@ -229,8 +229,7 @@ module Visits
         FROM visit_groups vg
         JOIN visit_motion vm USING (visit_id)
         GROUP BY vg.visit_id, vm.real_point_count, vm.avg_speed_mps
-        HAVING COUNT(*) >= ?
-          AND vm.real_point_count >= ?
+        HAVING vm.real_point_count >= ?
           AND COALESCE(
                 MAX(vg.timestamp) FILTER (WHERE vg.id > 0)
                 - MIN(vg.timestamp) FILTER (WHERE vg.id > 0),

--- a/app/services/visits/dbscan_clusterer.rb
+++ b/app/services/visits/dbscan_clusterer.rb
@@ -8,7 +8,6 @@ module Visits
     DENSITY_GAP_THRESHOLD_SECONDS = 60
     DENSITY_MAX_GAP_SECONDS = 12 * 3600
     DENSITY_MAX_DISTANCE_METERS = 50
-    TIME_GAP_SECONDS = 30 * 60
     STATIONARY_SPEED_MPS = 1.4
 
     attr_reader :user, :start_at, :end_at
@@ -94,6 +93,10 @@ module Visits
       user.safe_settings.visit_min_duration_minutes * 60
     end
 
+    def time_gap_seconds
+      user.safe_settings.time_threshold_minutes * 60
+    end
+
     def density_enabled?
       user.safe_settings.visit_density_fill_enabled?
     end
@@ -116,7 +119,7 @@ module Visits
         MAX_SYNTHETIC_PER_GAP,
         density_threshold_seconds, density_max_gap_seconds, density_max_distance_meters,
         eps_meters, min_points,
-        TIME_GAP_SECONDS,
+        time_gap_seconds,
         min_points, min_points, min_duration_seconds, STATIONARY_SPEED_MPS
       ]
       ActiveRecord::Base.sanitize_sql_array([<<-SQL.squish, *params])

--- a/app/services/visits/dbscan_clusterer.rb
+++ b/app/services/visits/dbscan_clusterer.rb
@@ -210,13 +210,21 @@ module Visits
           SELECT
             visit_id,
             COUNT(*) AS real_point_count,
-            AVG(
+            SUM(
               CASE
-                WHEN prev_lonlat IS NULL OR (timestamp - prev_timestamp) <= 0 THEN NULL
-                ELSE ST_Distance(lonlat::geography, prev_lonlat::geography)::double precision
-                     / (timestamp - prev_timestamp)
+                WHEN prev_lonlat IS NULL OR (timestamp - prev_timestamp) <= 0 THEN 0
+                ELSE ST_Distance(lonlat::geography, prev_lonlat::geography)
               END
-            ) AS avg_speed_mps
+            )::double precision
+            / NULLIF(
+                SUM(
+                  CASE
+                    WHEN prev_lonlat IS NULL OR (timestamp - prev_timestamp) <= 0 THEN 0
+                    ELSE (timestamp - prev_timestamp)
+                  END
+                ),
+                0
+              ) AS avg_speed_mps
           FROM real_point_motion
           GROUP BY visit_id
         )

--- a/app/views/settings/visits/show.html.erb
+++ b/app/views/settings/visits/show.html.erb
@@ -32,6 +32,15 @@
           </div>
 
           <div class="form-control mb-4">
+            <%= sf.label :visit_min_duration_minutes, 'Minimum visit duration (minutes)', class: 'label-text font-semibold' %>
+            <%= sf.number_field :visit_min_duration_minutes,
+                                value: current_user.safe_settings.visit_min_duration_minutes,
+                                in: 1..60, step: 1,
+                                class: 'input input-bordered w-32' %>
+            <span class="text-xs opacity-70 mt-1">Skip stops shorter than this. Raise to ignore short drive-bys; lower to catch brief errands. Default 5.</span>
+          </div>
+
+          <div class="form-control mb-4">
             <label class="label cursor-pointer justify-start gap-3">
               <%= sf.check_box :visit_density_fill_enabled,
                                { checked: current_user.safe_settings.visit_density_fill_enabled?,

--- a/spec/services/users/safe_settings_spec.rb
+++ b/spec/services/users/safe_settings_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Users::SafeSettings do
             timezone: 'UTC',
             visit_radius_meters: 100,
             visit_min_points: 3,
+            visit_min_duration_minutes: 5,
             visit_density_fill_enabled: true
           }
         )
@@ -138,6 +139,7 @@ RSpec.describe Users::SafeSettings do
             'timezone' => 'UTC',
             'visit_radius_meters' => 100,
             'visit_min_points' => 3,
+            'visit_min_duration_minutes' => 5,
             'visit_density_fill_enabled' => true
           }
         )
@@ -192,6 +194,7 @@ RSpec.describe Users::SafeSettings do
             timezone: 'UTC',
             visit_radius_meters: 100,
             visit_min_points: 3,
+            visit_min_duration_minutes: 5,
             visit_density_fill_enabled: true
           }
         )

--- a/spec/services/visits/dbscan_clusterer_spec.rb
+++ b/spec/services/visits/dbscan_clusterer_spec.rb
@@ -107,6 +107,48 @@ RSpec.describe Visits::DbscanClusterer do
     end
   end
 
+  describe 'user-tunable time-gap (same-cluster segmentation)' do
+    let(:settings_without_density_fill) do
+      { 'visit_density_fill_enabled' => false, 'visit_min_duration_minutes' => 1 }
+    end
+
+    it 'splits a stationary cluster into two visits when points cross the gap threshold' do
+      user.update!(settings: (user.settings || {}).merge(settings_without_density_fill,
+                                                        'time_threshold_minutes' => 10))
+
+      6.times do |i|
+        drift = i * 0.00001
+        make_point(at: base_ts + i * 30, lat: 52.5 + drift, lon: 13.4 + drift)
+      end
+      6.times do |i|
+        drift = i * 0.00001
+        make_point(at: base_ts + 900 + i * 30, lat: 52.5 + drift, lon: 13.4 + drift)
+      end
+
+      clusters = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 1200).call
+
+      expect(clusters.size).to eq(2)
+    end
+
+    it 'keeps the same cluster as one visit when the gap stays under the threshold' do
+      user.update!(settings: (user.settings || {}).merge(settings_without_density_fill,
+                                                        'time_threshold_minutes' => 30))
+
+      6.times do |i|
+        drift = i * 0.00001
+        make_point(at: base_ts + i * 30, lat: 52.5 + drift, lon: 13.4 + drift)
+      end
+      6.times do |i|
+        drift = i * 0.00001
+        make_point(at: base_ts + 900 + i * 30, lat: 52.5 + drift, lon: 13.4 + drift)
+      end
+
+      clusters = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 1200).call
+
+      expect(clusters.size).to eq(1)
+    end
+  end
+
   describe 'user-tunable minimum duration' do
     it 'respects visit_min_duration_minutes when raised above the default' do
       user.update!(settings: (user.settings || {}).merge('visit_min_duration_minutes' => 20))

--- a/spec/services/visits/dbscan_clusterer_spec.rb
+++ b/spec/services/visits/dbscan_clusterer_spec.rb
@@ -4,20 +4,26 @@ require 'rails_helper'
 
 RSpec.describe Visits::DbscanClusterer do
   let(:user) { create(:user) }
+  let(:base_ts) { 1_700_000_000 }
+
+  def make_point(at:, lat:, lon:, accuracy: 10, owner: user)
+    create(:point, user: owner, latitude: lat, longitude: lon,
+                   lonlat: "POINT(#{lon} #{lat})",
+                   timestamp: at, accuracy: accuracy, visit_id: nil)
+  end
 
   describe 'synthetic-point cap' do
     it 'caps generated synthetic points at MAX_SYNTHETIC_PER_GAP per gap' do
-      now = 1_700_000_000
-      far_future = now + 24 * 3600
-      create(:point, user: user, latitude: 52.5, longitude: 13.4, lonlat: 'POINT(13.4 52.5)',
-                     timestamp: now, accuracy: 10, visit_id: nil)
-      create(:point, user: user, latitude: 52.5001, longitude: 13.4001, lonlat: 'POINT(13.4001 52.5001)',
-                     timestamp: far_future, accuracy: 10, visit_id: nil)
+      make_point(at: base_ts,        lat: 52.5,      lon: 13.4)
+      make_point(at: base_ts + 1800, lat: 52.50001,  lon: 13.40001)
+      make_point(at: base_ts + 1830, lat: 52.500011, lon: 13.400011)
 
-      clusters = described_class.new(user, start_at: now - 1, end_at: far_future + 1).call
-      total_points = clusters.sum { |c| c[:point_count] }
+      clusters = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 1900).call
 
-      expect(total_points).to be <= described_class::MAX_SYNTHETIC_PER_GAP + 2
+      expect(clusters.size).to be <= 1
+      next if clusters.empty?
+
+      expect(clusters.first[:point_count]).to be <= described_class::MAX_SYNTHETIC_PER_GAP + 3
     end
   end
 
@@ -44,8 +50,7 @@ RSpec.describe Visits::DbscanClusterer do
     it 'emits a single structured INFO log on success' do
       ts = 1_700_000_000
       3.times do |i|
-        create(:point, user: user, latitude: 52.5, longitude: 13.4, lonlat: 'POINT(13.4 52.5)',
-                       timestamp: ts + i * 60, accuracy: 10, visit_id: nil)
+        make_point(at: ts + i * 60, lat: 52.5, lon: 13.4)
       end
 
       header = /\[Visits::DbscanClusterer\] user_id=#{user.id} range=\d+\.\.\d+/
@@ -53,6 +58,80 @@ RSpec.describe Visits::DbscanClusterer do
       expect(Rails.logger).to receive(:info).with(a_string_matching(log_pattern))
 
       described_class.new(user, start_at: ts - 1, end_at: ts + 600).call
+    end
+  end
+
+  describe 'stationarity gate' do
+    it 'accepts a clustered stop where the device is not moving' do
+      6.times do |i|
+        drift = i * 0.00001
+        make_point(at: base_ts + i * 60, lat: 52.5 + drift, lon: 13.4 + drift)
+      end
+
+      clusters = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 400).call
+
+      expect(clusters.size).to eq(1)
+      expect(clusters.first[:point_count]).to eq(6)
+    end
+
+    it 'rejects a drive-by cluster moving along a road faster than walking pace' do
+      6.times do |i|
+        lat_offset = i * 0.0005
+        make_point(at: base_ts + i * 12, lat: 52.5 + lat_offset, lon: 13.4)
+      end
+
+      clusters = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 100).call
+
+      expect(clusters).to be_empty
+    end
+
+    it 'rejects a cluster whose real points are dominated by sustained movement' do
+      make_point(at: base_ts,       lat: 52.5,    lon: 13.4)
+      make_point(at: base_ts + 60,  lat: 52.5003, lon: 13.4)
+      make_point(at: base_ts + 120, lat: 52.5006, lon: 13.4)
+
+      clusters = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 200).call
+
+      expect(clusters).to be_empty
+    end
+  end
+
+  describe 'minimum real points (synthetic fill cannot fabricate a visit)' do
+    it 'rejects a cluster where only two real points are surrounded by synthetic fill' do
+      make_point(at: base_ts,       lat: 52.5,     lon: 13.4)
+      make_point(at: base_ts + 600, lat: 52.50005, lon: 13.40005)
+
+      clusters = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 700).call
+
+      expect(clusters).to be_empty
+    end
+  end
+
+  describe 'user-tunable minimum duration' do
+    it 'respects visit_min_duration_minutes when raised above the default' do
+      user.update!(settings: (user.settings || {}).merge('visit_min_duration_minutes' => 20))
+
+      6.times do |i|
+        drift = i * 0.00001
+        make_point(at: base_ts + i * 60, lat: 52.5 + drift, lon: 13.4 + drift)
+      end
+
+      clusters = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 400).call
+
+      expect(clusters).to be_empty
+    end
+
+    it 'accepts shorter visits when visit_min_duration_minutes is lowered' do
+      user.update!(settings: (user.settings || {}).merge('visit_min_duration_minutes' => 2))
+
+      4.times do |i|
+        drift = i * 0.00001
+        make_point(at: base_ts + i * 60, lat: 52.5 + drift, lon: 13.4 + drift)
+      end
+
+      clusters = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 300).call
+
+      expect(clusters.size).to eq(1)
     end
   end
 end

--- a/spec/services/visits/dbscan_clusterer_spec.rb
+++ b/spec/services/visits/dbscan_clusterer_spec.rb
@@ -20,9 +20,7 @@ RSpec.describe Visits::DbscanClusterer do
 
       clusters = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 1900).call
 
-      expect(clusters.size).to be <= 1
-      next if clusters.empty?
-
+      expect(clusters.size).to eq(1)
       expect(clusters.first[:point_count]).to be <= described_class::MAX_SYNTHETIC_PER_GAP + 3
     end
   end
@@ -86,9 +84,12 @@ RSpec.describe Visits::DbscanClusterer do
     end
 
     it 'rejects a cluster whose real points are dominated by sustained movement' do
-      make_point(at: base_ts,       lat: 52.5,    lon: 13.4)
-      make_point(at: base_ts + 60,  lat: 52.5003, lon: 13.4)
-      make_point(at: base_ts + 120, lat: 52.5006, lon: 13.4)
+      user.update!(settings: (user.settings || {}).merge('visit_min_duration_minutes' => 1))
+
+      6.times do |i|
+        lat_offset = i * 0.0005
+        make_point(at: base_ts + i * 30, lat: 52.5 + lat_offset, lon: 13.4)
+      end
 
       clusters = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 200).call
 

--- a/spec/services/visits/smart_detect_spec.rb
+++ b/spec/services/visits/smart_detect_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Visits::SmartDetect do
 
   describe 'happy path' do
     it 'creates visits when DBSCAN finds clusters' do
-      5.times do |i|
+      6.times do |i|
         create(:point, user: user, latitude: 52.5, longitude: 13.4, lonlat: 'POINT(13.4 52.5)',
                        timestamp: base_ts + i * 60, accuracy: 10, visit_id: nil)
       end


### PR DESCRIPTION
## Summary

Visit suggestions in 1.7.8/1.7.9 land on arterial road centerlines for drive-by patterns. DBSCAN clusters anything within `visit_radius_meters` regardless of speed; the accuracy-weighted centroid of a "drove past this corner many times" cluster sits on the road, so reverse-geocode returns "Kent Street" / "Leach Highway" instead of the supermarket the user actually stopped at. Same root cause as #2775 (1.7.9 random spots) — the 1.7.9 fixes touched Place-per-visit and `select_place`, not clustering thresholds.

Three structural changes in `Visits::DbscanClusterer`, plus a user-tunable duration:

1. **Stationarity gate.** New CTEs compute `avg_speed_mps` over consecutive **real** points (synthetic fill excluded via `id > 0`). Clusters above `STATIONARY_SPEED_MPS = 1.4` (≈5 km/h walking pace) are rejected before reaching `Visits::Creator`. Drive-bys along a road no longer qualify.

2. **Real-point floor.** `HAVING` requires `real_point_count >= visit_min_points` so density-fill synthetics cannot fabricate a visit from two real fixes plus 200 interpolated ghosts.

3. **SQL param binding.** The existing params array was off-by-N relative to `?` placeholders in `synthetic_points`. Effective WHERE became `gap_seconds > 43200 AND gap_seconds <= 50` — unsatisfiable. **`visit_density_fill_enabled` has been dead code for everyone since 1.7.8.** Params reordered to match SQL position; the feature actually fires now.

`MIN_DURATION_SECONDS = 180` (hardcoded) replaced by `user.safe_settings.visit_min_duration_minutes` — new setting with default 5, clamp 1..60, surfaced under **Settings → Visit detection**.

## Risks / calibration notes

- **`STATIONARY_SPEED_MPS = 1.4`** is a constant, not a setting. Users with very noisy GPS (drift > 1.4 m/s while truly stationary) could lose visits. `AVG()` across all consecutive-pair speeds damps single-noise spikes. If wrong in practice, swap to `percentile_cont(0.5)` or expose as a setting.
- **Default min duration 5 min** is stricter than the prior hardcoded 3 min. Self-hosters who relied on the looser threshold can lower the new setting. Worth calling out in the 1.7.10 release notes.
- **Density-fill becoming active** is functionally new behavior for users who had it "enabled but inoperative" pre-fix. Net effect with the new gates: fewer-but-better visits; worst case sparse-tracker users see slightly more visits in their next nightly run.

## Test plan

- [x] `bundle exec rspec spec/services/visits/ spec/services/users/safe_settings_spec.rb` → 244 examples, 0 failures
- [x] `bundle exec rubocop` clean on touched files
- [x] 5 new regression specs in `spec/services/visits/dbscan_clusterer_spec.rb`:
  - stationary stop accepted
  - drive-by along a road rejected
  - sustained-movement cluster rejected
  - 2 real points + density fill cannot fabricate a visit
  - user-tunable duration respected in both directions
- [ ] Manual: run **Re-run detection on full history** on a multi-month commute dataset and confirm road-centerline ghost visits drop out
- [ ] Calibration review: confirm `STATIONARY_SPEED_MPS = 1.4` and default `visit_min_duration_minutes = 5` before merging

Closes #2736
Closes #2775