### PR TITLE
fix(map): unblock drawn-area creation, sync visit dots on deep links; harden e2e seed

### DIFF
--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -216,6 +216,13 @@ export default class extends Controller {
     // Initialize feature managers
     this.areaSelectionManager = new AreaSelectionManager(this)
     this.visitsManager = new VisitsManager(this)
+    // The moveend viewport-refetch normally attaches when the user flips the
+    // Visits toggle on. When the layer starts enabled (saved setting or the
+    // panel=timeline force-enable above), attach it here so panning keeps
+    // the dots in sync with the viewport.
+    if (this.settings.visitsEnabled) {
+      this.visitsManager.attachViewportRefetch()
+    }
     this.placesManager = new PlacesManager(this)
     this.routesManager = new RoutesManager(this)
 

--- a/app/views/map/maplibre/_area_creation_modal.html.erb
+++ b/app/views/map/maplibre/_area_creation_modal.html.erb
@@ -30,7 +30,7 @@
               </span>
             </label>
             <%= f.number_field :radius,
-                min: 10, step: 10,
+                min: 10,
                 placeholder: "Radius in meters",
                 class: "input input-bordered w-full",
                 data: {

--- a/lib/tasks/e2e.rake
+++ b/lib/tasks/e2e.rake
@@ -96,6 +96,24 @@ namespace :e2e do
     puts "\n🚀 Invoking demo:seed_data..."
     Rake::Task['demo:seed_data'].invoke(geojson_path)
 
+    # The import enqueues track generation / geocoding / stats jobs. Those
+    # rebuild tracks, which nullifies any track_id assigned below (the #2630
+    # polluter) — wait for the churn to settle before planting fixtures.
+    puts "\n⏳ Waiting for background jobs to settle..."
+    require 'sidekiq/api'
+    deadline = Time.current + 5.minutes
+    loop do
+      busy = Sidekiq::Workers.new.size
+      enqueued = Sidekiq::Queue.all.sum(&:size)
+      break if busy.zero? && enqueued.zero?
+
+      if Time.current > deadline
+        puts "  ↪ still busy after 5 minutes (busy=#{busy} enqueued=#{enqueued}) — continuing anyway"
+        break
+      end
+      sleep 2
+    end
+
     puts "\n⚠️  Planting anomaly fixtures..."
     Rake::Task['e2e:seed_anomalies'].invoke
 
@@ -157,14 +175,26 @@ namespace :e2e do
     count = user.points.where(tracker_id: 'e2e-anomaly').count
     puts "  ↪ planted #{count} anomaly points (#{count == E2E_ANOMALY_FIXTURE.size ? 'ok' : 'MISMATCH'})"
 
-    polluter = user.points.where(tracker_id: 'e2e-anomaly').order(:timestamp).first
+    # The #2630 polluter lives OUTSIDE the shared anomaly bbox (and under its
+    # own tracker_id) so the destructive area-selection specs that delete the
+    # ANOMALY_COORDS cluster never consume it mid-run. Keep in sync with
+    # POLLUTER_COORD in e2e-dawarich-playwright/v2/helpers/anomaly.js.
+    user.points.where(tracker_id: 'e2e-anomaly-polluter').delete_all
+    polluter_ts = (base_day + (16 * 3600).seconds).to_i
+    polluter = user.points.create!(
+      lonlat: 'POINT(13.7 52.7)',
+      timestamp: polluter_ts,
+      anomaly: true,
+      tracker_id: 'e2e-anomaly-polluter',
+      country_name: 'Germany'
+    )
     day_start = base_day.to_i
     day_end   = (base_day + 1.day).to_i
     polluter_track = user.tracks
                          .where('start_at >= ? AND start_at < ?', Time.zone.at(day_start), Time.zone.at(day_end))
                          .order(:start_at)
                          .first
-    if polluter && polluter_track
+    if polluter_track
       polluter.update_columns(track_id: polluter_track.id)
       puts "  ↪ assigned anomaly ##{polluter.id} to track ##{polluter_track.id} as #2630 controller-filter polluter"
     else


### PR DESCRIPTION
## What

**1. Drawn-area creation silently broken (user-facing, 1.8.0)**
`_area_creation_modal.html.erb` had `step: 10` on the radius number input, while the draw path writes `Math.round(radius)` — any radius that isn't a multiple of 10 (i.e. most drawn areas) fails HTML5 `stepMismatch` and the Create/Update submit is silently blocked. Same for editing legacy areas with arbitrary stored radii. Dropped `step`, kept `min: 10`. Worth a CHANGELOG line — left out of this PR to avoid colliding with in-flight release edits.

**2. Visits layer: stale dots on deep links**
The moveend viewport-refetch only attached via the Visits toggle handler. When the layer starts enabled (saved setting or the `panel=timeline` force-enable), panning never refetched, so dots went stale/missing. Now attached at init when `settings.visitsEnabled`.

**3. e2e seed hardening (`lib/tasks/e2e.rake`)**
- Wait for sidekiq churn to settle after the demo import before planting fixtures — track rebuilds were nullifying the #2630 polluter's `track_id`.
- Seed the polluter **outside** the shared anomaly bbox under its own `tracker_id` (`e2e-anomaly-polluter`, 52.7/13.7) so the destructive area-selection specs can't consume it mid-run. Kept in sync with `POLLUTER_COORD` in e2e-dawarich-playwright (`3eebbd2`).

## Verification
- Full Playwright suite vs self-hosted dev: 67 failures → 13 (remaining ones are spec-side, tracked separately)
- Targeted re-runs green: areas/visits/settings/anomaly files 19/19; timeline-map-sync + visit-row 13/13
- `biome check` + `rubocop` clean on touched files