### PR TITLE
Fix phantom 'new country visited' in yearly insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Insights no longer report a "new country visited" for border-crossing geocoding blips that the statistics pages already filter out; the yearly digest now applies the same rule as the monthly one (#2727)
+
 ## [1.8.0] - 2026-06-08
 
 Upgrade notes:

--- a/app/services/users/digests/first_time_visits_calculator.rb
+++ b/app/services/users/digests/first_time_visits_calculator.rb
@@ -56,7 +56,12 @@ module Users
           toponyms = stat.toponyms
           next [] unless toponyms.is_a?(Array)
 
-          toponyms.filter_map { |t| t['country'] if t.is_a?(Hash) && t['country'].present? }
+          toponyms.filter_map do |t|
+            next unless t.is_a?(Hash) && t['country'].present?
+            next unless t['cities'].is_a?(Array) && t['cities'].any?
+
+            t['country']
+          end
         end.uniq
       end
 

--- a/spec/regressions/yearly_first_time_countries_require_cities_spec.rb
+++ b/spec/regressions/yearly_first_time_countries_require_cities_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Yearly first-time visits ignore countries without qualifying cities' do
+  let(:user) { create(:user) }
+
+  let!(:previous_year_stat) do
+    create(:stat, user: user, year: 2025, month: 6, distance: 100, toponyms: [
+             { 'country' => 'Germany', 'cities' => [{ 'city' => 'Berlin', 'stayed_for' => 480 }] }
+           ])
+  end
+
+  let!(:current_year_stat) do
+    create(:stat, user: user, year: 2026, month: 4, distance: 100, toponyms: [
+             { 'country' => 'Germany', 'cities' => [{ 'city' => 'Berlin', 'stayed_for' => 480 }] },
+             { 'country' => 'France', 'cities' => [] }
+           ])
+  end
+
+  def yearly_first_time_countries
+    Users::Digests::FirstTimeVisitsCalculator.new(user, 2026).call['countries']
+  end
+
+  def monthly_first_time_countries
+    Users::Digests::MonthlyFirstTimeVisitsCalculator.new(user, 2026, 4).call['countries']
+  end
+
+  it 'does not report a country whose cities array is empty' do
+    expect(yearly_first_time_countries).to be_empty
+  end
+
+  it 'agrees with the monthly calculator on the same data' do
+    expect(yearly_first_time_countries).to eq(monthly_first_time_countries)
+  end
+
+  it 'still reports genuinely new countries with qualifying cities' do
+    current_year_stat.update!(toponyms: current_year_stat.toponyms + [
+      { 'country' => 'Spain', 'cities' => [{ 'city' => 'Madrid', 'stayed_for' => 300 }] }
+    ])
+
+    expect(yearly_first_time_countries).to eq(['Spain'])
+  end
+end


### PR DESCRIPTION
## Summary
Insights reported a "new country visited" for border-crossing geocoding blips that the statistics pages already filter out.

## Root cause
The #2581 fix (1.7.4) added an empty-cities guard to `extract_countries` — but only in the *monthly* first-time-visits calculator. The yearly `FirstTimeVisitsCalculator` kept the unguarded copy of the same method, so a toponym like `{country: France, cities: []}` counted there.

## Fix
Same guard ported to the yearly calculator.

## Verification
Regression spec feeds identical data to both calculators: they now agree (`[]`), and a genuinely new country with cities is still reported. 31 digest specs green.

Closes #2727

🤖 Generated with [Claude Code](https://claude.com/claude-code)
