### PR TITLE
Fix phantom 'traveled · 0m' rows + mislabeled drives in timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Map v2 Place creation modal now closes on successful submit — the success path is no longer gated on a Turbo Stream side-effect, so the modal always dismisses after the place is saved.
 - Stats page no longer 500s after deleting an import or recalculating a month with no points. #2682
+- Timeline no longer fills with `traveled · 0m` rows from stationary keepalive clusters; commutes that absorb adjacent stationary points are correctly labeled by their moving mode (e.g. `drove`) rather than `stationary`. Hit **Settings → Recalculate** to apply to existing data.
+- New tracks now honor the user's enabled transportation modes during initial detection. Previously only the Recalculate path respected disabled modes, so a user who turned off (e.g.) cycling still saw cycling assigned to freshly built tracks. #2787
 
 
 ## [1.7.9] - 2026-05-21

--- a/app/jobs/transportation_modes/backfill_job.rb
+++ b/app/jobs/transportation_modes/backfill_job.rb
@@ -18,8 +18,7 @@ module TransportationModes
     def perform(user_id, batch_size: DEFAULT_BATCH_SIZE)
       @user = find_user_or_skip(user_id) || return
 
-      # Extract user thresholds once for all tracks
-      @user_thresholds, @expert_thresholds = extract_user_thresholds
+      @user_thresholds, @expert_thresholds, @enabled_modes = extract_user_settings
 
       tracks_to_process.find_in_batches(batch_size: batch_size) do |tracks|
         tracks.each do |track|
@@ -32,9 +31,13 @@ module TransportationModes
 
     private
 
-    def extract_user_thresholds
+    def extract_user_settings
       safe_settings = Users::SafeSettings.new(@user.settings || {})
-      [safe_settings.transportation_thresholds, safe_settings.transportation_expert_thresholds]
+      [
+        safe_settings.transportation_thresholds,
+        safe_settings.transportation_expert_thresholds,
+        safe_settings.enabled_transportation_modes
+      ]
     end
 
     def tracks_to_process
@@ -60,7 +63,8 @@ module TransportationModes
         detector = TransportationModes::Detector.new(
           track, points,
           user_thresholds: @user_thresholds,
-          user_expert_thresholds: @expert_thresholds
+          user_expert_thresholds: @expert_thresholds,
+          enabled_modes: @enabled_modes
         )
         segment_data = detector.call
 

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -38,7 +38,8 @@ class Track < ApplicationRecord
   scope :with_unknown_mode, -> { where(dominant_mode: :unknown) }
   scope :with_detected_mode, -> { where.not(dominant_mode: :unknown) }
   scope :without_phantom_stationary, lambda { |distance_threshold_m|
-    where.not(dominant_mode: :stationary).or(where('distance >= ?', distance_threshold_m))
+    where('NOT (dominant_mode = ? AND distance < ?)',
+          dominant_modes[:stationary], distance_threshold_m)
   }
 
   # Convert raw distance + duration into a stored avg_speed (km/h),

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -184,12 +184,30 @@ class Track < ApplicationRecord
     track_segments.group(:transportation_mode).sum(:duration)
   end
 
-  def update_dominant_mode!
-    breakdown = activity_breakdown
-    return update_column(:dominant_mode, :unknown) if breakdown.empty?
+  MOVING_DISTANCE_THRESHOLD_M = 50
 
