### PR TITLE
chore: bump gems to close 9 CVEs (Rails 8.0.5, devise 5.0.4, jwt, httparty, ...)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,14 +8,14 @@ ruby File.read('.ruby-version').strip
 gem 'activerecord-postgis-adapter', '11.0'
 # https://meta.discourse.org/t/cant-rebuild-due-to-aws-sdk-gem-bump-and-new-aws-data-integrity-protections/354217/40
 gem 'apple_id', '~> 1.2'
-gem 'aws-sdk-core', '~> 3.215.1', require: false
-gem 'aws-sdk-kms', '~> 1.96.0', require: false
-gem 'aws-sdk-s3', '~> 1.177.0', require: false
+gem 'aws-sdk-core', '~> 3.234', require: false
+gem 'aws-sdk-kms', '~> 1.96', require: false
+gem 'aws-sdk-s3', '~> 1.208', require: false
 gem 'bootsnap', require: false
 gem 'chartkick'
 gem 'connection_pool', '< 3' # Pin to 2.x - version 3.0+ has breaking API changes with Rails RedisCacheStore
 gem 'data_migrate'
-gem 'devise'
+gem 'devise', '>= 5.0.4'
 gem 'devise-two-factor'
 gem 'fit4ruby', '~> 3.13'
 gem 'flipper', '~> 1.3'
@@ -27,9 +27,9 @@ gem 'google-id-token', '~> 1.4'
 gem 'gpx'
 gem 'groupdate'
 gem 'h3', '~> 3.7'
-gem 'httparty'
+gem 'httparty', '>= 0.24.0'
 gem 'importmap-rails'
-gem 'jwt', '~> 2.8'
+gem 'jwt', '~> 2.10.3'
 gem 'kaminari'
 gem 'lograge'
 gem 'oj'
@@ -45,7 +45,13 @@ gem 'puma'
 gem 'pundit', '>= 2.5.1'
 gem 'rack-attack'
 gem 'rack-session', '>= 2.1.2'
-gem 'rails', '~> 8.0'
+gem 'rails', '~> 8.0.5'
+gem 'addressable', '>= 2.9.0'
+gem 'bcrypt', '>= 3.1.22'
+gem 'faraday', '>= 2.14.2'
+gem 'json', '>= 2.19.2'
+gem 'net-imap', '>= 0.5.14'
+gem 'zlib', '>= 3.2.3'
 gem 'rails_icons'
 gem 'redis'
 gem 'resolv-replace', '~> 0.2.0'
@@ -60,7 +66,7 @@ gem 'rubyzip', '~> 3.2'
 gem 'sentry-rails', '>= 5.27.0'
 gem 'sentry-ruby'
 gem 'sidekiq', '8.0.10' # Pin to 8.0.x - sidekiq 8.1+ requires connection_pool 3.0+ breaking Rails
-gem 'sidekiq-cron', '>= 2.3.1'
+gem 'sidekiq-cron', '>= 2.4.0'
 gem 'sidekiq-limit_fetch'
 gem 'sprockets-rails'
 gem 'stackprof'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,29 +10,29 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (8.0.3)
-      actionpack (= 8.0.3)
-      activesupport (= 8.0.3)
+    actioncable (8.0.5)
+      actionpack (= 8.0.5)
+      activesupport (= 8.0.5)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
       zeitwerk (~> 2.6)
-    actionmailbox (8.0.3)
-      actionpack (= 8.0.3)
-      activejob (= 8.0.3)
-      activerecord (= 8.0.3)
-      activestorage (= 8.0.3)
-      activesupport (= 8.0.3)
+    actionmailbox (8.0.5)
+      actionpack (= 8.0.5)
+      activejob (= 8.0.5)
+      activerecord (= 8.0.5)
+      activestorage (= 8.0.5)
+      activesupport (= 8.0.5)
       mail (>= 2.8.0)
-    actionmailer (8.0.3)
-      actionpack (= 8.0.3)
-      actionview (= 8.0.3)
-      activejob (= 8.0.3)
-      activesupport (= 8.0.3)
+    actionmailer (8.0.5)
+      actionpack (= 8.0.5)
+      actionview (= 8.0.5)
+      activejob (= 8.0.5)
+      activesupport (= 8.0.5)
       mail (>= 2.8.0)
       rails-dom-testing (~> 2.2)
