### PR TITLE
Disable /admin/flipper rate limiting on self-hosted instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The Anomalies map layer now remembers being enabled across page reloads and day changes, like other layers (#2791)
 - Map v2 Replay now plays back proportionally to real elapsed time (at 1x, one real minute per second; speed multiplier compresses further) instead of one point per tick, so slow and fast journeys of equal duration take equal playback time; long point-free gaps are skipped quickly instead of stalling (#2845)
 - The replay marker now renders above track and route lines instead of being hidden beneath them
+- Self-hosted: the /admin/flipper feature-flag UI is no longer rate-limited, which made it unusable after a few clicks (#2897)
 
 ## [1.8.0] - 2026-06-08
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -239,6 +239,8 @@ end
 # Flipper admin UI: 30 req / 5 min per IP. The UI sits behind admin auth, but
 # limit hammering so an attacker (or buggy client) can't brute-force or scrape it.
 Rack::Attack.throttle('admin/flipper', limit: 30, period: 5.minutes) do |req|
+  next if DawarichSettings.self_hosted?
+
   req.ip if req.path.start_with?('/admin/flipper')
 end
 

--- a/spec/regressions/flipper_admin_throttle_self_hosted_spec.rb
+++ b/spec/regressions/flipper_admin_throttle_self_hosted_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Flipper admin UI throttling', type: :request do
+  let(:admin) { create(:user, :admin) }
+
+  before do
+    Rack::Attack.enabled = true
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.reset!
+    sign_in admin
+  end
+
+  after do
+    Rack::Attack.enabled = false
+  end
+
+  def browse_flipper(times)
+    (1..times).map do
+      get '/admin/flipper/features'
+      response.status
+    end
+  end
+
+  context 'when self-hosted' do
+    before do
+      allow(DawarichSettings).to receive(:self_hosted?).and_return(true)
+    end
+
+    it 'does not rate-limit the flipper UI' do
+      expect(browse_flipper(31)).not_to include(429)
+    end
+  end
+
+  context 'when not self-hosted' do
+    before do
+      allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+    end
+
+    it 'rate-limits the flipper UI after 30 requests' do
+      expect(browse_flipper(31).last).to eq(429)
+    end
+  end
+end


### PR DESCRIPTION
The `admin/flipper` Rack::Attack throttle (30 requests / 5 min per IP) made the feature-flag UI unusable on self-hosted instances — a few page loads of the asset-heavy UI hit the limit and everything 429'd.

- Skip the throttle when `DawarichSettings.self_hosted?` is true; Cloud keeps the existing limit
- Request specs covering both modes (self-hosted never 429s, Cloud still does after 30 requests)
- CHANGELOG entry

Fixes #2897