### PR TITLE
feat: family plan — effective-plan access model, gating, and creation gate

### DIFF
--- a/app/controllers/api/v1/plan_controller.rb
+++ b/app/controllers/api/v1/plan_controller.rb
@@ -4,14 +4,11 @@ class Api::V1::PlanController < ApiController
   skip_before_action :reject_pending_payment!, only: :show
 
   def show
-    features = if DawarichSettings.self_hosted? || current_api_user.pro?
-                 full_features
-               else
-                 lite_features
-               end
+    features = current_api_user.full_access? ? full_features : lite_features
 
     render json: {
       plan: current_api_user.plan,
+      effective_plan: current_api_user.effective_plan,
       status: current_api_user.status,
       subscription_source: current_api_user.subscription_source,
       active_until: current_api_user.active_until&.iso8601,

--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -66,7 +66,7 @@ class Api::V1::PointsController < ApiController
 
     # For Lite users on Cloud: include the unscoped count and scoped count
     # so the frontend can show how many points fall outside the 12-month data window.
-    if !DawarichSettings.self_hosted? && current_api_user.lite?
+    if current_api_user.plan_restricted?
       total_in_range = current_api_user.points
                                        .where(timestamp: start_at..end_at)
       total_in_range = total_in_range.where(import_id: params[:import_id]) if params[:import_id].present?

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -56,8 +56,7 @@ class ApiController < ApplicationController
 
   def require_pro_api!
     return unless current_api_user # auth already handled by authenticate_api_key
-    return if DawarichSettings.self_hosted?
-    return if current_api_user.pro?
+    return if current_api_user.full_access?
 
     render json: {
       error: 'pro_plan_required',
@@ -68,8 +67,7 @@ class ApiController < ApplicationController
 
   def require_write_api!
     return unless current_api_user # auth already handled by authenticate_api_key
-    return if DawarichSettings.self_hosted?
-    return if current_api_user.pro?
+    return if current_api_user.full_access?
 
     render json: {
       error: 'write_api_restricted',
@@ -87,8 +85,7 @@ class ApiController < ApplicationController
   # Applies the 12-month plan window to any point relation.
   # Use this when scoping points that don't start from user.points (e.g. track.points).
   def apply_plan_scope(relation, user = current_api_user)
-    return relation if DawarichSettings.self_hosted?
-    return relation unless user&.lite?
+    return relation unless user&.plan_restricted?
 
     relation.where('timestamp >= ?', DawarichSettings::LITE_DATA_WINDOW.ago.to_i)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,7 +103,7 @@ class ApplicationController < ActionController::Base
       return
     end
 
-    return if current_user.pro?
+    return if current_user.full_access?
 
     respond_to do |format|
       format.html do

--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -24,7 +24,10 @@ class FamiliesController < ApplicationController
     redirect_to family_path and return if current_user.in_family?
 
     @family = Family.new
-    authorize @family
+    @can_create_family = FamilyPolicy.new(current_user, @family).create?
+    return if @can_create_family
+
+    @family_upgrade_url = helpers.family_upgrade_url(utm_medium: 'family', utm_content: 'create_family')
   end
 
   def create

--- a/app/controllers/settings/integrations_controller.rb
+++ b/app/controllers/settings/integrations_controller.rb
@@ -6,7 +6,7 @@ class Settings::IntegrationsController < ApplicationController
   before_action :require_pro!, only: %i[update]
 
   def index
-    @pro_required = !DawarichSettings.self_hosted? && !current_user.pro?
+    @pro_required = !current_user.full_access?
   end
 
   def update

--- a/app/controllers/shared/digests_controller.rb
+++ b/app/controllers/shared/digests_controller.rb
@@ -21,7 +21,7 @@ class Shared::DigestsController < ApplicationController
     @user = @digest.user
     @distance_unit = @user.safe_settings.distance_unit || 'km'
     @is_public_view = true
-    @full_digest = DawarichSettings.self_hosted? || @user.pro?
+    @full_digest = @user.full_access?
 
     render 'users/digests/public_year'
   end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -23,7 +23,7 @@ class StatsController < ApplicationController
     @stat = current_user.scoped_stats.find_by(year: @year, month: @month)
     @previous_stat = current_user.scoped_stats.find_by(year: @year, month: @month - 1) if @month > 1
     @average_distance_this_year = current_user.scoped_stats.where(year: @year).average(:distance).to_i / 1000
-    @sharing_allowed = DawarichSettings.self_hosted? || current_user.pro?
+    @sharing_allowed = current_user.full_access?
   end
 
   def update

--- a/app/controllers/users/digests_controller.rb
+++ b/app/controllers/users/digests_controller.rb
@@ -15,7 +15,7 @@ class Users::DigestsController < ApplicationController
 
   def show
     @distance_unit = current_user.safe_settings.distance_unit || 'km'
-    @full_digest = DawarichSettings.self_hosted? || current_user.pro?
+    @full_digest = current_user.full_access?
   end
 
   def create

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@
 
 module ApplicationHelper
   def show_plan_data_window_alert?
-    !DawarichSettings.self_hosted? && current_user&.lite?
+    current_user&.plan_restricted? || false
   end
 
   def year_timespan(year)
@@ -212,8 +212,17 @@ module ApplicationHelper
     utm.any? ? "#{base}&#{utm.to_query}" : base
   end
 
+  def family_upgrade_url(utm_source: 'app', utm_medium: nil, utm_campaign: 'family_upgrade', utm_content: nil)
+    return '' if DawarichSettings.self_hosted?
+
+    token = current_user.generate_subscription_token(plan: 'family', interval: 'annual')
+    base = "#{MANAGER_URL}/auth/dawarich?token=#{token}"
+    utm = { utm_source:, utm_medium:, utm_campaign:, utm_content: }.compact
+    utm.any? ? "#{base}&#{utm.to_query}" : base
+  end
+
   def pro_badge_tag(preview: true)
-    return unless current_user&.lite?
+    return unless current_user&.plan_restricted?
 
     tooltip = preview ? 'Available on Pro — click to preview' : 'Available on Pro'
     link_to upgrade_url(utm_medium: 'badge', utm_content: 'pro_badge'),

--- a/app/jobs/lite/archival_warning_job.rb
+++ b/app/jobs/lite/archival_warning_job.rb
@@ -15,6 +15,8 @@ class Lite::ArchivalWarningJob < ApplicationJob
     return if DawarichSettings.self_hosted?
 
     User.where(plan: :lite).find_each do |user|
+      next if user.full_access?
+
       check_thresholds(user)
     end
   end

--- a/app/models/concerns/plan_scopable.rb
+++ b/app/models/concerns/plan_scopable.rb
@@ -3,8 +3,19 @@
 module PlanScopable
   extend ActiveSupport::Concern
 
+  def effective_plan
+    return plan.to_sym if DawarichSettings.self_hosted?
+    return :family if in_family? && family&.owner&.family?
+
+    plan.to_sym
+  end
+
+  def full_access?
+    DawarichSettings.self_hosted? || effective_plan != :lite
+  end
+
   def plan_restricted?
-    !DawarichSettings.self_hosted? && lite?
+    !DawarichSettings.self_hosted? && effective_plan == :lite
   end
 
   def data_window_start

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
   # `User#none?` predicate that collides with NilClass semantics in
   # conditional chains. Callers use `user.sub_source_none?` etc.
   enum :subscription_source, { none: 0, paddle: 1, apple_iap: 2, google_play: 3 }, default: :none, prefix: :sub_source
-  enum :plan, { lite: 0, pro: 1 }, default: :pro
+  enum :plan, { lite: 0, pro: 1, family: 2 }, default: :pro
   # No default: nil means the user has not yet been prompted about the
   # changelog widget. prefix avoids `granted?`/`declined?` collisions.
   attribute :changelog_consent, :integer

--- a/app/policies/family_policy.rb
+++ b/app/policies/family_policy.rb
@@ -9,9 +9,7 @@ class FamilyPolicy < ApplicationPolicy
     return false if user.in_family?
     return true if DawarichSettings.self_hosted?
 
-    # Add cloud subscription checks here when implemented
-    # For now, allow all users to create families
-    true
+    user.family?
   end
 
   def update?

--- a/app/services/families/create.rb
+++ b/app/services/families/create.rb
@@ -76,9 +76,7 @@ module Families
     def can_create_family?
       return true if DawarichSettings.self_hosted?
 
-      # TODO: Add cloud plan validation here when needed
-      # For now, allow all users to create families
-      true
+      user.family?
     end
 
     def create_family

--- a/app/services/users/transportation_thresholds_updater.rb
+++ b/app/services/users/transportation_thresholds_updater.rb
@@ -66,7 +66,7 @@ module Users
         end
       end
 
-      sanitize_gated_layers if @user.lite?
+      sanitize_gated_layers if @user.plan_restricted?
     end
 
     # The `maps` hash also carries V1 keys (name, url, preferred_version)

--- a/app/views/families/new.html.erb
+++ b/app/views/families/new.html.erb
@@ -11,6 +11,21 @@
       </p>
     </div>
 
+    <% if @can_create_family == false %>
+      <div class="bg-base-200 rounded-lg p-6 text-center">
+        <h2 class="text-xl font-bold mb-2">
+          <%= t('families.new.upgrade_title', default: 'Family plan required') %>
+        </h2>
+        <p class="text-base-content opacity-60 mb-6">
+          <%= t('families.new.upgrade_description',
+                default: 'Creating a family requires the Family plan. Upgrade to invite up to 5 members and share full access.') %>
+        </p>
+        <%= link_to t('families.new.upgrade_cta', default: 'Upgrade to Family'),
+              @family_upgrade_url,
+              target: '_blank', rel: 'noopener noreferrer',
+              class: 'btn btn-primary' %>
+      </div>
+    <% else %>
     <div class="bg-base-200 rounded-lg p-6">
       <%= form_with url: family_path, model: @family, local: true, class: "space-y-6" do |form| %>
         <% if @family.errors.any? %>
@@ -64,5 +79,6 @@
         </div>
       <% end %>
     </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/map/leaflet/index.html.erb
+++ b/app/views/map/leaflet/index.html.erb
@@ -15,7 +15,7 @@
     data-points-target="map"
     data-api_key="<%= current_user.api_key %>"
     data-self_hosted="<%= @self_hosted %>"
-    data-user_plan="<%= current_user.plan %>"
+    data-user_plan="<%= current_user.effective_plan %>"
     data-start_date="<%= @start_at.iso8601 %>"
     data-upgrade_url="<%= upgrade_url(utm_medium: 'map', utm_content: 'leaflet') %>"
     data-user_settings='<%= current_user.safe_settings.settings.to_json %>'

--- a/app/views/map/maplibre/_settings_panel.html.erb
+++ b/app/views/map/maplibre/_settings_panel.html.erb
@@ -586,7 +586,7 @@
             </div>
           </details>
 
-          <% can_customize_layers = DawarichSettings.self_hosted? || current_user.pro? %>
+          <% can_customize_layers = current_user.full_access? %>
           <details class="collapse collapse-arrow bg-base-200 rounded-lg">
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">

--- a/app/views/map/maplibre/_settings_panel.html.erb
+++ b/app/views/map/maplibre/_settings_panel.html.erb
@@ -1506,7 +1506,7 @@
               <span class="text-xs">Replay</span>
             </button>
 
-            <% if DawarichSettings.self_hosted? || current_user.pro? %>
+            <% if current_user.full_access? %>
               <button type="button"
                       class="btn btn-sm btn-outline flex flex-col items-center gap-1 h-auto py-3"
                       onclick="document.dispatchEvent(new CustomEvent('residency:open'))">
@@ -1515,7 +1515,7 @@
               </button>
             <% end %>
 
-            <% if current_user.immich_integration_configured? && (DawarichSettings.self_hosted? || current_user.pro?) %>
+            <% if current_user.immich_integration_configured? && current_user.full_access? %>
               <button type="button"
                       class="btn btn-sm btn-outline flex flex-col items-center gap-1 h-auto py-3"
                       id="immich-enrich-toggle-btn">
@@ -1526,7 +1526,7 @@
           </div>
 
           <!-- Immich Enrich Panel -->
-          <% if current_user.immich_integration_configured? && (DawarichSettings.self_hosted? || current_user.pro?) %>
+          <% if current_user.immich_integration_configured? && current_user.full_access? %>
             <div class="hidden mt-4"
                  data-controller="maps--immich-enrich"
                  data-maps--immich-enrich-api-key-value="<%= current_user.api_key %>"

--- a/app/views/map/maplibre/index.html.erb
+++ b/app/views/map/maplibre/index.html.erb
@@ -67,7 +67,7 @@
   <!-- Place creation modal (shared) -->
   <%= render 'shared/place_creation_modal' %>
 
-  <% if DawarichSettings.self_hosted? || current_user.pro? %>
+  <% if current_user.full_access? %>
     <!-- Residency day counter modal -->
     <%= render 'map/maplibre/residency_modal' %>
   <% end %>

--- a/app/views/map/maplibre/index.html.erb
+++ b/app/views/map/maplibre/index.html.erb
@@ -8,7 +8,7 @@
      data-maps--maplibre-start-date-value="<%= @start_at.iso8601 %>"
      data-maps--maplibre-end-date-value="<%= @end_at.iso8601 %>"
      data-maps--maplibre-timezone-value="<%= current_user.timezone %>"
-     data-maps--maplibre-user-plan-value="<%= current_user.plan %>"
+     data-maps--maplibre-user-plan-value="<%= current_user.effective_plan %>"
      data-maps--maplibre-import-id-value="<%= @import_id %>"
      data-maps--maplibre-upgrade-url-value="<%= upgrade_url(utm_medium: 'map', utm_content: 'maplibre') %>"
      data-maps--maplibre-realtime-enabled-value="true"

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -29,7 +29,7 @@ class Rack::Attack
   class << self
     attr_accessor :api_rate_limits, :shared_links_viewer_limit
   end
-  self.api_rate_limits = { 'lite' => 200, 'pro' => 1_000 }
+  self.api_rate_limits = { 'lite' => 200, 'pro' => 1_000, 'family' => 1_000 }
   self.shared_links_viewer_limit = 120
 end
 
@@ -46,7 +46,7 @@ Rack::Attack.throttle('api/token',
   next if api_key.blank?
 
   user_plan = Rails.cache.fetch("rack_attack/plan/#{api_key}", expires_in: 2.minutes) do
-    User.where(api_key: api_key).pick(:plan)
+    User.find_by(api_key: api_key)&.effective_plan&.to_s
   end
   next if user_plan.nil?
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 RSpec.describe ApplicationHelper, type: :helper do
   describe '#pro_badge_tag' do
-    context 'when user is not lite' do
+    context 'when user has full access' do
       before do
-        allow(helper).to receive(:current_user).and_return(double(lite?: false))
+        allow(helper).to receive(:current_user).and_return(double(plan_restricted?: false))
       end
 
       it 'returns nil' do
@@ -14,8 +14,8 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
 
-    context 'when user is lite' do
-      let(:fake_user) { double(lite?: true, generate_subscription_token: 'test_token') }
+    context 'when user is plan-restricted' do
+      let(:fake_user) { double(plan_restricted?: true, generate_subscription_token: 'test_token') }
 
       before do
         allow(helper).to receive(:current_user).and_return(fake_user)
@@ -88,6 +88,46 @@ RSpec.describe ApplicationHelper, type: :helper do
       it 'returns empty string without invoking JWT generation' do
         # Would raise KeyError on self-hosted (no JWT_SECRET_KEY) if not guarded.
         expect(helper.upgrade_url).to eq('')
+      end
+    end
+  end
+
+  describe '#family_upgrade_url' do
+    let(:secret) { ENV.fetch('JWT_SECRET_KEY', 'test_secret') }
+
+    def token_from(url)
+      url[/token=([^&]+)/, 1]
+    end
+
+    def decode(token)
+      JWT.decode(token, secret, true, { algorithm: 'HS256' }).first
+    end
+
+    context 'on cloud instances' do
+      let(:user) { create(:user) }
+
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        allow(helper).to receive(:current_user).and_return(user)
+        stub_const('MANAGER_URL', 'https://manager.example.com')
+      end
+
+      it 'embeds a token whose payload carries the family plan and annual interval' do
+        url = helper.family_upgrade_url
+
+        expect(url).to start_with('https://manager.example.com/auth/dawarich?token=')
+        payload = decode(token_from(url))
+        expect(payload['plan']).to eq('family')
+        expect(payload['interval']).to eq('annual')
+        expect(payload['user_id']).to eq(user.id)
+      end
+    end
+
+    context 'on self-hosted instances' do
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(true) }
+
+      it 'returns an empty string' do
+        expect(helper.family_upgrade_url).to eq('')
       end
     end
   end

--- a/spec/jobs/lite/archival_warning_job_spec.rb
+++ b/spec/jobs/lite/archival_warning_job_spec.rb
@@ -33,6 +33,22 @@ RSpec.describe Lite::ArchivalWarningJob, type: :job do
       end
     end
 
+    context 'when a Lite user is a member of a family-plan family' do
+      let!(:family_owner) { create(:user).tap { |u| u.update_column(:plan, User.plans[:family]) } }
+      let!(:family) { create(:family, creator: family_owner) }
+
+      before do
+        create(:family_membership, :owner, family: family, user: family_owner)
+        create(:family_membership, family: family, user: lite_user)
+        create(:point, user: lite_user, timestamp: 12.months.ago.to_i)
+      end
+
+      it 'does not create an archival warning for the family member' do
+        expect { described_class.perform_now }
+          .not_to(change { Notification.where(user: lite_user).count })
+      end
+    end
+
     context 'when a Lite user has data approaching 11 months old' do
       before do
         create(:point, user: lite_user, timestamp: 11.months.ago.to_i)

--- a/spec/models/concerns/plan_scopable_spec.rb
+++ b/spec/models/concerns/plan_scopable_spec.rb
@@ -32,6 +32,46 @@ RSpec.describe PlanScopable do
         user.update!(plan: :pro)
         expect(user.plan_restricted?).to be false
       end
+
+      it 'returns false for family owners' do
+        owner = create(:user, plan: :family, skip_auto_trial: true)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+
+        expect(owner.plan_restricted?).to be false
+      end
+
+      it 'returns false for a lite member of a family-plan family' do
+        owner = create(:user, plan: :family, skip_auto_trial: true)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        member = create(:user, plan: :lite, skip_auto_trial: true)
+        create(:family_membership, family: family, user: member)
+
+        expect(member.plan_restricted?).to be false
+      end
+    end
+  end
+
+  describe 'scoped relations for a lite family member' do
+    let(:owner) { create(:user, plan: :family, skip_auto_trial: true) }
+    let(:family) { create(:family, creator: owner) }
+    let(:member) { create(:user, plan: :lite, skip_auto_trial: true) }
+
+    before do
+      allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+      create(:family_membership, :owner, family: family, user: owner)
+      create(:family_membership, family: family, user: member)
+    end
+
+    it 'returns unscoped points, tracks, visits and stats' do
+      recent_point = create(:point, user: member, timestamp: 1.month.ago.to_i)
+      old_point = create(:point, user: member, timestamp: 2.years.ago.to_i)
+      recent_track = create(:track, user: member, start_at: 1.month.ago)
+      old_track = create(:track, user: member, start_at: 2.years.ago)
+
+      expect(member.scoped_points).to include(recent_point, old_point)
+      expect(member.scoped_tracks).to include(recent_track, old_track)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -64,6 +64,136 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#effective_plan' do
+    context 'when self-hosted' do
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(true) }
+
+      it 'returns the raw plan regardless of family membership' do
+        user = create(:user, plan: :lite, skip_auto_trial: true)
+
+        expect(user.effective_plan).to eq(:lite)
+      end
+    end
+
+    context 'when cloud' do
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
+
+      it 'returns :pro for a cloud pro user' do
+        user = create(:user, plan: :pro, skip_auto_trial: true)
+
+        expect(user.effective_plan).to eq(:pro)
+      end
+
+      it 'returns :family for a family owner' do
+        owner = create(:user, plan: :family, skip_auto_trial: true)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+
+        expect(owner.effective_plan).to eq(:family)
+      end
+
+      it 'returns :lite for a lite user not in a family' do
+        user = create(:user, plan: :lite, skip_auto_trial: true)
+
+        expect(user.effective_plan).to eq(:lite)
+      end
+
+      it 'returns :family for a lite member of a family-plan family' do
+        owner = create(:user, plan: :family, skip_auto_trial: true)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        member = create(:user, plan: :lite, skip_auto_trial: true)
+        create(:family_membership, family: family, user: member)
+
+        expect(member.effective_plan).to eq(:family)
+      end
+
+      it 'returns the raw plan for a lite member whose family owner is not on the family plan' do
+        owner = create(:user, plan: :pro, skip_auto_trial: true)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        member = create(:user, plan: :lite, skip_auto_trial: true)
+        create(:family_membership, family: family, user: member)
+
+        expect(member.effective_plan).to eq(:lite)
+      end
+
+      it 'reverts to the raw plan after the member leaves the family' do
+        owner = create(:user, plan: :family, skip_auto_trial: true)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        member = create(:user, plan: :lite, skip_auto_trial: true)
+        membership = create(:family_membership, family: family, user: member)
+
+        membership.destroy!
+        member.reload
+
+        expect(member.effective_plan).to eq(:lite)
+      end
+
+      it 'reverts all members when the owner plan drops below family, leaving the family dormant' do
+        owner = create(:user, plan: :family, skip_auto_trial: true)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        member = create(:user, plan: :lite, skip_auto_trial: true)
+        create(:family_membership, family: family, user: member)
+
+        expect(member.full_access?).to be true
+
+        owner.update!(plan: :pro)
+        member.reload
+
+        expect(member.full_access?).to be false
+        expect(member.effective_plan).to eq(:lite)
+        expect(member.in_family?).to be true
+        expect(Family.exists?(family.id)).to be true
+        expect(family.members).to include(member, owner)
+      end
+    end
+  end
+
+  describe '#full_access?' do
+    context 'when self-hosted' do
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(true) }
+
+      it 'is true even for a lite user' do
+        user = create(:user, plan: :lite, skip_auto_trial: true)
+
+        expect(user.full_access?).to be true
+      end
+    end
+
+    context 'when cloud' do
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
+
+      it 'is true for pro' do
+        expect(create(:user, plan: :pro, skip_auto_trial: true).full_access?).to be true
+      end
+
+      it 'is true for a family owner' do
+        owner = create(:user, plan: :family, skip_auto_trial: true)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+
+        expect(owner.full_access?).to be true
+      end
+
+      it 'is false for a lite user not in a family' do
+        expect(create(:user, plan: :lite, skip_auto_trial: true).full_access?).to be false
+      end
+
+      it 'is true for a lite member of a family-plan family' do
+        owner = create(:user, plan: :family, skip_auto_trial: true)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        member = create(:user, plan: :lite, skip_auto_trial: true)
+        create(:family_membership, family: family, user: member)
+
+        expect(member.full_access?).to be true
+      end
+    end
+  end
+
   describe 'callbacks' do
     describe '#create_api_key' do
       let(:user) { create(:user) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,7 +28,18 @@ RSpec.describe User, type: :model do
         .with_values(none: 0, paddle: 1, apple_iap: 2, google_play: 3)
         .with_prefix(:sub_source)
     }
-    it { is_expected.to define_enum_for(:plan).with_values(lite: 0, pro: 1) }
+    it { is_expected.to define_enum_for(:plan).with_values(lite: 0, pro: 1, family: 2) }
+  end
+
+  describe 'plan enum' do
+    it 'supports the family plan' do
+      user = create(:user, plan: :family, skip_auto_trial: true)
+      expect(user.family?).to be true
+    end
+
+    it 'has integer value 2 for family' do
+      expect(User.plans['family']).to eq(2)
+    end
   end
 
   describe 'changelog consent' do

--- a/spec/policies/family_policy_spec.rb
+++ b/spec/policies/family_policy_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FamilyPolicy, type: :policy do
+  describe 'create?' do
+    context 'when self-hosted' do
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(true) }
+
+      it 'permits any user not already in a family' do
+        user = create(:user, plan: :lite, skip_auto_trial: true)
+
+        expect(FamilyPolicy.new(user, Family)).to permit(:create)
+      end
+    end
+
+    context 'when cloud' do
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
+
+      it 'permits a user on the family plan' do
+        user = create(:user, plan: :family, skip_auto_trial: true)
+
+        expect(FamilyPolicy.new(user, Family)).to permit(:create)
+      end
+
+      it 'denies a pro user' do
+        user = create(:user, plan: :pro, skip_auto_trial: true)
+
+        expect(FamilyPolicy.new(user, Family)).not_to permit(:create)
+      end
+
+      it 'denies a lite user' do
+        user = create(:user, plan: :lite, skip_auto_trial: true)
+
+        expect(FamilyPolicy.new(user, Family)).not_to permit(:create)
+      end
+
+      it 'denies a family-plan user who is already in a family' do
+        user = create(:user, plan: :family, skip_auto_trial: true)
+        family = create(:family, creator: user)
+        create(:family_membership, :owner, family: family, user: user)
+
+        expect(FamilyPolicy.new(user, Family)).not_to permit(:create)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/rate_limiting_spec.rb
+++ b/spec/requests/api/v1/rate_limiting_spec.rb
@@ -62,6 +62,50 @@ RSpec.describe 'API Rate Limiting', type: :request do
       end
     end
 