-    actionpack (8.0.3)
-      actionview (= 8.0.3)
-      activesupport (= 8.0.3)
+    actionpack (8.0.5)
+      actionview (= 8.0.5)
+      activesupport (= 8.0.5)
       nokogiri (>= 1.8.5)
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
@@ -40,38 +40,38 @@ GEM
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
       useragent (~> 0.16)
-    actiontext (8.0.3)
-      actionpack (= 8.0.3)
-      activerecord (= 8.0.3)
-      activestorage (= 8.0.3)
-      activesupport (= 8.0.3)
+    actiontext (8.0.5)
+      actionpack (= 8.0.5)
+      activerecord (= 8.0.5)
+      activestorage (= 8.0.5)
+      activesupport (= 8.0.5)
       globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (8.0.3)
-      activesupport (= 8.0.3)
+    actionview (8.0.5)
+      activesupport (= 8.0.5)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activejob (8.0.3)
-      activesupport (= 8.0.3)
+    activejob (8.0.5)
+      activesupport (= 8.0.5)
       globalid (>= 0.3.6)
-    activemodel (8.0.3)
-      activesupport (= 8.0.3)
-    activerecord (8.0.3)
-      activemodel (= 8.0.3)
-      activesupport (= 8.0.3)
+    activemodel (8.0.5)
+      activesupport (= 8.0.5)
+    activerecord (8.0.5)
+      activemodel (= 8.0.5)
+      activesupport (= 8.0.5)
       timeout (>= 0.4.0)
     activerecord-postgis-adapter (11.0.0)
       activerecord (~> 8.0.0)
       rgeo-activerecord (~> 8.0.0)
-    activestorage (8.0.3)
-      actionpack (= 8.0.3)
-      activejob (= 8.0.3)
-      activerecord (= 8.0.3)
-      activesupport (= 8.0.3)
+    activestorage (8.0.5)
+      actionpack (= 8.0.5)
+      activejob (= 8.0.5)
+      activerecord (= 8.0.5)
+      activesupport (= 8.0.5)
       marcel (~> 1.0)
-    activesupport (8.0.3)
+    activesupport (8.0.5)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -84,8 +84,8 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     aes_key_wrap (1.1.0)
     anyway_config (2.8.0)
       ruby-next-core (~> 1.0)
@@ -97,23 +97,26 @@ GEM
     attr_extras (7.1.0)
     attr_required (1.0.2)
     aws-eventstream (1.3.2)