-    dominant = breakdown.max_by { |_mode, duration| duration || 0 }&.first
-    update_column(:dominant_mode, dominant || :unknown)
+  def update_dominant_mode!
+    segments = track_segments.reload
+    return update_column(:dominant_mode, :unknown) if segments.empty?
+
+    update_column(:dominant_mode, self.class.pick_dominant_mode(segments) || :unknown)
+  end
+
+  def self.pick_dominant_mode(segments)
+    distance_by_mode = Hash.new(0)
+    duration_by_mode = Hash.new(0)
+    segments.each do |s|
+      distance_by_mode[s.transportation_mode] += s.distance.to_i
+      duration_by_mode[s.transportation_mode] += s.duration.to_i
+    end
+
+    moving = distance_by_mode.reject { |mode, dist| mode.to_s == 'stationary' || dist < MOVING_DISTANCE_THRESHOLD_M }
+
+    if moving.any?
+      moving.max_by { |mode, dist| [dist, duration_by_mode[mode]] }&.first
+    else
+      duration_by_mode.max_by { |_, dur| dur }&.first
+    end
   end
 
   def broadcast_geojson_updated

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -37,6 +37,9 @@ class Track < ApplicationRecord
   scope :by_mode, ->(mode) { where(dominant_mode: mode) }
   scope :with_unknown_mode, -> { where(dominant_mode: :unknown) }
   scope :with_detected_mode, -> { where.not(dominant_mode: :unknown) }
+  scope :without_phantom_stationary, lambda { |distance_threshold_m|
+    where.not(dominant_mode: :stationary).or(where('distance >= ?', distance_threshold_m))
+  }
 
   # Convert raw distance + duration into a stored avg_speed (km/h),
   # capped to the column's precision limit.
@@ -201,7 +204,9 @@ class Track < ApplicationRecord
       duration_by_mode[s.transportation_mode] += s.duration.to_i
     end
 
-    moving = distance_by_mode.reject { |mode, dist| mode.to_s == 'stationary' || dist < MOVING_DISTANCE_THRESHOLD_M }
+    moving = distance_by_mode.reject do |mode, dist|
+      %w[stationary unknown].include?(mode.to_s) || dist < MOVING_DISTANCE_THRESHOLD_M
+    end
 
     if moving.any?
       moving.max_by { |mode, dist| [dist, duration_by_mode[mode]] }&.first

--- a/app/services/timeline/day_assembler.rb
+++ b/app/services/timeline/day_assembler.rb
@@ -76,11 +76,9 @@ module Timeline
     end
 
     def fetch_tracks
-      stationary_value = Track.dominant_modes[:stationary]
-
       user.scoped_tracks
           .where('start_at <= ? AND end_at >= ?', end_at, start_at)
-          .where.not('dominant_mode = ? AND distance < ?', stationary_value, PHANTOM_STATIONARY_DISTANCE_M)
+          .without_phantom_stationary(PHANTOM_STATIONARY_DISTANCE_M)
           .order(start_at: :asc)
     end
 
@@ -228,7 +226,8 @@ module Timeline
 
     def build_summary(visits, tracks, track_shares)
       total_distance_m = tracks.sum { |t| t.distance.to_f * track_shares.fetch(t.id, 1.0) }
-      moving_seconds = tracks.sum { |t| t.duration.to_f * track_shares.fetch(t.id, 1.0) }
+      moving_tracks = tracks.reject { |t| t.dominant_mode == 'stationary' }
+      moving_seconds = moving_tracks.sum { |t| t.duration.to_f * track_shares.fetch(t.id, 1.0) }
       # NOTE: visit.duration is stored in MINUTES (see Visits::Creator / Visits::Create).
       stationary_minutes = visits.sum(&:duration)
       status_counts = visits.group_by(&:status).transform_values(&:size)

--- a/app/services/timeline/day_assembler.rb
+++ b/app/services/timeline/day_assembler.rb
@@ -226,6 +226,9 @@ module Timeline
 
     def build_summary(visits, tracks, track_shares)
       total_distance_m = tracks.sum { |t| t.distance.to_f * track_shares.fetch(t.id, 1.0) }
+      # Asymmetry with fetch_tracks is intentional: stationary tracks with >=100m
+      # still surface in the timeline as "🛑 stayed" rows, but their duration must
+      # not contribute to "time_moving_minutes" — "stayed" is not "moving".
       moving_tracks = tracks.reject { |t| t.dominant_mode == 'stationary' }
       moving_seconds = moving_tracks.sum { |t| t.duration.to_f * track_shares.fetch(t.id, 1.0) }
       # NOTE: visit.duration is stored in MINUTES (see Visits::Creator / Visits::Create).