+    context 'when user is on family plan' do
+      let!(:user) do
+        u = create(:user)
+        u.update_columns(plan: User.plans[:family])
+        u
+      end
+
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+      end
+
+      it 'includes rate limit headers with a limit of 1000' do
+        get api_v1_points_url(api_key: user.api_key)
+
+        expect(response.headers['X-RateLimit-Limit']).to eq('1000')
+      end
+    end
+
+    context 'when user is a lite member of a family-plan family' do
+      let!(:owner) do
+        u = create(:user)
+        u.update_columns(plan: User.plans[:family])
+        u
+      end
+      let!(:family) { create(:family, creator: owner) }
+      let!(:member) do
+        u = create(:user)
+        u.update_columns(plan: User.plans[:lite])
+        u
+      end
+
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        create(:family_membership, :owner, family: family, user: owner)
+        create(:family_membership, family: family, user: member)
+      end
+
+      it 'gets the full 1000 limit via effective plan' do
+        get api_v1_points_url(api_key: member.api_key)
+
+        expect(response.headers['X-RateLimit-Limit']).to eq('1000')
+      end
+    end
+
     context 'when on a self-hosted instance' do
       let!(:user) { create(:user) }
 

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -253,6 +253,19 @@ RSpec.describe 'Api::V1::Subscriptions', type: :request do
         expect(response).to have_http_status(:ok)
         expect(user.reload.plan).to eq('pro')
       end
