### PR TITLE
fixed default value of RAILS_ENV

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -6,7 +6,7 @@
 # =============================================================================
 
 # Rails environment: development, staging, or production
-RAILS_ENV=development
+RAILS_ENV=production
 
 # =============================================================================
 # DATABASE CONFIGURATION


### PR DESCRIPTION
fixed default value of RAILS_ENV to be inline with the change from development to production in 1.3.0. 
This was mainly to fix my ongoing SMTP issues since I setup a new compose file with the default values some time ago not realizing the default RAILS_ENV has changed in 1.3.0 (https://github.com/Freika/dawarich/releases/tag/1.3.0)