### PR TITLE
test: fix export-import integration spec (user_data export files)

### DIFF
--- a/spec/services/users/export_import_integration_spec.rb
+++ b/spec/services/users/export_import_integration_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe 'Users Export-Import Integration', type: :service do
       content_type: 'application/json'
     )
 
-    export2 = create(:export, user: user, name: 'Q2 2024 Export', file_format: :json, file_type: :user_data)
+    export2 = create(:export, user: user, name: 'Q2 2024 Export', file_format: :json, file_type: :points)
     export2.file.attach(
       io: StringIO.new('{"type": "FeatureCollection", "features": []}'),
       filename: 'q2_2024.json',


### PR DESCRIPTION
Re-applies the spec fix that was **dropped** when #2878 squash-merged from a lagging PR head — `dev` still has the stale assertion and CircleCI's "Run RSpec tests" step fails on it (the only red `ci/circleci: test` cause; the rest of #2878 — puma + assetlinks — landed fine).

## Why it fails
The 1.8.0 export pipeline added `&& !export.user_data?` to `Users::ExportData::Exports#process_export`, so a `user_data` export's own file is no longer embedded in the archive. The integration spec seeded only one non-`user_data` export with a file (`Q1 2024 Export`, `:points`) yet still asserts `>= 2` export files restored after the cycle → `Expected 1 to be >= 2`.

## Fix
Make the second seeded export (`Q2 2024 Export`) a `:points` export, so two real export files round-trip again and the assertion is meaningful. The `user_data`-skip path stays covered by the export operation's own auto-created `user_data` export.

## Verification
`rspec spec/services/users/export_import_integration_spec.rb` → 6 examples, 0 failures (on current `dev`).