### PR TITLE
fix: import waypoints as places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- GPX waypoints (`<wpt>`) and GeoJSON `Point` features without a timestamp are now imported as places instead of being silently discarded. An OsmAnd favourites export imports directly, and a GPX file holding both tracks and waypoints fills the timeline and the places list in one go. Imported places keep their name and appear on the map without needing a tag or a confirmed visit. (#1261)
+
 ### Fixed
 
+- A file with nothing importable in it — a GPX whose track points carry no time, or a GeoJSON of untimed lines, unsupported shapes, or no features at all — now fails with an explanation instead of reporting a successful import of zero points. (#1261)
 - The Dawarich app and Sidekiq containers now restart automatically after a graceful (exit 0) shutdown instead of staying down, so a stray SIGHUP no longer takes an instance offline until manual intervention (#3099).
 - Nightly place- and area-visit calculation no longer fails when an instance contains legacy points without timestamps.
 - Import rows on the Imports page now update their status live as an import processes, instead of staying on "Processing" until the page is manually reloaded. (#3174)

--- a/app/errors/imports/no_importable_data_error.rb
+++ b/app/errors/imports/no_importable_data_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Imports
+  class NoImportableDataError < StandardError
+    DEFAULT_MESSAGE = 'No importable locations were found in this file. Dawarich puts timestamped ' \
+                      'points on your timeline and untimed waypoints in your places; this file ' \
+                      'contained neither.'
+
+    def initialize(message = DEFAULT_MESSAGE)
+      super
+    end
+  end
+end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -3,6 +3,7 @@
 class Import < ApplicationRecord
   belongs_to :user
   has_many :points, dependent: :destroy
+  has_many :places, dependent: :destroy
 
   has_one_attached :file
 

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -10,6 +10,7 @@ class Place < ApplicationRecord
   DEFAULT_NAME = 'Suggested place'
 
   belongs_to :user, optional: true # Optional until Stage 2 NOT NULL
+  belongs_to :import, optional: true
   has_many :visits, dependent: :nullify
   has_many :place_visits, dependent: :destroy
   has_many :suggested_visits, -> { distinct }, through: :place_visits, source: :visit
@@ -22,16 +23,17 @@ class Place < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :lonlat, presence: true
 
-  enum :source, { manual: 0, photon: 1 }
+  enum :source, { manual: 0, photon: 1, gpx_waypoint: 2, geojson_point: 3 }
 
   scope :for_user, ->(user) { where(user: user) }
   scope :ordered, -> { order(:name) }
+  scope :imported, -> { where(source: [sources[:gpx_waypoint], sources[:geojson_point]]) }
   scope :linked_to_confirmed_visits, lambda { |user|
     where(id: user.visits.confirmed.where.not(place_id: nil).select(:place_id))
   }
   scope :tagged, -> { where(id: Tagging.where(taggable_type: 'Place').select(:taggable_id)) }
   scope :map_visible, lambda { |user|
-    manual.or(linked_to_confirmed_visits(user)).or(tagged)
+    manual.or(imported).or(linked_to_confirmed_visits(user)).or(tagged)
   }
 
   def lon

--- a/app/services/geojson/importer.rb
+++ b/app/services/geojson/importer.rb
@@ -22,7 +22,10 @@ class Geojson::Importer
     ActiveRecord::Base.transaction do
       stream_features(path)
       flush_batch
+      flush_places
     end
+
+    raise Imports::NoImportableDataError if nothing_importable?
   ensure
     cleanup_temp_file
   end
@@ -39,7 +42,9 @@ class Geojson::Importer
 
   def initialize_stream
     @points_batch = []
+    @places_batch = []
     @processed_points = 0
+    @processed_places = 0
   end
 
   def stream_features(path)
@@ -55,12 +60,24 @@ class Geojson::Importer
   end
 
   def process_feature(feature)
-    Geojson::Params.new(feature).each_point do |point|
-      next if point[:lonlat].nil?
-
-      @points_batch << point.merge(point_metadata)
-      flush_batch if @points_batch.size >= BATCH_SIZE
+    Geojson::Params.new(feature).each_entry do |kind, payload|
+      case kind
+      when :point then buffer_point(payload)
+      when :place then buffer_place(payload)
+      end
     end
+  end
+
+  def buffer_point(point)
+    return if point[:lonlat].nil?
+
+    @points_batch << point.merge(point_metadata)
+    flush_batch if @points_batch.size >= BATCH_SIZE
+  end
+
+  def buffer_place(feature)
+    @places_batch << feature
+    flush_places if @places_batch.size >= BATCH_SIZE
   end
 
   def point_metadata
@@ -80,6 +97,22 @@ class Geojson::Importer
     bulk_insert_points(batch)
     @processed_points += batch.size
     broadcast_import_progress(import, @processed_points)
+  end
+
+  def flush_places
+    return if @places_batch.empty?
+
+    batch = @places_batch
+    @places_batch = []
+    @processed_places += Places::GeojsonPointImporter.new(import, user_id, batch).call
+  end
+
+  # Counts rows the file actually accounted for — inserted or already present —
+  # rather than features offered, so a feature whose coordinates turn out to be
+  # unusable cannot pass for a successful import. A file that yields nothing at
+  # all is reported the way the GPX importer reports it, not completed silently.
+  def nothing_importable?
+    @processed_points.zero? && @processed_places.zero?
   end
 
   def atomic_bulk_insert?

--- a/app/services/geojson/params.rb
+++ b/app/services/geojson/params.rb
@@ -16,32 +16,60 @@ class Geojson::Params
   def each_point(&block)
     return enum_for(:each_point) unless block
 
+    each_entry { |kind, payload| block.call(payload) if kind == :point }
+  end
+
+  # Yields [:point, attrs] for timestamped coordinates and [:place, feature]
+  # for Point features that carry no timestamp.
+  def each_entry(&block)
+    return enum_for(:each_entry) unless block
+
     case json['type']
     when 'Feature'
-      each_feature_point(json, &block)
+      classify_feature(json, &block)
     when 'FeatureCollection'
       Array(json['features']).each do |feature|
-        each_feature_point(feature, &block)
+        classify_feature(feature, &block)
       end
     end
   end
 
   private
 
-  def each_feature_point(feature)
+  def classify_feature(feature, &block)
     return if feature[:geometry].blank?
 
     case feature[:geometry][:type]
     when 'Point'
-      yield build_point(feature)
+      classify_point(feature, &block)
     when 'LineString'
-      feature[:geometry][:coordinates].each do |coordinate|
-        yield build_line_point(coordinate)
-      end
+      classify_line_points(feature[:geometry][:coordinates], &block)
     when 'MultiLineString'
-      feature[:geometry][:coordinates].each do |line|
-        line.each { |coordinate| yield build_line_point(coordinate) }
-      end
+      lines = Array(feature[:geometry][:coordinates])
+      classify_line_points(lines.lazy.flat_map { |line| Array(line) }, &block)
+    end
+  end
+
+  # A Point with no timestamp is a saved place — an OsmAnd favourite, a pin
+  # dropped in a mapping app — not a moment on a timeline.
+  def classify_point(feature, &block)
+    attrs = build_point(feature)
+
+    return block.call(:place, feature) if attrs[:timestamp].nil?
+
+    block.call(:point, attrs)
+  end
+
+  # Streams rather than collecting: a LineString can hold hundreds of thousands
+  # of coordinates, and the importer batches them anyway.
+  def classify_line_points(coordinates, &block)
+    return if coordinates.blank?
+
+    coordinates.each do |coordinate|
+      attrs = build_line_point(coordinate)
+      next if attrs[:timestamp].blank?
+
+      block.call(:point, attrs)
     end
   end
 

--- a/app/services/gpx/document_start.rb
+++ b/app/services/gpx/document_start.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Positions an IO at the start of the XML document, preserving a byte order
+# mark so Nokogiri can detect the encoding from it. Without a BOM, any preamble
+# before the first '<' is skipped.
+module Gpx::DocumentStart
+  BOMS = [
+    "\xEF\xBB\xBF".b,
+    "\xFE\xFF".b,
+    "\xFF\xFE".b,
+    "\x00\x00\xFE\xFF".b,
+    "\xFF\xFE\x00\x00".b
+  ].freeze
+
+  def self.seek(io)
+    prefix = io.read(256) || ''
+    offset = BOMS.any? { |bom| prefix.start_with?(bom) } ? 0 : prefix.index('<') || 0
+    io.seek(offset)
+  end
+end

--- a/app/services/gpx/track_importer.rb
+++ b/app/services/gpx/track_importer.rb
@@ -9,13 +9,6 @@ class Gpx::TrackImporter
   include Imports::FileLoader
 
   BATCH_SIZE = 1000
-  XML_BOMS = [
-    "\xEF\xBB\xBF".b,
-    "\xFE\xFF".b,
-    "\xFF\xFE".b,
-    "\x00\x00\xFE\xFF".b,
-    "\xFF\xFE\x00\x00".b
-  ].freeze
 
   attr_reader :import, :user_id, :file_path
 
@@ -26,11 +19,14 @@ class Gpx::TrackImporter
   end
 
   def call
+    path = resolve_file_path
+    trkpt_count = 0
     batch = []
-    each_trkpt do |point_hash, tracker_id|
+    saw_waypoints = each_trkpt(path) do |point_hash, tracker_id|
       data = prepare_point(point_hash, tracker_id)
       next unless data
 
+      trkpt_count += 1
       batch << data
       next if batch.size < BATCH_SIZE
 
@@ -38,25 +34,29 @@ class Gpx::TrackImporter
       batch = []
     end
     flush(batch) unless batch.empty?
+
+    # Waypoints are saved places (OsmAnd favourites and the like), not moments
+    # on a timeline, so they land in Places rather than Points. Most GPX files
+    # hold none, so the second pass only runs when the first saw one.
+    waypoints = Places::GpxWaypointImporter.new(import, user_id, path)
+    waypoints.call if saw_waypoints
+
+    raise Imports::NoImportableDataError if trkpt_count.zero? && waypoints.parsed_count.zero?
   ensure
     cleanup_temp_file
   end
 
   private
 
-  def each_trkpt(&block)
-    path = resolve_file_path
+  def each_trkpt(path, &block)
+    handler = TrkptStreamHandler.new(import.id, import.name, &block)
+
     File.open(path, 'rb') do |io|
-      seek_to_document_start(io)
-      handler = TrkptStreamHandler.new(import.id, import.name, &block)
+      Gpx::DocumentStart.seek(io)
       Nokogiri::XML::SAX::Parser.new(handler).parse(io)
     end
-  end
 
-  def seek_to_document_start(io)
-    prefix = io.read(256) || ''
-    offset = XML_BOMS.any? { |bom| prefix.start_with?(bom) } ? 0 : prefix.index('<') || 0
-    io.seek(offset)
+    handler.saw_waypoints?
   end
 
   def flush(batch)
@@ -111,9 +111,16 @@ class Gpx::TrackImporter
       @trk_identity_source = nil
       @capturing_trk_field = nil
       @capture_depth = 0
+      @saw_waypoints = false
+    end
+
+    def saw_waypoints?
+      @saw_waypoints
     end
 
     def start_element_namespace(name, attrs = [], _prefix = nil, _uri = nil, _namespaces = [])
+      @saw_waypoints = true if name == 'wpt'
+
       case name
       when 'trk'
         @trk_index += 1

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -60,6 +60,7 @@ class Imports::Create
     run_post_import_step('schedule_track_generation') { schedule_track_generation(user.id, import) }
     run_post_import_step('update_points_count') { update_import_points_count(import) }
     run_post_import_step('notify_if_all_skipped') { notify_if_all_skipped(import) }
+    run_post_import_step('notify_if_places_imported') { notify_if_places_imported(import) }
   end
 
   def run_post_import_step(step)
@@ -118,6 +119,22 @@ class Imports::Create
 
   def update_import_points_count(import)
     Import::UpdatePointsCountJob.perform_later(import.id)
+  end
+
+  # The imports table counts points, so a file of waypoints alone finishes
+  # showing a row of zeroes. Say where those locations went instead.
+  def notify_if_places_imported(import)
+    places_count = import.places.count
+    return if places_count.zero?
+
+    Notification.create!(
+      user_id: import.user_id,
+      title: 'Places imported',
+      content: "Your file #{import.name} contained #{places_count} " \
+               "#{'location'.pluralize(places_count)} without a time, saved to your places " \
+               'rather than your timeline. Find them on the map and in Places.',
+      kind: :info
+    )
   end
 
   def notify_if_all_skipped(import)

--- a/app/services/places/bulk_insertable.rb
+++ b/app/services/places/bulk_insertable.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Places
+  module BulkInsertable
+    extend ActiveSupport::Concern
+
+    BATCH_SIZE = 500
+    MAX_NAME_LENGTH = 255
+    LATITUDE_RANGE = (-90.0..90.0)
+    LONGITUDE_RANGE = (-180.0..180.0)
+
+    private
+
+    def place_row(name:, latitude:, longitude:, source:)
+      lat = coordinate(latitude, LATITUDE_RANGE)
+      lon = coordinate(longitude, LONGITUDE_RANGE)
+      return if lat.nil? || lon.nil?
+      return if Points::NullIsland.coordinates?(lon, lat)
+
+      now = Time.current
+
+      {
+        name: place_name(name),
+        latitude: lat,
+        longitude: lon,
+        lonlat: "POINT(#{lon} #{lat})",
+        source: source,
+        user_id: user_id,
+        import_id: import.id,
+        geodata: {},
+        # The name came from the user's own file, so nightly reverse geocoding
+        # must not rename it.
+        name_locked_at: now,
+        created_at: now,
+        updated_at: now
+      }
+    end
+
+    # Re-importing the same favourites file is routine — OsmAnd rewrites it on
+    # every edit — so a place already recorded under this name and position is
+    # re-claimed by the newer import rather than duplicated. The partial unique
+    # index makes that hold across concurrent imports too, which a read-then-
+    # write check cannot. Returns the number of rows this file accounted for,
+    # whether freshly inserted or already present.
+    def insert_places(rows)
+      deduped = rows.uniq { |row| place_key(row) }
+      return 0 if deduped.empty?
+
+      Place.upsert_all(
+        deduped,
+        unique_by: :index_imported_places_uniqueness,
+        update_only: %i[import_id],
+        returning: Arel.sql('id')
+      ).length
+    end
+
+    def place_key(row)
+      [row[:name], row[:latitude], row[:longitude]]
+    end
+
+    def place_name(value)
+      name = value.to_s.strip
+      return default_place_name if name.blank?
+
+      name.truncate(MAX_NAME_LENGTH)
+    end
+
+    # A file can carry junk where a number belongs; `to_f` would turn "north"
+    # into a confident 0.0, so anything non-numeric or off-globe is dropped.
+    def coordinate(value, range)
+      return if value.blank?
+
+      number = Float(value, exception: false)
+      return if number.nil? || !range.cover?(number)
+
+      number.round(6)
+    end
+  end
+end

--- a/app/services/places/geojson_point_importer.rb
+++ b/app/services/places/geojson_point_importer.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Places::GeojsonPointImporter
+  include Places::BulkInsertable
+
+  DEFAULT_NAME = 'Imported place'
+
+  attr_reader :import, :user_id, :features
+
+  def initialize(import, user_id, features)
+    @import = import
+    @user_id = user_id
+    @features = features
+  end
+
+  def call
+    return 0 if features.blank?
+
+    features.each_slice(BATCH_SIZE).sum do |slice|
+      insert_places(slice.filter_map { |feature| prepare_place(feature) })
+    end
+  end
+
+  private
+
+  def prepare_place(feature)
+    feature = feature.with_indifferent_access
+    coordinates = feature.dig(:geometry, :coordinates)
+    return if coordinates.blank?
+
+    place_row(
+      name: feature.dig(:properties, :name),
+      latitude: coordinates[1],
+      longitude: coordinates[0],
+      source: Place.sources[:geojson_point]
+    )
+  end
+
+  def default_place_name
+    DEFAULT_NAME
+  end
+end

--- a/app/services/places/gpx_waypoint_importer.rb
+++ b/app/services/places/gpx_waypoint_importer.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+
+class Places::GpxWaypointImporter
+  include Places::BulkInsertable
+
+  DEFAULT_NAME = 'Imported waypoint'
+
+  attr_reader :import, :user_id, :file_path, :parsed_count, :imported_count
+
+  def initialize(import, user_id, file_path)
+    @import = import
+    @user_id = user_id
+    @file_path = file_path
+    @parsed_count = 0
+    @imported_count = 0
+  end
+
+  def call
+    batch = []
+    each_wpt do |wpt|
+      row = prepare_place(wpt)
+      next unless row
+
+      @parsed_count += 1
+      batch << row
+      next if batch.size < BATCH_SIZE
+
+      flush(batch)
+      batch = []
+    end
+    flush(batch)
+    @imported_count
+  end
+
+  private
+
+  def each_wpt(&block)
+    File.open(file_path, 'rb') do |io|
+      Gpx::DocumentStart.seek(io)
+      handler = WptStreamHandler.new(&block)
+      Nokogiri::XML::SAX::Parser.new(handler).parse(io)
+    end
+  end
+
+  def prepare_place(wpt)
+    place_row(
+      name: wpt['name'],
+      latitude: wpt['lat'],
+      longitude: wpt['lon'],
+      source: Place.sources[:gpx_waypoint]
+    )
+  end
+
+  def default_place_name
+    DEFAULT_NAME
+  end
+
+  def flush(batch)
+    @imported_count += insert_places(batch)
+  end
+
+  class WptStreamHandler < Nokogiri::XML::SAX::Document
+    CAPTURED_CHILDREN = %w[name].freeze
+
+    def initialize(&block)
+      super()
+      @callback = block
+      @current = nil
+      @capturing_child = nil
+      @text = +''
+    end
+
+    def start_element_namespace(name, attrs = [], _prefix = nil, _uri = nil, _namespaces = [])
+      if name == 'wpt'
+        @current = attrs.each_with_object({}) { |a, h| h[a.localname] = a.value }
+        @capturing_child = nil
+        @text = +''
+        return
+      end
+
+      return unless @current
+      return unless CAPTURED_CHILDREN.include?(name)
+
+      @capturing_child = name
+      @text = +''
+    end
+
+    def characters(string)
+      @text << string if @capturing_child
+    end
+
+    def end_element_namespace(name, _prefix = nil, _uri = nil)
+      if name == 'wpt' && @current
+        @callback.call(@current)
+        @current = nil
+        @capturing_child = nil
+        @text = +''
+        return
+      end
+
+      return unless @capturing_child && name == @capturing_child
+
+      @current[@capturing_child] = @text.strip if @current
+      @capturing_child = nil
+      @text = +''
+    end
+
+    def error(message)
+      raise Nokogiri::XML::SyntaxError, "GPX parse error: #{message}"
+    end
+  end
+end

--- a/db/migrate/20260728190000_add_import_id_to_places.rb
+++ b/db/migrate/20260728190000_add_import_id_to_places.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AddImportIdToPlaces < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    add_column :places, :import_id, :bigint unless column_exists?(:places, :import_id)
+
+    unless index_exists?(:places, :import_id, name: 'index_places_on_import_id')
+      # Every place predating this column is NULL, and nothing looks those up
+      # by import, so they stay out of the index.
+      add_index :places, :import_id,
+                where: 'import_id IS NOT NULL',
+                name: 'index_places_on_import_id',
+                algorithm: :concurrently
+    end
+
+    return if index_exists?(:places, %i[user_id name latitude longitude], name: 'index_imported_places_uniqueness')
+
+    # Scoped to the two import sources, which no existing row can carry, so the
+    # index cannot conflict with places created by geocoding or by hand.
+    add_index :places, %i[user_id name latitude longitude],
+              unique: true,
+              where: 'source IN (2, 3)',
+              name: 'index_imported_places_uniqueness',
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :places, name: 'index_imported_places_uniqueness' if
+      index_exists?(:places, %i[user_id name latitude longitude], name: 'index_imported_places_uniqueness')
+    remove_index :places, name: 'index_places_on_import_id' if
+      index_exists?(:places, :import_id, name: 'index_places_on_import_id')
+    remove_column :places, :import_id if column_exists?(:places, :import_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_28_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -302,6 +302,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_130000) do
     t.datetime "created_at", null: false
     t.boolean "demo", default: false, null: false
     t.jsonb "geodata", default: {}, null: false
+    t.bigint "import_id"
     t.decimal "latitude", precision: 10, scale: 6, null: false
     t.decimal "longitude", precision: 10, scale: 6, null: false
     t.geography "lonlat", limit: {srid: 4326, type: "st_point", geographic: true}
@@ -314,7 +315,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_130000) do
     t.bigint "user_id"
     t.index "(((geodata -> 'properties'::text) ->> 'osm_id'::text))", name: "index_places_on_geodata_osm_id"
     t.index ["demo"], name: "index_places_on_demo_true", where: "(demo = true)"
+    t.index ["import_id"], name: "index_places_on_import_id", where: "(import_id IS NOT NULL)"
     t.index ["lonlat"], name: "index_places_on_lonlat", using: :gist
+    t.index ["user_id", "name", "latitude", "longitude"], name: "index_imported_places_uniqueness", unique: true, where: "(source = ANY (ARRAY[2, 3]))"
     t.index ["user_id"], name: "index_places_on_user_id"
   end
 

--- a/spec/fixtures/files/geojson/geojson_timeless_points.json
+++ b/spec/fixtures/files/geojson/geojson_timeless_points.json
@@ -1,0 +1,23 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": { "name": "point 1" },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [19.191084745141836, 14.964425139366881]
+      },
+      "id": 0
+    },
+    {
+      "type": "Feature",
+      "properties": { "name": "point 2" },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [19.528135643418466, 14.808920221513148]
+      },
+      "id": 1
+    }
+  ]
+}

