### PR TITLE
fix(timeline-v2): sync dates, live counts, onboarding modal, empty-day nav

### DIFF
--- a/app/controllers/map/maplibre_controller.rb
+++ b/app/controllers/map/maplibre_controller.rb
@@ -47,6 +47,7 @@ module Map
 
     def start_at
       return safe_timestamp(params[:start_at]) if params[:start_at].present?
+      return date_param_range.begin.to_i if date_param_range
       return import_window_start if import_window_start
 
       Time.zone.today.beginning_of_day.to_i
@@ -54,9 +55,35 @@ module Map
 
     def end_at
       return safe_timestamp(params[:end_at]) if params[:end_at].present?
+      return date_param_range.end.to_i if date_param_range
       return import_window_end if import_window_end
 
       Time.zone.today.end_of_day.to_i
+    end
+
+    # When the URL carries only `?date=` (deep-links, the unified-timeline
+    # redirect, the Timeline panel's own day navigation) — but no explicit
+    # start_at/end_at — derive the map's data window from that day so the
+    # map, the top date-range form, and the Timeline panel all agree.
+    # Without this the map silently stays on "today" while the panel shows
+    # the requested day (the C1 desync).
+    def date_param_range
+      return @date_param_range if defined?(@date_param_range)
+
+      @date_param_range =
+        if params[:date].present?
+          tz = current_user.safe_settings.timezone.presence || 'UTC'
+          Time.use_zone(tz) do
+            date = params[:date] == 'today' ? Date.current : safe_parse_date(params[:date])
+            date&.all_day
+          end
+        end
+    end
+
+    def safe_parse_date(value)
+      Date.parse(value.to_s)
+    rescue ArgumentError, TypeError
+      nil
     end
 
     def parsed_start_at

--- a/app/controllers/map/timeline_feeds_controller.rb
+++ b/app/controllers/map/timeline_feeds_controller.rb
@@ -15,6 +15,10 @@ module Map
         distance_unit: current_user.safe_settings.distance_unit
       ).call
       @distance_unit = current_user.safe_settings.distance_unit
+      # The day the frame was asked to render. Lets the empty state still show
+      # the "< Weekday, Month D >" day navigator so users can step days even
+      # when a day has no visits.
+      @requested_date = parsed_start_at.to_date.iso8601
     end
 
     def track_info

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -142,7 +142,10 @@ class VisitsController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.remove("visit_item_#{@visit.id}")
+        render turbo_stream: [
+          turbo_stream.remove("visit_item_#{@visit.id}"),
+          suggestions_badge_stream
+        ]
       end
       format.html { redirect_to build_timeline_url(date: 'today'), status: :see_other }
     end
@@ -237,6 +240,7 @@ class VisitsController < ApplicationController
     streams << turbo_stream.replace('filter-count-declined',
                                     partial: 'map/timeline_feeds/filter_count',
                                     locals: { status: 'declined', count: status_counts['declined'].to_i })
+    streams << suggestions_badge_stream
     streams << stream_flash(:notice, "#{count} #{'visit'.pluralize(count)} #{status}.")
     streams
   end
@@ -274,6 +278,7 @@ class VisitsController < ApplicationController
       turbo_stream.replace('filter-count-declined',
                            partial: 'map/timeline_feeds/filter_count',
                            locals: { status: 'declined', count: status_counts['declined'].to_i }),
+      suggestions_badge_stream,
       stream_flash(:notice, "Visit #{@visit.status}.")
     ]
   end
@@ -282,6 +287,15 @@ class VisitsController < ApplicationController
     params = { panel: 'timeline', date: date }
     params[:status] = status if status.present?
     "/map/v2?#{params.to_query}"
+  end
+
+  # Refreshes the lifetime pending-suggestion badge on the Timeline map button
+  # so it doesn't go stale after a confirm/decline/merge/delete (it would
+  # otherwise keep the count from the initial page render).
+  def suggestions_badge_stream
+    turbo_stream.replace('timeline-suggestions-badge',
+                         partial: 'map/timeline_feeds/suggestions_badge',
+                         locals: { count: current_user.scoped_visits.suggested.count })
   end
 
   # Visits-by-status counts scoped to the month containing `date_str`. Used by
@@ -400,6 +414,7 @@ class VisitsController < ApplicationController
     streams << turbo_stream.replace('filter-count-declined',
                                     partial: 'map/timeline_feeds/filter_count',
                                     locals: { status: 'declined', count: status_counts['declined'].to_i })