+
+      it 'updates plan to family when manager pushes plan=family' do
+        token = build_token(
+          user_id: user.id,
+          plan: 'family',
+          status: 'active',
+          active_until: 30.days.from_now.iso8601
+        )
+
+        post '/api/v1/subscriptions/callback', params: { token: token }, headers: webhook_headers
+        expect(response).to have_http_status(:ok)
+        expect(user.reload.plan).to eq('family')
+      end
     end
 
     context 'malformed JWT' do

--- a/spec/requests/families_spec.rb
+++ b/spec/requests/families_spec.rb
@@ -48,6 +48,43 @@ RSpec.describe 'Family', type: :request do
         expect(response).to redirect_to(family_path)
       end
     end
+
+    context 'when cloud and the user is not on the family plan' do
+      let(:cloud_user) { create(:user, plan: :pro, skip_auto_trial: true) }
+
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        allow(DawarichSettings).to receive(:family_feature_enabled?).and_return(true)
+        stub_const('MANAGER_URL', 'https://manager.example.com')
+        sign_in cloud_user
+      end
+
+      it 'renders the upgrade CTA instead of the create form' do
+        get '/family/new'
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('Upgrade to Family')
+        expect(response.body).to include('https://manager.example.com/auth/dawarich')
+        expect(response.body).not_to include('name="family[name]"')
+      end
+    end
+
+    context 'when cloud and the user is on the family plan' do
+      let(:cloud_family_user) { create(:user, plan: :family, skip_auto_trial: true) }
+
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        allow(DawarichSettings).to receive(:family_feature_enabled?).and_return(true)
+        sign_in cloud_family_user
+      end
+
+      it 'renders the create form' do
+        get '/family/new'
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('name="family[name]"')
+      end
+    end
   end
 
   describe 'POST /family' do

