### PR TITLE
Privacy zones in Map v2 (server-side, all layers)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,6 +390,7 @@ Even in these cases, wrap the integration in a Stimulus controller and connect i
    - Support UUID-based access in API endpoints when appropriate
    - Respect expiration settings and disable sharing when expired
    - Only expose minimal necessary data in public sharing contexts
+9. **Privacy zones on the map**: Any new map-context read endpoint (one whose payload renders on a map) MUST apply `Maps::PrivacyZoneMasker` when `mask_privacy_zones=true` is present, and MUST be added to `MASKED_MAP_ENDPOINTS` in `spec/requests/api/v1/privacy_zone_masking_spec.rb`. Masking is opt-in per request so exports, the programmatic API, and stats stay complete.
 
 ### Route Drawing Implementation (Critical)
 

--- a/app/controllers/api/v1/maps/hexagons_controller.rb
+++ b/app/controllers/api/v1/maps/hexagons_controller.rb
@@ -15,6 +15,8 @@ class Api::V1::Maps::HexagonsController < ApiController
       end_date: context[:end_date]
     ).call
 
+    result = mask_hexagons(result)
+
     render json: result
   rescue ActionController::ParameterMissing => e
     render json: { error: "Missing required parameter: #{e.param}" }, status: :bad_request
@@ -90,5 +92,21 @@ class Api::V1::Maps::HexagonsController < ApiController
 
   def public_sharing_request?
     params[:uuid].present?
+  end
+
+  def mask_hexagons(result)
+    return result if public_sharing_request?
+    return result unless mask_privacy_zones?
+
+    masker = privacy_zone_masker
+    return result unless masker.any?
+    return result unless result.is_a?(Hash) && result['features'].is_a?(Array)
+
+    features = result['features'].reject do |feature|
+      lon, lat = feature.dig('geometry', 'coordinates')
+      lon && lat && masker.in_zone?(lon.to_f, lat.to_f)
+    end
+
+    result.merge('features' => features)
   end
 end

--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -9,13 +9,13 @@ class Api::V1::PhotosController < ApiController
   def index
     cache_key = "photos_#{current_api_user.id}_#{params[:start_date]}_#{params[:end_date]}"
     cached_photos = Rails.cache.read(cache_key)
-    return render json: cached_photos, status: :ok if cached_photos.present?
+    return render json: mask_photos(cached_photos), status: :ok if cached_photos.present?
 
     search = Photos::Search.new(current_api_user, start_date: params[:start_date], end_date: params[:end_date])
     @photos = search.call
     Rails.cache.write(cache_key, @photos, expires_in: 30.minutes) if search.errors.blank? && @photos.present?
 
-    render json: @photos, status: :ok
+    render json: mask_photos(@photos), status: :ok
   rescue StandardError => e
     Rails.logger.error("Photo search failed: #{e.message}")
     render json: { error: 'Failed to fetch photos' }, status: :bad_gateway
@@ -59,5 +59,18 @@ class Api::V1::PhotosController < ApiController
   def unauthorized_integration
     render json: { error: "#{params[:source]&.capitalize} integration not configured" },
            status: :unauthorized
+  end
+
+  def mask_photos(photos)
+    return photos unless mask_privacy_zones?
+
+    masker = privacy_zone_masker
+    return photos unless masker.any?
+
+    Array(photos).reject do |photo|
+      lon = photo[:longitude] || photo['longitude']
+      lat = photo[:latitude] || photo['latitude']
+      lon && lat && masker.in_zone?(lon.to_f, lat.to_f)
+    end
   end
 end

--- a/app/controllers/api/v1/places_controller.rb
+++ b/app/controllers/api/v1/places_controller.rb
@@ -30,6 +30,8 @@ module Api
           end
         end
 
+        @places = privacy_zone_masker.mask_places(@places) if mask_privacy_zones?
+
         # Support pagination (defaults to page 1 with all results if no page param)
         page = params[:page].presence || 1
         per_page = [params[:per_page]&.to_i || 100, 500].min

--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -22,6 +22,8 @@ class Api::V1::PointsController < ApiController
                scoped_points.not_anomaly
              end
 
+    points = privacy_zone_masker.mask_points(points) if mask_privacy_zones?
+
     points = points
              .without_raw_data
              .where(timestamp: start_at..end_at)

--- a/app/controllers/api/v1/tracks/points_controller.rb
+++ b/app/controllers/api/v1/tracks/points_controller.rb
@@ -19,6 +19,8 @@ class Api::V1::Tracks::PointsController < ApiController
                .order(timestamp: :asc)
     end
 
+    points = privacy_zone_masker.mask_points(points) if mask_privacy_zones?
+
     # Support optional pagination (backward compatible - returns all if no page param)
     if params[:page].present?
       per_page = (params[:per_page].presence&.to_i || 1000).clamp(1, 1000)

--- a/app/controllers/api/v1/tracks_controller.rb
+++ b/app/controllers/api/v1/tracks_controller.rb
@@ -6,6 +6,7 @@ class Api::V1::TracksController < ApiController
     paginated_tracks = tracks_query.call
 
     geojson = Tracks::GeojsonSerializer.new(paginated_tracks).call
+    geojson = privacy_zone_masker.mask_track_geojson(geojson) if mask_privacy_zones?
 
     tracks_query.pagination_headers(paginated_tracks).each do |header, value|
       response.set_header(header, value)

--- a/app/controllers/api/v1/visits_controller.rb
+++ b/app/controllers/api/v1/visits_controller.rb
@@ -4,6 +4,15 @@ class Api::V1::VisitsController < ApiController
   def index
     visits = Visits::Finder.new(current_api_user, params).call
 
+    if mask_privacy_zones?
+      hidden_place_ids = privacy_zone_masker.in_zone_place_ids
+      if hidden_place_ids.any?
+        visits = visits.where(
+          'visits.place_id IS NULL OR visits.place_id NOT IN (?)', hidden_place_ids
+        )
+      end
+    end
+
     # Support optional pagination (backward compatible - returns all if no page param)
     if params[:page].present?
       per_page = [params[:per_page]&.to_i || 100, 500].min

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -93,6 +93,14 @@ class ApiController < ApplicationController
     relation.where('timestamp >= ?', DawarichSettings::LITE_DATA_WINDOW.ago.to_i)
   end
 
+  def mask_privacy_zones?
+    ActiveModel::Type::Boolean.new.cast(params[:mask_privacy_zones])
+  end
+
+  def privacy_zone_masker(user = current_api_user)
+    @privacy_zone_masker ||= Maps::PrivacyZoneMasker.new(user)
+  end
+
   def upgrade_url_for(user)
     return nil if DawarichSettings.self_hosted?
 

