### PR TITLE
Harden 1.7.10: filter PII in error payloads, validate Area inputs, guard PostHog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Map v2 family member markers show name + last-seen datetime on hover.
 - Map v2 area info card exposes an **Edit** button that opens the area modal pre-filled — rename and resize existing areas without redrawing. Backed by a new `PATCH /areas/:id` route.
 - Map v2 selection tool: **Delete N Anomaly Points** button appears when the selection contains anomaly points, so you can clean up GPS noise without touching real points.
+- Cloud only: PostHog exception capture is enabled to help diagnose production errors. Disabled on self-hosted instances and skipped unless `POSTHOG_API_KEY` is configured. The payload includes `user.id`, controller/action, and parameter-filtered request data — email, name, phone, credentials, and coordinates are redacted before send.
 
 ### Changed
 

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -7,6 +7,9 @@ class Area < ApplicationRecord
   has_many :visits, dependent: :destroy
 
   validates :name, :latitude, :longitude, :radius, presence: true
+  validates :radius, numericality: { greater_than: 0 }
+  validates :latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
+  validates :longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
 
   alias_attribute :lon, :longitude
   alias_attribute :lat, :latitude

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -7,6 +7,7 @@
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[
   passw secret token _key crypt salt certificate otp otp_attempt otp_secret ssn cvv cvc latitude longitude lat lng
+  email name first_name last_name phone
 ]
 
 SENSITIVE_SETTINGS_KEYS = %w[immich_api_key photoprism_api_key].freeze

--- a/config/initializers/posthog.rb
+++ b/config/initializers/posthog.rb
@@ -4,6 +4,7 @@
 # Place this file in config/initializers/posthog.rb
 
 return if DawarichSettings.self_hosted?
+return if ENV['POSTHOG_API_KEY'].blank?
 
 # ============================================================================
 # RAILS-SPECIFIC CONFIGURATION

--- a/spec/models/area_spec.rb
+++ b/spec/models/area_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe Area, type: :model do
     it { is_expected.to validate_presence_of(:latitude) }
     it { is_expected.to validate_presence_of(:longitude) }
     it { is_expected.to validate_presence_of(:radius) }
+    it { is_expected.to validate_numericality_of(:radius).is_greater_than(0) }
+
+    it do
+      is_expected.to validate_numericality_of(:latitude)
+        .is_greater_than_or_equal_to(-90).is_less_than_or_equal_to(90)
+    end
+
+    it do
+      is_expected.to validate_numericality_of(:longitude)
+        .is_greater_than_or_equal_to(-180).is_less_than_or_equal_to(180)
+    end
   end
 
   describe 'factory' do

--- a/spec/requests/areas_spec.rb
+++ b/spec/requests/areas_spec.rb
@@ -54,4 +54,79 @@ RSpec.describe '/areas', type: :request do
       end
     end
   end
+
+  describe 'PATCH /update' do
+    let(:area) { create(:area, user: user, name: 'Old Name', radius: 100) }
+    let(:valid_params) { { name: 'New Name', latitude: 52.52, longitude: 13.405, radius: 250 } }
+
+    context 'without authentication' do
+      it 'redirects to login' do
+        patch area_url(area), params: valid_params, as: :turbo_stream
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'when signed in' do
+      before { sign_in user }
+
+      context 'with valid params' do
+        it 'updates the area' do
+          patch area_url(area), params: valid_params, as: :turbo_stream
+
+          expect(area.reload.name).to eq('New Name')
+          expect(area.radius).to eq(250)
+        end
+
+        it 'returns turbo_stream with flash' do
+          patch area_url(area), params: valid_params, as: :turbo_stream
+
+          expect_turbo_stream_response
+          expect_flash_stream('Area updated successfully!')
+        end
+      end
+
+      context 'with non-positive radius' do
+        it 'does not update the area' do
+          patch area_url(area), params: valid_params.merge(radius: 0), as: :turbo_stream
+
+          expect(area.reload.radius).to eq(100)
+        end
+
+        it 'returns turbo_stream flash error' do
+          patch area_url(area), params: valid_params.merge(radius: -5), as: :turbo_stream
+
+          expect_turbo_stream_response
+          expect_flash_stream
+        end
+      end
+
+      context 'with out-of-range coordinates' do
+        it 'rejects latitude above 90' do
+          patch area_url(area), params: valid_params.merge(latitude: 91), as: :turbo_stream
+
+          expect(area.reload.latitude.to_f).not_to eq(91)
+          expect_flash_stream
+        end
+
+        it 'rejects longitude below -180' do
+          patch area_url(area), params: valid_params.merge(longitude: -181), as: :turbo_stream
+
+          expect(area.reload.longitude.to_f).not_to eq(-181)
+          expect_flash_stream
+        end
+      end
+
+      context "for another user's area" do
+        let(:other_area) { create(:area, user: create(:user), name: 'Other') }
+
+        it 'does not update it' do
+          patch area_url(other_area), params: valid_params, as: :turbo_stream
+
+          expect(other_area.reload.name).to eq('Other')
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Followups from a multi-perspective review of #2785. All changes are small, well-scoped, and verified locally.

- **Filter PII before it reaches PostHog/Sentry/logs.** `Rails.application.config.filter_parameters` did not include `email`/`name`/`phone`. PostHog's exception middleware ships `request.filtered_parameters` verbatim, so on auth/signup/profile-update exceptions the raw email landed in PostHog. Added `email name first_name last_name phone` to the filter list — affects logs + error-tracking payloads only, **not** the Rails console or direct attribute access.
- **Guard PostHog init when `POSTHOG_API_KEY` is blank.** Previously `PostHog.init` ran with `api_key: nil` on Cloud if the env var was unset, silently dropping events. One-line return.
- **Validate `Area` numericality.** The new `PATCH /areas/:id` route reuses `area_params` with only `presence` validations. The modal's `min: 10` on radius is bypassable. Added `radius > 0`, `latitude ∈ [-90, 90]`, `longitude ∈ [-180, 180]`.
- **Backfill request-spec coverage for `PATCH /areas/:id`.** The new endpoint shipped without request specs. Added success, non-positive radius, out-of-range coords, and cross-user-404 cases.
- **CHANGELOG entry for PostHog.** New third-party telemetry on Cloud was not mentioned. Added a bullet under Added that names the redacted fields so privacy-conscious users can audit it.

## Out of scope

A handful of Map v2 `visits_manager.js` concerns surfaced in the review (debounced fetches stacking without `AbortController`; programmatic `fitBounds` post-timeline-day-selection racing with the viewport refetch; initial-paint unbounded fallback when `getBounds()` hasn't settled). Those need the map running to verify behavior and are better as a focused follow-up PR.

## Test plan

- [x] `bundle exec rubocop config/initializers/filter_parameter_logging.rb config/initializers/posthog.rb app/models/area.rb spec/models/area_spec.rb spec/requests/areas_spec.rb` — 0 offenses
- [x] `bundle exec rspec spec/models/area_spec.rb spec/requests/areas_spec.rb` — 23 examples, 0 failures
- [ ] Manually confirm a sign-in exception in staging logs/PostHog no longer carries email
- [ ] Confirm Area edit modal still works end-to-end on Map v2