--- a/spec/fixtures/files/geojson/geojson_timeless_track.json
+++ b/spec/fixtures/files/geojson/geojson_timeless_track.json
@@ -1,0 +1,17 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {},
+      "geometry": {
+        "type": "LineString",
+        "coordinates": [
+          [13.404954, 52.520008],
+          [13.405100, 52.520100],
+          [13.405200, 52.520200]
+        ]
+      }
+    }
+  ]
+}

--- a/spec/fixtures/files/gpx/gpx_mixed_track_and_waypoints.gpx
+++ b/spec/fixtures/files/gpx/gpx_mixed_track_and_waypoints.gpx
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<gpx version="1.1" creator="MixedTool" xmlns="http://www.topografix.com/GPX/1/1">
+  <wpt lat="52.520008" lon="13.404954">
+    <name>Start Marker</name>
+  </wpt>
+  <wpt lat="52.521000" lon="13.405000">
+    <name>End Marker</name>
+  </wpt>
+  <trk>
+    <name>Berlin Walk</name>
+    <trkseg>
+      <trkpt lat="52.520100" lon="13.404960">
+        <ele>34.5</ele>
+        <time>2024-06-01T10:00:00Z</time>
+      </trkpt>
+      <trkpt lat="52.520200" lon="13.404970">
+        <ele>35.0</ele>
+        <time>2024-06-01T10:00:30Z</time>
+      </trkpt>
+      <trkpt lat="52.520300" lon="13.404980">
+        <ele>35.5</ele>
+        <time>2024-06-01T10:01:00Z</time>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/spec/fixtures/files/gpx/gpx_waypoints_only.gpx
+++ b/spec/fixtures/files/gpx/gpx_waypoints_only.gpx
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1">
+  <wpt lat="52.520008" lon="13.404954">
+    <name>Brandenburg Gate</name>
+    <ele>34.5</ele>
+  </wpt>
+  <wpt lat="48.858844" lon="2.294351">
+    <name>Eiffel Tower</name>
+    <ele>30.0</ele>
+  </wpt>
+  <wpt lat="41.902782" lon="12.496366">
+    <ele>21.0</ele>
+  </wpt>
+</gpx>

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Place, type: :model do
   end
 
   describe 'enums' do
