### PR TITLE
fix: guard altitude_decimal in GPX track importer so import doesn't fail when column is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- GPX imports work when the optional decimal elevation column is absent (#2721, #3046).
+
 - Upgrades rebuild invalid statistics indexes left by interrupted migrations and restore duplicate protection (#2700)
 - Browser and API password sign-in now respect OIDC-only configuration (#2961)
 

--- a/app/services/gpx/track_importer.rb
+++ b/app/services/gpx/track_importer.rb
@@ -61,10 +61,9 @@ class Gpx::TrackImporter
 
     elevation = point['ele'].to_f
 
-    {
+    attrs = {
       lonlat: "POINT(#{point['lon'].to_d} #{point['lat'].to_d})",
       altitude: elevation,
-      altitude_decimal: elevation,
       timestamp: Time.zone.parse(point['time']).utc.to_i,
       tracker_id: tracker_id,
       import_id: import.id,
@@ -74,6 +73,8 @@ class Gpx::TrackImporter
       created_at: Time.current,
       updated_at: Time.current
     }
+    attrs[:altitude_decimal] = elevation if Point.altitude_decimal_supported?
+    attrs
   end
 
   def importer_name

--- a/app/services/gpx/track_importer.rb
+++ b/app/services/gpx/track_importer.rb
@@ -82,10 +82,9 @@ class Gpx::TrackImporter
 
     elevation = point['ele'].to_f
 
-    {
+    attrs = {
       lonlat: "POINT(#{point['lon'].to_d} #{point['lat'].to_d})",
       altitude: elevation,
-      altitude_decimal: elevation,
       timestamp: Time.zone.parse(point['time']).utc.to_i,
       tracker_id: tracker_id,
       import_id: import.id,
@@ -94,6 +93,8 @@ class Gpx::TrackImporter
       created_at: Time.current,
       updated_at: Time.current
     }
+    attrs[:altitude_decimal] = elevation if Point.altitude_decimal_supported?
+    attrs
   end
 
   def importer_name

--- a/spec/services/gpx/track_importer_spec.rb
+++ b/spec/services/gpx/track_importer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'tempfile'
 
 RSpec.describe Gpx::TrackImporter do
   describe '#call' do
@@ -20,10 +21,36 @@ RSpec.describe Gpx::TrackImporter do
         expect { parser }.to change { Point.count }.by(10)
       end
 
+      it 'stores altitude_decimal when supported' do
+        parser
+
+        expect(user.points.order(:timestamp).first.altitude_decimal).to eq(BigDecimal('824.93'))
+      end
+
       it 'broadcasts importing progress' do
         expect_any_instance_of(Imports::Broadcaster).to receive(:broadcast_import_progress).exactly(1).time
 
         parser
+      end
+    end
+
+    context 'when altitude_decimal is not supported' do
+      let(:upserted_rows) { [] }
+
+      before do
+        allow(Point).to receive(:altitude_decimal_supported?).and_return(false)
+        allow(Point).to receive(:upsert_all).and_wrap_original do |original, records, **options|
+          upserted_rows.concat(records)
+          original.call(records, **options)
+        end
+      end
+
+      it 'imports points without passing altitude_decimal to upsert_all' do
+        expect { parser }.to change { Point.count }.by(10)
+
+        expect(upserted_rows).not_to be_empty
+        expect(upserted_rows).to all(satisfy { |attrs| attrs.key?(:altitude) && !attrs.key?(:altitude_decimal) })
+        expect(user.points.order(:timestamp).first.read_attribute(:altitude)).to be_present
       end
     end
 
@@ -96,6 +123,42 @@ RSpec.describe Gpx::TrackImporter do
         it 'creates points' do
           expect { parser }.to change { Point.count }.by(6)
         end
+      end
+    end
+
+    context 'when trackpoints have blank or missing elevation' do
+      let(:file_path) { gpx_path }
+      let(:gpx_path) do
+        file = Tempfile.new(['gpx_blank_elevation', '.gpx'])
+        file.write(gpx_content)
+        file.close
+        file.path
+      end
+      let(:gpx_content) do
+        <<~GPX
+          <?xml version="1.0" encoding="UTF-8"?>
+          <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+            <trk>
+              <trkseg>
+                <trkpt lat="51.0" lon="7.0">
+                  <ele></ele>
+                  <time>2026-01-01T00:00:00Z</time>
+                </trkpt>
+                <trkpt lat="51.1" lon="7.1">
+                  <time>2026-01-01T00:01:00Z</time>
+                </trkpt>
+              </trkseg>
+            </trk>
+          </gpx>
+        GPX
+      end
+
+      after { FileUtils.rm_f(gpx_path) }
+
+      it 'imports points with zero elevation' do
+        expect { parser }.to change { Point.count }.by(2)
+
+        expect(user.points.order(:timestamp).pluck(:altitude_decimal)).to eq([BigDecimal('0.0'), BigDecimal('0.0')])
       end
     end
   end

--- a/spec/services/gpx/track_importer_spec.rb
+++ b/spec/services/gpx/track_importer_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'tempfile'
 
 RSpec.describe Gpx::TrackImporter do
   describe '#call' do
@@ -20,10 +21,36 @@ RSpec.describe Gpx::TrackImporter do
         expect { parser }.to change { Point.count }.by(10)
       end
 
+      it 'stores altitude_decimal when supported' do
+        parser
+
+        expect(user.points.order(:timestamp, :id).first.altitude_decimal).to eq(BigDecimal('824.93'))
+      end
+
       it 'broadcasts importing progress' do
         expect_any_instance_of(Imports::Broadcaster).to receive(:broadcast_import_progress).exactly(1).time
 
         parser
+      end
+    end
+
+    context 'when altitude_decimal is not supported' do
+      let(:upserted_rows) { [] }
+
+      before do
+        allow(Point).to receive(:altitude_decimal_supported?).and_return(false)
+        allow(Point).to receive(:upsert_all).and_wrap_original do |original, records, **options|
+          upserted_rows.concat(records)
+          original.call(records, **options)
+        end
+      end
+
+      it 'imports points without passing altitude_decimal to upsert_all' do
+        expect { parser }.to change { Point.count }.by(10)
+
+        expect(upserted_rows).not_to be_empty
+        expect(upserted_rows).to all(satisfy { |attrs| attrs.key?(:altitude) && !attrs.key?(:altitude_decimal) })
+        expect(user.points.order(:timestamp).first.read_attribute(:altitude)).to be_present
       end
     end
 
@@ -144,6 +171,42 @@ RSpec.describe Gpx::TrackImporter do
 
       it 'decodes the UTF-16 track via the preserved BOM' do
         expect { parser }.to change { Point.count }.by(1)
+      end
+    end
+
+    context 'when trackpoints have blank or missing elevation' do
+      let(:file_path) { gpx_path }
+      let(:gpx_path) do
+        file = Tempfile.new(['gpx_blank_elevation', '.gpx'])
+        file.write(gpx_content)
+        file.close
+        file.path
+      end
+      let(:gpx_content) do
+        <<~GPX
+          <?xml version="1.0" encoding="UTF-8"?>
+          <gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">
+            <trk>
+              <trkseg>
+                <trkpt lat="51.0" lon="7.0">
+                  <ele></ele>
+                  <time>2026-01-01T00:00:00Z</time>
+                </trkpt>
+                <trkpt lat="51.1" lon="7.1">
+                  <time>2026-01-01T00:01:00Z</time>
+                </trkpt>
+              </trkseg>
+            </trk>
+          </gpx>
+        GPX
+      end
+
+      after { FileUtils.rm_f(gpx_path) }
+
+      it 'imports points with zero elevation' do
+        expect { parser }.to change { Point.count }.by(2)
+
+        expect(user.points.order(:timestamp).pluck(:altitude_decimal)).to eq([BigDecimal('0.0'), BigDecimal('0.0')])
       end
     end
   end


### PR DESCRIPTION
GPX import now skips altitude_decimal when that optional column is absent, allowing imports on older schemas while retaining altitude when available. This updates the original contributor fix onto current dev.

Validation: 24 focused GPX examples passed; final combined application passed 9721 RSpec examples and 284 JavaScript tests. Physical-schema verification used separate Rails processes and a disposable PostgreSQL database: with altitude_decimal the candidate persisted all 10 points including decimal elevation; after physically dropping the column before Rails boot, baseline imported 0 points and produced an unknown-attribute error notification, while the candidate persisted all 10 points and retained legacy altitude. No model/schema stubs were used in this physical test.

Fixes #2721. Addresses only the GPX part of #3046; the KML report remains open.

Integration note: Release D (#3480) removes altitude_decimal and its helper entirely; remove this transitional guard together with them when that larger migration lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TeslaMate integration for configuring and syncing vehicle drives.
  * Added per-segment route speed coloring when zoomed in.
  * Added Simplified Chinese language support and translated guides.
  * Added safer import downloads that preserve filenames and prepare wrapped archives.
  * Added lazy-loading for shared trip photo galleries.
  * Added background verification for Immich photo enrichment.

* **Bug Fixes**
  * Improved GPX, Polarsteps, OwnTracks, Traccar, and archive imports.
  * Improved statistics rebuilding, timezone updates, track processing, and shared-link security.
  * Password login is now correctly restricted on OIDC-only installations.
  * Improved rate-limit consistency across formatted API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Final combined verification on dev 5eb0e15c: 9721 RSpec examples, 0 failures, using a freshly prepared disposable test database; 284 JavaScript tests passed. Current CI status is shown in the PR checks.