--- a/app/services/timeline/day_assembler.rb
+++ b/app/services/timeline/day_assembler.rb
@@ -7,6 +7,8 @@ module Timeline
     # memory just to compute bounds.
     MAX_RANGE = 31.days
 
+    PHANTOM_STATIONARY_DISTANCE_M = 100
+
     def initialize(user, start_at:, end_at:, distance_unit: 'km')
       @user = user
       @start_at = start_at.present? ? Time.zone.parse(start_at) : nil
@@ -74,8 +76,11 @@ module Timeline
     end
 
     def fetch_tracks
+      stationary_value = Track.dominant_modes[:stationary]
+
       user.scoped_tracks
           .where('start_at <= ? AND end_at >= ?', end_at, start_at)
+          .where.not('dominant_mode = ? AND distance < ?', stationary_value, PHANTOM_STATIONARY_DISTANCE_M)
           .order(start_at: :asc)
     end
 

--- a/app/services/tracks/merger.rb
+++ b/app/services/tracks/merger.rb
@@ -26,6 +26,10 @@ class Tracks::Merger
     @newer_track = newer_track
   end
 
+  def user
+    @older_track&.user
+  end
+
   def call
     return false if invalid_merge?
 

--- a/app/services/tracks/reprocessor.rb
+++ b/app/services/tracks/reprocessor.rb
@@ -149,8 +149,8 @@ module Tracks
       all_segments = track.track_segments.reload.to_a
       return if all_segments.empty?
 
-      dominant = all_segments.max_by { |s| s.duration || 0 }
-      track.update!(dominant_mode: dominant.transportation_mode)
+      mode = Track.pick_dominant_mode(all_segments)
+      track.update!(dominant_mode: mode) if mode
     end
   end
 end

--- a/app/services/tracks/segment_editor.rb
+++ b/app/services/tracks/segment_editor.rb
@@ -61,8 +61,8 @@ module Tracks
       segments = track.track_segments.reload.to_a
       return if segments.empty?
 
-      dominant = segments.max_by { |s| s.duration || 0 }
-      track.update!(dominant_mode: dominant.transportation_mode)
+      mode = Track.pick_dominant_mode(segments)
+      track.update!(dominant_mode: mode) if mode
     end
 
     def success

--- a/app/services/tracks/track_builder.rb
+++ b/app/services/tracks/track_builder.rb
@@ -227,10 +227,8 @@ module Tracks::TrackBuilder
   def update_dominant_mode(track, segments)
     return if segments.empty?
 
-    dominant_segment = segments.max_by { |s| s.duration || 0 }
-    return unless dominant_segment
-
-    track.update_column(:dominant_mode, dominant_segment.transportation_mode)
+    mode = Track.pick_dominant_mode(segments)
+    track.update_column(:dominant_mode, mode) if mode
   end
 
   private

--- a/app/services/tracks/track_builder.rb
+++ b/app/services/tracks/track_builder.rb
@@ -199,7 +199,13 @@ module Tracks::TrackBuilder
   end
 
   def detect_and_create_segments(track, points)
-    detector = TransportationModes::Detector.new(track, points)
+    safe_settings = Users::SafeSettings.new(track.user.settings || {})
+    detector = TransportationModes::Detector.new(
+      track, points,
+      user_thresholds:        safe_settings.transportation_thresholds,
+      user_expert_thresholds: safe_settings.transportation_expert_thresholds,
+      enabled_modes:          safe_settings.enabled_transportation_modes
+    )
     segment_data = detector.call
 
     return if segment_data.empty?

--- a/app/services/tracks/track_builder.rb
+++ b/app/services/tracks/track_builder.rb
@@ -199,7 +199,7 @@ module Tracks::TrackBuilder
   end
 
   def detect_and_create_segments(track, points)
