### PR TITLE
Delete location-sharing requests when deleting a family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The Anomalies map layer now remembers being enabled across page reloads and day changes, like other layers (#2791)
 - Map v2 Replay now plays back proportionally to real elapsed time (at 1x, one real minute per second; speed multiplier compresses further) instead of one point per tick, so slow and fast journeys of equal duration take equal playback time; long point-free gaps are skipped quickly instead of stalling (#2845)
 - The replay marker now renders above track and route lines instead of being hidden beneath them
+- Deleting a family no longer fails with a 500 error when location-sharing requests exist for it (#2916)
 
 ## [1.8.0] - 2026-06-08
 

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -4,6 +4,7 @@ class Family < ApplicationRecord
   has_many :family_memberships, dependent: :destroy, class_name: 'Family::Membership'
   has_many :members, through: :family_memberships, source: :user
   has_many :family_invitations, dependent: :destroy, class_name: 'Family::Invitation'
+  has_many :location_requests, dependent: :delete_all, class_name: 'Family::LocationRequest'
   belongs_to :creator, class_name: 'User'
 
   validates :name, presence: true, length: { maximum: 50 }

--- a/spec/regressions/family_destroy_with_location_requests_spec.rb
+++ b/spec/regressions/family_destroy_with_location_requests_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Family deletion with location-sharing requests' do
+  it 'destroys the family and its location requests' do
+    family = create(:family)
+    create(:family_location_request, family: family)
+
+    expect { family.destroy! }.to change(Family::LocationRequest, :count).by(-1)
+
+    expect(Family.exists?(family.id)).to be(false)
+  end
+end


### PR DESCRIPTION
Deleting a family failed with a 500 when `family_location_requests` rows existed for it — the association was missing, so the FK blocked the destroy.

- Add `has_many :location_requests, dependent: :delete_all` to `Family`
- Regression spec covering family destroy with an existing location request
- CHANGELOG entry

Fixes #2916