### PR TITLE
Fix Places page 500 when place has nil lonlat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- The Places page no longer returns a 500 error when a place is missing its computed `lonlat` coordinate. Places created before the spatial column was introduced now fall back to their stored latitude/longitude so the page renders correctly. (#2826)
 - Reverse geocoding (and other background work) no longer stalls behind GPS anomaly detection. Every incoming location used to trigger an anomaly check that re-scanned the whole current month of points — up to ~30 seconds late in a busy tracking month — and those jobs monopolized the worker pool, starving the reverse-geocoding queue. The check now inspects only the newly-received points plus their immediate neighbours, so it runs in milliseconds regardless of how full the month is.
 - Renaming a suggested visit no longer auto-confirms it. Editing the name — or just opening the inline rename and clicking away — used to silently mark the visit confirmed and create a place from the typed text. Renaming now only changes the name; confirming happens solely through the suggested-place picker.
 - Map v2 Timeline calendar: the per-day "suggested visits" dot now clears as soon as you confirm or delete the last suggestion for that day, instead of lingering until a full page reload.

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -24,11 +24,11 @@ class Place < ApplicationRecord
   scope :ordered, -> { order(:name) }
 
   def lon
-    lonlat.x
+    lonlat&.x || longitude
   end
 
   def lat
-    lonlat.y
+    lonlat&.y || latitude
   end
 
   def osm_id

--- a/spec/regressions/places_index_renders_with_nil_lonlat_spec.rb
+++ b/spec/regressions/places_index_renders_with_nil_lonlat_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Places with nil lonlat', type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  def place_with_nil_lonlat
+    place = build(:place, user: user, latitude: 52.52, longitude: 13.405)
+    place.save!(validate: false)
+    place.update_column(:lonlat, nil)
+    place
+  end
+
+  describe Place do
+    it 'returns the latitude column value when lonlat is nil' do
+      place = place_with_nil_lonlat
+
+      expect(place.lat).to eq(52.52)
+    end
+
+    it 'returns the longitude column value when lonlat is nil' do
+      place = place_with_nil_lonlat
+
+      expect(place.lon).to eq(13.405)
+    end
+  end
+
+  describe 'GET /places' do
+    it 'renders successfully when a place has nil lonlat' do
+      place_with_nil_lonlat
+
+      get places_url
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
Places created before the spatial `lonlat` column was introduced crashed the Places index with a 500. They now fall back to their stored latitude/longitude so the page renders.

Closes #2826