-    safe_settings = Users::SafeSettings.new(track.user.settings || {})
+    safe_settings = Users::SafeSettings.new(user.settings || {})
     detector = TransportationModes::Detector.new(
       track, points,
       user_thresholds:        safe_settings.transportation_thresholds,

--- a/app/views/map/timeline_feeds/_journey_entry.html.erb
+++ b/app/views/map/timeline_feeds/_journey_entry.html.erb
@@ -11,6 +11,7 @@
     'flying'     => { emoji: "✈️", verb: 'flew' },
     'boat'       => { emoji: "⛵", verb: 'sailed' },
     'motorcycle' => { emoji: "\u{1F3CD}️", verb: 'rode' },
+    'stationary' => { emoji: "\u{1F6D1}", verb: 'stayed' },
     'unknown'    => { emoji: nil, verb: 'traveled' }
   }
   mode = entry[:dominant_mode].presence || 'unknown'

--- a/spec/jobs/transportation_modes/backfill_job_spec.rb
+++ b/spec/jobs/transportation_modes/backfill_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TransportationModes::BackfillJob do
+  describe '#perform' do
+    let(:user) do
+      create(:user, settings: {
+               'enabled_transportation_modes' => %w[stationary walking driving],
+               'time_threshold_minutes' => '30'
+             })
+    end
+
+    let!(:track) do
+      create(:track, user: user,
+                     start_at: 1.hour.ago,
+                     end_at: 30.minutes.ago,
+                     distance: 0,
+                     dominant_mode: :unknown)
+    end
+
+    let!(:points) do
+      base = 1.hour.ago.to_i
+      18.times.map do |i|
+        create(:point, user: user, track: track,
+                       lonlat: "POINT(#{-74.0060 + (i * 0.0010)} #{40.7128 + (i * 0.0005)})",
+                       timestamp: base + (i * 30),
+                       altitude: 100,
+                       velocity: 4.5)
+      end
+    end
+
+    it 'does not assign cycling segments when cycling is disabled in user settings' do
+      described_class.new.perform(user.id)
+
+      modes = track.reload.track_segments.pluck(:transportation_mode)
+      expect(modes).not_to include('cycling')
+    end
+  end
+end

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -242,6 +242,32 @@ RSpec.describe Track, type: :model do
         expect(track.reload.dominant_mode).to eq('driving')
       end
     end
+
+    context 'when a stationary keepalive segment outlasts a moving segment' do
+      before do
+        create(:track_segment, track: track, transportation_mode: :stationary,
+                               distance: 50,  duration: 3600)
+        create(:track_segment, track: track, transportation_mode: :driving,
+                               distance: 3000, duration: 1800)
+      end
+
+      it 'picks the moving mode even though stationary lasts longer' do
+        track.update_dominant_mode!
+        expect(track.reload.dominant_mode).to eq('driving')
+      end
+    end
+
+    context 'when only a stationary segment exists' do
+      before do
+        create(:track_segment, track: track, transportation_mode: :stationary,
+                               distance: 5, duration: 1800)
+      end
+
+      it 'sets dominant_mode to stationary' do
+        track.update_dominant_mode!
+        expect(track.reload.dominant_mode).to eq('stationary')
+      end
+    end
   end
 
   describe 'Calculateable concern' do

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -193,6 +193,28 @@ RSpec.describe Track, type: :model do
         expect(Track.with_detected_mode).not_to include(unknown_track)
       end
     end
+
+    describe '.without_phantom_stationary' do
+      let!(:driving_with_zero_distance)  { create(:track, user: user, dominant_mode: :driving, distance: 0) }
+      let!(:stationary_below_threshold)  { create(:track, user: user, dominant_mode: :stationary, distance: 50) }
+      let!(:stationary_at_threshold)     { create(:track, user: user, dominant_mode: :stationary, distance: 100) }
+      let!(:stationary_above_threshold)  { create(:track, user: user, dominant_mode: :stationary, distance: 250) }
+
+      subject(:scope) { Track.without_phantom_stationary(100) }
+
+      it 'keeps non-stationary tracks regardless of distance' do
+        expect(scope).to include(driving_with_zero_distance)
+      end
+
+      it 'excludes stationary tracks below the threshold' do
+        expect(scope).not_to include(stationary_below_threshold)
+      end
+
+      it 'keeps stationary tracks at or above the threshold' do
+        expect(scope).to include(stationary_at_threshold)
+        expect(scope).to include(stationary_above_threshold)
+      end
+    end
   end
 
   describe '#activity_breakdown' do