-    aws-partitions (1.1072.0)
-    aws-sdk-core (3.215.1)
+    aws-partitions (1.1253.0)
+    aws-sdk-core (3.249.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
+      base64
+      bigdecimal
       jmespath (~> 1, >= 1.6.1)
+      logger
     aws-sdk-kms (1.96.0)
       aws-sdk-core (~> 3, >= 3.210.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.177.0)
-      aws-sdk-core (~> 3, >= 3.210.0)
+    aws-sdk-s3 (1.224.0)
+      aws-sdk-core (~> 3, >= 3.248.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.11.0)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
-    bcrypt (3.1.20)
+    bcrypt (3.1.22)
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     bindata (2.4.15)
@@ -157,10 +160,10 @@ GEM
     debug (1.11.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    devise (4.9.4)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     devise-two-factor (6.4.0)
@@ -188,13 +191,13 @@ GEM
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
     fakeredis (0.1.4)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-follow_redirects (0.4.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     ffaker (2.25.0)
     ffi (1.17.2-aarch64-linux-gnu)
@@ -219,7 +222,7 @@ GEM
       sanitize (< 8)
     foreman (0.90.0)
       thor (~> 1.4)
-    fugit (1.12.1)
+    fugit (1.12.2)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
     globalid (1.3.0)
@@ -239,7 +242,7 @@ GEM
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
-    httparty (0.23.1)
+    httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -256,7 +259,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.19.1)
+    json (2.19.6)
     json-jwt (1.17.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -266,7 +269,7 @@ GEM
       faraday-follow_redirects
     json-schema (5.0.1)
       addressable (~> 2.8)
-    jwt (2.10.1)
+    jwt (2.10.3)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -297,7 +300,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
@@ -311,7 +314,7 @@ GEM
       bigdecimal (>= 3.1, < 5)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.5.12)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -444,20 +447,20 @@ GEM
       rack (>= 1.3)
     rackup (2.3.1)
       rack (>= 3)
-    rails (8.0.3)
-      actioncable (= 8.0.3)
-      actionmailbox (= 8.0.3)
-      actionmailer (= 8.0.3)
-      actionpack (= 8.0.3)
-      actiontext (= 8.0.3)
-      actionview (= 8.0.3)
-      activejob (= 8.0.3)
-      activemodel (= 8.0.3)
-      activerecord (= 8.0.3)
-      activestorage (= 8.0.3)
-      activesupport (= 8.0.3)
+    rails (8.0.5)
+      actioncable (= 8.0.5)
+      actionmailbox (= 8.0.5)
+      actionmailer (= 8.0.5)
+      actionpack (= 8.0.5)
+      actiontext (= 8.0.5)
+      actionview (= 8.0.5)
+      activejob (= 8.0.5)
+      activemodel (= 8.0.5)
+      activerecord (= 8.0.5)
+      activestorage (= 8.0.5)
+      activesupport (= 8.0.5)
       bundler (>= 1.15.0)
-      railties (= 8.0.3)
+      railties (= 8.0.5)
     rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
@@ -468,9 +471,9 @@ GEM
     rails_icons (1.4.0)
       nokogiri (~> 1.16, >= 1.16.4)
       rails (> 6.1)
-    railties (8.0.3)
-      actionpack (= 8.0.3)
-      activesupport (= 8.0.3)
+    railties (8.0.5)
+      actionpack (= 8.0.5)
+      activesupport (= 8.0.5)
       irb (~> 1.13)
       rackup (>= 1.0.0)
       rake (>= 12.2)
@@ -495,9 +498,9 @@ GEM
     resolv (0.7.0)
     resolv-replace (0.2.0)
       resolv
-    responders (3.1.1)
-      actionpack (>= 5.2)
-      railties (>= 5.2)
+    responders (3.2.0)
+      actionpack (>= 7.0)
+      railties (>= 7.0)
     rexml (3.4.4)
     rgeo (3.0.1)
     rgeo-activerecord (8.0.0)
@@ -587,7 +590,7 @@ GEM
       logger (>= 1.6.2)
       rack (>= 3.1.0)
       redis-client (>= 0.23.2)
-    sidekiq-cron (2.3.1)
+    sidekiq-cron (2.4.0)
       cronex (>= 0.13.0)
       fugit (~> 1.8, >= 1.11.1)
       globalid (>= 1.0.1)
@@ -697,6 +700,7 @@ GEM
       sidekiq
       yabeda (~> 0.6)
     zeitwerk (2.7.5)
+    zlib (3.2.3)
 
 PLATFORMS
   aarch64-linux
@@ -708,10 +712,12 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-postgis-adapter (= 11.0)
+  addressable (>= 2.9.0)
   apple_id (~> 1.2)
-  aws-sdk-core (~> 3.215.1)
-  aws-sdk-kms (~> 1.96.0)
-  aws-sdk-s3 (~> 1.177.0)
+  aws-sdk-core (~> 3.234)
+  aws-sdk-kms (~> 1.96)
+  aws-sdk-s3 (~> 1.208)
+  bcrypt (>= 3.1.22)
   bootsnap
   brakeman
   bundler-audit
@@ -721,11 +727,12 @@ DEPENDENCIES
   data_migrate
   database_consistency (>= 2.0.5)
   debug
-  devise
+  devise (>= 5.0.4)
   devise-two-factor
   dotenv-rails
   factory_bot_rails
   fakeredis
+  faraday (>= 2.14.2)
   ffaker
   fit4ruby (~> 3.13)
   flipper (~> 1.3)
@@ -737,11 +744,13 @@ DEPENDENCIES
   gpx
   groupdate
   h3 (~> 3.7)
-  httparty
+  httparty (>= 0.24.0)
   importmap-rails
-  jwt (~> 2.8)
+  json (>= 2.19.2)
+  jwt (~> 2.10.3)
   kaminari
   lograge
+  net-imap (>= 0.5.14)
   oj
   omniauth-github (~> 2.0.0)
   omniauth-google-oauth2
@@ -757,7 +766,7 @@ DEPENDENCIES
   pundit (>= 2.5.1)
   rack-attack
   rack-session (>= 2.1.2)
-  rails (~> 8.0)
+  rails (~> 8.0.5)
   rails_icons
   redis
   resolv-replace (~> 0.2.0)
@@ -777,7 +786,7 @@ DEPENDENCIES
   sentry-ruby
   shoulda-matchers
   sidekiq (= 8.0.10)
-  sidekiq-cron (>= 2.3.1)
+  sidekiq-cron (>= 2.4.0)
   sidekiq-limit_fetch
   simplecov
   sprockets-rails
@@ -795,6 +804,7 @@ DEPENDENCIES
   yabeda-puma-plugin
   yabeda-rails
   yabeda-sidekiq
+  zlib (>= 3.2.3)
 
 RUBY VERSION
    ruby 3.4.6p54

--- a/spec/requests/api/v1/visits_spec.rb
+++ b/spec/requests/api/v1/visits_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe 'Api::V1::Visits', type: :request do
     end
 
     context 'when updating name together with place_id' do
-      let(:new_place) { create(:place, name: 'Coffee Shop') }
+      let(:new_place) { create(:place, name: 'Coffee Shop', user: user) }
 
       it 'preserves the user-provided name instead of overwriting it with the place name' do
         put "/api/v1/visits/#{visit.id}",


### PR DESCRIPTION
Closes every gem CVE `bundle-audit` was reporting on `dev` (9 of them), plus the noisier subset Trivy flags on the container image. Triggered by #2822.

## Triage

| CVE | Gem | Exploitable on prod cloud? |
|---|---|---|
| CVE-2026-33195 | activestorage path traversal in DiskService | No — cloud uses S3 service, blob keys never come from user input (we only use `find_signed`). Bump for hygiene + self-hosters on disk. |
| CVE-2026-33202 | activestorage glob injection in DiskService | No — same reasons. |
| CVE-2026-27820 | zlib `GzipReader` buffer overflow in `ungetc` path | No — every call site uses `gz.read` / `each_line` only, and no user-uploaded gzip reaches `GzipReader` (archives are system-created + AES-encrypted). |
| CVE-2026-33210 | json format-string DoS | No — only triggers with `allow_duplicate_key: false`, not opted into anywhere. |
| CVE-2026-42257/42258 | net-imap CRLF injection | No — gem pulled in transitively via `mail`, never invoked. |
| CVE-2026-45363 | jwt empty-key HMAC bypass | **Yes** — we sign API tokens with HS256. Direct user-impacting auth bug. |
| CVE-2025-68696 | httparty SSRF + API-key leakage | **Yes** for any outbound httparty call with user-influenced URLs. |
| CVE-2026-40295 | devise open-redirect via timeoutable session referrer | **Yes** — we have `:timeoutable` enabled. |
| CVE-2025-67202 | sidekiq-cron admin XSS | Low — admin UI behind basic auth. |
| Others (addressable, bcrypt, faraday, aws-sdk-s3) | Low-to-no direct exposure | Bumped for hygiene. |

Even the "no" CVEs are worth bumping: it silences Trivy / bundle-audit so future scans stay signal-only, and it patches self-hosters who *do* run on disk storage.

## Changes

Direct gem bumps:
- `rails ~> 8.0.5`
- `devise >= 5.0.4` (4.9.4 → 5.0.4, major — no breakage: we use no removed APIs)
- `jwt ~> 2.10.3`, `httparty >= 0.24.0`, `sidekiq-cron >= 2.4.0`
- `aws-sdk-core ~> 3.234` (required by `aws-sdk-s3 ~> 1.208` resolver)
- `aws-sdk-s3 ~> 1.208`, `addressable >= 2.9.0`, `bcrypt >= 3.1.22`, `faraday >= 2.14.2`
- `json >= 2.19.2`, `net-imap >= 0.5.14`, `zlib >= 3.2.3`

Transitive bumps (pulled by the above): `aws-partitions`, `faraday-net_http`, `fugit`, `marcel`, `responders`.

## Drive-by

`spec/requests/api/v1/visits_spec.rb` had 3 pre-existing failures on `dev`. They surfaced during validation. Root cause: the specs were written before f3dde359 added place-ownership validation; the `new_place` factory was creating a place with a random user, so the controller now (correctly) returns 422 and the visit name is never updated. Fix: pass `user: user` to the factory.

## Verification

```
bundle exec bundle-audit check   # No vulnerabilities found
bundle exec rspec                # 5791 examples, 0 failures
```