### PR TITLE
Count overnight distance and repair historical statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Daily and monthly distance statistics now include the distance traveled across midnight (e.g. overnight flights); previously the segment between the last point of one day and the first point of the next was silently dropped (#2843)
+
 ## [1.8.0] - 2026-06-08
 
 Upgrade notes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Statistics include valid segments crossing midnight and older calculations are scheduled for repair (#2843).
+
 - Upgrades rebuild invalid statistics indexes left by interrupted migrations and restore duplicate protection (#2700)
 - Browser and API password sign-in now respect OIDC-only configuration (#2961)
 

--- a/app/queries/stats/daily_distance_query.rb
+++ b/app/queries/stats/daily_distance_query.rb
@@ -24,16 +24,10 @@ class Stats::DailyDistanceQuery
         SELECT
           (to_timestamp(timestamp) AT TIME ZONE $1)::date as local_date,
           CASE
-            WHEN LAG(lonlat) OVER (
-              PARTITION BY (to_timestamp(timestamp) AT TIME ZONE $1)::date
-              ORDER BY timestamp
-            ) IS NOT NULL THEN
+            WHEN LAG(lonlat) OVER (ORDER BY timestamp) IS NOT NULL THEN
               ST_Distance(
                 lonlat::geography,
-                LAG(lonlat) OVER (
-                  PARTITION BY (to_timestamp(timestamp) AT TIME ZONE $1)::date
-                  ORDER BY timestamp
-                )::geography
+                LAG(lonlat) OVER (ORDER BY timestamp)::geography
               )
             ELSE 0
           END as segment_distance

--- a/app/queries/stats/daily_distance_query.rb
+++ b/app/queries/stats/daily_distance_query.rb
@@ -46,7 +46,6 @@ class Stats::DailyDistanceQuery
           LEFT JOIN imports ON imports.id = points.import_id
         ) AS points
         WINDOW w AS (
-          PARTITION BY (to_timestamp(timestamp) AT TIME ZONE $1)::date
           ORDER BY timestamp, id
         )
       ),

--- a/app/services/stats/calculate_month.rb
+++ b/app/services/stats/calculate_month.rb
@@ -4,7 +4,7 @@ class Stats::CalculateMonth
   # Version 2 was used by #3509 for geocoding refresh scheduling and may
   # exist in deployed databases. Reserve it permanently; the next change
   # to calculation semantics must use version 3 or higher.
-  CALCULATION_VERSION = 2
+  CALCULATION_VERSION = 3
 
   def initialize(user_id, year, month, notify_on_failure: true)
     @user = User.find(user_id)

--- a/app/services/stats/calculate_month.rb
+++ b/app/services/stats/calculate_month.rb
@@ -4,7 +4,7 @@ class Stats::CalculateMonth
   # Version 2 was used by #3509 for geocoding refresh scheduling and may
   # exist in deployed databases. Reserve it permanently; the next change
   # to calculation semantics must use version 3 or higher.
-  CALCULATION_VERSION = 1
+  CALCULATION_VERSION = 2
 
   def initialize(user_id, year, month, notify_on_failure: true)
     @user = User.find(user_id)

--- a/spec/queries/stats/daily_distance_query_spec.rb
+++ b/spec/queries/stats/daily_distance_query_spec.rb
@@ -362,9 +362,9 @@ RSpec.describe Stats::DailyDistanceQuery do
 
       subject { described_class.new(monthly_points, timespan, 'Etc/UTC', minutes_between_routes: 30).call }
 
-      it 'does not carry the segment across the day partition' do
+      it 'attributes the segment crossing midnight to the arrival day' do
         expect(subject.find { |day, _| day == 1 }&.last).to eq(0)
-        expect(subject.find { |day, _| day == 2 }&.last).to eq(0)
+        expect(subject.find { |day, _| day == 2 }&.last).to be_between(1_300, 1_400)
       end
     end
 

--- a/spec/regressions/cross_midnight_distance_counted_spec.rb
+++ b/spec/regressions/cross_midnight_distance_counted_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Daily distance includes segments crossing midnight' do
+  let(:user) { create(:user) }
+
+  let(:departure) { Time.utc(2026, 5, 23, 23, 0) }
+
+  before do
+    [
+      [[11.5820, 48.1351], departure],
+      [[25.0000, 50.0000], departure + 50.minutes],
+      [[116.4074, 39.9042], departure + 150.minutes]
+    ].each do |(lon, lat), time|
+      create(:point, user: user, timestamp: time.to_i, lonlat: "POINT(#{lon} #{lat})")
+    end
+  end
+
+  def recalculate
+    Stats::CalculateMonth.new(user.id, 2026, 5).call
+    user.stats.find_by(year: 2026, month: 5)
+  end
+
+  def full_route_distance
+    Point.connection.select_value(<<~SQL.squish).to_i
+      SELECT ROUND(SUM(d)) FROM (
+        SELECT ST_Distance(lonlat::geography, LAG(lonlat) OVER (ORDER BY timestamp)::geography) AS d
+        FROM points WHERE user_id = #{user.id}
+      ) segments
+    SQL
+  end
+
+  it 'counts the segment that crosses midnight' do
+    stat = recalculate
+    day_24 = stat.daily_distance.to_h[24] || stat.daily_distance.to_h['24']
+
+    expect(day_24).to be > 6_000_000
+  end
+
+  it 'sums the month to the full route distance' do
+    stat = recalculate
+
+    expect(stat.distance).to be_within(full_route_distance * 0.01).of(full_route_distance)
+  end
+
+  it 'still attributes the pre-midnight segment to the departure day' do
+    stat = recalculate
+    day_23 = stat.daily_distance.to_h[23] || stat.daily_distance.to_h['23']
+
+    expect(day_23).to be_between(900_000, 1_100_000)
+  end
+end

--- a/spec/regressions/cross_midnight_distance_counted_spec.rb
+++ b/spec/regressions/cross_midnight_distance_counted_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Daily distance includes segments crossing midnight' do
+  let(:user) { create(:user) }
+
+  let(:departure) { Time.utc(2026, 5, 23, 22, 0) }
+  let(:import) { create(:import, user: user, source: 'gpx') }
+
+  before do
+    [
+      [[11.5820, 48.1351], departure],
+      [[25.0000, 50.0000], departure + 90.minutes],
+      [[116.4074, 39.9042], departure + 10.hours]
+    ].each do |(lon, lat), time|
+      create(:point, user: user, import: import, timestamp: time.to_i, lonlat: "POINT(#{lon} #{lat})")
+    end
+  end
+
+  def recalculate
+    Stats::CalculateMonth.new(user.id, 2026, 5).call
+    user.stats.find_by(year: 2026, month: 5)
+  end
+
+  def full_route_distance
+    Point.connection.select_value(<<~SQL.squish).to_i
+      SELECT ROUND(SUM(d)) FROM (
+        SELECT ST_Distance(lonlat::geography, LAG(lonlat) OVER (ORDER BY timestamp)::geography) AS d
+        FROM points WHERE user_id = #{user.id}
+      ) segments
+    SQL
+  end
+
+  it 'counts the segment that crosses midnight' do
+    stat = recalculate
+    day_24 = stat.daily_distance.to_h[24] || stat.daily_distance.to_h['24']
+
+    expect(day_24).to be > 6_000_000
+  end
+
+  it 'sums the month to the full route distance' do
+    stat = recalculate
+
+    expect(stat.distance).to be_within(full_route_distance * 0.01).of(full_route_distance)
+  end
+
+  it 'still attributes the pre-midnight segment to the departure day' do
+    stat = recalculate
+    day_23 = stat.daily_distance.to_h[23] || stat.daily_distance.to_h['23']
+
+    expect(day_23).to be_between(900_000, 1_100_000)
+  end
+
+  [Time.utc(2026, 6, 1), Time.utc(2027, 1, 1)].each do |boundary|
+    it "counts a realistic imported segment across #{boundary.strftime('%Y-%m')}" do
+      create(:point, user: user, import: import, lonlat: 'POINT(13.40 52.50)', timestamp: (boundary - 10.minutes).to_i)
+      create(:point, user: user, import: import, lonlat: 'POINT(13.41 52.51)', timestamp: (boundary + 10.minutes).to_i)
+
+      Stats::CalculateMonth.new(user.id, boundary.year, boundary.month).call
+
+      stat = user.stats.find_by!(year: boundary.year, month: boundary.month)
+      expect(stat.daily_distance.to_h[1] || stat.daily_distance.to_h['1']).to be_between(1_200, 1_400)
+    end
+  end
+
+  it 'schedules repair for a previously current calculation version' do
+    user.points.update_all(created_at: 1.day.ago)
+    user.update_column(:stats_swept_at, Time.current)
+    create(:stat, user: user, year: 2026, month: 5, calculation_version: 1)
+      .update_column(:updated_at, 1.day.ago)
+
+    expect { Stats::BulkCalculator.new(user.id).call }
+      .to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2026, 5, notify_on_failure: false)
+  end
+end

--- a/spec/regressions/cross_midnight_distance_counted_spec.rb
+++ b/spec/regressions/cross_midnight_distance_counted_spec.rb
@@ -64,13 +64,15 @@ RSpec.describe 'Daily distance includes segments crossing midnight' do
     end
   end
 
-  it 'schedules repair for a previously current calculation version' do
-    user.points.update_all(created_at: 1.day.ago)
-    user.update_column(:stats_swept_at, Time.current)
-    create(:stat, user: user, year: 2026, month: 5, calculation_version: 1)
-      .update_column(:updated_at, 1.day.ago)
+  [1, 2].each do |version|
+    it "schedules repair for historical calculation version #{version}" do
+      user.points.update_all(created_at: 1.day.ago)
+      user.update_column(:stats_swept_at, Time.current)
+      create(:stat, user: user, year: 2026, month: 5, calculation_version: version)
+        .update_column(:updated_at, 1.day.ago)
 
-    expect { Stats::BulkCalculator.new(user.id).call }
-      .to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2026, 5, notify_on_failure: false)
+      expect { Stats::BulkCalculator.new(user.id).call }
+        .to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2026, 5, notify_on_failure: false)
+    end
   end
 end


### PR DESCRIPTION
Valid route segments crossing local midnight now contribute to the arrival day instead of disappearing. Speed, timestamp-gap and import guards are retained. Calculation version 3 schedules bounded background repair of existing statistics versions 1 and 2; historical totals are repaired progressively.

Validation: Regression coverage includes overnight flights, month/year boundaries and historical versions 1/2. Full combined RSpec: 9652 examples, 0 failures. Additional Berlin midnight and DST checks passed.

Fixes #2843.

Final combined verification on dev 5eb0e15c: 9721 RSpec examples, 0 failures, using a freshly prepared disposable test database; 284 JavaScript tests passed. Current CI status is shown in the PR checks.