-    it { is_expected.to define_enum_for(:source).with_values(%i[manual photon]) }
+    it { is_expected.to define_enum_for(:source).with_values(%i[manual photon gpx_waypoint geojson_point]) }
   end
 
   describe 'scopes' do

--- a/spec/regressions/geojson_timeless_points_imported_as_places_spec.rb
+++ b/spec/regressions/geojson_timeless_points_imported_as_places_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GeoJSON Point features without timestamps imported as Places' do
+  subject(:run_import) { Geojson::Importer.new(import, user.id).call }
+
+  let(:user) { create(:user) }
+  let(:file_path) { Rails.root.join('spec/fixtures/files/geojson/geojson_timeless_points.json') }
+  let(:file) { Rack::Test::UploadedFile.new(file_path, 'application/json') }
+  let(:import) { create(:import, user:, name: 'points.json', source: 'geojson') }
+
+  before do
+    import.file.attach(io: File.open(file_path), filename: 'points.json', content_type: 'application/json')
+  end
+
+  it 'creates one Place per timeless Point feature with source :geojson_point' do
+    expect { run_import }.to change { Place.where(user: user, source: :geojson_point).count }.by(2)
+    expect(Place.where(user: user).pluck(:name)).to contain_exactly('point 1', 'point 2')
+  end
+
+  it 'creates no Points (timeless features do not belong on the timeline)' do
+    expect { run_import }.not_to(change { Point.count })
+  end
+
+  it 'does not raise NoImportableDataError when all features land as Places' do
+    expect { run_import }.not_to raise_error
+  end
+end

