### PR TITLE
fix(imports): reject points with blank coordinates during bulk insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,38 +10,18 @@ Upgrade notes:
 
 1. **Trips redesign:** the trip detail page has a new sticky-map layout with per-day accordion and timeline replay. Existing trip rich-text "notes" are renamed to "description" by an automatic migration; nothing to do manually.
 
-2. **Points with missing coordinates:** this release stops *new* points with missing coordinates from being created, but it does not touch points that were already saved without coordinates by older versions. If your points API still returns a 500, clean up the existing rows as follows. Open a database console on your instance with `bundle exec rails dbconsole` (or `psql` directly), then:
-
-   **Count how many points are missing coordinates:**
+2. **Points with missing coordinates:** the `points.lonlat` column is now `NOT NULL` at the database level. Older versions could save points without coordinates (the bug behind the points-API 500s fixed in this release); a migration resolves them automatically before adding the constraint — it rebuilds `lonlat` from the legacy `latitude`/`longitude` columns wherever those still hold values, deletes any remaining points that have no coordinates at all (`lonlat`, `latitude`, and `longitude` all NULL) and re-syncs the affected users' `points_count`, then sets the `NOT NULL` constraint via a validated check constraint (so the change does not lock the table for a full scan). To preview how many points will be affected before upgrading, run with `bundle exec rails dbconsole` (or `psql`):
 
    ```sql
+   -- Points missing coordinates (the migration will recover or remove these)
    SELECT COUNT(*) FROM points WHERE lonlat IS NULL;
+
+   -- Of those, how many are recoverable from the legacy columns
+   SELECT COUNT(*) FROM points
+   WHERE lonlat IS NULL AND latitude IS NOT NULL AND longitude IS NOT NULL;
    ```
 
-   **(Optional) Delete every point that is missing coordinates:**
-
-   ```sql
-   DELETE FROM points WHERE lonlat IS NULL;
-   ```
-
-   **Or recover coordinates from the legacy `latitude`/`longitude` columns first:**
-
-   ```sql
-   UPDATE points
-   SET lonlat = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
-   WHERE lonlat IS NULL
-     AND latitude IS NOT NULL
-     AND longitude IS NOT NULL;
-   ```
-
-   **Then delete the points that are beyond recovery:**
-
-   ```sql
-   DELETE FROM points
-   WHERE lonlat IS NULL
-     AND latitude IS NULL
-     AND longitude IS NULL;
-   ```
+   The difference between the two counts is the number of points that will be deleted as unrecoverable.
 
 ### Added
 
@@ -56,6 +36,7 @@ Upgrade notes:
 - Edit and Delete actions on the trip page moved into the header next to the trip title; the bottom of the page now only carries a "Back to trips" link.
 - Per-day trip stats are now computed in a single PostGIS query (`ST_MakeLine`/`ST_Length`) instead of a Ruby Geocoder loop; cache key now also invalidates when individual trip points are updated.
 - Ruby version updated to 3.4.9
+- The `points.lonlat` column is now `NOT NULL` at the database level, enforcing that every point has coordinates.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ Upgrade notes:
 
 1. **Trips redesign:** the trip detail page has a new sticky-map layout with per-day accordion and timeline replay. Existing trip rich-text "notes" are renamed to "description" by an automatic migration; nothing to do manually.
 