--- a/spec/requests/family/location_sharing_spec.rb
+++ b/spec/requests/family/location_sharing_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Family::LocationSharing', type: :request do
 
         expect(response).to have_http_status(:ok)
         user.reload
-        expect(user.family_history_window).to eq('24h')
+        expect(user.family_history_window).to eq(UserFamily::DEFAULT_HISTORY_WINDOW)
       end
     end
 

--- a/spec/requests/family_plan_access_spec.rb
+++ b/spec/requests/family_plan_access_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Family plan access gating', type: :request do
+  before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
+
+  let(:owner) { create(:user, plan: :family, skip_auto_trial: true) }
+  let(:family) { create(:family, creator: owner) }
+  let(:member) { create(:user, plan: :lite, skip_auto_trial: true) }
+
+  before do
+    create(:family_membership, :owner, family: family, user: owner)
+    create(:family_membership, family: family, user: member)
+  end
+
+  describe 'write API (require_write_api!)' do
+    it 'allows a family owner to recalculate' do
+      post "/api/v1/recalculations?api_key=#{owner.api_key}"
+
+      expect(response).to have_http_status(:accepted)
+    end
+
+    it 'allows a lite family member to recalculate' do
+      post "/api/v1/recalculations?api_key=#{member.api_key}"
+
+      expect(response).to have_http_status(:accepted)
+    end
+
+    it 'still blocks a lite user who is not in a family' do
+      lone_lite = create(:user, plan: :lite, skip_auto_trial: true)
+
+      post "/api/v1/recalculations?api_key=#{lone_lite.api_key}"
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)['error']).to eq('write_api_restricted')
+    end
+  end
+
+  describe 'pro read API (require_pro_api!)' do
+    it 'allows a lite family member to access the residency endpoint' do
+      get "/api/v1/residency?api_key=#{member.api_key}"
+
+      expect(response).not_to have_http_status(:forbidden)
+    end
+
+    it 'blocks a lite user who is not in a family' do
+      lone_lite = create(:user, plan: :lite, skip_auto_trial: true)
+
+      get "/api/v1/residency?api_key=#{lone_lite.api_key}"
+
+      expect(response).to have_http_status(:forbidden)
+      expect(JSON.parse(response.body)['error']).to eq('pro_plan_required')
+    end
+  end
+
+  describe 'GET /api/v1/plan' do
+    it 'reports full features and family effective plan for a lite family member' do
+      get api_v1_plan_url(api_key: member.api_key)
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json['plan']).to eq('lite')
+      expect(json['effective_plan']).to eq('family')
+      expect(json['features']['heatmap']).to be(true)
+      expect(json['features']['write_api']).to be(true)
+      expect(json['features']['data_window']).to be_nil
+    end
+
+    it 'reports full features for the family owner' do
+      get api_v1_plan_url(api_key: owner.api_key)
+
+      json = JSON.parse(response.body)
+      expect(json['plan']).to eq('family')
+      expect(json['effective_plan']).to eq('family')
+      expect(json['features']['integrations']).to be(true)
+    end
+  end
+end