--- a/spec/regressions/geojson_timeless_track_raises_clear_error_spec.rb
+++ b/spec/regressions/geojson_timeless_track_raises_clear_error_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GeoJSON track without timestamps raises a clear error' do
+  subject(:run_import) { Geojson::Importer.new(import, user.id).call }
+
+  let(:user) { create(:user) }
+  let(:file_path) { Rails.root.join('spec/fixtures/files/geojson/geojson_timeless_track.json') }
+  let(:file) { Rack::Test::UploadedFile.new(file_path, 'application/json') }
+  let(:import) { create(:import, user:, name: 'track.json', source: 'geojson') }
+
+  before do
+    import.file.attach(io: File.open(file_path), filename: 'track.json', content_type: 'application/json')
+  end
+
+  it 'raises Imports::NoImportableDataError with a user-facing message' do
+    expect { run_import }.to raise_error(Imports::NoImportableDataError, /No importable locations/)
+  end
+
+  it 'creates no Points and no Places' do
+    expect do
+      run_import
+    rescue Imports::NoImportableDataError
+      nil
+    end.not_to(change { Point.count + Place.count })
+  end
+end

--- a/spec/regressions/google_phone_takeout_invalid_utf8_spec.rb
+++ b/spec/regressions/google_phone_takeout_invalid_utf8_spec.rb
@@ -38,11 +38,20 @@ RSpec.describe 'Google phone takeout import with invalid UTF-8 bytes' do
   end
 
   it 'imports without raising when content comes from storage download' do