--- a/app/javascript/controllers/maps/maplibre/data_loader.js
+++ b/app/javascript/controllers/maps/maplibre/data_loader.js
@@ -63,6 +63,7 @@ export class DataLoader {
     this.api = api
     this.apiKey = apiKey
     this.settings = settings
+    this.privacyZones = []
   }
 
   /**
@@ -70,6 +71,14 @@ export class DataLoader {
    */
   updateSettings(settings) {
     this.settings = settings
+  }
+
+  /**
+   * Set privacy zones used to break route segments at masked areas.
+   * @param {Array} zones - [{ lon, lat, radiusMeters }]
+   */
+  setPrivacyZones(zones) {
+    this.privacyZones = zones || []
   }
 
   /**
@@ -86,6 +95,7 @@ export class DataLoader {
     let routesGeoJSON = RoutesLayer.pointsToRoutes(points, {
       distanceThresholdMeters: this.settings.metersBetweenRoutes || 500,
       timeThresholdMinutes: this.settings.minutesBetweenRoutes || 60,
+      privacyZones: this.privacyZones,
     })
 
     // Keep original routes before speed coloring for low-zoom rendering
@@ -261,6 +271,7 @@ export class DataLoader {
       data.routesGeoJSON = RoutesLayer.pointsToRoutes(data.points, {
         distanceThresholdMeters: this.settings.metersBetweenRoutes || 500,
         timeThresholdMinutes: this.settings.minutesBetweenRoutes || 60,
+        privacyZones: this.privacyZones,
       })
 
       // Keep original routes before speed coloring for low-zoom rendering

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -343,6 +343,9 @@ export default class extends Controller {
       new Date(this.endDateValue),
     )
 
+    const privacyZones = await this.api.fetchPrivacyZones()
+    this.dataLoader.setPrivacyZones(privacyZones)
+
     this.loadMapData().then(() => {
       if (this.settings?.familyEnabled) {
         this.loadFamilyMembers()

--- a/app/javascript/maps_maplibre/services/api_client.js
+++ b/app/javascript/maps_maplibre/services/api_client.js
@@ -21,6 +21,7 @@ export class ApiClient {
       per_page: per_page.toString(),
       slim: "true",
       order: "asc",
+      mask_privacy_zones: "true",
     })
 
     const response = await fetch(`${this.baseURL}/points?${params}`, {
@@ -186,6 +187,7 @@ export class ApiClient {
       end_at,
       page: page.toString(),
       per_page: per_page.toString(),
+      mask_privacy_zones: "true",
     })
 
     if (
@@ -282,6 +284,7 @@ export class ApiClient {
     const params = new URLSearchParams({
       page: page.toString(),
       per_page: per_page.toString(),
+      mask_privacy_zones: "true",
     })
 
     if (tag_ids && tag_ids.length > 0) {
@@ -353,6 +356,7 @@ export class ApiClient {
     const params = new URLSearchParams({
       start_date: start_at,
       end_date: end_at,
+      mask_privacy_zones: "true",
     })
 
     const url = `${this.baseURL}/photos?${params}`
@@ -408,6 +412,7 @@ export class ApiClient {
     const params = new URLSearchParams({
       page: page.toString(),
       per_page: per_page.toString(),
+      mask_privacy_zones: "true",
     })
 
     if (start_at) params.append("start_at", start_at)
@@ -772,6 +777,7 @@ export class ApiClient {
     const params = new URLSearchParams({
       page: page.toString(),
       per_page: per_page.toString(),
+      mask_privacy_zones: "true",
     })
 
     const response = await fetch(
@@ -849,6 +855,29 @@ export class ApiClient {
     }
 
     return response.json()
+  }
+
+  /**
+   * Fetch the user's privacy zones as circles for client-side route breaking.
+   * Returns [{ lon, lat, radiusMeters }] flattened across all zone places.
+   */
+  async fetchPrivacyZones() {
+    const response = await fetch(`${this.baseURL}/tags/privacy_zones`, {
+      headers: this.getHeaders(),
+    })
+
+    if (!response.ok) {
+      return []
+    }
+
+    const zones = await response.json()
+    return zones.flatMap((zone) =>
+      (zone.places || []).map((place) => ({
+        lon: place.longitude,
+        lat: place.latitude,
+        radiusMeters: zone.radius_meters,
+      })),
+    )
   }
 
   getHeaders() {

--- a/app/javascript/maps_maplibre/utils/route_segmenter.js
+++ b/app/javascript/maps_maplibre/utils/route_segmenter.js
@@ -145,6 +145,42 @@ export class RouteSegmenter {
   }
 
   /**
+   * True if the segment prev→curr passes within `radiusMeters` of any zone center.
+   * Uses an equirectangular planar approximation (zones are small, ≤5km).
+   * @param {Object} prev - point with latitude/longitude
+   * @param {Object} curr - point with latitude/longitude
+   * @param {Array} zones - [{ lon, lat, radiusMeters }]
+   */
+  static segmentCrossesZone(prev, curr, zones) {
+    if (!zones || zones.length === 0) return false
+
+    const R = 6371000
+    const toRad = (d) => (d * Math.PI) / 180
+    const project = (lat, lon, lat0) => ({
+      x: R * toRad(lon) * Math.cos(toRad(lat0)),
+      y: R * toRad(lat),
+    })
+
+    return zones.some((zone) => {
+      const lat0 = zone.lat
+      const a = project(Number(prev.latitude), Number(prev.longitude), lat0)
+      const b = project(Number(curr.latitude), Number(curr.longitude), lat0)
+      const c = project(zone.lat, zone.lon, lat0)
+
+      const dx = b.x - a.x
+      const dy = b.y - a.y
+      const lenSq = dx * dx + dy * dy
+      let t = lenSq === 0 ? 0 : ((c.x - a.x) * dx + (c.y - a.y) * dy) / lenSq
+      t = Math.max(0, Math.min(1, t))
+      const px = a.x + t * dx
+      const py = a.y + t * dy
+      const dist = Math.hypot(c.x - px, c.y - py)
+
+      return dist <= zone.radiusMeters
+    })
+  }
+
+  /**
    * Calculate total distance for a segment
    * @param {Array} segment - Array of points
    * @returns {number} Total distance in kilometers
@@ -191,8 +227,18 @@ export class RouteSegmenter {
       // Calculate time difference in minutes
       const timeDiff = (curr.timestamp - prev.timestamp) / 60
 
+      const crossesZone = RouteSegmenter.segmentCrossesZone(
+        prev,
+        curr,
+        options.privacyZones,
+      )
+
       // Split if any threshold is exceeded
-      if (distance > distanceThresholdKm || timeDiff > timeThresholdMinutes) {
+      if (
+        distance > distanceThresholdKm ||
+        timeDiff > timeThresholdMinutes ||
+        crossesZone
+      ) {
         if (currentSegment.length > 1) {
           segments.push(currentSegment)
         }
@@ -277,6 +323,7 @@ export class RouteSegmenter {
       const segments = RouteSegmenter.splitIntoSegments(sorted, {
         distanceThresholdKm,
         timeThresholdMinutes,
+        privacyZones: options.privacyZones,
       })
       return segments.map((segment) => RouteSegmenter.segmentToFeature(segment))
     })

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -150,7 +150,7 @@ class Point < ApplicationRecord
 
   # Metrics/AbcSize
   def broadcast_coordinates
-    if user.safe_settings.live_map_enabled
+    if user.safe_settings.live_map_enabled && !in_privacy_zone?
       PointsChannel.broadcast_to(
         user,
         [
@@ -167,6 +167,10 @@ class Point < ApplicationRecord
     end
 
     broadcast_to_family if should_broadcast_to_family?
+  end
+
+  def in_privacy_zone?
+    Maps::PrivacyZoneMasker.new(user).in_zone?(lon, lat)
   end
 
   def should_broadcast_to_family?

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -33,6 +33,9 @@ class Point < ApplicationRecord
   scope :not_visited, -> { where(visit_id: nil) }
   scope :not_anomaly, -> { where(anomaly: [false, nil]) }
   scope :anomaly, -> { where(anomaly: true) }
+  scope :outside_privacy_zones, lambda { |user|
+    Maps::PrivacyZoneMasker.new(user).mask_points(all)
+  }
 
   after_create :async_reverse_geocode, if: -> { DawarichSettings.store_geodata? && !reverse_geocoded? }
   after_create :set_country

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -223,12 +223,30 @@ class Track < ApplicationRecord
 
     Rails.logger.info "[Track#broadcast_geojson_updated] GeoJSON feature id: #{geojson_feature[:properties][:id]}"
 
-    TracksChannel.broadcast_to(user, { action: 'geojson_updated', track: geojson_feature })
+    masked_feature = mask_geojson_feature(geojson_feature)
+    return if masked_feature.nil?
+
+    TracksChannel.broadcast_to(user, { action: 'geojson_updated', track: masked_feature })
 
     Rails.logger.info "[Track#broadcast_geojson_updated] Broadcast complete for track #{id}"
   end
 
   private
+
+  def mask_geojson_feature(feature)
+    masker = Maps::PrivacyZoneMasker.new(user)
+    return feature unless masker.any?
+
+    collection = masker.mask_track_geojson(
+      { 'type' => 'FeatureCollection', 'features' => [feature.deep_stringify_keys] }
+    )
+    segments = collection['features'].map { |f| f['geometry']['coordinates'] }
+    return nil if segments.empty?
+
+    feature.deep_stringify_keys.merge(
+      'geometry' => { 'type' => 'MultiLineString', 'coordinates' => segments }
+    )
+  end
 
   def broadcast_track_created
     broadcast_track_update('created')

--- a/app/services/maps/privacy_zone_masker.rb
+++ b/app/services/maps/privacy_zone_masker.rb
@@ -2,14 +2,12 @@
 
 module Maps
   class PrivacyZoneMasker
-    Circle = Struct.new(:lon, :lat, :radius_meters)
+    Circle = Struct.new(:lon, :lat, :radius_meters, keyword_init: true)
+
+    delegate :any?, to: :circles
 
     def initialize(user)
       @user = user
-    end
-
-    def any?
-      circles.any?
     end
 
     def mask_points(relation)
@@ -39,7 +37,7 @@ module Maps
     def circles
       @circles ||= user.tags.privacy_zones.includes(:places).flat_map do |tag|
         tag.places.map do |place|
-          Circle.new(place.longitude.to_f, place.latitude.to_f, tag.privacy_radius_meters)
+          Circle.new(lon: place.longitude.to_f, lat: place.latitude.to_f, radius_meters: tag.privacy_radius_meters)
         end
       end
     end

--- a/app/services/maps/privacy_zone_masker.rb
+++ b/app/services/maps/privacy_zone_masker.rb
@@ -32,9 +32,10 @@ module Maps
     def mask_track_geojson(geojson)
       return geojson unless any?
 
-      features = Array(geojson['features']).flat_map { |feature| split_feature(feature) }
+      normalized = geojson.deep_stringify_keys
+      features = Array(normalized['features']).flat_map { |feature| split_feature(feature) }
 
-      geojson.merge('features' => features)
+      normalized.merge('features' => features)
     end
 
     private
@@ -95,7 +96,7 @@ module Maps
       end
       segments << current unless current.empty?
 
-      segments
+      segments.reject { |s| s.length < 2 }
     end
 
     def haversine_m(lat1, lon1, lat2, lon2)

--- a/app/services/maps/privacy_zone_masker.rb
+++ b/app/services/maps/privacy_zone_masker.rb
@@ -29,6 +29,14 @@ module Maps
       circles.any? { |c| haversine_m(lat, lon, c.lat, c.lon) <= c.radius_meters }
     end
 
+    def mask_track_geojson(geojson)
+      return geojson unless any?
+
+      features = Array(geojson['features']).flat_map { |feature| split_feature(feature) }
+
+      geojson.merge('features' => features)
+    end
+
     private
 
     attr_reader :user
@@ -55,6 +63,39 @@ module Maps
           Circle.new(lon: place.longitude.to_f, lat: place.latitude.to_f, radius_meters: tag.privacy_radius_meters)
         end
       end
+    end
+
+    def split_feature(feature)
+      geometry = feature['geometry']
+      lines =
+        case geometry&.fetch('type', nil)
+        when 'LineString' then [geometry['coordinates']]
+        when 'MultiLineString' then geometry['coordinates']
+        else return [feature]
+        end
+
+      lines.flat_map { |line| split_line(line) }.map do |segment|
+        feature.merge(
+          'geometry' => { 'type' => 'LineString', 'coordinates' => segment }
+        )
+      end
+    end
+
+    def split_line(coords)
+      segments = []
+      current = []
+
+      coords.each do |(lon, lat)|
+        if in_zone?(lon, lat)
+          segments << current unless current.empty?
+          current = []
+        else
+          current << [lon, lat]
+        end
+      end
+      segments << current unless current.empty?
+
+      segments
     end
 
     def haversine_m(lat1, lon1, lat2, lon2)

--- a/app/services/maps/privacy_zone_masker.rb
+++ b/app/services/maps/privacy_zone_masker.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Maps
+  class PrivacyZoneMasker
+    Circle = Struct.new(:lon, :lat, :radius_meters)
+
+    def initialize(user)
+      @user = user
+    end
+
+    def any?
+      circles.any?
+    end
+
+    def mask_points(relation)
+      mask_relation(relation, 'points.lonlat')
+    end
+
+    private
+
+    attr_reader :user
+
+    def mask_relation(relation, column)
+      return relation unless any?
+
+      relation.where("NOT (#{within_sql(column)})", *binds)
+    end
+
+    def within_sql(column)
+      circles
+        .map { "ST_DWithin(#{column}, ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)" }
+        .join(' OR ')
+    end
+
+    def binds
+      circles.flat_map { |c| [c.lon, c.lat, c.radius_meters] }
+    end
+
+    def circles
+      @circles ||= user.tags.privacy_zones.includes(:places).flat_map do |tag|
+        tag.places.map do |place|
+          Circle.new(place.longitude.to_f, place.latitude.to_f, tag.privacy_radius_meters)
+        end
+      end
+    end
+  end
+end

--- a/app/services/maps/privacy_zone_masker.rb
+++ b/app/services/maps/privacy_zone_masker.rb
@@ -3,6 +3,7 @@
 module Maps
   class PrivacyZoneMasker
     Circle = Struct.new(:lon, :lat, :radius_meters, keyword_init: true)
+    EARTH_RADIUS_M = 6_371_000.0
 
     delegate :any?, to: :circles
 
@@ -12,6 +13,20 @@ module Maps
 
     def mask_points(relation)
       mask_relation(relation, 'points.lonlat')
+    end
+
+    def mask_places(relation)
+      mask_relation(relation, 'places.lonlat')
+    end
+
+    def in_zone_place_ids
+      return [] unless any?
+
+      user.places.where(within_sql('places.lonlat'), *binds).pluck(:id)
+    end
+
+    def in_zone?(lon, lat)
+      circles.any? { |c| haversine_m(lat, lon, c.lat, c.lon) <= c.radius_meters }
     end
 
     private
@@ -40,6 +55,15 @@ module Maps
           Circle.new(lon: place.longitude.to_f, lat: place.latitude.to_f, radius_meters: tag.privacy_radius_meters)
         end
       end
+    end
+
+    def haversine_m(lat1, lon1, lat2, lon2)
+      rad = Math::PI / 180
+      d_lat = (lat2 - lat1) * rad
+      d_lon = (lon2 - lon1) * rad
+      a = (Math.sin(d_lat / 2)**2) +
+          (Math.cos(lat1 * rad) * Math.cos(lat2 * rad) * (Math.sin(d_lon / 2)**2))
+      2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(a))
     end
   end
 end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -25,6 +25,10 @@ FactoryBot.define do
       color { '#FF9800' }
     end
 
+    trait :privacy_zone do
+      privacy_radius_meters { 1000 }
+    end
+
     trait :without_color do
       color { nil }
     end

--- a/spec/models/point_spec.rb
+++ b/spec/models/point_spec.rb
@@ -205,6 +205,22 @@ RSpec.describe Point, type: :model do
     end
   end
 
+  describe '.outside_privacy_zones' do
+    it 'excludes points inside the user\'s privacy zones' do
+      user = create(:user)
+      tag = create(:tag, :privacy_zone, user: user, privacy_radius_meters: 1000)
+      place = create(:place, user: user, latitude: 52.444, longitude: 13.500)
+      create(:tagging, tag: tag, taggable: place)
+      inside = create(:point, user: user, lonlat: 'POINT(13.500 52.444)')
+      outside = create(:point, user: user, lonlat: 'POINT(13.700 52.600)')
+
+      result = Point.outside_privacy_zones(user)
+
+      expect(result).to include(outside)
+      expect(result).not_to include(inside)
+    end
+  end
+
   describe '.dedup_key' do
     let(:timestamp) { Time.zone.at(1_700_000_000) }
 

--- a/spec/models/point_spec.rb
+++ b/spec/models/point_spec.rb
@@ -205,6 +205,34 @@ RSpec.describe Point, type: :model do
     end
   end
 
+  describe '#broadcast_coordinates privacy zone suppression' do
+    let(:user) { create(:user) }
+    let(:tag) { create(:tag, :privacy_zone, user: user, privacy_radius_meters: 500) }
+    let(:place) { create(:place, user: user, latitude: 52.444, longitude: 13.500) }
+
+    before do
+      create(:tagging, tag: tag, taggable: place)
+      user.settings['live_map_enabled'] = true
+      user.save!
+    end
+
+    context 'when a point is inside a privacy zone' do
+      it 'does not broadcast to PointsChannel' do
+        expect do
+          create(:point, user: user, lonlat: 'POINT(13.500 52.444)')
+        end.not_to have_broadcasted_to(user).from_channel(PointsChannel)
+      end
+    end
+
+    context 'when a point is outside all privacy zones' do
+      it 'broadcasts to PointsChannel' do
+        expect do
+          create(:point, user: user, lonlat: 'POINT(13.700 52.600)')
+        end.to have_broadcasted_to(user).from_channel(PointsChannel)
+      end
+    end
+  end
+
   describe '.outside_privacy_zones' do
     it 'excludes points inside the user\'s privacy zones' do
       user = create(:user)

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe Tag, type: :model do
     end
   end
 
+  describe ':privacy_zone factory trait' do
+    it 'builds a tag that reports as a privacy zone' do
+      tag = create(:tag, :privacy_zone)
+
+      expect(tag.privacy_zone?).to be(true)
+      expect(tag.privacy_radius_meters).to eq(1000)
+    end
+  end
+
   describe 'scopes' do
     let!(:tag1) { create(:tag, name: 'A') }
     let!(:tag2) { create(:tag, name: 'B', user: tag1.user) }

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -306,6 +306,77 @@ RSpec.describe Track, type: :model do
     end
   end
 
+  describe '#broadcast_geojson_updated privacy zone masking' do
+    let(:user) { create(:user) }
+    let(:tag) { create(:tag, :privacy_zone, user: user, privacy_radius_meters: 500) }
+    let(:place) { create(:place, user: user, latitude: 52.444, longitude: 13.500) }
+
+    before do
+      create(:tagging, tag: tag, taggable: place)
+    end
+
+    context 'when a track crosses a privacy zone' do
+      # Two points before the zone, the in-zone vertex, then two points after —
+      # so each surviving segment has ≥2 points after masking.
+      let!(:track) do
+        create(:track, user: user,
+               original_path: 'LINESTRING(13.380 52.390, 13.390 52.395, 13.500 52.444, 13.610 52.493, 13.700 52.600)')
+      end
+
+      it 'broadcasts a masked geometry with in-zone vertex removed' do
+        expect do
+          track.broadcast_geojson_updated
+        end.to have_broadcasted_to(user).from_channel(TracksChannel)
+      end
+
+      it 'broadcasts a MultiLineString geometry with in-zone vertex absent' do
+        broadcasts = []
+        allow(TracksChannel).to receive(:broadcast_to) do |target, payload|
+          broadcasts << [target, payload]
+        end
+
+        track.broadcast_geojson_updated
+
+        geojson_broadcasts = broadcasts.select { |_, p| p[:action] == 'geojson_updated' }
+        expect(geojson_broadcasts.length).to eq(1)
+        _target, payload = geojson_broadcasts.first
+        geometry = payload[:track]['geometry']
+        expect(geometry['type']).to eq('MultiLineString')
+        all_coords = geometry['coordinates'].flatten(1)
+        in_zone_coord = [13.500, 52.444]
+        expect(all_coords).not_to include(in_zone_coord)
+      end
+    end
+
+    context 'when an entire track is inside a privacy zone' do
+      # Both vertices are within 500 m of the zone centre.
+      let!(:track) do
+        create(:track, user: user,
+               original_path: 'LINESTRING(13.500 52.444, 13.502 52.445)')
+      end
+
+      it 'does not broadcast geojson_updated' do
+        expect do
+          track.broadcast_geojson_updated
+        end.not_to have_broadcasted_to(user).from_channel(TracksChannel)
+      end
+    end
+
+    context 'when the user has no privacy zones' do
+      let(:other_user) { create(:user) }
+      let!(:track) do
+        create(:track, user: other_user,
+               original_path: 'LINESTRING(13.400 52.400, 13.600 52.500)')
+      end
+
+      it 'broadcasts the original geometry unchanged' do
+        expect do
+          track.broadcast_geojson_updated
+        end.to have_broadcasted_to(other_user).from_channel(TracksChannel)
+      end
+    end
+  end
+
   describe 'Calculateable concern' do
     let(:user) { create(:user) }
     let(:track) { create(:track, user: user, distance: 1000, avg_speed: 25, duration: 3600) }

--- a/spec/requests/api/v1/maps/hexagons_spec.rb
+++ b/spec/requests/api/v1/maps/hexagons_spec.rb
@@ -283,6 +283,44 @@ RSpec.describe 'Api::V1::Maps::Hexagons', type: :request do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    describe 'privacy zone masking' do
+      let(:pz_user) { create(:user) }
+      let(:pz_headers) { { 'Authorization' => "Bearer #{pz_user.api_key}" } }
+
+      before do
+        tag = create(:tag, :privacy_zone, user: pz_user, privacy_radius_meters: 1000)
+        place = create(:place, user: pz_user, latitude: 52.444, longitude: 13.500)
+        create(:tagging, tag: tag, taggable: place)
+        allow_any_instance_of(Maps::HexagonRequestHandler).to receive(:call).and_return(
+          {
+            'type' => 'FeatureCollection',
+            'features' => [
+              { 'type' => 'Feature', 'geometry' => { 'type' => 'Point', 'coordinates' => [13.500, 52.444] }, 'properties' => {} },
+              { 'type' => 'Feature', 'geometry' => { 'type' => 'Point', 'coordinates' => [13.700, 52.600] }, 'properties' => {} }
+            ]
+          }
+        )
+      end
+
+      it 'drops hexagon features whose center is in a zone when flagged' do
+        get '/api/v1/maps/hexagons',
+            params: { mask_privacy_zones: 'true', start_date: '2026-01-01', end_date: '2026-01-31' },
+            headers: pz_headers
+
+        centers = JSON.parse(response.body)['features'].map { |f| f['geometry']['coordinates'] }
+        expect(centers).to eq([[13.700, 52.600]])
+      end
+
+      it 'returns all hexagons without the flag' do
+        get '/api/v1/maps/hexagons',
+            params: { start_date: '2026-01-01', end_date: '2026-01-31' },
+            headers: pz_headers
+
+        centers = JSON.parse(response.body)['features'].map { |f| f['geometry']['coordinates'] }
+        expect(centers).to contain_exactly([13.500, 52.444], [13.700, 52.600])
+      end
+    end
   end
 
   describe 'GET /api/v1/maps/hexagons/bounds' do

--- a/spec/requests/api/v1/photos_spec.rb
+++ b/spec/requests/api/v1/photos_spec.rb
@@ -91,6 +91,42 @@ RSpec.describe 'Api::V1::Photos', type: :request do
       end
     end
 
+    describe 'privacy zone masking' do
+      let(:pz_user) { create(:user, :with_photoprism_integration) }
+
+      before do
+        Rails.cache.clear
+        tag = create(:tag, :privacy_zone, user: pz_user, privacy_radius_meters: 1000)
+        place = create(:place, user: pz_user, latitude: 52.444, longitude: 13.500)
+        create(:tagging, tag: tag, taggable: place)
+        allow_any_instance_of(Photos::Search).to receive(:errors).and_return([])
+        allow_any_instance_of(Photos::Search).to receive(:call).and_return(
+          [
+            { 'id' => 'in',  'latitude' => 52.444, 'longitude' => 13.500, 'source' => 'photoprism' },
+            { 'id' => 'out', 'latitude' => 52.600, 'longitude' => 13.700, 'source' => 'photoprism' }
+          ]
+        )
+      end
+
+      it 'omits in-zone photos when flagged' do
+        get '/api/v1/photos',
+            params: { api_key: pz_user.api_key, mask_privacy_zones: 'true',
+                      start_date: '2026-01-01', end_date: '2026-12-31' }
+
+        ids = JSON.parse(response.body).map { |p| p['id'] }
+        expect(ids).to eq(['out'])
+      end
+
+      it 'returns all photos without the flag' do
+        get '/api/v1/photos',
+            params: { api_key: pz_user.api_key,
+                      start_date: '2026-01-01', end_date: '2026-12-31' }
+
+        ids = JSON.parse(response.body).map { |p| p['id'] }
+        expect(ids).to contain_exactly('in', 'out')
+      end
+    end
+
     context 'when the integration is not configured' do
       let(:user) { create(:user) }
 

--- a/spec/requests/api/v1/places_spec.rb
+++ b/spec/requests/api/v1/places_spec.rb
@@ -200,4 +200,31 @@ RSpec.describe 'Api::V1::Places', type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
   end
+
+  describe 'privacy zone masking' do
+    let(:pz_user) { create(:user) }
+    let(:pz_headers) { { 'Authorization' => "Bearer #{pz_user.api_key}" } }
+
+    before do
+      tag = create(:tag, :privacy_zone, user: pz_user, privacy_radius_meters: 1000)
+      @zone_place = create(:place, user: pz_user, latitude: 52.444, longitude: 13.500)
+      create(:tagging, tag: tag, taggable: @zone_place)
+      @far_place = create(:place, user: pz_user, latitude: 52.600, longitude: 13.700)
+    end
+
+    it 'omits in-zone places when flagged' do
+      get '/api/v1/places', params: { mask_privacy_zones: 'true' }, headers: pz_headers
+
+      ids = JSON.parse(response.body).map { |p| p['id'] }
+      expect(ids).to include(@far_place.id)
+      expect(ids).not_to include(@zone_place.id)
+    end
+
+    it 'returns all places without the flag' do
+      get '/api/v1/places', headers: pz_headers
+
+      ids = JSON.parse(response.body).map { |p| p['id'] }
+      expect(ids).to include(@zone_place.id, @far_place.id)
+    end
+  end
 end

--- a/spec/requests/api/v1/points_spec.rb
+++ b/spec/requests/api/v1/points_spec.rb
@@ -692,6 +692,33 @@ RSpec.describe 'Api::V1::Points', type: :request do
     end
   end
 
+  describe 'privacy zone masking' do
+    let(:pz_user) { create(:user) }
+
+    before do
+      tag = create(:tag, :privacy_zone, user: pz_user, privacy_radius_meters: 1000)
+      place = create(:place, user: pz_user, latitude: 52.444, longitude: 13.500)
+      create(:tagging, tag: tag, taggable: place)
+      create(:point, user: pz_user, lonlat: 'POINT(13.500 52.444)', timestamp: 1.hour.ago.to_i)
+      create(:point, user: pz_user, lonlat: 'POINT(13.700 52.600)', timestamp: 30.minutes.ago.to_i)
+    end
+
+    it 'omits in-zone points when mask_privacy_zones=true' do
+      get api_v1_points_url(api_key: pz_user.api_key, mask_privacy_zones: 'true', per_page: 100)
+
+      coords = JSON.parse(response.body).map { |p| [p['longitude'].to_f, p['latitude'].to_f] }
+      expect(coords).to include([13.700, 52.600])
+      expect(coords).not_to include([13.500, 52.444])
+    end
+
+    it 'returns all points without the flag' do
+      get api_v1_points_url(api_key: pz_user.api_key, per_page: 100)
+
+      coords = JSON.parse(response.body).map { |p| [p['longitude'].to_f, p['latitude'].to_f] }
+      expect(coords).to include([13.700, 52.600], [13.500, 52.444])
+    end
+  end
+
   describe 'GET /index bbox validation' do
     it 'rejects an inverted bbox with 400' do
       get "/api/v1/points?api_key=#{user.api_key}&" \

--- a/spec/requests/api/v1/privacy_zone_masking_spec.rb
+++ b/spec/requests/api/v1/privacy_zone_masking_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 # mask_privacy_zones=true. Adding a new map endpoint? Add it here and
 # implement masking, or this spec stays red.
 MASKED_MAP_ENDPOINTS = %w[
-  points places visits photos tracks hexagons
+  points places visits photos tracks hexagons track_points
 ].freeze
 
 RSpec.describe 'Privacy zone masking contract', type: :request do
@@ -20,7 +20,7 @@ RSpec.describe 'Privacy zone masking contract', type: :request do
 
   it 'enumerates every masked map endpoint (update when adding a map layer)' do
     expect(MASKED_MAP_ENDPOINTS).to contain_exactly(
-      'points', 'places', 'visits', 'photos', 'tracks', 'hexagons'
+      'points', 'places', 'visits', 'photos', 'tracks', 'hexagons', 'track_points'
     )
   end
 

--- a/spec/requests/api/v1/privacy_zone_masking_spec.rb
+++ b/spec/requests/api/v1/privacy_zone_masking_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The authoritative list of map read endpoints that MUST honour
+# mask_privacy_zones=true. Adding a new map endpoint? Add it here and
+# implement masking, or this spec stays red.
+MASKED_MAP_ENDPOINTS = %w[
+  points places visits photos tracks hexagons
+].freeze
+
+RSpec.describe 'Privacy zone masking contract', type: :request do
+  let(:user) { create(:user) }
+
+  before do
+    tag = create(:tag, :privacy_zone, user: user, privacy_radius_meters: 1000)
+    place = create(:place, user: user, latitude: 52.444, longitude: 13.500)
+    create(:tagging, tag: tag, taggable: place)
+  end
+
+  it 'enumerates every masked map endpoint (update when adding a map layer)' do
+    expect(MASKED_MAP_ENDPOINTS).to contain_exactly(
+      'points', 'places', 'visits', 'photos', 'tracks', 'hexagons'
+    )
+  end
+
+  it 'omits the in-zone point from points#index with the flag' do
+    create(:point, user: user, lonlat: 'POINT(13.500 52.444)', timestamp: 1.hour.ago.to_i)
+    create(:point, user: user, lonlat: 'POINT(13.700 52.600)', timestamp: 1.hour.ago.to_i)
+
+    get api_v1_points_url(api_key: user.api_key, mask_privacy_zones: 'true', per_page: 100)
+
+    coords = JSON.parse(response.body).map { |p| [p['longitude'].to_f, p['latitude'].to_f] }
+    expect(coords).not_to include([13.500, 52.444])
+  end
+
+  it 'omits the in-zone place from places#index with the flag' do
+    zone_place = user.places.first
+    far = create(:place, user: user, latitude: 52.600, longitude: 13.700)
+
+    get '/api/v1/places',
+        params: { mask_privacy_zones: 'true' },
+        headers: { 'Authorization' => "Bearer #{user.api_key}" }
+
+    ids = JSON.parse(response.body).map { |p| p['id'] }
+    expect(ids).to include(far.id)
+    expect(ids).not_to include(zone_place.id)
+  end
+end

--- a/spec/requests/api/v1/tracks/points_spec.rb
+++ b/spec/requests/api/v1/tracks/points_spec.rb
@@ -198,5 +198,39 @@ RSpec.describe '/api/v1/tracks/:track_id/points', type: :request do
         expect(point_ids).not_to include(other_user_point.id)
       end
     end
+
+    context 'privacy zone masking' do
+      let(:pz_user) { create(:user) }
+      let(:pz_headers) { { 'Authorization' => "Bearer #{pz_user.api_key}" } }
+
+      before do
+        tag = create(:tag, :privacy_zone, user: pz_user, privacy_radius_meters: 1000)
+        place = create(:place, user: pz_user, latitude: 52.444, longitude: 13.500)
+        create(:tagging, tag: tag, taggable: place)
+        @pz_track = create(:track, user: pz_user, start_at: 2.hours.ago, end_at: 1.hour.ago)
+        create(:point, user: pz_user, track: @pz_track,
+               lonlat: 'POINT(13.500 52.444)', timestamp: 90.minutes.ago.to_i)
+        create(:point, user: pz_user, track: @pz_track,
+               lonlat: 'POINT(13.700 52.600)', timestamp: 80.minutes.ago.to_i)
+      end
+
+      it 'omits in-zone track points when flagged' do
+        get api_v1_track_points_url(@pz_track),
+            headers: pz_headers,
+            params: { mask_privacy_zones: 'true' }
+
+        coords = JSON.parse(response.body).map { |p| [p['longitude'].to_f, p['latitude'].to_f] }
+        expect(coords).to include([13.7, 52.6])
+        expect(coords).not_to include([13.5, 52.444])
+      end
+
+      it 'returns all track points without the flag' do
+        get api_v1_track_points_url(@pz_track), headers: pz_headers
+
+        coords = JSON.parse(response.body).map { |p| [p['longitude'].to_f, p['latitude'].to_f] }
+        expect(coords).to include([13.5, 52.444])
+        expect(coords).to include([13.7, 52.6])
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/tracks_spec.rb
+++ b/spec/requests/api/v1/tracks_spec.rb
@@ -234,4 +234,39 @@ RSpec.describe '/api/v1/tracks', type: :request do
       end
     end
   end
+
+  describe 'privacy zone masking' do
+    let(:pz_user) { create(:user) }
+
+    before do
+      tag = create(:tag, :privacy_zone, user: pz_user, privacy_radius_meters: 1000)
+      place = create(:place, user: pz_user, latitude: 52.444, longitude: 13.500)
+      create(:tagging, tag: tag, taggable: place)
+      path = 'LINESTRING(13.300 52.444, 13.350 52.444, 13.500 52.444, 13.650 52.444, 13.700 52.444)'
+      @track = create(:track, user: pz_user,
+                      start_at: 2.hours.ago, end_at: 1.hour.ago,
+                      original_path: path)
+    end
+
+    it 'splits a track that crosses a zone into multiple line features' do
+      get '/api/v1/tracks',
+          params: { api_key: pz_user.api_key, mask_privacy_zones: 'true',
+                    start_at: 3.hours.ago.iso8601, end_at: Time.current.iso8601 }
+
+      features = JSON.parse(response.body)['features']
+      line_features = features.select { |f| f['geometry']['type'] == 'LineString' }
+      all_coords = line_features.flat_map { |f| f['geometry']['coordinates'] }
+      expect(all_coords).not_to include([13.500, 52.444])
+      expect(line_features.length).to be >= 2
+    end
+
+    it 'returns the unsplit track without the flag' do
+      get '/api/v1/tracks',
+          params: { api_key: pz_user.api_key,
+                    start_at: 3.hours.ago.iso8601, end_at: Time.current.iso8601 }
+
+      features = JSON.parse(response.body)['features']
+      expect(features.length).to eq(1)
+    end
+  end
 end

--- a/spec/requests/api/v1/visits_spec.rb
+++ b/spec/requests/api/v1/visits_spec.rb
@@ -367,6 +367,8 @@ RSpec.describe 'Api::V1::Visits', type: :request do
                        started_at: 2.hours.ago, ended_at: 1.hour.ago)
       @shown = create(:visit, user: pz_user, place: far_place,
                       started_at: 2.hours.ago, ended_at: 1.hour.ago)
+      @nil_place_visit = create(:visit, user: pz_user, place: nil,
+                                started_at: 2.hours.ago, ended_at: 1.hour.ago)
     end
 
     it 'omits visits whose place is in a zone when flagged' do
@@ -377,6 +379,7 @@ RSpec.describe 'Api::V1::Visits', type: :request do
 
       ids = JSON.parse(response.body).pluck('id')
       expect(ids).to include(@shown.id)
+      expect(ids).to include(@nil_place_visit.id)
       expect(ids).not_to include(@hidden.id)
     end
 

--- a/spec/requests/api/v1/visits_spec.rb
+++ b/spec/requests/api/v1/visits_spec.rb
@@ -354,6 +354,42 @@ RSpec.describe 'Api::V1::Visits', type: :request do
     end
   end
 
+  describe 'privacy zone masking' do
+    let(:pz_user) { create(:user) }
+    let(:pz_auth_headers) { { 'Authorization' => "Bearer #{pz_user.api_key}" } }
+
+    before do
+      tag = create(:tag, :privacy_zone, user: pz_user, privacy_radius_meters: 1000)
+      zone_place = create(:place, user: pz_user, latitude: 52.444, longitude: 13.500)
+      create(:tagging, tag: tag, taggable: zone_place)
+      far_place = create(:place, user: pz_user, latitude: 52.600, longitude: 13.700)
+      @hidden = create(:visit, user: pz_user, place: zone_place,
+                       started_at: 2.hours.ago, ended_at: 1.hour.ago)
+      @shown = create(:visit, user: pz_user, place: far_place,
+                      started_at: 2.hours.ago, ended_at: 1.hour.ago)
+    end
+
+    it 'omits visits whose place is in a zone when flagged' do
+      get '/api/v1/visits',
+          params: { mask_privacy_zones: 'true',
+                    start_at: 3.hours.ago.iso8601, end_at: Time.current.iso8601 },
+          headers: pz_auth_headers
+
+      ids = JSON.parse(response.body).pluck('id')
+      expect(ids).to include(@shown.id)
+      expect(ids).not_to include(@hidden.id)
+    end
+
+    it 'returns both visits without the flag' do
+      get '/api/v1/visits',
+          params: { start_at: 3.hours.ago.iso8601, end_at: Time.current.iso8601 },
+          headers: pz_auth_headers
+
+      ids = JSON.parse(response.body).pluck('id')
+      expect(ids).to include(@hidden.id, @shown.id)
+    end
+  end
+
   describe 'DELETE /api/v1/visits/:id' do
     let!(:visit) { create(:visit, user: user, place: place) }
     let!(:other_user_visit) { create(:visit, user: other_user, place: place) }

--- a/spec/services/maps/privacy_zone_masker_spec.rb
+++ b/spec/services/maps/privacy_zone_masker_spec.rb
@@ -103,4 +103,50 @@ RSpec.describe Maps::PrivacyZoneMasker do
       expect(described_class.new(user).in_zone?(13.500, 52.444)).to be(false)
     end
   end
+
+  describe '#mask_track_geojson' do
+    let(:masker) do
+      make_zone(lat: 52.444, lon: 13.500, radius: 1000)
+      described_class.new(user)
+    end
+
+    def feature_collection(coords)
+      {
+        'type' => 'FeatureCollection',
+        'features' => [
+          {
+            'type' => 'Feature',
+            'geometry' => { 'type' => 'LineString', 'coordinates' => coords },
+            'properties' => { 'id' => 1 }
+          }
+        ]
+      }
+    end
+
+    it 'breaks a line that passes through a zone into two features' do
+      coords = [[13.300, 52.444], [13.500, 52.444], [13.700, 52.444]]
+
+      result = masker.mask_track_geojson(feature_collection(coords))
+
+      expect(result['features'].length).to eq(2)
+      coordinate_sets = result['features'].map { |f| f['geometry']['coordinates'] }
+      expect(coordinate_sets).to contain_exactly([[13.300, 52.444]], [[13.700, 52.444]])
+        .or contain_exactly([[13.700, 52.444]], [[13.300, 52.444]])
+    end
+
+    it 'drops a feature entirely when every vertex is in a zone' do
+      coords = [[13.500, 52.444], [13.5005, 52.4441]]
+
+      result = masker.mask_track_geojson(feature_collection(coords))
+
+      expect(result['features']).to be_empty
+    end
+
+    it 'returns the collection untouched when there are no zones' do
+      no_zone_masker = described_class.new(create(:user))
+      fc = feature_collection([[13.300, 52.444], [13.700, 52.444]])
+
+      expect(no_zone_masker.mask_track_geojson(fc)).to eq(fc)
+    end
+  end
 end

--- a/spec/services/maps/privacy_zone_masker_spec.rb
+++ b/spec/services/maps/privacy_zone_masker_spec.rb
@@ -57,4 +57,50 @@ RSpec.describe Maps::PrivacyZoneMasker do
       expect(result).not_to include(berlin, munich)
     end
   end
+
+  describe '#mask_places' do
+    it 'excludes the zone-defining place itself and keeps places outside' do
+      make_zone(lat: 52.444, lon: 13.500, radius: 1000)
+      far = create(:place, user: user, latitude: 52.600, longitude: 13.700)
+
+      result = described_class.new(user).mask_places(user.places)
+
+      expect(result).to include(far)
+      expect(result.map { |p| [p.latitude.to_f, p.longitude.to_f] })
+        .not_to include([52.444, 13.500])
+    end
+  end
+
+  describe '#in_zone_place_ids' do
+    it 'returns ids of places inside any zone' do
+      tag = make_zone(lat: 52.444, lon: 13.500, radius: 1000)
+      center = tag.places.first
+      far = create(:place, user: user, latitude: 52.600, longitude: 13.700)
+
+      ids = described_class.new(user).in_zone_place_ids
+
+      expect(ids).to include(center.id)
+      expect(ids).not_to include(far.id)
+    end
+
+    it 'is empty when there are no zones' do
+      create(:place, user: user, latitude: 52.444, longitude: 13.500)
+
+      expect(described_class.new(user).in_zone_place_ids).to be_empty
+    end
+  end
+
+  describe '#in_zone?' do
+    it 'is true for a coordinate inside a zone, false outside' do
+      make_zone(lat: 52.444, lon: 13.500, radius: 1000)
+      masker = described_class.new(user)
+
+      expect(masker.in_zone?(13.500, 52.444)).to be(true)
+      expect(masker.in_zone?(13.700, 52.600)).to be(false)
+    end
+
+    it 'is always false when there are no zones' do
+      expect(described_class.new(user).in_zone?(13.500, 52.444)).to be(false)
+    end
+  end
 end

--- a/spec/services/maps/privacy_zone_masker_spec.rb
+++ b/spec/services/maps/privacy_zone_masker_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Maps::PrivacyZoneMasker do
+  let(:user) { create(:user) }
+
+  def make_zone(lat:, lon:, radius: 1000)
+    tag = create(:tag, :privacy_zone, user: user, privacy_radius_meters: radius)
+    place = create(:place, user: user, latitude: lat, longitude: lon)
+    create(:tagging, tag: tag, taggable: place)
+    tag
+  end
+
+  describe '#any?' do
+    it 'is false when the user has no privacy zones' do
+      expect(described_class.new(user).any?).to be(false)
+    end
+
+    it 'is true when the user has a privacy zone with a place' do
+      make_zone(lat: 52.444, lon: 13.500)
+
+      expect(described_class.new(user).any?).to be(true)
+    end
+  end
+
+  describe '#mask_points' do
+    it 'returns the relation untouched when there are no zones' do
+      inside = create(:point, user: user, lonlat: 'POINT(13.500 52.444)')
+
+      result = described_class.new(user).mask_points(user.points)
+
+      expect(result).to include(inside)
+    end
+
+    it 'excludes points inside a zone and keeps points outside' do
+      make_zone(lat: 52.444, lon: 13.500, radius: 1000)
+      inside = create(:point, user: user, lonlat: 'POINT(13.500 52.444)')
+      outside = create(:point, user: user, lonlat: 'POINT(13.700 52.600)')
+
+      result = described_class.new(user).mask_points(user.points)
+
+      expect(result).to include(outside)
+      expect(result).not_to include(inside)
+    end
+
+    it 'excludes a point inside any of several zones' do
+      make_zone(lat: 52.444, lon: 13.500, radius: 1000)
+      make_zone(lat: 48.137, lon: 11.575, radius: 1000)
+      berlin = create(:point, user: user, lonlat: 'POINT(13.500 52.444)')
+      munich = create(:point, user: user, lonlat: 'POINT(11.575 48.137)')
+      elsewhere = create(:point, user: user, lonlat: 'POINT(2.349 48.853)')
+
+      result = described_class.new(user).mask_points(user.points)
+
+      expect(result).to contain_exactly(elsewhere)
+      expect(result).not_to include(berlin, munich)
+    end
+  end
+end

--- a/spec/services/maps/privacy_zone_masker_spec.rb
+++ b/spec/services/maps/privacy_zone_masker_spec.rb
@@ -124,14 +124,19 @@ RSpec.describe Maps::PrivacyZoneMasker do
     end
 
     it 'breaks a line that passes through a zone into two features' do
-      coords = [[13.300, 52.444], [13.500, 52.444], [13.700, 52.444]]
+      coords = [
+        [13.300, 52.444], [13.350, 52.444],
+        [13.500, 52.444],
+        [13.650, 52.444], [13.700, 52.444]
+      ]
 
       result = masker.mask_track_geojson(feature_collection(coords))
 
-      expect(result['features'].length).to eq(2)
       coordinate_sets = result['features'].map { |f| f['geometry']['coordinates'] }
-      expect(coordinate_sets).to contain_exactly([[13.300, 52.444]], [[13.700, 52.444]])
-        .or contain_exactly([[13.700, 52.444]], [[13.300, 52.444]])
+      expect(coordinate_sets).to contain_exactly(
+        [[13.300, 52.444], [13.350, 52.444]],
+        [[13.650, 52.444], [13.700, 52.444]]
+      )
     end
 
     it 'drops a feature entirely when every vertex is in a zone' do


### PR DESCRIPTION
## Summary

Brings privacy zones to **Map v2 (MapLibre)** with **server-side, opt-in** masking, replacing the Leaflet-only client-side filter. A privacy zone is a `Tag` with `privacy_radius_meters` attached to one or more `Place`s.

- **Single source of truth:** `Maps::PrivacyZoneMasker` (point/place masking, in-zone predicate, track-geometry splitting). Applied at every map read endpoint, gated by a `mask_privacy_zones=true` request flag the Map v2 client sends.
- **Map-rendering scope only:** exports, the no-flag programmatic API, stats/distance, and Map v1 are unchanged. Masking is opt-in per request.
- **Layers covered:** points/anomalies/heatmap/fog/scratch (via masked points), routes (broken client-side at zones using zone geometry only — interior points never reach the browser), tracks (split server-side) + `tracks/:id/points`, visits (in-zone-place visits dropped; place-less visits preserved), photos (masked on render, cache keeps full set), places (hidden entirely), hexagons (in-zone centers dropped; public sharing exempt).
- **Live realtime:** `Point#broadcast_coordinates` skips `PointsChannel` for in-zone points; `Track#broadcast_geojson_updated` masks/suppresses in-zone track geometry. Family broadcast left unmasked.
- **Future-layer guard:** `spec/requests/api/v1/privacy_zone_masking_spec.rb` enumerates masked endpoints; CLAUDE.md item 9 documents the convention.

**Intentional exemptions:** family layer; the area-selection edit tool (`fetchPointsInArea`/`fetchVisitsInArea` see real data so users can manage in-zone points).

**Known follow-ups:** precise hexagon masking (needs stat-calc-time exclusion); family-member self-masking on share; `/timeline` visit entries still carry in-zone place coords (temporal feed, not a map plot); a per-broadcast zone-query optimization for high-frequency live ingestion.

## Test Plan

- [x] `Maps::PrivacyZoneMasker` unit specs (point/place/predicate/track-split, multi-zone, no-zone no-op)
- [x] Per-endpoint request specs: points, places, visits (incl. place-less), photos, tracks, tracks/:id/points, hexagons (incl. public-sharing exemption) — masked WITH the flag, full data WITHOUT it
- [x] Live-broadcast specs: in-zone point not broadcast; track geometry masked/suppressed; non-zone users unaffected
- [x] Enumeration contract spec + non-regression (no-flag reads and exports unchanged)
- [x] RuboCop + Biome clean on all changed files
- [ ] Manual browser check on a real Map v2 instance with a `home` zone (recommended before merge)