### PR TITLE
Fix Map v2 visits ignoring date range when bbox is sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Map v2 visits layer now honours the selected date range. Since 1.7.10 the viewport-bounded visits fetch silently dropped the `start_at`/`end_at` filter on the backend, so all visits inside the viewport were rendered regardless of the date filter. (#2817)
+
 ## [1.7.10] - 2026-05-26
 
 ### ⚠️ Upgrade notes

--- a/app/services/visits/find_within_bounding_box.rb
+++ b/app/services/visits/find_within_bounding_box.rb
@@ -17,23 +17,38 @@ module Visits
       @sw_lng = params[:sw_lng].to_f
       @ne_lat = params[:ne_lat].to_f
       @ne_lng = params[:ne_lng].to_f
+      @start_at = parse_time(params[:start_at])
+      @end_at = parse_time(params[:end_at])
     end
 
     def call
-      user.scoped_visits
-          .left_outer_joins(:place, :area)
-          .includes(:place, :area)
-          .references(:place, :area)
-          .where(
-            "(#{PLACE_INSIDE}) OR (#{AREA_INSIDE})",
-            sw_lng, sw_lat, ne_lng, ne_lat,
-            sw_lng, sw_lat, ne_lng, ne_lat
-          )
-          .order(started_at: :desc)
+      relation = user.scoped_visits
+                     .left_outer_joins(:place, :area)
+                     .includes(:place, :area)
+                     .references(:place, :area)
+                     .where(
+                       "(#{PLACE_INSIDE}) OR (#{AREA_INSIDE})",
+                       sw_lng, sw_lat, ne_lng, ne_lat,
+                       sw_lng, sw_lat, ne_lng, ne_lat
+                     )
+
+      # Filter by started_at only — mirrors Visits::FindInTime; adding an
+      # ended_at predicate silently drops boundary-crossing visits.
+      relation = relation.where(started_at: start_at..end_at) if start_at && end_at
+
+      relation.order(started_at: :desc)
     end
 
     private
 
-    attr_reader :user, :sw_lat, :sw_lng, :ne_lat, :ne_lng
+    attr_reader :user, :sw_lat, :sw_lng, :ne_lat, :ne_lng, :start_at, :end_at
+
+    def parse_time(time_string)
+      return nil if time_string.blank?
+
+      Time.zone.parse(time_string.to_s)
+    rescue ArgumentError
+      nil
+    end
   end
 end

--- a/spec/regressions/visits_bbox_query_respects_date_range_spec.rb
+++ b/spec/regressions/visits_bbox_query_respects_date_range_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/visits with bbox selection respects date range', type: :request do
+  let(:user) { create(:user) }
+  let(:auth_headers) { { 'Authorization' => "Bearer #{user.api_key}" } }
+
+  let(:place_inside) { create(:place, latitude: 50.0, longitude: 14.0) }
+
+  let!(:visit_in_range) do
+    create(:visit, user: user, place: place_inside,
+                   started_at: 1.day.ago, ended_at: 1.day.ago + 1.hour)
+  end
+
+  let!(:visit_out_of_range) do
+    create(:visit, user: user, place: place_inside,
+                   started_at: 5.years.ago, ended_at: 5.years.ago + 1.hour)
+  end
+
+  it 'returns only visits inside the date range when bbox selection is active' do
+    get '/api/v1/visits', params: {
+      selection: 'true',
+      sw_lat: '49.0', sw_lng: '13.0',
+      ne_lat: '51.0', ne_lng: '15.0',
+      start_at: 2.days.ago.iso8601,
+      end_at: Time.zone.now.iso8601
+    }, headers: auth_headers
+
+    expect(response).to have_http_status(:ok)
+    ids = JSON.parse(response.body).pluck('id')
+    expect(ids).to include(visit_in_range.id)
+    expect(ids).not_to include(visit_out_of_range.id)
+  end
+
+  it 'returns all visits inside the bbox when no date range is given' do
+    get '/api/v1/visits', params: {
+      selection: 'true',
+      sw_lat: '49.0', sw_lng: '13.0',
+      ne_lat: '51.0', ne_lng: '15.0'
+    }, headers: auth_headers
+
+    expect(response).to have_http_status(:ok)
+    ids = JSON.parse(response.body).pluck('id')
+    expect(ids).to include(visit_in_range.id, visit_out_of_range.id)
+  end
+end

--- a/spec/services/visits/find_within_bounding_box_spec.rb
+++ b/spec/services/visits/find_within_bounding_box_spec.rb
@@ -157,5 +157,66 @@ RSpec.describe Visits::FindWithinBoundingBox do
         expect(result).to include(visit_inside_1, visit_inside_2)
       end
     end
+
+    context 'with a date range' do
+      let!(:old_visit_inside) do
+        create(
+          :visit,
+          user: user,
+          place: place_inside_1,
+          started_at: 5.years.ago,
+          ended_at: 5.years.ago + 1.hour
+        )
+      end
+
+      let(:params) do
+        {
+          sw_lat: sw_lat.to_s,
+          sw_lng: sw_lng.to_s,
+          ne_lat: ne_lat.to_s,
+          ne_lng: ne_lng.to_s,
+          start_at: 1.day.ago.iso8601,
+          end_at: Time.zone.now.iso8601
+        }
+      end
+
+      it 'excludes visits whose started_at is outside the range' do
+        expect(result).to include(visit_inside_1, visit_inside_2)
+        expect(result).not_to include(old_visit_inside)
+      end
+
+      context 'when only one of start_at/end_at is provided' do
+        let(:params) do
+          {
+            sw_lat: sw_lat.to_s,
+            sw_lng: sw_lng.to_s,
+            ne_lat: ne_lat.to_s,
+            ne_lng: ne_lng.to_s,
+            start_at: 1.day.ago.iso8601
+          }
+        end
+
+        it 'ignores the partial date range' do
+          expect(result).to include(visit_inside_1, visit_inside_2, old_visit_inside)
+        end
+      end
+
+      context 'when start_at is unparseable' do
+        let(:params) do
+          {
+            sw_lat: sw_lat.to_s,
+            sw_lng: sw_lng.to_s,
+            ne_lat: ne_lat.to_s,
+            ne_lng: ne_lng.to_s,
+            start_at: 'not-a-date',
+            end_at: Time.zone.now.iso8601
+          }
+        end
+
+        it 'ignores the malformed range and returns bbox matches' do
+          expect(result).to include(visit_inside_1, visit_inside_2, old_visit_inside)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- `Visits::FindWithinBoundingBox` now filters by `started_at` when both `start_at` and `end_at` parse, mirroring `Visits::FindInTime`'s contract (started_at-only, to keep boundary-crossing visits attached to their start day).
- Since 1.7.10 (`df97a95a`), Map v2's visits fetch always passes the viewport bbox, which sends `selection=true` and routes every request through `FindWithinBoundingBox`. That service ignored the date range entirely, so the layer rendered every in-viewport visit regardless of the selected date filter. Reported in #2817.
- Map v1 is unaffected — its default visits fetch doesn't send bbox params, so it stays on the `FindInTime` path.
- Partial / malformed date params fall back to bbox-only behaviour rather than raising. Existing v1 drawn-selection callers that never sent dates keep working unchanged.

## Test plan

- [x] `bundle exec rspec spec/regressions/visits_bbox_query_respects_date_range_spec.rb` — new request-level regression, confirmed RED before fix / GREEN after
- [x] `bundle exec rspec spec/services/visits/find_within_bounding_box_spec.rb` — three new contexts (in-range filter, partial range ignored, unparseable start_at ignored)
- [x] `bundle exec rspec spec/services/visits/ spec/requests/api/v1/visits_spec.rb spec/regressions/visits_bbox_query_respects_date_range_spec.rb` — 57 examples, 0 failures
- [x] `bundle exec rubocop` on the three modified Ruby files — no offences

Closes #2817