+    downloaded = Tempfile.new(['timeline-download', '.json'])
+    downloaded.binmode
+    downloaded.write(json_with_latin1_degree_signs)
+    downloaded.close
+
     downloader = instance_double(
-      Imports::SecureFileDownloader, download_with_verification: json_with_latin1_degree_signs
+      Imports::SecureFileDownloader,
+      download_with_verification: json_with_latin1_degree_signs,
+      download_to_temp_file: downloaded.path
     )
     allow(Imports::SecureFileDownloader).to receive(:new).and_return(downloader)
 
     expect { GoogleMaps::PhoneTakeoutImporter.new(import, user.id).call }.not_to raise_error
+  ensure
+    downloaded&.unlink
   end
 end

--- a/spec/regressions/gpx_mixed_track_and_waypoints_imports_both_spec.rb
+++ b/spec/regressions/gpx_mixed_track_and_waypoints_imports_both_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GPX with both <trk> and <wpt> imports tracks as Points and waypoints as Places' do
+  subject(:run_import) { Gpx::TrackImporter.new(import, user.id).call }
+
+  let(:user) { create(:user) }
+  let(:file_path) { Rails.root.join('spec/fixtures/files/gpx/gpx_mixed_track_and_waypoints.gpx') }
+  let(:file) { Rack::Test::UploadedFile.new(file_path, 'application/xml') }
+  let(:import) { create(:import, user:, name: 'mixed.gpx', source: 'gpx') }
+
+  before { import.file.attach(file) }
+
+  it 'creates Points for the trkpts' do
+    expect { run_import }.to change { Point.count }.by(3)
+  end
+
+  it 'creates Places for the waypoints with source :gpx_waypoint' do
+    expect { run_import }.to change { Place.where(user: user, source: :gpx_waypoint).count }.by(2)
+    expect(Place.where(user: user).pluck(:name)).to contain_exactly('Start Marker', 'End Marker')
+  end
+
+  it 'does not raise even though waypoints have no timestamps' do
+    expect { run_import }.not_to raise_error
+  end
+end