--- a/spec/requests/family_plan_access_spec.rb
+++ b/spec/requests/family_plan_access_spec.rb
@@ -76,4 +76,31 @@ RSpec.describe 'Family plan access gating', type: :request do
       expect(json['features']['integrations']).to be(true)
     end
   end
+
+  describe 'map views inject the effective plan for JS layer gating' do
+    it 'passes family to Map v2 for a lite family member' do
+      sign_in member
+
+      get map_v2_path
+
+      expect(response.body).to include('data-maps--maplibre-user-plan-value="family"')
+    end
+
+    it 'passes family to Map v1 for a lite family member' do
+      sign_in member
+
+      get map_v1_path
+
+      expect(response.body).to include('data-user_plan="family"')
+    end
+
+    it 'still passes lite for a lite user not in a family' do
+      lone_lite = create(:user, plan: :lite, skip_auto_trial: true)
+      sign_in lone_lite
+
+      get map_v2_path
+
+      expect(response.body).to include('data-maps--maplibre-user-plan-value="lite"')
+    end
+  end
 end

--- a/spec/services/families/accept_invitation_spec.rb
+++ b/spec/services/families/accept_invitation_spec.rb
@@ -38,6 +38,28 @@ RSpec.describe Families::AcceptInvitation do
       end
     end
 