+    streams << suggestions_badge_stream
     streams << stream_flash(:notice, 'Visits merged.')
     streams
   end
@@ -416,6 +431,7 @@ class VisitsController < ApplicationController
     day_stream = build_day_frame_stream(visible_date, tz)
     streams << day_stream if day_stream
     streams.concat(filter_count_streams(counts_date_str))
+    streams << suggestions_badge_stream
     streams << stream_flash(:notice, bulk_destroy_success_message(count))
     streams
   end

--- a/app/javascript/controllers/onboarding_modal_controller.js
+++ b/app/javascript/controllers/onboarding_modal_controller.js
@@ -10,6 +10,7 @@ export default class extends Controller {
     "demoButton",
   ]
   static values = {
+    auto: Boolean,
     showable: Boolean,
     onboardingUrl: String,
     userTrial: Boolean,
@@ -20,8 +21,17 @@ export default class extends Controller {
   }
 
   connect() {
-    if (this.showableValue) {
+    // Auto-open is gated to the map page (auto=true is set only by the map
+    // layout's render). Other pages still render the dialog for the navbar's
+    // manual "Getting started" trigger, but never pop it open on load.
+    if (this.autoValue && this.showableValue) {
       document.addEventListener("turbo:load", this.handleTurboLoad)
+      // The map page is reached via a full (non-Turbo) navigation after
+      // signup, where turbo:load never fires — so open from connect() too.
+      // Defer one task so a Turbo-swapped <dialog> is ready for showModal();
+      // checkAndShowModal is idempotent (localStorage guard) and only marks
+      // "shown" once the dialog actually opens, so turbo:load can still retry.
+      setTimeout(() => this.checkAndShowModal(), 0)
     }
     this.updateDemoButton()
   }
@@ -34,7 +44,7 @@ export default class extends Controller {
   }
 
   handleTurboLoad = () => {
-    if (this.showableValue) {
+    if (this.autoValue && this.showableValue) {
       this.checkAndShowModal()
     }
   }
@@ -47,6 +57,11 @@ export default class extends Controller {
 
     if (!hasShownModal && this.hasModalTarget) {
       this.modalTarget.showModal()
+      // If showModal didn't take (called too early during a Turbo render),
+      // don't mark it shown — let turbo:load retry instead of silently
+      // burning the one-time guard.
+      if (!this.modalTarget.open) return
+
       localStorage.setItem(storageKey, "true")
       this.trackEvent("onboarding_shown")
 

--- a/app/javascript/controllers/timeline_feed_controller.js
+++ b/app/javascript/controllers/timeline_feed_controller.js
@@ -179,7 +179,15 @@ export default class extends Controller {
 
     // Date selection — "today" means the user's local today, not UTC today.
     // Using toISOString() would shift the date near midnight in non-UTC zones.
-    const date = params.get("date")
+    // Fall back to the range's end date when there's no explicit `date=` param
+    // (arriving via the top date-range form / Search / Last 7 days) so the
+    // panel lands on the most recent day of the range instead of going blank —
+    // keeping the range and the panel in sync (C1).
+    let date = params.get("date")
+    if (!date) {
+      const endAt = params.get("end_at")
+      if (endAt) date = endAt.slice(0, 10)
+    }
     if (date) {
       const isoDate =
         date === "today" ? new Date().toLocaleDateString("en-CA") : date
@@ -291,11 +299,6 @@ export default class extends Controller {
     params.set("date", date)
     window.history.pushState({}, "", `/map/v2?${params.toString()}`)
 
-    const startInput = document.querySelector('input[name="start_at"]')
-    const endInput = document.querySelector('input[name="end_at"]')
-    if (startInput) startInput.value = `${date}T00:00`
-    if (endInput) endInput.value = `${date}T23:59`
-
     document.dispatchEvent(
       new CustomEvent("timeline-feed:date-navigated", {
         detail: { date, startAt: startAtLocal, endAt: endAtLocal },
@@ -353,6 +356,14 @@ export default class extends Controller {
         day: "numeric",
       })
     }
+
+    // Keep the top date-range form inputs aligned with the selected day so the
+    // range and the panel never silently disagree — applies on calendar/arrow
+    // navigation AND on URL hydration (deep-links), both ways (C1).
+    const startInput = document.querySelector('input[name="start_at"]')
+    const endInput = document.querySelector('input[name="end_at"]')
+    if (startInput) startInput.value = `${date}T00:00`
+    if (endInput) endInput.value = `${date}T23:59`
   }
 
   // Pure UI update — no navigation. Called on connect() when URL params

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -10,6 +10,7 @@ class Visit < ApplicationRecord
 
   after_commit :cleanup_old_place_if_orphan, on: :update
   after_destroy_commit :cleanup_place_if_orphan
+  after_commit :bust_timeline_month_summary_cache
 
   validates :started_at, :ended_at, :duration, :name, :status, presence: true
 
@@ -71,5 +72,27 @@ class Visit < ApplicationRecord
     return unless place_id
 
     Places::DeleteIfOrphanJob.perform_later(place_id)
+  end
+
+  # Keeps the Timeline calendar/filter-count cache fresh when visits are
+  # created or changed by ANY path — background import/detection jobs as well
+  # as the controller. Without this, MonthSummary (cached 5 min) serves stale
+  # status_counts right after a visit is auto-detected, so the FILTER pills
+  # read 0 until the user happens to act. Busts both the old and new month so
+  # edits that move a visit across a month boundary clear both.
+  def bust_timeline_month_summary_cache
+    return unless user
+
+    tz = user.safe_settings.timezone.presence || 'UTC'
+    times = [started_at]
+    times << saved_change_to_started_at&.first if saved_change_to_started_at?
+
+    Time.use_zone(tz) do
+      times.compact.map { |t| t.in_time_zone.to_date.beginning_of_month }.uniq.each do |month_start|
+        Rails.cache.delete(Timeline::MonthSummary.cache_key_for(user, month_start))
+      end
+    end
+  rescue StandardError => e
+    Rails.logger.warn("[Visit##{id}] timeline month cache bust failed: #{e.class}: #{e.message}")
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,6 +62,8 @@
       </div>
     </div>
 
-    <%= render 'map/onboarding_modal' %>
+    <%# auto_open: false — non-map pages keep the dialog only for the navbar's
+        manual "Getting started" trigger; it never pops open on load (N1). %>
+    <%= render 'map/onboarding_modal', auto_open: false %>
   </body>
 </html>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -66,6 +66,6 @@
       <%= render 'shared/legal_footer' %>
     </div>
 
-    <%= render 'map/onboarding_modal' %>
+    <%= render 'map/onboarding_modal', auto_open: true %>
   </body>
 </html>

--- a/app/views/map/_onboarding_modal.html.erb
+++ b/app/views/map/_onboarding_modal.html.erb
@@ -1,5 +1,6 @@
 <% if user_signed_in? %>
 <div data-controller="onboarding-modal"
+     data-onboarding-modal-auto-value="<%= local_assigns.fetch(:auto_open, false) %>"
      data-onboarding-modal-showable-value="<%= onboarding_modal_showable?(current_user) %>"
      data-onboarding-modal-onboarding-url-value="<%= settings_onboarding_path %>"
      data-onboarding-modal-user-trial-value="<%= current_user.trial? %>"

--- a/app/views/map/maplibre/_button_cluster.html.erb
+++ b/app/views/map/maplibre/_button_cluster.html.erb
@@ -8,12 +8,7 @@
           aria-keyshortcuts="T"
           title="Timeline (T)">
     <%= icon 'calendar-clock' %>
-    <% count = @suggestions_pending_count.to_i %>
-    <% if count.positive? %>
-      <span class="map-button-cluster__badge" aria-label="<%= count %> suggestions pending">
-        <%= count > 99 ? '99+' : count %>
-      </span>
-    <% end %>
+    <%= render 'map/timeline_feeds/suggestions_badge', count: @suggestions_pending_count.to_i %>
   </button>
 
   <button type="button"

--- a/app/views/map/timeline_feeds/_day.html.erb
+++ b/app/views/map/timeline_feeds/_day.html.erb
@@ -9,25 +9,7 @@
 %>
 <div class="timeline-day" data-day="<%= day[:date] %>" data-bounds="<%= day_bounds_json(day) %>">
   <div class="timeline-day-header">
-    <div class="timeline-day-header__nav">
-      <button data-testid="day-prev"
-              data-action="click->timeline-feed#navigateDay"
-              data-direction="prev"
-              title="Previous day"
-              aria-label="Previous day"
-              class="btn btn-ghost btn-xs btn-square">
-        <%= icon 'chevron-left', class: 'w-4 h-4' %>
-      </button>
-      <div class="font-semibold text-sm text-center flex-1" data-testid="day-header-label"><%= day_label(day) %></div>
-      <button data-testid="day-next"
-              data-action="click->timeline-feed#navigateDay"
-              data-direction="next"
-              title="Next day"
-              aria-label="Next day"
-              class="btn btn-ghost btn-xs btn-square">
-        <%= icon 'chevron-right', class: 'w-4 h-4' %>
-      </button>
-    </div>
+    <%= render 'map/timeline_feeds/day_nav', date: day[:date] %>
     <div class="timeline-day-header__meta">
       <%= pluralize(day_total_visits_count(day), 'visit') %>
       <% if day_total_visits_count(day) >= 2 %>

--- a/app/views/map/timeline_feeds/_day_nav.html.erb
+++ b/app/views/map/timeline_feeds/_day_nav.html.erb
@@ -1,0 +1,23 @@
+<%# The "< Weekday, Month D >" day navigator. Shared by the populated day view
+    (_day) and the empty-day state (_feed) so day-stepping works even when a
+    day has no visits. navigateDay reads the controller's selectedDate, so the
+    prev/next buttons need no date attribute. Locals: date - "YYYY-MM-DD" %>
+<div class="timeline-day-header__nav">
+  <button data-testid="day-prev"
+          data-action="click->timeline-feed#navigateDay"
+          data-direction="prev"
+          title="Previous day"
+          aria-label="Previous day"
+          class="btn btn-ghost btn-xs btn-square">
+    <%= icon 'chevron-left', class: 'w-4 h-4' %>
+  </button>
+  <div class="font-semibold text-sm text-center flex-1" data-testid="day-header-label"><%= Date.parse(date.to_s).strftime('%A, %B %-d') %></div>
+  <button data-testid="day-next"
+          data-action="click->timeline-feed#navigateDay"
+          data-direction="next"
+          title="Next day"
+          aria-label="Next day"
+          class="btn btn-ghost btn-xs btn-square">
+    <%= icon 'chevron-right', class: 'w-4 h-4' %>
+  </button>
+</div>

--- a/app/views/map/timeline_feeds/_feed.html.erb
+++ b/app/views/map/timeline_feeds/_feed.html.erb
@@ -1,9 +1,18 @@
 <div>
   <% if days.empty? %>
-    <div class="text-center text-base-content/60 py-8">
-      <%= render 'shared/plan_data_window_alert', utm_content: 'timeline_feed' %>
-      <p class="text-sm">No visits tracked this day.</p>
-      <p class="text-xs mt-1">Visits are auto-detected daily from your location data.</p>
+    <%# Keep the day navigator visible on empty days so users can still step
+        between days (otherwise they get stuck with no way to move). %>
+    <div class="timeline-day">
+      <% if local_assigns[:requested_date].present? %>
+        <div class="timeline-day-header">
+          <%= render 'map/timeline_feeds/day_nav', date: requested_date %>
+        </div>
+      <% end %>
+      <div class="text-center text-base-content/60 py-8">
+        <%= render 'shared/plan_data_window_alert', utm_content: 'timeline_feed' %>
+        <p class="text-sm">No visits tracked this day.</p>
+        <p class="text-xs mt-1">Visits are auto-detected daily from your location data.</p>
+      </div>
     </div>
   <% else %>
     <% days.each do |day| %>

--- a/app/views/map/timeline_feeds/_suggestions_badge.html.erb
+++ b/app/views/map/timeline_feeds/_suggestions_badge.html.erb
@@ -1,0 +1,11 @@
+<%# Pending-suggestion badge on the Timeline map button. Lifetime-scoped count.
+    The id wrapper always renders (even at 0) so VisitsController turbo_streams
+    can replace it after confirm/decline/merge/delete and keep it in sync.
+    Locals: count - Integer %>
+<span id="timeline-suggestions-badge">
+  <% if count.to_i.positive? %>
+    <span class="map-button-cluster__badge" aria-label="<%= count.to_i %> suggestions pending">
+      <%= count.to_i > 99 ? '99+' : count.to_i %>
+    </span>
+  <% end %>
+</span>

--- a/app/views/map/timeline_feeds/index.html.erb
+++ b/app/views/map/timeline_feeds/index.html.erb
@@ -1,3 +1,3 @@
 <turbo-frame id="timeline-feed-frame">
-  <%= render partial: 'map/timeline_feeds/feed', locals: { days: @days } %>
+  <%= render partial: 'map/timeline_feeds/feed', locals: { days: @days, requested_date: @requested_date } %>
 </turbo-frame>

--- a/app/views/shared/map/_date_navigation_v2.html.erb
+++ b/app/views/shared/map/_date_navigation_v2.html.erb
@@ -18,11 +18,16 @@
     data-map-controls-target="panel"
     class="hidden lg:!block bg-base-100 rounded-lg p-4 mt-2 lg:mt-0">
     <%= form_with url: map_v2_path(import_id: params[:import_id]), method: :get do |f| %>
+      <%# Keep the Timeline panel open across a Search so the range and the
+          panel stay in sync (C1). A GET form drops the action URL's query, so
+          panel must ride along as a hidden field. The panel reads the new
+          range's end date as its day via timeline_feed#hydrateFromUrl. %>
+      <% if params[:panel].present? %><%= f.hidden_field :panel, value: params[:panel] %><% end %>
       <div class="flex flex-col space-y-4 lg:flex-row lg:space-y-0 lg:space-x-4 lg:items-end">
         <div class="w-full lg:w-1/12">
           <div class="flex flex-col space-y-2">
             <span class="tooltip tooltip-bottom" data-tip="<%= human_date(start_at - 1.day) %>">
-              <%= link_to map_v2_path(start_at: (start_at - 1.day).iso8601, end_at: (end_at - 1.day).iso8601, import_id: params[:import_id]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" do %>
+              <%= link_to map_v2_path(start_at: (start_at - 1.day).iso8601, end_at: (end_at - 1.day).iso8601, import_id: params[:import_id], panel: params[:panel]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" do %>
                 <%= icon 'chevron-left' %>
               <% end %>
             </span>
@@ -37,7 +42,7 @@
         <div class="w-full lg:w-1/12">
           <div class="flex flex-col space-y-2">
             <span class="tooltip tooltip-bottom" data-tip="<%= human_date(start_at + 1.day) %>">
-              <%= link_to map_v2_path(start_at: (start_at + 1.day).iso8601, end_at: (end_at + 1.day).iso8601, import_id: params[:import_id]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" do %>
+              <%= link_to map_v2_path(start_at: (start_at + 1.day).iso8601, end_at: (end_at + 1.day).iso8601, import_id: params[:import_id], panel: params[:panel]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" do %>
                 <%= icon 'chevron-right' %>
               <% end %>
             </span>
@@ -51,18 +56,18 @@
         <div class="w-full lg:w-1/12">
           <div class="flex flex-col space-y-2 text-center">
             <%= link_to "Today",
-              map_v2_path(start_at: Time.current.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id]),
+              map_v2_path(start_at: Time.current.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id], panel: params[:panel]),
               class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
           </div>
         </div>
         <div class="w-full lg:w-2/12">
           <div class="flex flex-col space-y-2 text-center">
-            <%= link_to "Last 7 days", map_v2_path(start_at: 1.week.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
+            <%= link_to "Last 7 days", map_v2_path(start_at: 1.week.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id], panel: params[:panel]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
           </div>
         </div>
         <div class="w-full lg:w-2/12">
           <div class="flex flex-col space-y-2 text-center">
-            <%= link_to "Last month", map_v2_path(start_at: 1.month.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
+            <%= link_to "Last month", map_v2_path(start_at: 1.month.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id], panel: params[:panel]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
           </div>
         </div>
       </div>

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -82,4 +82,35 @@ RSpec.describe Visit, type: :model do
       end
     end
   end
+
+  describe 'timeline month-summary cache invalidation' do
+    let(:user)     { create(:user) }
+    let(:month)    { Time.current.strftime('%Y-%m') }
+    let(:in_month) { Time.current.beginning_of_month.change(hour: 10) }
+
+    def summary_status_counts
+      Timeline::MonthSummary.new(user: user, month: month).call[:status_counts]
+    end
+
+    it 'reflects a newly created visit instead of serving stale cached counts' do
+      expect(summary_status_counts).to eq({}) # warms the 5-minute cache with zero visits
+
+      create(:visit, user: user, area: nil, place: nil, status: :suggested,
+                     started_at: in_month, ended_at: in_month + 1.hour, duration: 60)
+
+      expect(summary_status_counts).to include('suggested' => 1)
+    end
+
+    it 'reflects a status change after the cache is warm' do
+      visit = create(:visit, user: user, area: nil, place: nil, status: :suggested,
+                             started_at: in_month, ended_at: in_month + 1.hour, duration: 60)
+      expect(summary_status_counts).to include('suggested' => 1) # warm cache
+
+      visit.update!(status: :confirmed)
+
+      counts = summary_status_counts
+      expect(counts).to include('confirmed' => 1)
+      expect(counts).not_to include('suggested')
+    end
+  end
 end

--- a/spec/requests/map/maplibre_spec.rb
+++ b/spec/requests/map/maplibre_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Map v2 (maplibre)', type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  describe 'GET /map/v2 date window (C1)' do
+    it 'derives the data window from ?date= when start_at/end_at are absent' do
+      get map_v2_path(date: '2026-05-28', panel: 'timeline')
+
+      expect(response).to have_http_status(:ok)
+      # The top date-range form must render the requested day so the map,
+      # the form, and the Timeline panel all agree (no silent desync).
+      expect(response.body).to include('2026-05-28T00:00')
+      expect(response.body).to include('2026-05-28T23:59')
+    end
+
+    it 'still honors explicit start_at/end_at over ?date=' do
+      get map_v2_path(date: '2026-05-28', start_at: '2026-05-20T00:00', end_at: '2026-05-20T23:59')
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('2026-05-20T00:00')
+    end
+
+    it 'keeps the Timeline panel open across the date-range form (preserves panel param)' do
+      get map_v2_path(date: 'today', panel: 'timeline')
+
+      expect(response.body).to include('name="panel"')
+      expect(response.body).to include('value="timeline"')
+    end
+  end
+end

--- a/spec/requests/visits_spec.rb
+++ b/spec/requests/visits_spec.rb
@@ -157,6 +157,16 @@ RSpec.describe '/visits', type: :request do
         expect_turbo_stream_action('replace', "visit_entry_#{visit.id}")
       end
 
+      it 'refreshes the pending-suggestions badge so it does not go stale' do
+        create_list(:visit, 2, user:, status: :suggested) # 3 suggested total
+
+        patch visit_url(visit), params: { visit: { status: :confirmed } }, as: :turbo_stream
+
+        expect_turbo_stream_action('replace', 'timeline-suggestions-badge')
+        # One of the three was just confirmed → badge should read 2.
+        expect(response.body).to match(/timeline-suggestions-badge.*\b2\b/m)
+      end
+
       it 'sets visit name from place when place_id is provided' do
         place = create(:place, user:, name: 'Coffee Shop')
         patch visit_url(visit), params: { visit: { place_id: place.id } }, as: :turbo_stream


### PR DESCRIPTION
Fixes five UX issues found while clicking through the Map v2 **Timeline** panel (validated against a fresh account seeded via the real onboarding "Explore with demo data" flow).

## Changes

**C1 — bidirectional date sync (top range ↔ Timeline panel day ↔ map)**
Previously a deep-link/redirect like `?panel=timeline&date=2025-10-15` set only the panel day while the top date-range form and the map stayed on *today* (the map showed a blank world view).
- `maplibre_controller` now derives the map's data window from `?date=` when no explicit `start_at`/`end_at` is given.
- `applySelectedDayUI` syncs the top date-form inputs on every path, including URL hydration (not just arrow/calendar nav).
- The date-range form (Search / Today / Last 7 days / prev–next) preserves `panel=timeline`, and `hydrateFromUrl` falls back to the range's end date so changing the range keeps the panel open and lands it on that day.

**C2 — filter counters compute on load**
The `Confirmed / Suggested / Declined` chips read `0` on first load because `MonthSummary` is cached 5 min and only the controller busted it — background import/detection-created visits didn't. Added a `Visit after_commit` that busts the affected month(s) on create/update/destroy.

**C3 — reactive pending-suggestions badge**
The Timeline map-button badge went stale after confirm/decline. Extracted it into a turbo-replaceable partial and stream it on confirm/decline/merge/delete.

**N1 — onboarding modal opens on the map only**
The "Welcome to Dawarich" modal never auto-opened for new users (it waited on `turbo:load`, which the map page doesn't emit). It now auto-opens from `connect()` on the map layout only; other pages still render the dialog for the navbar trigger but never pop it open.

**Empty-day navigator**
When a day has no visits the `< Weekday, Month D >` day navigator disappeared, stranding the user. Extracted a shared `_day_nav` partial and render it in the empty state too.

## Tests
- New specs: `Visit` month-summary cache invalidation, `VisitsController` badge refresh, `Map v2` date-window derivation + panel preservation.
- `bundle exec rspec spec/models/visit_spec.rb spec/requests/visits_spec.rb spec/requests/map/ spec/services/timeline/month_summary_spec.rb` → **114 examples, 0 failures**.
- RuboCop + Biome clean on all changed files.
- Manually verified all five via Playwright on a running instance (deep-link alignment, badge decrement, empty-day stepping, signup→map modal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)