+2. **Points with missing coordinates:** this release stops *new* points with missing coordinates from being created, but it does not touch points that were already saved without coordinates by older versions. If your points API still returns a 500, clean up the existing rows as follows. Open a database console on your instance with `bundle exec rails dbconsole` (or `psql` directly), then:
+
+   **Count how many points are missing coordinates:**
+
+   ```sql
+   SELECT COUNT(*) FROM points WHERE lonlat IS NULL;
+   ```
+
+   **(Optional) Delete every point that is missing coordinates:**
+
+   ```sql
+   DELETE FROM points WHERE lonlat IS NULL;
+   ```
+
+   **Or recover coordinates from the legacy `latitude`/`longitude` columns first:**
+
+   ```sql
+   UPDATE points
+   SET lonlat = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
+   WHERE lonlat IS NULL
+     AND latitude IS NOT NULL
+     AND longitude IS NOT NULL;
+   ```
+
+   **Then delete the points that are beyond recovery:**
+
+   ```sql
+   DELETE FROM points
+   WHERE lonlat IS NULL
+     AND latitude IS NULL
+     AND longitude IS NULL;
+   ```
+
 ### Added
 
 - Run the app and Sidekiq containers under a custom user via `PUID`/`PGID` environment variables: the container starts as root, fixes ownership of the mounted volumes, then drops privileges. Use this instead of Compose `user:`, which cannot write to root-owned volumes (#1159).
@@ -33,6 +66,7 @@ Upgrade notes:
 - Users signed in via Google will now be able to sign in with new password after setting it up, instead of being locked out by the old password being ignored.
 - Suggested visits now always show a Confirm and Delete control, including visits with no matched place — which previously rendered no action and got stuck with no way to confirm or remove them. #2917
 - Searching for a place by name now also matches your areas by name, so an area outside the nearby radius shows up in the results instead of being hidden. #2918
+- Importers no longer persist points with missing coordinates, which previously caused the points API to return a 500 when serializing them. (#2519)
 
 ## [1.8.1] - 2026-06-11
 
@@ -129,7 +163,6 @@ Upgrade notes:
 - `POST /api/v1/visits` no longer links a new visit to a place owned by another user. Passing a foreign `place_id` is ignored — the visit gets a place owned by the requester at the requested coordinates, and the response no longer echoes the other user's place id or coordinates.
 - Map v2 settings panel: "Apply Settings" now actually saves your changes. Points rendering mode, speed-colored routes, live mode, and fog-of-war toggles all persist on click and reload. Apply/Reset buttons moved above the Transportation Mode section so they sit inside the outer form. #2680
 - The app no longer trips firewall blocks by repeatedly checking family status when you're not part of a family.
-
 
 ## [1.7.10] - 2026-05-26
 

--- a/app/jobs/data_migrations/backfill_altitude_user_job.rb
+++ b/app/jobs/data_migrations/backfill_altitude_user_job.rb
@@ -45,7 +45,7 @@ class DataMigrations::BackfillAltitudeUserJob < ApplicationJob
       if updates.any?
         update_cols = [:altitude]
         update_cols << :altitude_decimal if Point.altitude_decimal_supported?
-        Point.upsert_all(updates, unique_by: :id, update_only: update_cols)
+        Points::BulkUpdater.call(updates, update_cols)
         stats[:updated] += updates.size
       end
 
@@ -100,7 +100,7 @@ class DataMigrations::BackfillAltitudeUserJob < ApplicationJob
 
     update_cols = [:altitude]
     update_cols << :altitude_decimal if Point.altitude_decimal_supported?
-    Point.upsert_all(meaningful_updates, unique_by: :id, update_only: update_cols)
+    Points::BulkUpdater.call(meaningful_updates, update_cols)
     stats[:archived] += meaningful_updates.size
   end
 

--- a/app/jobs/data_migrations/backfill_motion_data_job.rb
+++ b/app/jobs/data_migrations/backfill_motion_data_job.rb
@@ -13,10 +13,7 @@ class DataMigrations::BackfillMotionDataJob < ApplicationJob
     Point.where(motion_data: {}).where.not(raw_data: {}).find_in_batches(batch_size: batch_size) do |points|
       updates = points.filter_map { |point| build_update(point) }
 
-      if updates.any?
-        Point.upsert_all(updates, unique_by: :id, update_only: [:motion_data])
-        # rubocop:enable Rails/SkipsModelValidations
-      end
+      Points::BulkUpdater.call(updates, [:motion_data]) if updates.any?
 
       processed += points.size
       Rails.logger.info("Backfilled motion_data for #{processed} points")

--- a/app/services/imports/bulk_insertable.rb
+++ b/app/services/imports/bulk_insertable.rb
@@ -9,7 +9,10 @@ module Imports
     def bulk_insert_points(batch)
       return 0 if batch.empty?
 
-      unique_batch = batch.compact.uniq { |record| [record[:lonlat], record[:timestamp], record[:user_id]] }
+      records = reject_blank_lonlat(batch.compact)
+      return 0 if records.empty?
+
+      unique_batch = records.uniq { |record| [record[:lonlat], record[:timestamp], record[:user_id]] }
 
       result = Point.upsert_all(
         unique_batch,
@@ -27,6 +30,14 @@ module Imports
       on_bulk_insert_error(e)
       create_import_error_notification("Failed to process #{importer_name} data: #{e.message}")
       0
+    end
+
+    def reject_blank_lonlat(records)
+      valid, invalid = records.partition { |record| record[:lonlat].present? }
+
+      Rails.logger.warn("#{importer_name}: skipped #{invalid.size} point(s) with blank lonlat") if invalid.any?
+
+      valid
     end
 
     def record_batch_counters(attempted, skipped)

--- a/app/services/points/bulk_updater.rb
+++ b/app/services/points/bulk_updater.rb
@@ -61,7 +61,10 @@ module Points
     end
 
     def sql_type(column)
-      Point.columns_hash[column.to_s].sql_type
+      column_definition = Point.columns_hash[column.to_s]
+      raise ArgumentError, "Unknown points column: #{column}" unless column_definition
+
+      column_definition.sql_type
     end
 
     def quote_column(column)

--- a/app/services/points/bulk_updater.rb
+++ b/app/services/points/bulk_updater.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Points
+  class BulkUpdater
+    def self.call(rows, columns)
+      new(rows, columns).call
+    end
+
+    def initialize(rows, columns)
+      @rows = rows
+      @columns = columns.map(&:to_sym)
+    end
+
+    def call
+      return 0 if @rows.empty?
+
+      connection.exec_update(update_sql)
+    end
+
+    private
+
+    attr_reader :rows, :columns
+
+    def connection
+      Point.connection
+    end
+
+    def all_columns
+      [:id, *columns]
+    end
+
+    def update_sql
+      <<~SQL.squish
+        UPDATE points AS p
+        SET #{set_clause}
+        FROM (VALUES #{values_list}) AS v (#{column_list})
+        WHERE p.id = v.id
+      SQL
+    end
+
+    def set_clause
+      columns.map { |column| "#{quote_column(column)} = v.#{quote_column(column)}" }.join(', ')
+    end
+
+    def column_list
+      all_columns.map { |column| quote_column(column) }.join(', ')
+    end
+
+    def values_list
+      rows.map { |row| "(#{tuple(row)})" }.join(', ')
+    end
+
+    def tuple(row)
+      all_columns.map { |column| cast_value(row[column], column) }.join(', ')
+    end
+
+    def cast_value(value, column)
+      serialized = Point.type_for_attribute(column.to_s).serialize(value)
+
+      "#{connection.quote(serialized)}::#{sql_type(column)}"
+    end
+
+    def sql_type(column)
+      Point.columns_hash[column.to_s].sql_type
+    end
+
+    def quote_column(column)
+      connection.quote_column_name(column)
+    end
+  end
+end

--- a/app/services/points/raw_data/restorer.rb
+++ b/app/services/points/raw_data/restorer.rb
@@ -122,9 +122,7 @@ module Points
           { id: id, raw_data: raw_data, raw_data_archived: false, raw_data_archive_id: nil }
         end
 
-        Point.upsert_all(updates, unique_by: :id,
-                          update_only: %i[raw_data raw_data_archived raw_data_archive_id])
-        # rubocop:enable Rails/SkipsModelValidations
+        Points::BulkUpdater.call(updates, %i[raw_data raw_data_archived raw_data_archive_id])
       end
 
       def restore_archive_to_cache(archive, cache_key_prefix)

--- a/db/migrate/20260528225731_clean_up_and_constrain_null_lonlat_points.rb
+++ b/db/migrate/20260528225731_clean_up_and_constrain_null_lonlat_points.rb
@@ -4,6 +4,7 @@ class CleanUpAndConstrainNullLonlatPoints < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
   CONSTRAINT_NAME = 'points_lonlat_null'
+  BATCH_SIZE = 10_000
 
   def up
     backfill_lonlat_from_legacy_columns
@@ -15,26 +16,31 @@ class CleanUpAndConstrainNullLonlatPoints < ActiveRecord::Migration[8.0]
   end
 
   def down
+    # Points deleted in `up` are not recoverable; this only drops the constraint.
     remove_check_constraint :points, name: CONSTRAINT_NAME if constraint_present?
   end
 
   private
 
   def backfill_lonlat_from_legacy_columns
-    result = execute(<<~SQL.squish)
-      UPDATE points
-      SET lonlat = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
-      WHERE lonlat IS NULL
-        AND latitude IS NOT NULL
-        AND longitude IS NOT NULL
-    SQL
+    backfilled = 0
 
-    Rails.logger.info("[#{self.class.name}] backfilled #{result.cmd_tuples} point(s) from legacy latitude/longitude")
+    Point.where(lonlat: nil).where.not(latitude: nil).where.not(longitude: nil)
+         .in_batches(of: BATCH_SIZE) do |batch|
+      backfilled += batch.update_all('lonlat = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)')
+    end
+
+    Rails.logger.info("[#{self.class.name}] backfilled #{backfilled} point(s) from legacy latitude/longitude")
   end
 
   def delete_points_without_coordinates
-    affected_user_ids = select_values('SELECT DISTINCT user_id FROM points WHERE lonlat IS NULL').compact
-    deleted = execute('DELETE FROM points WHERE lonlat IS NULL').cmd_tuples
+    affected_user_ids = Set.new
+    deleted = 0
+
+    Point.where(lonlat: nil).in_batches(of: BATCH_SIZE) do |batch|
+      affected_user_ids.merge(batch.distinct.pluck(:user_id))
+      deleted += batch.delete_all
+    end
 
     Rails.logger.info("[#{self.class.name}] deleted #{deleted} point(s) without coordinates")
 
@@ -42,16 +48,15 @@ class CleanUpAndConstrainNullLonlatPoints < ActiveRecord::Migration[8.0]
   end
 
   def resync_points_counters(user_ids)
-    user_ids.each do |user_id|
-      execute(<<~SQL.squish)
-        UPDATE users
-        SET points_count = (SELECT COUNT(*) FROM points WHERE points.user_id = #{user_id.to_i})
-        WHERE id = #{user_id.to_i}
-      SQL
-    end
+    ids = user_ids.compact
+    return if ids.empty?
+
+    User.unscoped.where(id: ids).update_all(
+      'points_count = (SELECT COUNT(*) FROM points WHERE points.user_id = users.id)'
+    )
   end
 
   def constraint_present?
-    select_value("SELECT 1 FROM pg_constraint WHERE conname = '#{CONSTRAINT_NAME}'").present?
+    select_value("SELECT 1 FROM pg_constraint WHERE conname = #{quote(CONSTRAINT_NAME)}").present?
   end
 end

--- a/db/migrate/20260528225731_clean_up_and_constrain_null_lonlat_points.rb
+++ b/db/migrate/20260528225731_clean_up_and_constrain_null_lonlat_points.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class CleanUpAndConstrainNullLonlatPoints < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  CONSTRAINT_NAME = 'points_lonlat_null'
+
+  def up
+    backfill_lonlat_from_legacy_columns
+    delete_points_without_coordinates
+
+    return if constraint_present?
+
+    add_check_constraint :points, 'lonlat IS NOT NULL', name: CONSTRAINT_NAME, validate: false
+  end
+
+  def down
+    remove_check_constraint :points, name: CONSTRAINT_NAME if constraint_present?
+  end
+
+  private
+
+  def backfill_lonlat_from_legacy_columns
+    result = execute(<<~SQL.squish)
+      UPDATE points
+      SET lonlat = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
+      WHERE lonlat IS NULL
+        AND latitude IS NOT NULL
+        AND longitude IS NOT NULL
+    SQL
+
+    Rails.logger.info("[#{self.class.name}] backfilled #{result.cmd_tuples} point(s) from legacy latitude/longitude")
+  end
+
+  def delete_points_without_coordinates
+    affected_user_ids = select_values('SELECT DISTINCT user_id FROM points WHERE lonlat IS NULL').compact
+    deleted = execute('DELETE FROM points WHERE lonlat IS NULL').cmd_tuples
+
+    Rails.logger.info("[#{self.class.name}] deleted #{deleted} point(s) without coordinates")
+
+    resync_points_counters(affected_user_ids)
+  end
+
+  def resync_points_counters(user_ids)
+    user_ids.each do |user_id|
+      execute(<<~SQL.squish)
+        UPDATE users
+        SET points_count = (SELECT COUNT(*) FROM points WHERE points.user_id = #{user_id.to_i})
+        WHERE id = #{user_id.to_i}
+      SQL
+    end
+  end
+
+  def constraint_present?
+    select_value("SELECT 1 FROM pg_constraint WHERE conname = '#{CONSTRAINT_NAME}'").present?
+  end
+end

--- a/db/migrate/20260528225732_validate_null_lonlat_points_constraint.rb
+++ b/db/migrate/20260528225732_validate_null_lonlat_points_constraint.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ValidateNullLonlatPointsConstraint < ActiveRecord::Migration[8.0]
+  CONSTRAINT_NAME = 'points_lonlat_null'
+
+  def up
+    validate_check_constraint :points, name: CONSTRAINT_NAME
+    change_column_null :points, :lonlat, false
+    remove_check_constraint :points, name: CONSTRAINT_NAME
+  end
+
+  def down
+    change_column_null :points, :lonlat, true
+    add_check_constraint :points, 'lonlat IS NOT NULL', name: CONSTRAINT_NAME, validate: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -302,7 +302,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_10_090000) do
     t.decimal "course", precision: 8, scale: 5
     t.decimal "course_accuracy", precision: 8, scale: 5
     t.string "external_track_id"
-    t.geography "lonlat", limit: {srid: 4326, type: "st_point", geographic: true}
+    t.geography "lonlat", limit: {srid: 4326, type: "st_point", geographic: true}, null: false
     t.bigint "country_id"
     t.bigint "track_id"
     t.string "country_name"

--- a/spec/jobs/data_migrations/migrate_points_latlon_job_spec.rb
+++ b/spec/jobs/data_migrations/migrate_points_latlon_job_spec.rb
@@ -6,14 +6,11 @@ RSpec.describe DataMigrations::MigratePointsLatlonJob, type: :job do
   describe '#perform' do
     it 'updates the lonlat column for all tracked points' do
       user = create(:user)
-      point = create(:point, latitude: 2.0, longitude: 1.0, user: user)
-
-      # Clear the lonlat to simulate points that need migration
-      point.update_column(:lonlat, nil)
+      point = create(:point, latitude: 2.0, longitude: 1.0, lonlat: 'POINT(0 0)', user: user)
 
       expect { subject.perform(user.id) }.to change {
         point.reload.lonlat
-      }.from(nil).to(RGeo::Geographic.spherical_factory.point(1.0, 2.0))
+      }.to(RGeo::Geographic.spherical_factory.point(1.0, 2.0))
     end
   end
 end

--- a/spec/regressions/bulk_insert_rejects_blank_lonlat_spec.rb
+++ b/spec/regressions/bulk_insert_rejects_blank_lonlat_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Bulk point insertion rejects records with blank lonlat' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user:) }
+
+  let(:inserter_class) do
+    Class.new do
+      include Imports::BulkInsertable
+
+      attr_reader :import
+
+      def initialize(import)
+        @import = import
+      end
+
+      def insert(batch)
+        bulk_insert_points(batch)
+      end
+
+      def importer_name
+        'Test'
+      end
+    end
+  end
+
+  let(:inserter) { inserter_class.new(import) }
+
+  let(:valid_record) do
+    { lonlat: 'POINT(13.4 52.5)', timestamp: 1_700_000_000, user_id: user.id }
+  end
+
+  let(:nil_lonlat_record) do
+    { lonlat: nil, timestamp: 1_700_000_001, user_id: user.id }
+  end
+
+  it 'does not persist points with nil lonlat' do
+    inserter.insert([valid_record, nil_lonlat_record])
+
+    expect(Point.where(user_id: user.id).count).to eq(1)
+    expect(Point.where(user_id: user.id, lonlat: nil)).to be_empty
+  end
+
+  it 'returns the count of inserted valid points only' do
+    expect(inserter.insert([valid_record, nil_lonlat_record])).to eq(1)
+  end
+
+  it 'returns 0 when every record has a blank lonlat' do
+    expect(inserter.insert([nil_lonlat_record, { lonlat: '', timestamp: 1, user_id: user.id }])).to eq(0)
+  end
+end

--- a/spec/regressions/points_lonlat_not_null_constraint_spec.rb
+++ b/spec/regressions/points_lonlat_not_null_constraint_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'points.lonlat NOT NULL database constraint' do
+  let(:user) { create(:user) }
+
+  it 'rejects inserting a point without coordinates' do
+    expect do
+      ActiveRecord::Base.connection.execute(
+        'INSERT INTO points ("timestamp", user_id, created_at, updated_at) ' \
+        "VALUES (1, #{user.id}, NOW(), NOW())"
+      )
+    end.to raise_error(ActiveRecord::NotNullViolation)
+  end
+end

--- a/spec/services/points/bulk_updater_spec.rb
+++ b/spec/services/points/bulk_updater_spec.rb
@@ -46,5 +46,13 @@ RSpec.describe Points::BulkUpdater do
 
       expect(point.reload.city).to be_nil
     end
+
+    it 'raises ArgumentError for an unknown column' do
+      point = create(:point, user:)
+
+      expect do
+        Points::BulkUpdater.call([{ id: point.id, nonexistent: 'x' }], %i[nonexistent])
+      end.to raise_error(ArgumentError, /Unknown points column: nonexistent/)
+    end
   end
 end

--- a/spec/services/points/bulk_updater_spec.rb
+++ b/spec/services/points/bulk_updater_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Points::BulkUpdater do
+  let(:user) { create(:user) }
+
+  describe '.call' do
+    it 'updates the given columns for each row by id' do
+      point = create(:point, user:, raw_data: { 'a' => 1 }, raw_data_archived: true)
+
+      Points::BulkUpdater.call(
+        [{ id: point.id, raw_data: { 'b' => 2 }, raw_data_archived: false }],
+        %i[raw_data raw_data_archived]
+      )
+
+      point.reload
+      expect(point.raw_data).to eq({ 'b' => 2 })
+      expect(point.raw_data_archived).to be(false)
+    end
+
+    it 'does not touch columns outside the given list' do
+      point = create(:point, user:, lonlat: 'POINT(13.4 52.5)', city: 'Berlin')
+
+      Points::BulkUpdater.call([{ id: point.id, city: 'Munich' }], %i[city])
+
+      point.reload
+      expect(point.city).to eq('Munich')
+      expect(point.lon).to be_within(0.0001).of(13.4)
+    end
+
+    it 'does not insert a row for an id that does not exist' do
+      expect do
+        Points::BulkUpdater.call([{ id: 999_999_999, city: 'Nowhere' }], %i[city])
+      end.not_to change(Point, :count)
+    end
+
+    it 'returns 0 for an empty batch' do
+      expect(Points::BulkUpdater.call([], %i[city])).to eq(0)
+    end
+
+    it 'writes NULL when a value is nil' do
+      point = create(:point, user:, city: 'Berlin')
+
+      Points::BulkUpdater.call([{ id: point.id, city: nil }], %i[city])
+
+      expect(point.reload.city).to be_nil
+    end
+  end
+end

--- a/spec/services/reverse_geocoding/points/fetch_data_spec.rb
+++ b/spec/services/reverse_geocoding/points/fetch_data_spec.rb
@@ -146,20 +146,6 @@ RSpec.describe ReverseGeocoding::Points::FetchData do
     end
   end
 
-  context 'when point has nil lonlat' do
-    let(:point) { create(:point) }
-
-    before do
-      point.update_column(:lonlat, nil)
-    end
-
-    it 'skips geocoding without raising' do
-      expect(Geocoder).not_to receive(:search)
-
-      expect { fetch_data }.not_to raise_error
-    end
-  end
-
   context 'when Geocoder returns an error' do
     before do
       allow(Geocoder).to receive(:search).and_return([double(city: nil, country: nil, data: { 'error' => 'Error' })])

--- a/spec/services/users/export_data/points_spec.rb
+++ b/spec/services/users/export_data/points_spec.rb
@@ -225,21 +225,6 @@ RSpec.describe Users::ExportData::Points, type: :service do
         point
       end
 
-      let!(:point_with_coordinates_only) do
-        # Point with coordinates but missing lonlat
-        point = create(:point, user: user, longitude: 15.0, latitude: 55.0, external_track_id: 'coords-only')
-        # Clear lonlat field to simulate missing geometry
-        point.update_columns(lonlat: nil)
-        point
-      end
-
-      let!(:point_without_coordinates) do
-        # Point with no coordinate data at all
-        point = create(:point, user: user, external_track_id: 'no-coords')
-        point.update_columns(longitude: nil, latitude: nil, lonlat: nil)
-        point
-      end
-
       it 'includes all coordinate fields for points with lonlat only' do
         point_data = subject.find { |p| p['external_track_id'] == 'lonlat-only' }
 
@@ -247,21 +232,6 @@ RSpec.describe Users::ExportData::Points, type: :service do
         expect(point_data['lonlat']).to be_present
         expect(point_data['longitude']).to eq(10.0)
         expect(point_data['latitude']).to eq(50.0)
-      end
-
-      it 'includes all coordinate fields for points with coordinates only' do
-        point_data = subject.find { |p| p['external_track_id'] == 'coords-only' }
-
-        expect(point_data).to be_present
-        expect(point_data['lonlat']).to eq('POINT(15.0 55.0)')
-        expect(point_data['longitude']).to eq(15.0)
-        expect(point_data['latitude']).to eq(55.0)
-      end
-
-      it 'skips points without any coordinate data' do
-        point_data = subject.find { |p| p['external_track_id'] == 'no-coords' }
-
-        expect(point_data).to be_nil
       end
     end
 


### PR DESCRIPTION
## Problem

`Point` validates `lonlat` presence (`app/models/point.rb:14`), but the importers that insert through `Point.upsert_all` bypass model validations, so a point with a `nil` `lonlat` could be persisted. Reading it back through the points API then raised a 500 while serializing the missing coordinates.

This is an alternative to #2519. That PR guarded `Point#lat`/`#lon` to return `nil` instead of raising — but those getters are called from ~18 call sites (track geometry builder, ActionCable broadcasts, serializers), so tolerating `nil` there trades a loud 500 for silent bad data downstream (e.g. `Tracks::BuildPath` turning `nil` into `(0.0, 0.0)`). This PR fixes the invariant at the write path and enforces it in the database instead, keeping the getters strict.

## Changes

**1. Stop creating coordinate-less points (`fix(imports)`)**
- `Imports::BulkInsertable#bulk_insert_points` drops records with a blank `lonlat` before `upsert_all` and logs the skipped count. One chokepoint covers all importers, mirroring the existing guard in `OwnTracks::PointCreator`.

**2. Enforce the invariant at the database (`feat(points)`)**
- Migration recovers `lonlat` from the legacy `latitude`/`longitude` columns where present, deletes points with no coordinates at all (re-syncing affected users' `points_count`), then sets `points.lonlat NOT NULL` via a validated check constraint (no blocking full-table scan), following the repo's existing add→validate split.
- The constraint is incompatible with `update_only` upserts that omit `lonlat` (Postgres NOT-NULL-checks the candidate INSERT row of `INSERT … ON CONFLICT DO UPDATE` even when it resolves to an UPDATE). Introduced `Points::BulkUpdater` (`UPDATE … FROM VALUES`, never inserts) and switched `Points::RawData::Restorer` and the altitude/motion backfill jobs to it.

## ⚠️ Migration deletes data

The migration **deletes** points where `lonlat`, `latitude`, and `longitude` are all NULL (no location at all). On Cloud, where the legacy `latitude`/`longitude` columns are already nil, this means coordinate-less rows are removed rather than recovered. The CHANGELOG upgrade notes document this and include a preview query to count affected rows before upgrading.

## Tests

- New: `Points::BulkUpdater` spec; regressions for the bulk-insert guard and the `NOT NULL` constraint.
- Updated specs that constructed now-impossible nil-`lonlat` fixtures (reverse-geocoding skip, export missing-coords, migrate-latlon job).
- `bundle exec rubocop` clean; full `spec/services spec/jobs spec/models` sweep: 3620 examples, 0 failures.

## Out of scope (follow-ups)

- Auditing the non-`BulkInsertable` creators (`overland`, `traccar`, `semantic_history_importer`, `raw_data/restorer`, `import_data/points`) for the write-path guard.
- Now-redundant defensive nil-`lonlat` guards in a few readers (harmless; left in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)