@@ -246,7 +268,7 @@ RSpec.describe Track, type: :model do
     context 'when a stationary keepalive segment outlasts a moving segment' do
       before do
         create(:track_segment, track: track, transportation_mode: :stationary,
-                               distance: 50,  duration: 3600)
+                               distance: 50, duration: 3600)
         create(:track_segment, track: track, transportation_mode: :driving,
                                distance: 3000, duration: 1800)
       end

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -268,6 +268,20 @@ RSpec.describe Track, type: :model do
         expect(track.reload.dominant_mode).to eq('stationary')
       end
     end
+
+    context 'when an unknown segment outdistances a real moving segment' do
+      before do
+        create(:track_segment, track: track, transportation_mode: :unknown,
+                               distance: 200, duration: 60)
+        create(:track_segment, track: track, transportation_mode: :driving,
+                               distance: 60,  duration: 30)
+      end
+
+      it 'prefers the real moving mode over unknown' do
+        track.update_dominant_mode!
+        expect(track.reload.dominant_mode).to eq('driving')
+      end
+    end
   end
 
   describe 'Calculateable concern' do

--- a/spec/services/timeline/day_assembler_spec.rb
+++ b/spec/services/timeline/day_assembler_spec.rb
@@ -838,9 +838,9 @@ RSpec.describe Timeline::DayAssembler do
         expect(track_ids).not_to include(phantom_stationary_track.id)
       end
 
-      it 'excludes phantom stationary tracks from time_moving_minutes' do
+      it 'excludes all stationary tracks from time_moving_minutes regardless of distance' do
         summary = subject.first[:summary]
-        expect(summary[:time_moving_minutes]).to eq(35)
+        expect(summary[:time_moving_minutes]).to eq(30)
       end
     end
   end

--- a/spec/services/timeline/day_assembler_spec.rb
+++ b/spec/services/timeline/day_assembler_spec.rb
@@ -792,6 +792,57 @@ RSpec.describe Timeline::DayAssembler do
         expect(result).to eq([])
       end
     end
+
+    context 'with stationary phantom tracks (keepalive clusters)' do
+      let(:day) { Time.zone.parse('2026-05-12 00:00:00') }
+
+      let!(:drive_track) do
+        create(:track,
+               user: user,
+               start_at: day + 7.hours,
+               end_at:   day + 7.hours + 30.minutes,
+               distance: 3700,
+               duration: 1800,
+               dominant_mode: :driving)
+      end
+
+      let!(:phantom_stationary_track) do
+        create(:track,
+               user: user,
+               start_at: day + 10.hours,
+               end_at:   day + 10.hours + 30.minutes,
+               distance: 8,
+               duration: 1800,
+               dominant_mode: :stationary)
+      end
+
+      let!(:real_stationary_movement_track) do
+        create(:track,
+               user: user,
+               start_at: day + 12.hours,
+               end_at:   day + 12.hours + 5.minutes,
+               distance: 200,
+               duration: 300,
+               dominant_mode: :stationary)
+      end
+
+      subject do
+        described_class.new(user, start_at: day.iso8601, end_at: (day + 1.day).iso8601).call
+      end
+
+      it 'omits low-distance stationary tracks from the journey entries' do
+        entries = subject.first[:entries]
+        track_ids = entries.select { |e| e[:type] == 'journey' }.map { |e| e[:track_id] }
+        expect(track_ids).to include(drive_track.id)
+        expect(track_ids).to include(real_stationary_movement_track.id)
+        expect(track_ids).not_to include(phantom_stationary_track.id)
+      end
+
+      it 'excludes phantom stationary tracks from time_moving_minutes' do
+        summary = subject.first[:summary]
+        expect(summary[:time_moving_minutes]).to eq(35)
+      end
+    end
   end
 
   describe '#build_visit_entry suggested_places injection' do