--- a/spec/regressions/gpx_waypoints_imported_as_places_spec.rb
+++ b/spec/regressions/gpx_waypoints_imported_as_places_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GPX waypoints (<wpt>) imported as Places' do
+  subject(:run_import) { Gpx::TrackImporter.new(import, user.id).call }
+
+  let(:user) { create(:user) }
+  let(:file_path) { Rails.root.join('spec/fixtures/files/gpx/gpx_waypoints_only.gpx') }
+  let(:file) { Rack::Test::UploadedFile.new(file_path, 'application/xml') }
+  let(:import) { create(:import, user:, name: 'favourites.gpx', source: 'gpx') }
+
+  before { import.file.attach(file) }
+
+  it 'creates one Place per <wpt> with source :gpx_waypoint' do
+    expect { run_import }.to change {
+      user.reload
+      Place.where(user: user).count
+    }.by(3)
+
+    places = Place.where(user: user, source: :gpx_waypoint)
+    expect(places.count).to eq(3)
+    expect(places.pluck(:name)).to contain_exactly('Brandenburg Gate', 'Eiffel Tower', 'Imported waypoint')
+  end
+
+  it 'creates no Points (waypoints have no timestamps and do not belong on the timeline)' do
+    expect { run_import }.not_to(change { Point.count })
+  end
+
+  it 'persists coordinates from lat/lon attributes' do
+    run_import
+
+    brandenburg = Place.find_by(user: user, name: 'Brandenburg Gate')
+    expect(brandenburg.longitude.to_f).to be_within(0.000001).of(13.404954)
+    expect(brandenburg.latitude.to_f).to be_within(0.000001).of(52.520008)
+  end
+end

