### PR TITLE
fix: gpx importer altitude decimal guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- GPX import no longer fails with "unknown attribute 'altitude_decimal' for Point" on instances whose database hasn't applied the altitude-decimal migration yet. (#2730)
+
 ## [1.7.8] - 2026-05-16
 
 ### ⚠️ Upgrade notes

--- a/app/services/gpx/track_importer.rb
+++ b/app/services/gpx/track_importer.rb
@@ -61,10 +61,9 @@ class Gpx::TrackImporter
 
     elevation = point['ele'].to_f
 
-    {
+    attrs = {
       lonlat: "POINT(#{point['lon'].to_d} #{point['lat'].to_d})",
       altitude: elevation,
-      altitude_decimal: elevation,
       timestamp: Time.zone.parse(point['time']).utc.to_i,
       tracker_id: tracker_id,
       import_id: import.id,
@@ -74,6 +73,8 @@ class Gpx::TrackImporter
       created_at: Time.current,
       updated_at: Time.current
     }
+    attrs[:altitude_decimal] = elevation if Point.altitude_decimal_supported?
+    attrs
   end
 
   def importer_name

--- a/spec/regressions/gpx_track_importer_tolerates_missing_altitude_decimal_column_spec.rb
+++ b/spec/regressions/gpx_track_importer_tolerates_missing_altitude_decimal_column_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GPX track importer tolerates a points table without the altitude_decimal column' do
+  let(:user) { create(:user) }
+  let(:file_path) { Rails.root.join('spec/fixtures/files/gpx/gpx_track_single_segment.gpx') }
+  let(:file) { Rack::Test::UploadedFile.new(file_path, 'application/xml') }
+  let(:import) { create(:import, user:, name: 'gpx_track.gpx', source: 'gpx') }
+
+  before do
+    import.file.attach(file)
+    allow(Point).to receive(:altitude_decimal_supported?).and_return(false)
+  end
+
+  it 'imports points without writing altitude_decimal' do
+    expect { Gpx::TrackImporter.new(import, user.id).call }.not_to raise_error
+
+    expect(user.points.count).to eq(10)
+    expect(user.points.pluck(:altitude_decimal)).to all(be_nil)
+  end
+end


### PR DESCRIPTION
Auto-opened draft PR to track work in the `fix/gpx-importer-altitude-decimal-guard` worktree.