+    context 'effective access lifecycle (cloud, family-plan owner)' do
+      let(:owner) { create(:user, plan: :family, skip_auto_trial: true) }
+      let(:family) { create(:family, creator: owner) }
+      let(:invitee) { create(:user, plan: :lite, email: 'invitee@example.com', skip_auto_trial: true) }
+
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        create(:family_membership, :owner, family: family, user: owner)
+      end
+
+      it 'grants full access immediately upon joining without changing the stored plan' do
+        expect(invitee.full_access?).to be false
+
+        service.call
+        invitee.reload
+
+        expect(invitee.plan).to eq('lite')
+        expect(invitee.full_access?).to be true
+        expect(invitee.plan_restricted?).to be false
+      end
+    end
+
     context 'when user is already in another family' do
       let(:other_family) { create(:family) }
       let!(:existing_membership) { create(:family_membership, user: invitee, family: other_family) }

--- a/spec/services/families/create_spec.rb
+++ b/spec/services/families/create_spec.rb
@@ -73,5 +73,27 @@ RSpec.describe Families::Create do
         expect(service.error_message).to eq('You have already created a family. Each user can only create one family')
       end
     end
+
+    context 'when cloud and the user is not on the family plan' do
+      let(:user) { create(:user, plan: :pro, skip_auto_trial: true) }
+
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
+
+      it 'returns false and does not create a family' do
+        expect(service.call).to be false
+        expect { service.call }.not_to change(Family, :count)
+        expect(service.error_message).to eq('Family feature requires an active subscription')
+      end
+    end
+
+    context 'when cloud and the user is on the family plan' do
+      let(:user) { create(:user, plan: :family, skip_auto_trial: true) }
+
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
+
+      it 'creates a family' do
+        expect { service.call }.to change(Family, :count).by(1)
+      end
+    end
   end
 end

