### PR TITLE
Fix weekday label alignment in the Insights activity heatmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Weekday labels in the Insights "Activity Overview" heatmap now line up with their grid rows (#2896)
+
 ## [1.8.0] - 2026-06-08
 
 Upgrade notes:

--- a/app/views/insights/_activity_heatmap.html.erb
+++ b/app/views/insights/_activity_heatmap.html.erb
@@ -31,10 +31,10 @@
           <!-- Grid with day labels -->
           <div class="flex">
             <!-- Day labels -->
-            <div class="flex flex-col justify-around mr-2 text-xs text-base-content/60" style="height: 98px;">
-              <span>Mon</span>
-              <span>Wed</span>
-              <span>Fri</span>
+            <div class="flex flex-col gap-0.5 mr-2 text-xs text-base-content/60">
+              <% ['Mon', nil, 'Wed', nil, 'Fri', nil, nil].each do |day_label| %>
+                <span class="h-3 flex items-center leading-none"><%= day_label %></span>
+              <% end %>
             </div>
 
             <!-- Cells grid -->


### PR DESCRIPTION
## Summary
Mon/Wed/Fri labels in the Insights "Activity Overview" heatmap floated ~1.5 rows below their rows.

## Root cause
The label column used `justify-around` inside a fixed 98px box, geometrically unrelated to the grid's 12px cells + 2px gaps.

## Fix
The label column now mirrors the grid: seven `h-3` slots with the same `gap-0.5`, labels in rows 1/3/5 — alignment is structural rather than tuned.

## Verification
Before/after screenshots on local dev; Mon sits exactly on the top row.

Closes #2896

🤖 Generated with [Claude Code](https://claude.com/claude-code)