--- a/spec/regressions/import_rejects_unusable_locations_spec.rb
+++ b/spec/regressions/import_rejects_unusable_locations_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Imports reject unusable locations' do
+  let(:user) { create(:user) }
+
+  def import_gpx(waypoint)
+    body = <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <gpx version="1.1" creator="test" xmlns="http://www.topografix.com/GPX/1/1">
+      #{waypoint}
+      </gpx>
+    XML
+    path = Rails.root.join('tmp', "#{SecureRandom.hex(4)}-waypoints.gpx")
+    File.write(path, body)
+    import = create(:import, user:, name: File.basename(path), source: 'gpx')
+    import.file.attach(Rack::Test::UploadedFile.new(path, 'application/xml'))
+    Gpx::TrackImporter.new(import, user.id).call
+  ensure
+    File.delete(path) if path && File.exist?(path)
+  end
+
+  def import_geojson(json)
+    path = Rails.root.join('tmp', "#{SecureRandom.hex(4)}-features.json")
+    File.write(path, json)
+    import = create(:import, user:, name: File.basename(path), source: 'geojson')
+    import.file.attach(Rack::Test::UploadedFile.new(path, 'application/json'))
+    Geojson::Importer.new(import, user.id).call
+  ensure
+    File.delete(path) if path && File.exist?(path)
+  end
+
+  def feature_collection(*features)
+    %({"type":"FeatureCollection","features":[#{features.join(',')}]})
+  end
+
+  def point_feature(name, coordinates)
+    %({"type":"Feature","properties":{"name":"#{name}"},"geometry":{"type":"Point","coordinates":#{coordinates}}})
+  end
+
+  it 'drops a waypoint whose latitude is not a number instead of placing it on the equator' do
+    expect { import_gpx('<wpt lat="north" lon="13.404954"><name>Nonsense</name></wpt>') }
+      .to raise_error(Imports::NoImportableDataError)
+    expect(Place.count).to eq(0)
+  end
+
+  it 'drops a waypoint whose coordinates are off the globe' do
+    expect { import_gpx('<wpt lat="91.5" lon="13.404954"><name>Off globe</name></wpt>') }
+      .to raise_error(Imports::NoImportableDataError)
+    expect(Place.count).to eq(0)
+  end
+
+  it 'reports a GeoJSON file whose geometries are all unsupported' do
+    ring = '[[[13.0,52.0],[13.1,52.0],[13.1,52.1],[13.0,52.0]]]'
+    polygon = %({"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":#{ring}}})
+
+    expect { import_geojson(feature_collection(polygon)) }.to raise_error(Imports::NoImportableDataError)
+  end
+
+  it 'reports a GeoJSON file whose untimed points all have unusable coordinates' do
+    garbage = feature_collection(
+      point_feature('off globe', '[13.4,999.0]'),
+      point_feature('nonsense', '["east",52.5]')
+    )
+
+    expect { import_geojson(garbage) }.to raise_error(Imports::NoImportableDataError)
+    expect(Place.count).to eq(0)
+  end
+
+  it 'reports a GeoJSON file with no features at all' do
+    expect { import_geojson(feature_collection) }.to raise_error(Imports::NoImportableDataError)
+  end
+end

--- a/spec/regressions/imported_places_belong_to_their_import_spec.rb
+++ b/spec/regressions/imported_places_belong_to_their_import_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Imported places belong to their import' do
+  let(:user) { create(:user) }
+  let(:file_path) { Rails.root.join('spec/fixtures/files/gpx/gpx_waypoints_only.gpx') }
+  let(:import) { create(:import, user:, name: 'favourites.gpx', source: 'gpx') }
+
+  before do
+    import.file.attach(Rack::Test::UploadedFile.new(file_path, 'application/xml'))
+    Imports::Create.new(user, import).call
+  end
+
+  it 'records which import created each place' do
+    expect(Place.where(user: user).pluck(:import_id).uniq).to eq([import.id])
+  end
+
+  it 'removes the places when the import is deleted' do
+    expect { import.destroy! }.to change { Place.where(user: user).count }.from(3).to(0)
+  end
+
+  it 'tells the user where the untimed locations went, since the points count stays zero' do
+    expect(import.reload.points.count).to eq(0)
+    expect(Notification.where(user_id: user.id).pluck(:title)).to include('Places imported')
+  end
+end

--- a/spec/regressions/imported_places_survive_reimport_spec.rb
+++ b/spec/regressions/imported_places_survive_reimport_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Re-importing a waypoint file' do
+  let(:user) { create(:user) }
+  let(:file_path) { Rails.root.join('spec/fixtures/files/gpx/gpx_waypoints_only.gpx') }
+
+  def run_import(name)
+    import = create(:import, user:, name:, source: 'gpx')
+    import.file.attach(Rack::Test::UploadedFile.new(file_path, 'application/xml'))
+    Gpx::TrackImporter.new(import, user.id).call
+    import
+  end
+
+  it 'does not duplicate places that were already imported' do
+    run_import('favourites.gpx')
+
+    expect { run_import('favourites-again.gpx') }.not_to(change { Place.where(user: user).count })
+  end
+
+  it 'does not report the file as timestampless when every waypoint already exists' do
+    run_import('favourites.gpx')
+
+    expect { run_import('favourites-again.gpx') }.not_to raise_error
+  end
+
+  it 'shows imported places on the map without needing a tag or a confirmed visit' do
+    run_import('favourites.gpx')
+
+    expect(Place.map_visible(user).pluck(:name)).to include('Brandenburg Gate', 'Eiffel Tower')
+  end
+
+  it 'locks imported names so nightly reverse geocoding cannot rename them' do
+    run_import('favourites.gpx')
+
+    place = Place.find_by(user: user, name: 'Brandenburg Gate')
+    expect(place).to be_name_locked
+  end
+
+  it 'names a waypoint that carries no name' do
+    run_import('favourites.gpx')
+
+    expect(Place.where(user: user).pluck(:name)).to include(Places::GpxWaypointImporter::DEFAULT_NAME)
+  end
+
+  it 'hands ownership to the newest import so deleting an older one keeps the places' do
+    first = run_import('favourites.gpx')
+    run_import('favourites-again.gpx')
+
+    expect { first.destroy! }.not_to(change { Place.where(user: user).count })
+  end
+
+  it 'still reports the places when every waypoint already existed' do
+    run_import('favourites.gpx')
+    second = create(:import, user:, name: 'favourites-again.gpx', source: 'gpx')
+    second.file.attach(Rack::Test::UploadedFile.new(file_path, 'application/xml'))
+
+    Imports::Create.new(user, second).call
+
+    expect(second.reload.places.count).to eq(3)
+  end
+end


### PR DESCRIPTION
Closes the import half of #1261.

## The problem

`Gpx::TrackImporter` only ever opened a parse stack on `<trkpt>`, so `<wpt>` elements were skipped entirely — an OsmAnd favourites export imported zero points and reported success. GeoJSON `Point` features without a timestamp were inserted as points with a `NULL` timestamp, which every map and API query filters out, so they were invisible and left a `Stats::CalculatingJob(user_id, nil, nil)` behind.

## What changes

Both now become places rather than timeline points:

- **GPX `<wpt>`** → `Place` with source `gpx_waypoint`. The GPX spec already separates waypoints from track points, so the `<time>` a waypoint carries (OsmAnd writes the moment the favourite was saved) is not treated as a timeline position.
- **Timeless GeoJSON `Point`** → `Place` with source `geojson_point`. A `Point` that *does* carry a timestamp still becomes a timeline point.
- A GPX holding both tracks and waypoints fills the timeline and the places list in one import.

Imported places are named from the file, `name_locked_at` is set so nightly reverse geocoding cannot rename them, and they are added to `Place.map_visible` so they show up without needing a tag or a confirmed visit.

They are tied to their import via a new `places.import_id`, so deleting the import removes them. Re-importing an edited favourites file re-claims existing rows via `upsert_all` against a partial unique index on `(user_id, name, latitude, longitude) WHERE source IN (2, 3)` — no duplicates, and no read-then-write race between concurrent imports.

A file with nothing importable in it now raises `Imports::NoImportableDataError` instead of completing with zero points: untimed track points, untimed GeoJSON lines, unsupported geometries, no features at all, or coordinates that are non-numeric or off the globe. A waypoint-only import also posts a "Places imported" notification, since the imports table counts points and would otherwise show a row of zeroes.

## Migration

`AddImportIdToPlaces` adds a nullable `places.import_id` plus two partial indexes, both `CONCURRENTLY`. The uniqueness index is scoped to sources 2 and 3, which no existing row can carry, so it cannot conflict with places created by geocoding or by hand.

## Still outstanding

The second half of #1261 — the watcher re-processing a `favourites.gpx` that OsmAnd overwrites in place — is not addressed here. `Imports::Watcher#create_import` returns early on `import.persisted?`, so a file that keeps its name never re-imports. That needs its own change, so this references the issue rather than closing it.

## Verification

- Full suite: 7190 examples, 0 failures. RuboCop clean.
- Verified against the reporter's own `favorites-Dawarich.gpx` from the issue thread: 5 places, correct names, name-locked, map-visible, no error. Their GeoJSON sample: 2 places, no `NULL`-timestamp points.
- Regression specs under `spec/regressions/` cover waypoint-only, mixed track+waypoint, timeless GeoJSON points, unusable coordinates, re-import dedup and ownership transfer, and the empty-file error.
