### PR TITLE
Refresh the anomalies layer immediately after select-area deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Deleting points or anomaly points via the map's "Select Area" tool now removes them from the anomalies layer immediately, without requiring a page reload (#2790)
+
 ## [1.8.0] - 2026-06-08
 
 Upgrade notes:

--- a/app/javascript/controllers/maps/maplibre/area_selection_manager.js
+++ b/app/javascript/controllers/maps/maplibre/area_selection_manager.js
@@ -553,6 +553,15 @@ export class AreaSelectionManager {
     Toast.info("Selection cancelled")
   }
 
+  async refreshAnomaliesIfEnabled() {
+    const toggleOn =
+      this.controller.hasAnomaliesToggleTarget &&
+      this.controller.anomaliesToggleTarget.checked
+    if (!toggleOn) return
+
+    await this.controller.routesManager.refreshAnomalies({ enabled: true })
+  }
+
   /**
    * Delete only anomaly points within the current selection. Backed by the
    * same bulkDeletePoints API as deleteSelectedPoints — the filter just
@@ -594,6 +603,7 @@ export class AreaSelectionManager {
           fitBounds: false,
           showToast: false,
         })
+        await this.refreshAnomaliesIfEnabled()
       } catch (reloadError) {
         console.error(
           "[Maps V2] Map refresh failed after anomaly delete:",
@@ -667,6 +677,7 @@ export class AreaSelectionManager {
           fitBounds: false,
           showToast: false,
         })
+        await this.refreshAnomaliesIfEnabled()
       } catch (reloadError) {
         console.error("[Maps V2] Map refresh failed after delete:", reloadError)
         Toast.error(


### PR DESCRIPTION
## Summary
Deleting anomaly points via the select-area tool left their dots on the map until a full page reload.

## Root cause
Both select-area delete paths call `loadMapData()`, which does not refresh the anomalies source — every other caller chains `refreshAnomalies()` afterwards; the delete paths didn't.

## Fix
New `refreshAnomaliesIfEnabled()` helper (guarded by the anomalies toggle) chained after `loadMapData()` in both delete paths.

## Verification
Live before/after: deleted 6 anomalies — on unfixed code the dots persisted (server-side deletion confirmed via SQL); with the fix the anomalies source drops to the surviving points immediately, no reload.

Closes #2790

🤖 Generated with [Claude Code](https://claude.com/claude-code)
