### PR TITLE
fix: timeline calendar points fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Map v2 Timeline calendar now lights up days that have raw points even before Track or Visit generation has caught up, matching the Insights → Activity Overview calendar. (#2579)
+
+
 ## [1.7.10] - 2026-05-26
 
 ### ⚠️ Upgrade notes

--- a/app/services/timeline/month_summary.rb
+++ b/app/services/timeline/month_summary.rb
@@ -37,7 +37,7 @@ module Timeline
       d = normalize_month(date)
       tz = user.safe_settings.timezone.presence || 'UTC'
       plan_segment = user.plan_restricted? ? 'lite' : 'pro'
-      ['timeline_month_summary', user.id, d.strftime('%Y-%m'), tz, plan_segment, 'v2']
+      ['timeline_month_summary', user.id, d.strftime('%Y-%m'), tz, plan_segment, 'v3']
     end
 
     def self.normalize_month(date)
@@ -117,6 +117,13 @@ module Timeline
           result[date_str][:track_count] += count.to_i
         end
 
+        # Point presence keeps the day active even when track/visit pipelines
+        # haven't produced a record yet — matches Activity Overview coverage.
+        points_by_day.each do |date_str, count|
+          result[date_str] ||= default_day
+          result[date_str][:point_count] += count.to_i
+        end
+
         result
       end
     end
@@ -125,6 +132,7 @@ module Timeline
       {
         tracked_seconds: 0,
         track_count: 0,
+        point_count: 0,
         visit_count: 0,
         suggested_count: 0,
         confirmed_count: 0,
@@ -176,6 +184,14 @@ module Timeline
       @user.scoped_tracks.where('start_at <= ? AND end_at >= ?', month_range.last, month_range.first)
     end
 
+    def points_by_day
+      @points_by_day ||= @user.scoped_points
+                              .where(timestamp: month_range.first.to_i..month_range.last.to_i)
+                              .group(date_sql_expr_epoch('points.timestamp'))
+                              .count
+                              .transform_keys(&:to_s)
+    end
+
     def visit_status_label(status)
       return status.to_s if status.is_a?(String)
 
@@ -185,6 +201,11 @@ module Timeline
     def date_sql_expr(column)
       quoted_tz = ActiveRecord::Base.connection.quote(tz)
       Arel.sql("DATE(#{column} AT TIME ZONE 'UTC' AT TIME ZONE #{quoted_tz})")
+    end
+
+    def date_sql_expr_epoch(column)
+      quoted_tz = ActiveRecord::Base.connection.quote(tz)
+      Arel.sql("DATE(TO_TIMESTAMP(#{column}) AT TIME ZONE #{quoted_tz})")
     end
 
     def weeks
@@ -215,6 +236,7 @@ module Timeline
         in_month: date.month == @month_start.month,
         tracked_seconds: data[:tracked_seconds],
         track_count: data[:track_count],
+        point_count: data[:point_count],
         visit_count: data[:visit_count],
         suggested_count: data[:suggested_count],
         disabled: disabled_cell?(date)
@@ -236,7 +258,8 @@ module Timeline
     def cell_has_activity?(cell)
       cell[:tracked_seconds].to_i.positive? ||
         cell[:visit_count].to_i.positive? ||
-        cell[:track_count].to_i.positive?
+        cell[:track_count].to_i.positive? ||
+        cell[:point_count].to_i.positive?
     end
 
     def disabled_cell?(date)

--- a/spec/services/timeline/month_summary_spec.rb
+++ b/spec/services/timeline/month_summary_spec.rb
@@ -143,6 +143,63 @@ RSpec.describe Timeline::MonthSummary do
         expect(cell[:heat_bucket]).to be >= 1
       end
     end
+
+    context 'with no points, tracks, or visits' do
+      it 'returns heat_bucket 0 for every in-month cell' do
+        in_month_cells = summary[:weeks].flatten.select { |c| c[:in_month] }
+        expect(in_month_cells).not_to be_empty
+        in_month_cells.each do |cell|
+          expect(cell[:heat_bucket]).to eq(0)
+        end
+      end
+    end
+
+    context 'with a points-only month' do
+      before do
+        3.times do |i|
+          create(:point,
+                 user: user,
+                 timestamp: (Time.zone.parse('2026-04-15 14:00:00 +0200') + (i * 10).minutes).to_i)
+        end
+      end
+
+      it 'clamps the active day to heat_bucket 1 when month_max is 0' do
+        cell = summary[:weeks].flatten.find { |c| c[:date] == '2026-04-15' }
+        expect(cell[:heat_bucket]).to eq(1)
+      end
+    end
+
+    context 'with America/Los_Angeles timezone (negative UTC offset)' do
+      let(:user) { create(:user, settings: { 'timezone' => 'America/Los_Angeles' }) }
+
+      subject(:summary) { described_class.new(user: user, month: '2026-03').call }
+
+      before do
+        create(:point, user: user, timestamp: Time.zone.parse('2026-03-31 23:30:00 -0700').to_i)
+      end
+
+      it 'attributes a late-night local point to the local date, not the UTC date' do
+        cell = summary[:weeks].flatten.find { |c| c[:date] == '2026-03-31' }
+        expect(cell[:heat_bucket]).to be >= 1
+      end
+
+      it 'does not attribute the point to April 1 (its UTC date)' do
+        expect(summary[:days]['2026-04-01']).to be_nil
+      end
+    end
+
+    context 'across a DST spring-forward day in Europe/Berlin' do
+      subject(:summary) { described_class.new(user: user, month: '2026-03').call }
+
+      before do
+        create(:point, user: user, timestamp: Time.zone.parse('2026-03-29 10:00:00 +0200').to_i)
+      end
+
+      it 'attributes the point to March 29 without crashing' do
+        cell = summary[:weeks].flatten.find { |c| c[:date] == '2026-03-29' }
+        expect(cell[:heat_bucket]).to be >= 1
+      end
+    end
   end
 
   describe 'Lite plan restrictions' do
@@ -162,6 +219,14 @@ RSpec.describe Timeline::MonthSummary do
       summary = described_class.new(user: lite_user, month: Date.current.strftime('%Y-%m')).call
       in_month_cells = summary[:weeks].flatten.select { |c| c[:in_month] }
       expect(in_month_cells).to all(include(disabled: false))
+    end
+
+    it 'does not light up disabled cells with out-of-window points' do
+      out_of_window_time = 18.months.ago.beginning_of_month + 1.day
+      create(:point, user: lite_user, timestamp: out_of_window_time.to_i)
+      summary = described_class.new(user: lite_user, month: out_of_window_time.strftime('%Y-%m')).call
+      in_month_cells = summary[:weeks].flatten.select { |c| c[:in_month] }
+      expect(in_month_cells).to all(include(heat_bucket: 0, disabled: true))
     end
   end
 

--- a/spec/services/timeline/month_summary_spec.rb
+++ b/spec/services/timeline/month_summary_spec.rb
@@ -114,6 +114,35 @@ RSpec.describe Timeline::MonthSummary do
         expect(summary[:days]['2026-04-22']).to be_nil
       end
     end
+
+    context 'with points only (no track or visit) on a day' do
+      let(:active_day_local) { Time.zone.parse('2026-04-15 14:00:00 +0200') }
+      let(:empty_day_local)  { Time.zone.parse('2026-04-16 14:00:00 +0200') }
+
+      before do
+        3.times do |i|
+          create(:point, user: user, timestamp: (active_day_local + (i * 10).minutes).to_i)
+        end
+      end
+
+      it 'still marks the day as active (heat_bucket >= 1)' do
+        cell = summary[:weeks].flatten.find { |c| c[:date] == '2026-04-15' }
+        expect(cell[:heat_bucket]).to be >= 1
+      end
+
+      it 'leaves an empty day with no activity (heat_bucket == 0)' do
+        cell = summary[:weeks].flatten.find { |c| c[:date] == '2026-04-16' }
+        expect(cell[:heat_bucket]).to eq(0)
+      end
+
+      it 'groups points by the user timezone when computing the active day' do
+        # 22:30 UTC on April 14 = 00:30 April 15 in Europe/Berlin (CEST +02:00).
+        # Point's UTC date is 14th, but locally it falls on the 15th.
+        create(:point, user: user, timestamp: Time.zone.parse('2026-04-14 22:30:00 UTC').to_i)
+        cell = summary[:weeks].flatten.find { |c| c[:date] == '2026-04-15' }
+        expect(cell[:heat_bucket]).to be >= 1
+      end
+    end
   end
 
   describe 'Lite plan restrictions' do


### PR DESCRIPTION
Auto-opened draft PR to track work in the `fix/timeline-calendar-points-fallback` worktree.