--- a/spec/services/families/memberships/destroy_spec.rb
+++ b/spec/services/families/memberships/destroy_spec.rb
@@ -43,6 +43,33 @@ RSpec.describe Families::Memberships::Destroy do
       end
     end
 
+    context 'effective access lifecycle (cloud, family-plan owner)' do
+      let(:user) { create(:user, plan: :family, skip_auto_trial: true) }
+      let(:family) { create(:family, creator: user) }
+      let(:member) { create(:user, plan: :lite, skip_auto_trial: true) }
+      let!(:owner_membership) { create(:family_membership, user: user, family: family, role: :owner) }
+      let!(:member_membership) { create(:family_membership, user: member, family: family, role: :member) }
+      let(:service) { described_class.new(user: user, member_to_remove: member) }
+
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
+
+      it 'revokes full access when the member is removed, without deleting their data' do
+        recent_point = create(:point, user: member, timestamp: 1.month.ago.to_i)
+        old_point = create(:point, user: member, timestamp: 2.years.ago.to_i)
+
+        expect(member.full_access?).to be true
+
+        service.call
+        member.reload
+
+        expect(member.full_access?).to be false
+        expect(member.plan_restricted?).to be true
+        expect(member.points).to include(recent_point, old_point)
+        expect(member.scoped_points).to include(recent_point)
+        expect(member.scoped_points).not_to include(old_point)
+      end
+    end
+
     context 'when user is family owner with no other members' do
       let!(:membership) { create(:family_membership, user: user, family: family, role: :owner) }
 

