### PR TITLE
Reword suggested-visit empty state to point at place search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- The suggested-visit card no longer promises alternative suggestions that never arrive; it now points to the visit's search button for picking a different place (#2852)
+
 ## [1.8.0] - 2026-06-08
 
 Upgrade notes:

--- a/app/views/map/timeline_feeds/_suggested_picker.html.erb
+++ b/app/views/map/timeline_feeds/_suggested_picker.html.erb
@@ -58,7 +58,7 @@
 
     <% if visible.size <= 1 && overflow.empty? %>
       <p class="suggested-picker__note" data-testid="visit-no-alternatives">
-        No alternative suggestions yet. Confirm or decline this place, or edit it from the visit detail.
+        Not the right place? Use the search button on this visit to find and assign another one.
       </p>
     <% end %>
   <% end %>


### PR DESCRIPTION
## Summary
The suggested-visit picker promised "No alternative suggestions yet" — but since the suggestion pipeline stopped minting multiple candidate places, alternatives never arrive; the copy gaslit users.

## Fix
Copy-only change: "Not the right place? Use the search button on this visit to find and assign another one." — pointing at the per-visit place search (#2846) on the same row. testid unchanged; no spec or e2e referenced the old string.

## Verification
Live screenshot of the new copy under a single-candidate suggestion.

Closes #2852

🤖 Generated with [Claude Code](https://claude.com/claude-code)
