### PR TITLE
Normalize OIDC_ISSUER containing the full discovery URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- OIDC login no longer fails with "undefined method 'with_indifferent_access'" when OIDC_ISSUER is set to the full discovery URL — the trailing /.well-known/openid-configuration is now stripped automatically (#2056)
+
 ## [1.8.0] - 2026-06-08
 
 Upgrade notes:

--- a/lib/oidc_config.rb
+++ b/lib/oidc_config.rb
@@ -27,13 +27,20 @@ module OidcConfig
     }
 
     if env['OIDC_ISSUER'].to_s.strip != ''
-      config[:issuer] = env['OIDC_ISSUER']
+      config[:issuer] = normalize_issuer(env['OIDC_ISSUER'])
       config[:discovery] = true
     elsif env['OIDC_HOST'].to_s.strip != ''
       config[:client_options].merge!(manual_endpoints(env))
     end
 
     config
+  end
+
+  # Discovery expects the bare issuer; the gem appends the well-known path
+  # itself. Configs pasting the full discovery URL would otherwise request a
+  # doubled path and fail with an opaque NoMethodError.
+  def self.normalize_issuer(issuer)
+    issuer.strip.sub(%r{/\.well-known/openid-configuration\z}, '').chomp('/')
   end
 
   def self.pkce_enabled?(env = ENV)

--- a/spec/lib/oidc_config_spec.rb
+++ b/spec/lib/oidc_config_spec.rb
@@ -38,6 +38,29 @@ RSpec.describe OidcConfig do
       expect(config[:client_options]).not_to have_key(:host)
     end
 
+    it 'strips a trailing /.well-known/openid-configuration from the issuer' do
+      config = described_class.build(
+        base_env.merge('OIDC_ISSUER' => 'https://auth.example.com/.well-known/openid-configuration')
+      )
+
+      expect(config[:issuer]).to eq('https://auth.example.com')
+      expect(config[:discovery]).to be true
+    end
+
+    it 'strips a trailing slash from the issuer' do
+      config = described_class.build(base_env.merge('OIDC_ISSUER' => 'https://auth.example.com/'))
+
+      expect(config[:issuer]).to eq('https://auth.example.com')
+    end
+
+    it 'keeps a path-based issuer intact apart from the well-known suffix' do
+      config = described_class.build(
+        base_env.merge('OIDC_ISSUER' => 'https://idp.example.com/realms/main/.well-known/openid-configuration')
+      )
+
+      expect(config[:issuer]).to eq('https://idp.example.com/realms/main')
+    end
+
     it 'builds a manual-mode config when host is present without issuer' do
       env = base_env.merge(
         'OIDC_HOST' => 'auth.example.com',


### PR DESCRIPTION
## Summary
Setting `OIDC_ISSUER` to the full `/.well-known/openid-configuration` URL (an easy mistake) broke OIDC login with the opaque `undefined method 'with_indifferent_access' for an instance of String`.

## Root cause
Discovery appends the well-known path itself; with the suffixed issuer it requests a doubled path, and a 200/plain-text answer there (PocketID's catch-all) produces the NoMethodError. Reproduced deterministically with WebMock.

## Fix
`OidcConfig.normalize_issuer` strips a trailing `/.well-known/openid-configuration` and trailing slash; path-based issuers (Keycloak realms) are preserved.

## Verification
3 new examples in the OidcConfig spec (red before, green after); 15/15.

Closes #2056

🤖 Generated with [Claude Code](https://claude.com/claude-code)
