### PR TITLE
Fix invisible/unhoverable small bars on the Stats page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Months with very small distances on the Stats page now render a visible bar and show their tooltip; months without data no longer render a bar at all (#2864)
+
 ## [1.8.0] - 2026-06-08
 
 Upgrade notes:

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -104,7 +104,8 @@
           <% month_colors = ['#397bb5', '#5A4E9D', '#3B945E', '#7BC96F', '#FFD54F', '#FFA94D', '#FF6B6B', '#FF8C42', '#C97E4F', '#8B4513', '#5A2E2E', '#265d7d'] %>
           <%= column_chart(
             @year_distances[year].map { |month_name, distance_meters|
-              [month_name, Stat.convert_distance(distance_meters, current_user.safe_settings.distance_unit).round]
+              converted = Stat.convert_distance(distance_meters, current_user.safe_settings.distance_unit).round
+              [month_name, distance_meters.zero? ? nil : converted]
             },
             id: "chart-year-distance-#{year}",
             height: '200px',
@@ -113,7 +114,12 @@
             ytitle: 'Distance',
             colors: month_colors,
             library: {
-              datasets: { backgroundColor: month_colors, borderWidth: 0 }
+              datasets: {
+                backgroundColor: month_colors,
+                borderWidth: 0,
+                bar: { minBarLength: 4 }
+              },
+              interaction: { mode: 'index', intersect: false }
             }
           ) %>
         </div>


### PR DESCRIPTION
## Summary
Months with small distances next to a large month rendered sub-pixel, unhoverable bars (114 km next to 14,716 km looked like no data).

## Fix
- `minBarLength: 4` so any month with data renders a visible bar.
- `interaction: { mode: 'index', intersect: false }` so the tooltip fires anywhere in the column.
- Zero-distance months map to `nil` so the minimum bar length doesn't fabricate bars for empty months.

## Verification
Seeded the reporter's exact numbers locally; before/after screenshots, including the tooltip on the previously invisible June bar.

Closes #2864

🤖 Generated with [Claude Code](https://claude.com/claude-code)