--- a/spec/services/tracks/track_builder_spec.rb
+++ b/spec/services/tracks/track_builder_spec.rb
@@ -320,6 +320,36 @@ RSpec.describe Tracks::TrackBuilder do
     end
   end
 
+  describe 'honors user-disabled transportation modes during initial detection' do
+    let(:user) do
+      create(:user, settings: {
+               'enabled_transportation_modes' => %w[stationary walking driving],
+               'time_threshold_minutes' => '30'
+             })
+    end
+
+    let!(:points) do
+      base = 1.hour.ago.to_i
+      coords = 8.times.map do |i|
+        [-74.0060 + (i * 0.0010), 40.7128 + (i * 0.0005)]
+      end
+      coords.each_with_index.map do |(lon, lat), i|
+        create(:point, user: user,
+                       lonlat: "POINT(#{lon} #{lat})",
+                       timestamp: base + (i * 30),
+                       altitude: 100,
+                       velocity: 4.5)
+      end
+    end
+
+    it 'does not assign cycling segments when cycling is disabled by the user' do
+      builder.create_track_from_points(points, 1200)
+
+      modes = TrackSegment.all.pluck(:transportation_mode)
+      expect(modes).not_to include('cycling')
+    end
+  end
+
   describe 'integration test' do
     let!(:points) do
       [


### PR DESCRIPTION
## Summary

Three related bugs visible in the daily timeline view + one mode-classification bug surfaced during review:

1. **Phantom `traveled · 0m` rows.** Sparse OwnTracks/Overland keepalive points while a user is stationary (every ~30 min at home or office) get split into separate 2–3-point Tracks by the segmentation logic. `MovementAnalyzer` correctly classifies them as `dominant_mode='stationary'`, but they still surfaced as journey rows. The `_journey_entry.html.erb` partial had no mapping for `'stationary'`, so they fell through to the `'unknown'` bucket whose verb is `"traveled"` — yielding endless `"traveled · 0m"` rows. Their durations were summed into `time_moving_minutes`, inflating the "moving" stat by many hours.
2. **Real drives mislabeled as stationary.** When a Track absorbs adjacent keepalive points (e.g. a 30-min commute followed by a few stationary GPS readings), the stationary segment ends up longer than the moving one. `update_dominant_mode` picked the segment with **max duration**, so the commute got saved as `dominant_mode='stationary'` and rendered as `"traveled · 2.2 km"` instead of `"drove · 2.2 km"`.
3. **Disabled transportation modes still got assigned.** A user who disabled (e.g.) cycling in settings still saw cycling segments assigned to new tracks. The Recalculate button was the only path that honored `enabled_modes` — because `Tracks::Reprocessor` passed it to the Detector, while `Tracks::TrackBuilder#detect_and_create_segments` (used by `ParallelGenerator` / `TimeChunkProcessorJob` / `Merger` on every new track) called `Detector.new(track, points)` with no thresholds and no enabled modes at all. `TransportationModes::BackfillJob` had the same gap.

## Reproducer

Reproduced locally via a synthetic day (overnight keepalive + drive + walk + office keepalive + evening drive + overnight keepalive). Before this PR: 17 tracks in the timeline, 14 of them `traveled · 0m`, morning drive labeled `traveled`, `time_moving_minutes=648`. After: 2 tracks, 0 phantom rows, both drives labeled `drove`, `time_moving_minutes=135`.

## Changes

**Commit 1 — `Track.pick_dominant_mode` picks max distance, not max duration**
- New `Track.pick_dominant_mode` class method: prefers non-stationary modes with ≥50 m total distance, picks max distance, tiebreaks on duration. Falls back to max-duration only when nothing is moving.
- `Track#update_dominant_mode!`, `TrackBuilder#update_dominant_mode`, `Reprocessor#recompute_dominant_mode`, `SegmentEditor#recompute_dominant_mode!` all delegate to the new helper.

**Commit 2 — Hide phantom stationary tracks from timeline + label fallback**
- `Timeline::DayAssembler#fetch_tracks` excludes tracks where `dominant_mode='stationary' AND distance < 100 m`. Genuinely-stationary-but-walking-around tracks (>100 m) stay visible.
- `_journey_entry.html.erb` gets a `'stationary'` entry in `mode_config` (emoji 🛑, verb `"stayed"`) as a defensive label fallback.

**Commit 3 — Tighten dominant_mode + timeline filter (QA review)**
- `pick_dominant_mode` rejects `'unknown'` segments alongside `'stationary'` so the detector's `default_unknown_segment` fallback (with ≥50m distance) can't outrank a smaller real driving segment.
- New `Track.without_phantom_stationary(threshold)` scope replaces the raw `Track.dominant_modes[:stationary]` integer cast in `DayAssembler#fetch_tracks`. Robust to future enum renumbering.
- `DayAssembler#build_summary` excludes **all** stationary tracks from `moving_seconds`, not just sub-100m phantom ones. A track shown to the user as "stayed" should not contribute to the "moving" stat. Asymmetry with `fetch_tracks` is intentional and commented.

**Commit 4 — Thread `enabled_modes` through initial track build + backfill**
- `Tracks::TrackBuilder#detect_and_create_segments` and `TransportationModes::BackfillJob` now read the user's full settings (`transportation_thresholds`, `transportation_expert_thresholds`, `enabled_transportation_modes`) and pass them to the Detector. New tracks classify against the user's configured mode list from the moment they're built.

**Commit 5 — Review follow-ups**
- `without_phantom_stationary` rewritten as explicit `NOT (dominant_mode = ? AND distance < ?)` — same SQL, clearer intent.
- `TrackBuilder#detect_and_create_segments` reads settings from the including class's `user` instead of `track.user.settings`, avoiding a per-track AR lookup in bulk-generation hot loops.
- CHANGELOG entries added under [1.7.10] Unreleased → Fixed.

## Backfill

Existing tracks in production keep their wrong `dominant_mode` until the user hits the **Recalculate transportation modes** button in settings — that flow runs `Tracks::TransportationModeRecalculationJob` → `Tracks::Reprocessor.reprocess` → `recompute_dominant_mode`, which now uses the new logic and also honors `enabled_modes`. No separate backfill migration is required.

## Test plan

- [x] New specs (RED → GREEN):
  - `spec/models/track_spec.rb` — keepalive-outlasts-drive picks `driving`; stationary-only picks `stationary`; unknown segment outdistancing driving still picks `driving`.
  - `spec/services/timeline/day_assembler_spec.rb` — phantom stationary tracks excluded from entries; all stationary tracks excluded from `time_moving_minutes`.
  - `spec/services/tracks/track_builder_spec.rb` — cycling-disabled user with cycling-speed points produces no cycling segment.
- [x] Full regression suite: 398/398 passing across `spec/services/tracks/` + `spec/services/timeline/` + `spec/services/transportation_modes/` + `spec/models/track_spec.rb`.
- [x] `bundle exec rubocop` — clean.
- [ ] Manual QA: hit the Recalculate button on a real account and confirm overnight `traveled · 0m` rows disappear; toggle a transportation mode off and confirm new tracks no longer use it.

## Known limitation (out of scope)

The underlying segmentation still produces 2–3-point Tracks from keepalive clusters. We're now hiding them at the rendering layer rather than not creating them. A structural fix (don't emit a Track when the candidate cluster has negligible movement) would compound with the visit-detection stationarity gate in #2786 and is a natural follow-up.