### PR TITLE
1.8.1 release review follow-ups, round 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.8.1] - 2026-06-11
 
+Upgrade notes:
+
+1. A migration removes duplicate year-end digests that could accumulate before this release. If a yearly recap in Insights showed odd numbers, they may change after the upgrade — that's the duplicates being cleaned up.
+
 ### Added
 
 - Fog of War (Map v2) can now reveal explored areas per hexagon instead of per point, using precalculated monthly statistics. Switch between "Per point" and "Per hexagon" in the map settings panel. (#2899)

--- a/app/javascript/maps_maplibre/layers/fog_hexagon_source.js
+++ b/app/javascript/maps_maplibre/layers/fog_hexagon_source.js
@@ -1,11 +1,16 @@
 import { resolutionForZoom } from "../utils/h3_resolution"
 
+const KM_PER_DEGREE = 111
+const BBOX_MARGIN_FACTOR = 2
+const MIN_COS_LAT = 0.2
+
 export class FogHexagonSource {
   constructor() {
     this.h3 = null
     this.rawCellIds = []
     this.displayRes = null
-    this._boundariesByRes = new Map()
+    this._cellsByRes = new Map()
+    this._coordsById = new Map()
   }
 
   get loaded() {
@@ -21,7 +26,8 @@ export class FogHexagonSource {
     this.h3 = h3
     this.rawCellIds = data.h3_indexes || []
     this.displayRes = null
-    this._boundariesByRes.clear()
+    this._cellsByRes.clear()
+    this._coordsById.clear()
   }
 
   resolutionChanged(zoom) {
@@ -34,7 +40,7 @@ export class FogHexagonSource {
     const res = resolutionForZoom(zoom)
     this.displayRes = res
 
-    const cached = this._boundariesByRes.get(res)
+    const cached = this._cellsByRes.get(res)
     if (cached) return cached
 
     const displayIds = new Set()
@@ -45,23 +51,37 @@ export class FogHexagonSource {
       displayIds.add(cellRes > res ? this.h3.cellToParent(id, res) : id)
     }
 
-    const boundaries = [...displayIds].map((id) => this._buildBoundary(id))
-    this._boundariesByRes.set(res, boundaries)
-    return boundaries
+    const latMargin =
+      (this.h3.getHexagonEdgeLengthAvg(res, this.h3.UNITS.km) / KM_PER_DEGREE) *
+      BBOX_MARGIN_FACTOR
+    const cells = [...displayIds].map((id) => this._buildCell(id, latMargin))
+    this._cellsByRes.set(res, cells)
+    return cells
   }
 
-  _buildBoundary(id) {
-    const coords = this.h3.cellToBoundary(id, true)
-    let minLng = Infinity
-    let maxLng = -Infinity
-    let minLat = Infinity
-    let maxLat = -Infinity
-    for (const [lng, lat] of coords) {
-      if (lng < minLng) minLng = lng
-      if (lng > maxLng) maxLng = lng
-      if (lat < minLat) minLat = lat
-      if (lat > maxLat) maxLat = lat
+  _buildCell(id, latMargin) {
+    const [lat, lng] = this.h3.cellToLatLng(id)
+    const cosLat = Math.max(Math.cos((lat * Math.PI) / 180), MIN_COS_LAT)
+    const lngMargin = latMargin / cosLat
+    const source = this
+
+    return {
+      minLng: lng - lngMargin,
+      maxLng: lng + lngMargin,
+      minLat: lat - latMargin,
+      maxLat: lat + latMargin,
+      get coords() {
+        return source._coordsFor(id)
+      },
     }
-    return { coords, minLng, maxLng, minLat, maxLat }
+  }
+
+  _coordsFor(id) {
+    let coords = this._coordsById.get(id)
+    if (!coords) {
+      coords = this.h3.cellToBoundary(id, true)
+      this._coordsById.set(id, coords)
+    }
+    return coords
   }
 }

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -66,6 +66,24 @@ class Imports::Create
     yield
   rescue StandardError => e
     ExceptionReporter.call(e, "Post-import processing failed: #{step}")
+    create_post_import_failure_notification(step)
+  end
+
+  def create_post_import_failure_notification(step)
+    return if @post_import_failure_notified
+
+    @post_import_failure_notified = true
+
+    Notifications::Create.new(
+      user:,
+      kind: :warning,
+      title: 'Import post-processing incomplete',
+      content: "Your import \"#{import.name}\" finished and all points were saved, but the " \
+               "#{step.tr('_', ' ')} step failed. Statistics, tracks or visit suggestions " \
+               'may be missing or outdated. You can trigger a recalculation from Settings.'
+    ).call
+  rescue StandardError => e
+    ExceptionReporter.call(e, 'Failed to create post-import failure notification')
   end
 
   def run_importer(path)

--- a/app/services/stats/hexagon_calculator.rb
+++ b/app/services/stats/hexagon_calculator.rb
@@ -4,6 +4,7 @@ class Stats::HexagonCalculator
   # H3 Configuration
   DEFAULT_H3_RESOLUTION = 8 # Small hexagons for good detail
   MAX_HEXAGONS = 10_000 # Maximum number of hexagons to prevent memory issues
+  BATCH_SIZE = 50_000
 
   class PostGISError < StandardError; end
 
@@ -38,32 +39,27 @@ class Stats::HexagonCalculator
 
   # Unified hexagon calculation method
   def calculate_hexagons(h3_resolution)
-    return nil if coordinate_rows.empty?
+    h3_hash = build_h3_hash(h3_resolution)
 
-    begin
-      h3_hash = build_h3_hash(coordinate_rows, h3_resolution)
-
-      if h3_hash.empty?
-        Rails.logger.info "No H3 hex IDs calculated for user #{user.id}, #{year}-#{month} (no data)"
-        return nil
-      end
-
-      if h3_hash.size > MAX_HEXAGONS
-        Rails.logger.warn "Too many hexagons (#{h3_hash.size}), using lower resolution"
-        # Try with lower resolution (larger hexagons)
-        lower_resolution = [h3_resolution - 2, 0].max
-        Rails.logger.info "Recalculating with lower H3 resolution: #{lower_resolution}"
-        # Recursively call with lower resolution; re-aggregates from in-memory rows
-        return calculate_hexagons(lower_resolution)
-      end
-
-      Rails.logger.info "Generated #{h3_hash.size} H3 hexagons at resolution #{h3_resolution} for user #{user.id}"
-      h3_hash
-    rescue StandardError => e
-      message = "Failed to calculate H3 hexagon centers: #{e.message}"
-      ExceptionReporter.call(e, message) if defined?(ExceptionReporter)
-      raise PostGISError, message
+    if h3_hash.empty?
+      Rails.logger.info "No H3 hex IDs calculated for user #{user.id}, #{year}-#{month} (no data)"
+      return nil
     end
+
+    if h3_hash.size > MAX_HEXAGONS
+      Rails.logger.warn "Too many hexagons (#{h3_hash.size}), using lower resolution"
+      # Try with lower resolution (larger hexagons)
+      lower_resolution = [h3_resolution - 2, 0].max
+      Rails.logger.info "Recalculating with lower H3 resolution: #{lower_resolution}"
+      return calculate_hexagons(lower_resolution)
+    end
+
+    Rails.logger.info "Generated #{h3_hash.size} H3 hexagons at resolution #{h3_resolution} for user #{user.id}"
+    h3_hash
+  rescue StandardError => e
+    message = "Failed to calculate H3 hexagon centers: #{e.message}"
+    ExceptionReporter.call(e, message) if defined?(ExceptionReporter)
+    raise PostGISError, message
   end
 
   def start_timestamp
@@ -93,24 +89,39 @@ class Stats::HexagonCalculator
               .order(timestamp: :asc)
   end
 
-  def coordinate_rows
-    @coordinate_rows ||= points.unscope(:select, :order).pluck(
-      Arel.sql('ST_Y(lonlat::geometry)'), Arel.sql('ST_X(lonlat::geometry)'), :timestamp
-    )
-  end
-
-  def build_h3_hash(rows, h3_resolution)
+  def build_h3_hash(h3_resolution)
+    resolution = h3_resolution.clamp(0, 15)
     h3_data = {}
-    rows.each do |lat, lng, timestamp|
-      h3_index_string = H3.from_geo_coordinates([lat, lng], h3_resolution.clamp(0, 15)).to_s(16)
-      if (data = h3_data[h3_index_string])
-        data[0] += 1
-        data[1] = [data[1], timestamp].min
-        data[2] = [data[2], timestamp].max
-      else
-        h3_data[h3_index_string] = [1, timestamp, timestamp]
+
+    each_coordinate_batch do |rows|
+      rows.each do |_id, lat, lng, timestamp|
+        h3_index_string = H3.from_geo_coordinates([lat, lng], resolution).to_s(16)
+        if (data = h3_data[h3_index_string])
+          data[0] += 1
+          data[1] = [data[1], timestamp].min
+          data[2] = [data[2], timestamp].max
+        else
+          h3_data[h3_index_string] = [1, timestamp, timestamp]
+        end
       end
     end
+
     h3_data
+  end
+
+  def each_coordinate_batch
+    relation = points.unscope(:select, :order).reorder(:id)
+    last_id = 0
+
+    loop do
+      rows = relation.where('points.id > ?', last_id).limit(BATCH_SIZE).pluck(
+        :id, Arel.sql('ST_Y(lonlat::geometry)'), Arel.sql('ST_X(lonlat::geometry)'), :timestamp
+      )
+      break if rows.empty?
+
+      last_id = rows.last.first
+      yield rows
+      break if rows.size < BATCH_SIZE
+    end
   end
 end

--- a/app/services/users/digests/calculate_year.rb
+++ b/app/services/users/digests/calculate_year.rb
@@ -29,9 +29,9 @@ module Users
         digest.save!
         digest
       rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
-        raise if @retried
+        @attempts = @attempts.to_i + 1
+        raise if @attempts >= 3
 
-        @retried = true
         retry
       end
 

--- a/spec/services/imports/create_spec.rb
+++ b/spec/services/imports/create_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe Imports::Create do
         it 'still writes the points from the importer' do
           expect { service.call }.to change { import.points.count }.from(0)
         end
+
+        it 'notifies the user that post-processing is incomplete' do
+          service.call
+
+          expect(user.notifications.warning.where('title ILIKE ?', '%post-processing%')).to exist
+        end
+
+        it 'creates a single notification when multiple steps fail' do
+          allow(Points::AnomalyFilter).to receive(:new).and_raise(StandardError, 'boom')
+
+          expect { service.call }.to change { user.notifications.warning.count }.by(1)
+        end
       end
 
       context 'when an early post-import step raises' do

--- a/spec/services/stats/hexagon_calculator_spec.rb
+++ b/spec/services/stats/hexagon_calculator_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Stats::HexagonCalculator do
         before do
           # Stub to simulate too many hexagons on first call, then acceptable on second
           call_count = 0
-          allow_any_instance_of(described_class).to receive(:build_h3_hash) do |_instance, _rows, _resolution|
+          allow_any_instance_of(described_class).to receive(:build_h3_hash) do |_instance, _resolution|
             call_count += 1
             if call_count == 1
               # First call: return too many hexagons
@@ -134,8 +134,27 @@ RSpec.describe Stats::HexagonCalculator do
 
         expect(points_query_count).to eq(1),
                                       "Expected exactly 1 points query but got #{points_query_count}. " \
-                                      'The old find_each path issues one query for empty? and one for find_each. ' \
-                                      'After refactor, coordinate_rows memoizes the pluck so only 1 query fires.'
+                                      'A month that fits in one batch should be read with a single pluck; ' \
+                                      'no per-point or per-check queries are allowed.'
+      end
+
+      it 'aggregates identically when the month spans multiple batches' do
+        stub_const('Stats::HexagonCalculator::BATCH_SIZE', 1)
+
+        points_query_count = 0
+        counter = lambda do |_name, _start, _finish, _id, payload|
+          sql = payload[:sql].to_s
+          points_query_count += 1 if sql =~ /FROM ["']?points["']?/i && payload[:name] != 'SCHEMA'
+        end
+
+        result = nil
+        ActiveSupport::Notifications.subscribed(counter, 'sql.active_record') do
+          result = calculate_hexagons
+        end
+
+        expect(points_query_count).to be > 1
+        expect(result.sum { |record| record[1] }).to eq(2)
+        expect(result.map(&:first)).to include('881f191b27fffff')
       end
 
       context 'when H3 raises an error' do

--- a/spec/services/users/digests/calculate_year_spec.rb
+++ b/spec/services/users/digests/calculate_year_spec.rb
@@ -253,6 +253,27 @@ RSpec.describe Users::Digests::CalculateYear do
           expect(existing_digest.reload.distance).to eq(125_000)
         end
       end
+
+      context 'when concurrent calculations keep colliding' do
+        it 'retries until the collision clears' do
+          attempts = 0
+          allow_any_instance_of(Users::Digest).to receive(:save!).and_wrap_original do |original, *args|
+            attempts += 1
+            raise ActiveRecord::RecordNotUnique, 'duplicate key' if attempts < 3
+
+            original.call(*args)
+          end
+
+          expect(calculate_digest).to be_persisted
+        end
+
+        it 'gives up after repeated collisions' do
+          allow_any_instance_of(Users::Digest).to receive(:save!)
+            .and_raise(ActiveRecord::RecordNotUnique, 'duplicate key')
+
+          expect { calculate_digest }.to raise_error(ActiveRecord::RecordNotUnique)
+        end
+      end
     end
 
     context 'with previous year data for comparison' do


### PR DESCRIPTION
Second round of follow-ups from the 1.8.1 release review (after #2921).

## Changes

- **Stats::HexagonCalculator**: coordinates are now read in keyset-paginated batches (`BATCH_SIZE = 50_000`) instead of one pluck of the whole month, bounding worker memory for point-heavy months. The lower-resolution fallback re-aggregates from a fresh scan instead of retained rows.
- **Imports::Create**: when a post-import step fails, the user now gets a single warning notification ("Import post-processing incomplete") instead of a silently successful import with missing stats/tracks/visit suggestions. Failures are still reported per step to the exception reporter.
- **Users::Digests::CalculateYear**: the unique-collision rescue now retries up to three attempts instead of one, so sustained concurrent recalculations can still converge.
- **Fog of War hexagon mode**: hexagon boundaries are built lazily — cells get a cheap center-based bounding box up front, and `cellToBoundary` runs only for cells that enter the viewport (cached per cell). Avoids computing tens of thousands of boundaries up front for heavy accounts.
- **CHANGELOG**: added a 1.8.1 upgrade note about the yearly-digest dedupe migration, since it can change Insights numbers for affected accounts.

## Verification

- New specs for batching equivalence, post-import failure notification (incl. dedupe across multiple failing steps), and digest retry behavior — all written failing-first.
- `spec/services/stats` + `spec/services/imports` + `spec/services/users/digests`: 280 examples, 0 failures.
- RuboCop and Biome clean on changed files.
- Fog bbox margin math validated against vendored h3-js 4.4.0 across latitudes (equator to 78°N): no hexagon vertex falls outside the cull margin.