### PR TITLE
Recover imports stuck in 'Deleting' forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Deleting an import no longer gets stuck on an endless spinner: failed deletions revert to a retriable state, and imports stalled in "Deleting" for over an hour show a retry button (#2835)
+
 ## [1.8.0] - 2026-06-08
 
 Upgrade notes:

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -17,7 +17,7 @@ class ImportsController < ApplicationController
 
   def index
     scope = policy_scope(Import)
-            .select(:id, :name, :source, :created_at, :processed, :doubles, :status, :error_message, :demo)
+            .select(:id, :name, :source, :created_at, :updated_at, :processed, :doubles, :status, :error_message, :demo)
             .with_attached_file
 
     @imports = sorted(scope).page(params[:page])

--- a/app/jobs/imports/destroy_job.rb
+++ b/app/jobs/imports/destroy_job.rb
@@ -15,9 +15,21 @@ class Imports::DestroyJob < ApplicationJob
     broadcast_deletion_complete(import)
   rescue ActiveRecord::RecordNotFound
     Rails.logger.warn "Import #{import_id} not found, may have already been deleted"
+  rescue StandardError
+    revert_deleting_status(import)
+    raise
   end
 
   private
+
+  def revert_deleting_status(import)
+    return unless import && Import.exists?(import.id)
+
+    import.failed!
+    broadcast_status_update(import)
+  rescue StandardError => e
+    Rails.logger.warn "Failed to revert deleting status for import #{import.id}: #{e.message}"
+  end
 
   def broadcast_status_update(import)
     ImportsChannel.broadcast_to(

--- a/app/views/imports/_table_row.html.erb
+++ b/app/views/imports/_table_row.html.erb
@@ -34,9 +34,16 @@
   <td class="px-4 py-3 text-sm text-base-content/50"><%= human_datetime(import.created_at, current_user.safe_settings.timezone) %></td>
   <td class="px-4 py-3 text-right">
     <div class="flex items-center gap-1 justify-end">
-      <% if import.deleting? %>
+      <% if import.deleting? && import.updated_at > 1.hour.ago %>
         <span class="loading loading-spinner loading-sm"></span>
         <span class="text-xs text-base-content/50">Deleting...</span>
+      <% elsif import.deleting? %>
+        <span class="text-xs text-base-content/50">Deletion stalled</span>
+        <div class="tooltip tooltip-left" data-tip="Retry deletion">
+          <%= link_to import, data: { turbo_confirm: "Are you sure?", turbo_method: :delete }, class: "btn btn-ghost btn-xs text-error hover:bg-error/10" do %>
+            <%= icon 'trash-2', class: 'w-4 h-4' %>
+          <% end %>
+        </div>
       <% else %>
         <div class="tooltip" data-tip="View on map">
           <%= link_to preferred_map_path(import_id: import.id), class: 'btn btn-ghost btn-xs' do %>

--- a/spec/jobs/imports/destroy_job_spec.rb
+++ b/spec/jobs/imports/destroy_job_spec.rb
@@ -154,12 +154,12 @@ RSpec.describe Imports::DestroyJob, type: :job do
         expect { described_class.perform_now(import.id) }.to raise_error(StandardError, 'Destroy failed')
       end
 
-      it 'has already set status to deleting before service is called' do
+      it 'reverts the status so the import is not stuck in deleting' do
         expect do
           described_class.perform_now(import.id)
         rescue StandardError
           StandardError
-        end.to change { import.reload.status }.to('deleting')
+        end.to change { import.reload.status }.to('failed')
       end
     end
 

--- a/spec/regressions/import_deletion_failure_resets_status_spec.rb
+++ b/spec/regressions/import_deletion_failure_resets_status_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Import deletion failure leaves a recoverable status' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, status: :completed) }
+
+  context 'when the destroy service raises' do
+    before do
+      destroy_service = instance_double(Imports::Destroy)
+      allow(Imports::Destroy).to receive(:new).and_return(destroy_service)
+      allow(destroy_service).to receive(:call).and_raise(ActiveRecord::StatementInvalid, 'canceling statement')
+    end
+
+    it 're-raises the error so the job can retry' do
+      expect { Imports::DestroyJob.perform_now(import.id) }
+        .to raise_error(ActiveRecord::StatementInvalid)
+    end
+
+    it 'does not leave the import stuck in deleting' do
+      begin
+        Imports::DestroyJob.perform_now(import.id)
+      rescue ActiveRecord::StatementInvalid
+        nil
+      end
+
+      expect(import.reload).to be_failed
+    end
+  end
+
+  context 'when the import is already stuck in deleting' do
+    let(:import) { create(:import, user: user, status: :deleting) }
+
+    it 'can be re-enqueued and deletes the import' do
+      Imports::DestroyJob.perform_now(import.id)
+
+      expect(Import.find_by(id: import.id)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary
A failed or killed deletion left an import in `deleting` forever: endless spinner, no actions, no recovery path short of the console.

## Fix
- `Imports::DestroyJob` rescues failures, reverts the import to `failed` (and re-raises so Sidekiq retries).
- Imports stuck in `deleting` for over an hour show "Deletion stalled" + a retry button instead of the spinner (the destroy path is idempotent, so premature retries are harmless).
- `updated_at` added to the imports index select (the view needs it).

## Verification
Regression spec (status reverts on failure; stuck imports can be re-enqueued); one pre-existing spec asserting the stuck state as intended was updated. 42 import specs green. Live screenshot of the stalled-state retry affordance.

Closes #2835

🤖 Generated with [Claude Code](https://claude.com/claude-code)