--- a/spec/services/families/update_location_sharing_spec.rb
+++ b/spec/services/families/update_location_sharing_spec.rb
@@ -115,10 +115,10 @@ RSpec.describe Families::UpdateLocationSharing do
         let(:share_history) { nil }
         let(:history_window) { 'invalid_value' }
 
-        it 'falls back to 24h' do
+        it 'falls back to the default window' do
           call_service
           user.reload
-          expect(user.family_history_window).to eq('24h')
+          expect(user.family_history_window).to eq(UserFamily::DEFAULT_HISTORY_WINDOW)
         end
       end
 

--- a/spec/services/users/transportation_thresholds_updater_spec.rb
+++ b/spec/services/users/transportation_thresholds_updater_spec.rb
@@ -111,6 +111,8 @@ RSpec.describe Users::TransportationThresholdsUpdater do
         u.reload
       end
 
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
+
       it 'strips gated layers from enabled_map_layers before saving' do
         params = { 'enabled_map_layers' => ['Tracks', 'Heatmap', 'Fog of War', 'Scratch map', 'Points'] }
         described_class.new(user, params).call


### PR DESCRIPTION
## Summary

Dawarich side of the Family plan launch (Phases 2–4 of the launch plan). Adds the read-time effective-plan access model and rewires every plan gate to it.

- **`family: 2` plan enum** on `User#plan`.
- **`User#effective_plan` + `full_access?`** (in `PlanScopable`) — a member of a family whose owner is on the family plan gets full access computed at read time; leaving the family or the owner downgrading reverts access automatically, no sync jobs.
- **Gating rewrite** — `require_pro_api!`, `require_write_api!`, `apply_plan_scope`, integrations, map customization, stat sharing, digests, and archival warnings now use `full_access?` / `plan_restricted?` (effective-plan aware) instead of raw `pro?`/`lite?`.
- **Map layer JS** (v1 + v2) receives `effective_plan` instead of the raw plan, so lite family members see heatmap/fog/scratch/globe.
- **Family creation gate** — on Cloud, only a `family`-plan user may create a family (`FamilyPolicy#create?`); non-family users see an upgrade CTA. Joining via invitation stays ungated.
- **Family upgrade URL** — checkout token carries `plan: 'family', interval: 'annual'`.
- **rack-attack** — explicit `family => 1_000` rate limit.

## Rollout

Deploy this before the manager side (dawarich-app/manager#60) so a `family` JWT callback is never dropped. Nothing is user-visible until the manager's `FAMILY_PLAN_ENABLED` flag flips; note that once released, cloud family *creation* is gated on the plan.

## Testing

- Full lifecycle specs: member gains access on `AcceptInvitation`, loses it on leave/removal/owner downgrade, data never deleted (only filtered).
- Request specs for write API, pro API, `/api/v1/plan` (`effective_plan` surfaced), map view plan injection.
- Known unrelated red on dev: `update_location_sharing_spec.rb:118` (24h→7d default from #3079, spec fix pending).