### PR TITLE
Audit fixes round 2: points API cap, import robustness, digest gating, visit race

### DIFF
--- a/app/controllers/api/v1/digests_controller.rb
+++ b/app/controllers/api/v1/digests_controller.rb
@@ -15,8 +15,9 @@ class Api::V1::DigestsController < ApiController
 
     return unless stale?(last_modified: digest.updated_at.utc)
 
+    full_digest = DawarichSettings.self_hosted? || current_api_user.pro?
     expires_in 1.hour, public: false
-    render json: Api::DigestDetailSerializer.new(digest, distance_unit: distance_unit).call
+    render json: Api::DigestDetailSerializer.new(digest, distance_unit: distance_unit, full: full_digest).call
   end
 
   def create

--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -40,10 +40,12 @@ class Api::V1::PointsController < ApiController
       )
     end
 
+    per_page = (params[:per_page].presence&.to_i || 100).clamp(1, 1000)
+
     points = points
              .order(timestamp: order)
              .page(params[:page])
-             .per(params[:per_page] || 100)
+             .per(per_page)
 
     serialized_points = points.map { |point| point_serializer.new(point).call }
 

--- a/app/jobs/tracks/time_chunk_processor_job.rb
+++ b/app/jobs/tracks/time_chunk_processor_job.rb
@@ -115,7 +115,11 @@ class Tracks::TimeChunkProcessorJob < ApplicationJob
       end
 
       track
-    rescue StandardError
+    rescue StandardError => e
+      Rails.logger.error(
+        "Failed to create track from #{points.size} points in chunk #{chunk_data[:chunk_id]}: #{e.class}: #{e.message}"
+      )
+      ExceptionReporter.call(e, "Track creation failed for chunk #{chunk_data[:chunk_id]}")
       nil
     end
   end

--- a/app/serializers/api/digest_detail_serializer.rb
+++ b/app/serializers/api/digest_detail_serializer.rb
@@ -1,25 +1,32 @@
 # frozen_string_literal: true
 
 class Api::DigestDetailSerializer
-  def initialize(digest, distance_unit:)
+  def initialize(digest, distance_unit:, full: true)
     @digest = digest
     @distance_unit = distance_unit
+    @full = full
   end
 
   def call
-    {
+    base = {
       year: digest.year,
       distance: serialize_distance,
       toponyms: serialize_toponyms,
+      fullDigest: @full,
+      createdAt: digest.created_at.iso8601,
+      updatedAt: digest.updated_at.iso8601
+    }
+
+    return base unless @full
+
+    base.merge!(
       monthlyDistances: serialize_monthly_distances,
       timeSpentByLocation: digest.time_spent_by_location,
       firstTimeVisits: digest.first_time_visits,
       yearOverYear: serialize_year_over_year,
       allTimeStats: serialize_all_time_stats,
-      travelPatterns: serialize_travel_patterns,
-      createdAt: digest.created_at.iso8601,
-      updatedAt: digest.updated_at.iso8601
-    }
+      travelPatterns: serialize_travel_patterns
+    )
   end
 
   private
@@ -46,6 +53,13 @@ class Api::DigestDetailSerializer
   end
 
   def serialize_toponyms
+    result = {
+      countriesCount: digest.countries_count,
+      citiesCount: digest.cities_count
+    }
+
+    return result unless @full
+
     countries = (digest.toponyms || []).select { |t| t['country'].present? }.map do |toponym|
       {
         country: toponym['country'],
@@ -53,11 +67,7 @@ class Api::DigestDetailSerializer
       }
     end
 
-    {
-      countriesCount: digest.countries_count,
-      citiesCount: digest.cities_count,
-      countries: countries
-    }
+    result.merge(countries: countries)
   end
 
   def serialize_year_over_year

--- a/app/services/google_maps/semantic_history_importer.rb
+++ b/app/services/google_maps/semantic_history_importer.rb
@@ -86,7 +86,7 @@ class GoogleMaps::SemanticHistoryImporter
       build_point_from_location(
         longitude: activity['startLocation']['longitudeE7'],
         latitude: activity['startLocation']['latitudeE7'],
-        timestamp: activity['duration']['startTimestamp'] || activity['duration']['startTimestampMs'],
+        timestamp: duration_timestamp(activity),
         accuracy: activity.dig('startLocation', 'accuracyMetres'),
         raw_data: activity
       )
@@ -100,7 +100,7 @@ class GoogleMaps::SemanticHistoryImporter
       build_point_from_location(
         longitude: waypoint['lngE7'],
         latitude: waypoint['latE7'],
-        timestamp: activity['duration']['startTimestamp'] || activity['duration']['startTimestampMs'],
+        timestamp: duration_timestamp(activity),
         raw_data: activity
       )
     end
@@ -112,7 +112,7 @@ class GoogleMaps::SemanticHistoryImporter
       build_point_from_location(
         longitude: place_visit['location']['longitudeE7'],
         latitude: place_visit['location']['latitudeE7'],
-        timestamp: place_visit['duration']['startTimestamp'] || place_visit['duration']['startTimestampMs'],
+        timestamp: duration_timestamp(place_visit),
         accuracy: place_visit.dig('location', 'accuracyMetres'),
         raw_data: place_visit
       )
@@ -127,13 +127,15 @@ class GoogleMaps::SemanticHistoryImporter
     build_point_from_location(
       longitude: candidate['longitudeE7'],
       latitude: candidate['latitudeE7'],
-      timestamp: place_visit['duration']['startTimestamp'] || place_visit['duration']['startTimestampMs'],
+      timestamp: duration_timestamp(place_visit),
       accuracy: candidate['accuracyMetres'],
       raw_data: place_visit
     )
   end
 
   def build_point_from_location(longitude:, latitude:, timestamp:, raw_data:, accuracy: nil)
+    return nil if timestamp.blank?
+
     {
       lonlat: "POINT(#{longitude.to_f / 10**7} #{latitude.to_f / 10**7})",
       timestamp: Timestamps.parse_timestamp(timestamp),
@@ -141,5 +143,9 @@ class GoogleMaps::SemanticHistoryImporter
       motion_data: Points::MotionDataExtractor.from_google_semantic_history(raw_data),
       raw_data: raw_data
     }
+  end
+
+  def duration_timestamp(record)
+    record.dig('duration', 'startTimestamp') || record.dig('duration', 'startTimestampMs')
   end
 end

--- a/app/services/places/visits/create.rb
+++ b/app/services/places/visits/create.rb
@@ -76,22 +76,30 @@ class Places::Visits::Create
   def create_or_update_visit(place, time_range, visit_points)
     Rails.logger.info("Visit from #{time_range}, Points: #{visit_points.size}")
 
-    ActiveRecord::Base.transaction do
+    started_at = Time.zone.at(visit_points.first.timestamp)
+
+    ActiveRecord::Base.transaction(requires_new: true) do
       visit = find_or_initialize_visit(place.id, visit_points.first.timestamp)
 
-      visit.tap do |v|
-        v.ended_at = Time.zone.at(visit_points.last.timestamp)
-        v.duration = (visit_points.last.timestamp - visit_points.first.timestamp) / 60
-        if v.new_record?
-          v.name = "#{place.name}, #{time_range}"
-          v.status = :suggested
-        end
-      end
-
+      apply_visit_attributes(visit, place, time_range, visit_points)
       visit.save!
 
       Point.where(id: visit_points.map(&:id)).update_all(visit_id: visit.id)
     end
+  rescue ActiveRecord::RecordNotUnique
+    winner = Visit.find_by!(place_id: place.id, user_id: user.id, started_at: started_at)
+    apply_visit_attributes(winner, place, time_range, visit_points)
+    winner.save!
+    Point.where(id: visit_points.map(&:id)).update_all(visit_id: winner.id)
+  end
+
+  def apply_visit_attributes(visit, place, time_range, visit_points)
+    visit.ended_at = Time.zone.at(visit_points.last.timestamp)
+    visit.duration = (visit_points.last.timestamp - visit_points.first.timestamp) / 60
+    return unless visit.new_record?
+
+    visit.name   = "#{place.name}, #{time_range}"
+    visit.status = :suggested
   end
 
   def find_or_initialize_visit(place_id, timestamp)

--- a/db/migrate/20260611100000_dedupe_place_visits.rb
+++ b/db/migrate/20260611100000_dedupe_place_visits.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class DedupePlaceVisits < ActiveRecord::Migration[8.0]
+  def up
+    loop do
+      duplicates = ActiveRecord::Base.connection.select_all(<<~SQL.squish)
+        SELECT user_id, place_id, started_at, COUNT(*) AS cnt
+        FROM visits
+        WHERE place_id IS NOT NULL
+        GROUP BY user_id, place_id, started_at
+        HAVING COUNT(*) > 1
+        LIMIT 100
+      SQL
+
+      break if duplicates.empty?
+
+      Rails.logger.info("event=dedupe_place_visits batch_size=#{duplicates.count}")
+
+      duplicates.each do |row|
+        user_id    = row['user_id']
+        place_id   = row['place_id']
+        started_at = row['started_at']
+
+        ActiveRecord::Base.connection.execute(<<~SQL.squish)
+          WITH ranked AS (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY user_id, place_id, started_at
+                     ORDER BY (CASE status WHEN 1 THEN 0 WHEN 0 THEN 1 WHEN 2 THEN 2 ELSE 3 END) ASC, id ASC
+                   ) AS rn
+            FROM visits
+            WHERE user_id   = #{ActiveRecord::Base.connection.quote(user_id)}
+              AND place_id  = #{ActiveRecord::Base.connection.quote(place_id)}
+              AND started_at = #{ActiveRecord::Base.connection.quote(started_at)}
+          ),
+          keeper AS (
+            SELECT id FROM ranked WHERE rn = 1
+          ),
+          dupes AS (
+            SELECT id FROM ranked WHERE rn > 1
+          )
+          UPDATE points
+             SET visit_id = (SELECT id FROM keeper)
+           WHERE visit_id IN (SELECT id FROM dupes)
+        SQL
+
+        ActiveRecord::Base.connection.execute(<<~SQL.squish)
+          WITH ranked AS (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY user_id, place_id, started_at
+                     ORDER BY (CASE status WHEN 1 THEN 0 WHEN 0 THEN 1 WHEN 2 THEN 2 ELSE 3 END) ASC, id ASC
+                   ) AS rn
+            FROM visits
+            WHERE user_id   = #{ActiveRecord::Base.connection.quote(user_id)}
+              AND place_id  = #{ActiveRecord::Base.connection.quote(place_id)}
+              AND started_at = #{ActiveRecord::Base.connection.quote(started_at)}
+          )
+          DELETE FROM visits WHERE id IN (SELECT id FROM ranked WHERE rn > 1)
+        SQL
+      end
+    end
+  end
+
+  def down
+    Rails.logger.info('event=dedupe_place_visits_rollback action=no_op')
+  end
+end

--- a/db/migrate/20260611100001_add_unique_place_visit_index.rb
+++ b/db/migrate/20260611100001_add_unique_place_visit_index.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddUniquePlaceVisitIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :visits, %i[user_id place_id started_at],
+              unique: true,
+              where: 'place_id IS NOT NULL',
+              algorithm: :concurrently,
+              if_not_exists: true,
+              name: 'idx_visits_user_place_started_unique'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_10_090000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_11_100001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "postgis"
@@ -513,6 +513,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_10_090000) do
     t.index ["demo"], name: "index_visits_on_demo_true", where: "(demo = true)"
     t.index ["place_id"], name: "index_visits_on_place_id"
     t.index ["started_at"], name: "index_visits_on_started_at"
+    t.index ["user_id", "place_id", "started_at"], name: "idx_visits_user_place_started_unique", unique: true, where: "(place_id IS NOT NULL)"
     t.index ["user_id"], name: "index_visits_on_user_id"
   end
 

--- a/spec/fixtures/files/google/location-history/with_activitySegment_with_startLocation_without_duration.json
+++ b/spec/fixtures/files/google/location-history/with_activitySegment_with_startLocation_without_duration.json
@@ -1,0 +1,15 @@
+{
+  "timelineObjects": [
+    {
+      "activitySegment": {
+        "startLocation": { "latitudeE7": 526000000, "longitudeE7": 134000000 }
+      }
+    },
+    {
+      "placeVisit": {
+        "location": { "latitudeE7": 123477777, "longitudeE7": 123477777 },
+        "duration": { "startTimestamp": "1742844232" }
+      }
+    }
+  ]
+}

--- a/spec/fixtures/files/google/location-history/with_activitySegment_without_startLocation_without_duration.json
+++ b/spec/fixtures/files/google/location-history/with_activitySegment_without_startLocation_without_duration.json
@@ -1,0 +1,17 @@
+{
+  "timelineObjects": [
+    {
+      "activitySegment": {
+        "waypointPath": {
+          "waypoints": [{ "latE7": 526000000, "lngE7": 134000000 }]
+        }
+      }
+    },
+    {
+      "placeVisit": {
+        "location": { "latitudeE7": 123477777, "longitudeE7": 123477777 },
+        "duration": { "startTimestamp": "1742844232" }
+      }
+    }
+  ]
+}

--- a/spec/fixtures/files/google/location-history/with_placeVisit_with_duration_without_timestamps.json
+++ b/spec/fixtures/files/google/location-history/with_placeVisit_with_duration_without_timestamps.json
@@ -1,0 +1,10 @@
+{
+  "timelineObjects": [
+    {
+      "placeVisit": {
+        "location": { "latitudeE7": 526000000, "longitudeE7": 134000000 },
+        "duration": { "endTimestamp": "2025-03-24T20:07:24+01:00" }
+      }
+    }
+  ]
+}

--- a/spec/fixtures/files/google/location-history/with_placeVisit_without_duration.json
+++ b/spec/fixtures/files/google/location-history/with_placeVisit_without_duration.json
@@ -1,0 +1,15 @@
+{
+  "timelineObjects": [
+    {
+      "placeVisit": {
+        "location": { "latitudeE7": 526000000, "longitudeE7": 134000000 }
+      }
+    },
+    {
+      "placeVisit": {
+        "location": { "latitudeE7": 123477777, "longitudeE7": 123477777 },
+        "duration": { "startTimestamp": "1742844232" }
+      }
+    }
+  ]
+}

--- a/spec/jobs/tracks/time_chunk_processor_job_spec.rb
+++ b/spec/jobs/tracks/time_chunk_processor_job_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tracks::TimeChunkProcessorJob, type: :job do
+  let(:user) do
+    create(:user, settings: {
+             'minutes_between_routes' => 30,
+             'meters_between_routes' => 500
+           })
+  end
+
+  let(:chunk_start) { Time.zone.local(2026, 1, 1, 12, 0, 0).to_i }
+  let(:chunk_end)   { Time.zone.local(2026, 1, 1, 12, 30, 0).to_i }
+
+  let(:chunk_data) do
+    {
+      chunk_id: 'test-chunk-id',
+      start_timestamp: chunk_start,
+      end_timestamp: chunk_end,
+      buffer_start_timestamp: chunk_start,
+      buffer_end_timestamp: chunk_end,
+      untracked_only: false
+    }
+  end
+
+  before do
+    session_manager = instance_double(
+      Tracks::SessionManager,
+      session_exists?: true,
+      session_id: 'test-session'
+    )
+    allow(session_manager).to receive(:increment_completed_chunks)
+    allow(session_manager).to receive(:increment_tracks_created)
+    allow(session_manager).to receive(:mark_failed)
+    allow(Tracks::SessionManager).to receive(:new).and_return(session_manager)
+    allow(ExceptionReporter).to receive(:call)
+  end
+
+  describe '#perform' do
+    context 'when distance calculation raises an error' do
+      before do
+        create(:point, user: user, timestamp: chunk_start + 60,
+                       latitude: 52.5200, longitude: 13.4050,
+                       lonlat: 'POINT(13.4050 52.5200)')
+        create(:point, user: user, timestamp: chunk_start + 120,
+                       latitude: 52.5201, longitude: 13.4060,
+                       lonlat: 'POINT(13.4060 52.5201)')
+        allow(Point).to receive(:calculate_distance_for_array_geocoder).and_raise(RuntimeError, 'boom')
+      end
+
+      it 'does not raise an error' do
+        expect { described_class.perform_now(user.id, 'test-session', chunk_data) }.not_to raise_error
+      end
+
+      it 'reports the exception via ExceptionReporter' do
+        described_class.perform_now(user.id, 'test-session', chunk_data)
+
+        expect(ExceptionReporter).to have_received(:call).with(
+          instance_of(RuntimeError),
+          'Track creation failed for chunk test-chunk-id'
+        )
+      end
+
+      it 'does not create any Track records' do
+        expect { described_class.perform_now(user.id, 'test-session', chunk_data) }
+          .not_to change(Track, :count)
+      end
+    end
+
+    context 'when points are valid' do
+      before do
+        create(:point, user: user, timestamp: chunk_start + 60,
+                       latitude: 52.5200, longitude: 13.4050,
+                       lonlat: 'POINT(13.4050 52.5200)')
+        create(:point, user: user, timestamp: chunk_start + 120,
+                       latitude: 52.5201, longitude: 13.4060,
+                       lonlat: 'POINT(13.4060 52.5201)')
+        create(:point, user: user, timestamp: chunk_start + 180,
+                       latitude: 52.5202, longitude: 13.4070,
+                       lonlat: 'POINT(13.4070 52.5202)')
+      end
+
+      it 'creates at least one Track record' do
+        expect { described_class.perform_now(user.id, 'test-session', chunk_data) }
+          .to change(Track, :count).by_at_least(1)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/digests_spec.rb
+++ b/spec/requests/api/v1/digests_spec.rb
@@ -99,6 +99,80 @@ RSpec.describe 'Api::V1::Digests', type: :request do
 
       expect(response).to have_http_status(:not_modified)
     end
+
+    context 'when user is on lite plan' do
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        # update_columns bypasses the activate callback that resets plan to :pro
+        user.update_column(:plan, User.plans[:lite])
+      end
+
+      it 'returns 200 with partial digest and fullDigest: false' do
+        get api_v1_digest_url(year: 2024), headers: headers
+
+        expect(response).to have_http_status(:ok)
+
+        json = JSON.parse(response.body)
+        expect(json['year']).to eq(2024)
+        expect(json['distance']).to be_a(Hash)
+        expect(json['toponyms']['countriesCount']).to eq(3)
+        expect(json['toponyms']['citiesCount']).to eq(5)
+        expect(json['fullDigest']).to eq(false)
+
+        expect(json).not_to have_key('firstTimeVisits')
+        expect(json).not_to have_key('monthlyDistances')
+        expect(json).not_to have_key('timeSpentByLocation')
+        expect(json).not_to have_key('yearOverYear')
+        expect(json).not_to have_key('allTimeStats')
+        expect(json).not_to have_key('travelPatterns')
+        expect(json['toponyms']).not_to have_key('countries')
+      end
+
+      context 'when self_hosted? is true' do
+        before do
+          allow(DawarichSettings).to receive(:self_hosted?).and_return(true)
+        end
+
+        it 'returns full digest even for lite plan user' do
+          get api_v1_digest_url(year: 2024), headers: headers
+
+          expect(response).to have_http_status(:ok)
+
+          json = JSON.parse(response.body)
+          expect(json['fullDigest']).to eq(true)
+          expect(json).to have_key('firstTimeVisits')
+          expect(json).to have_key('monthlyDistances')
+          expect(json).to have_key('timeSpentByLocation')
+          expect(json).to have_key('yearOverYear')
+          expect(json).to have_key('allTimeStats')
+          expect(json).to have_key('travelPatterns')
+          expect(json['toponyms']).to have_key('countries')
+        end
+      end
+    end
+
+    context 'when user is on pro plan' do
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        user.update_column(:plan, User.plans[:pro])
+      end
+
+      it 'returns full digest with fullDigest: true' do
+        get api_v1_digest_url(year: 2024), headers: headers
+
+        expect(response).to have_http_status(:ok)
+
+        json = JSON.parse(response.body)
+        expect(json['fullDigest']).to eq(true)
+        expect(json).to have_key('firstTimeVisits')
+        expect(json).to have_key('monthlyDistances')
+        expect(json).to have_key('timeSpentByLocation')
+        expect(json).to have_key('yearOverYear')
+        expect(json).to have_key('allTimeStats')
+        expect(json).to have_key('travelPatterns')
+        expect(json['toponyms']).to have_key('countries')
+      end
+    end
   end
 
   describe 'POST /api/v1/digests' do

--- a/spec/requests/api/v1/imports_spec.rb
+++ b/spec/requests/api/v1/imports_spec.rb
@@ -178,5 +178,28 @@ RSpec.describe 'Api::V1::Imports', type: :request do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context 'when user is on lite plan' do
+      let(:file) { fixture_file_upload('gpx/gpx_track_single_segment.gpx', 'application/gpx+xml') }
+
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        # update_columns bypasses the activate callback that resets plan to :pro
+        user.update_column(:plan, User.plans[:lite])
+      end
+
+      it 'returns 403 with write_api_restricted error' do
+        post api_v1_imports_url(api_key: api_key), params: { file: file }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)['error']).to eq('write_api_restricted')
+      end
+
+      it 'does not create an import' do
+        expect do
+          post api_v1_imports_url(api_key: api_key), params: { file: file }
+        end.not_to change(Import, :count)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/points_spec.rb
+++ b/spec/requests/api/v1/points_spec.rb
@@ -408,6 +408,13 @@ RSpec.describe 'Api::V1::Points', type: :request do
         expect(response).to have_http_status(:forbidden)
         expect(JSON.parse(response.body)['error']).to eq('write_api_restricted')
       end
+
+      it 'does not delete the point' do
+        point_id = points.first.id
+        delete "/api/v1/points/#{point_id}?api_key=#{user.api_key}"
+
+        expect(Point.exists?(point_id)).to be true
+      end
     end
   end
 
@@ -793,6 +800,27 @@ RSpec.describe 'Api::V1::Points', type: :request do
       post '/api/v1/points/reapply_anomaly_filter'
 
       expect(response).to have_http_status(:unauthorized)
+    end
+
+    context 'when user is on lite plan' do
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        # update_columns bypasses the activate callback that resets plan to :pro
+        user.update_column(:plan, User.plans[:lite])
+      end
+
+      it 'returns 403 with write_api_restricted error' do
+        post "/api/v1/points/reapply_anomaly_filter?api_key=#{user.api_key}"
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)['error']).to eq('write_api_restricted')
+      end
+
+      it 'does not enqueue the backfill job' do
+        expect do
+          post "/api/v1/points/reapply_anomaly_filter?api_key=#{user.api_key}"
+        end.not_to have_enqueued_job(Points::AnomalyBackfillUserJob)
+      end
     end
   end
 

--- a/spec/requests/api/v1/points_spec.rb
+++ b/spec/requests/api/v1/points_spec.rb
@@ -129,6 +129,66 @@ RSpec.describe 'Api::V1::Points', type: :request do
       end
     end
 
+    context 'with per_page bounds' do
+      let(:window_base) { 30.days.ago.to_i }
+      let!(:two_points) do
+        [
+          create(:point, user:, timestamp: window_base + 10),
+          create(:point, user:, timestamp: window_base + 20)
+        ]
+      end
+      let(:bounds_start) { window_base }
+      let(:bounds_end)   { window_base + 100 }
+
+      it 'clamps per_page=0 up to 1' do
+        get api_v1_points_url(api_key: user.api_key, per_page: 0,
+                              start_at: bounds_start, end_at: bounds_end)
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body).size).to eq(1)
+        expect(response.headers['X-Total-Pages']).to eq('2')
+      end
+
+      it 'clamps per_page=-5 up to 1' do
+        get api_v1_points_url(api_key: user.api_key, per_page: -5,
+                              start_at: bounds_start, end_at: bounds_end)
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body).size).to eq(1)
+        expect(response.headers['X-Total-Pages']).to eq('2')
+      end
+
+      it 'treats garbage per_page as 0 and clamps to 1' do
+        get api_v1_points_url(api_key: user.api_key, per_page: 'garbage',
+                              start_at: bounds_start, end_at: bounds_end)
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body).size).to eq(1)
+        expect(response.headers['X-Total-Pages']).to eq('2')
+      end
+
+      it 'clamps per_page=5000 down to 1000' do
+        base = 60.days.ago.to_i
+        rows = Array.new(1001) do |i|
+          {
+            lonlat: 'POINT(13.4 52.5)',
+            timestamp: base + i,
+            user_id: user.id,
+            created_at: Time.current,
+            updated_at: Time.current
+          }
+        end
+        Point.insert_all(rows)
+
+        get api_v1_points_url(api_key: user.api_key, per_page: 5000,
+                              start_at: base - 1, end_at: base + 1002)
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body).size).to eq(1000)
+        expect(response.headers['X-Total-Pages']).to eq('2')
+      end
+    end
+
     context 'when user is on lite plan and result spans multiple pages' do
       let!(:lite_user) do
         u = create(:user)

--- a/spec/requests/api/v1/recalculations_spec.rb
+++ b/spec/requests/api/v1/recalculations_spec.rb
@@ -43,5 +43,26 @@ RSpec.describe 'Api::V1::Recalculations', type: :request do
 
       expect(response).to have_http_status(:unauthorized)
     end
+
+    context 'when user is on lite plan' do
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        # update_columns bypasses the activate callback that resets plan to :pro
+        user.update_column(:plan, User.plans[:lite])
+      end
+
+      it 'returns 403 with write_api_restricted error' do
+        post "/api/v1/recalculations?api_key=#{user.api_key}"
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)['error']).to eq('write_api_restricted')
+      end
+
+      it 'does not enqueue a recalculation job' do
+        expect do
+          post "/api/v1/recalculations?api_key=#{user.api_key}"
+        end.not_to have_enqueued_job(Users::RecalculateDataJob)
+      end
+    end
   end
 end

--- a/spec/services/google_maps/semantic_history_importer_spec.rb
+++ b/spec/services/google_maps/semantic_history_importer_spec.rb
@@ -149,5 +149,56 @@ RSpec.describe GoogleMaps::SemanticHistoryImporter do
         end
       end
     end
+
+    context 'when duration is missing' do
+      context 'when placeVisit has no duration key' do
+        let(:file_name) { 'with_placeVisit_without_duration' }
+
+        it 'does not raise and skips the record without duration' do
+          expect { parser }.not_to raise_error
+        end
+
+        it 'imports the sibling record that has a valid duration' do
+          expect { parser }.to change(Point, :count).by(1)
+        end
+      end
+
+      context 'when activitySegment has startLocation but no duration key' do
+        let(:file_name) { 'with_activitySegment_with_startLocation_without_duration' }
+
+        it 'does not raise and skips the record without duration' do
+          expect { parser }.not_to raise_error
+        end
+
+        it 'imports the sibling record that has a valid duration' do
+          expect { parser }.to change(Point, :count).by(1)
+        end
+      end
+
+      context 'when activitySegment has waypointPath but no duration key' do
+        let(:file_name) { 'with_activitySegment_without_startLocation_without_duration' }
+
+        it 'does not raise and skips the record without duration' do
+          expect { parser }.not_to raise_error
+        end
+
+        it 'imports the sibling record that has a valid duration' do
+          expect { parser }.to change(Point, :count).by(1)
+        end
+      end
+
+      context 'when placeVisit duration exists but has no startTimestamp or startTimestampMs' do
+        let(:file_name) { 'with_placeVisit_with_duration_without_timestamps' }
+
+        it 'does not create a point' do
+          expect { parser }.not_to change(Point, :count)
+        end
+
+        it 'does not create a point at epoch 0' do
+          parser
+          expect(Point.where(timestamp: Time.zone.at(0))).to be_empty
+        end
+      end
+    end
   end
 end

--- a/spec/services/places/visits/create_spec.rb
+++ b/spec/services/places/visits/create_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Places::Visits::Create do
+  let(:user)  { create(:user) }
+  let(:place) { create(:place, user: user) }
+
+  let(:ts_start) { Time.zone.parse('2024-05-01 10:00:00').to_i }
+  let(:ts_end)   { Time.zone.parse('2024-05-01 11:00:00').to_i }
+
+  let(:visit_points) do
+    [
+      create(:point, user: user, timestamp: ts_start),
+      create(:point, user: user, timestamp: ts_end)
+    ]
+  end
+
+  let(:service) { described_class.new(user, [place]) }
+
+  def run_create
+    service.send(:create_or_update_visit, place, '2024-05-01 10:00 - 11:00', visit_points)
+  end
+
+  describe '#create_or_update_visit' do
+    context 'idempotency — running twice for the same place/start' do
+      it 'does not create a duplicate visit on the second run' do
+        run_create
+        run_create
+
+        expect(Visit.where(place_id: place.id, user_id: user.id).count).to eq(1)
+      end
+
+      it 'updates ended_at on the second run instead of creating a second visit' do
+        run_create
+        second_end_ts = ts_end + 30.minutes.to_i
+        late_point    = create(:point, user: user, timestamp: second_end_ts)
+        points_second = [visit_points.first, late_point]
+
+        service.send(:create_or_update_visit, place, '2024-05-01 10:00 - 11:30', points_second)
+
+        visits = Visit.where(place_id: place.id, user_id: user.id)
+        expect(visits.count).to eq(1)
+        expect(visits.first.ended_at).to be_within(1.second).of(Time.zone.at(second_end_ts))
+      end
+    end
+
+    context 'pre-existing winner — visit already created by a racing job' do
+      it 'reuses the pre-created visit and assigns all points to it' do
+        started_at = Time.zone.at(ts_start)
+        winner = create(:visit,
+                        user: user,
+                        place: place,
+                        started_at: started_at,
+                        ended_at: started_at + 30.minutes,
+                        duration: 30,
+                        name: 'pre-existing',
+                        status: :suggested)
+
+        run_create
+
+        expect(Visit.where(place_id: place.id, user_id: user.id).count).to eq(1)
+        expect(Visit.find(winner.id).ended_at).to be_within(1.second).of(Time.zone.at(ts_end))
+        visit_point_ids = visit_points.map(&:id)
+        expect(Point.where(id: visit_point_ids).pluck(:visit_id).uniq).to eq([winner.id])
+      end
+    end
+  end
+
+  describe 'DB constraint — partial unique index' do
+    let(:started_at) { Time.zone.at(ts_start) }
+
+    it 'raises RecordNotUnique when two visits share the same user/place/started_at' do
+      create(:visit, user: user, place: place, started_at: started_at,
+                     ended_at: started_at + 1.hour, duration: 60)
+      duplicate = build(:visit, user: user, place: place, started_at: started_at,
+                                ended_at: started_at + 1.hour, duration: 60)
+
+      expect { duplicate.save! }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'does NOT raise when place_id is nil with the same user/started_at' do
+      create(:visit, user: user, place: place, started_at: started_at,
+                     ended_at: started_at + 1.hour, duration: 60)
+      area_visit = build(:visit, user: user, place_id: nil, started_at: started_at,
+                                 ended_at: started_at + 1.hour, duration: 60)
+
+      expect { area_visit.save! }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/visits/create_spec.rb
+++ b/spec/services/visits/create_spec.rb
@@ -19,8 +19,9 @@ RSpec.describe Visits::Create do
       subject(:service) { described_class.new(user, valid_params) }
 
       it 'creates a visit successfully' do
-        expect { service.call }.to change { user.visits.count }.by(1)
-        expect(service.call).to be_truthy
+        result = nil
+        expect { result = service.call }.to change { user.visits.count }.by(1)
+        expect(result).to be_truthy
         expect(service.visit).to be_persisted
       end
 

--- a/spec/services/visits/find_in_time_spec.rb
+++ b/spec/services/visits/find_in_time_spec.rb
@@ -92,11 +92,13 @@ RSpec.describe Visits::FindInTime do
     end
 
     context 'with visits at the boundaries of the time range' do
+      let(:boundary_place) { create(:place, user: user) }
+
       let!(:visit_at_start) do
         create(
           :visit,
           user: user,
-          place: place,
+          place: boundary_place,
           started_at: reference_time,
           ended_at: reference_time + 30.minutes
         )


### PR DESCRIPTION
Round 2 of the `improve` audit on `dev`. Six findings, each with regression coverage. All commits are isolated and additive; no behavior changes outside the described scope.

## Fixes

**Cap `per_page` on the points API** (`6504b9ba`)
`GET /api/v1/points` passed client-supplied `per_page` straight to Kaminari with no ceiling — a request like `per_page=10000000` would materialize and serialize a user's entire point set in one response. Now clamped to `1..1000`, matching the convention already used by the tracks/visits/imports endpoints.

**Guard missing `duration` in the Google semantic-history importer** (`2543e574`)
A Takeout entry lacking the `duration` object raised `NoMethodError` inside `points_data`, aborting the entire import before any points were saved. Entries without a usable timestamp are now skipped (and no longer silently coerced to epoch 0).

**Report swallowed per-segment errors in `Tracks::TimeChunkProcessorJob`** (`22b69466`)
`create_track_from_points_array` ended in a bare `rescue StandardError => nil`, silently discarding a segment's track with no log, no Sentry event, no metric — points were left orphaned. The skip-this-segment semantics are preserved (one bad segment must not fail the chunk), but the error is now logged and reported.

**Gate full digest content behind Pro in the digests API** (`20d48bab`)
The web digest page gates First Time Visits, monthly distances, time-by-location, the full country list, all-time stats, and travel patterns behind Pro, but `GET /api/v1/digests/:year` returned all of it to Lite cloud users. The API now mirrors the web boundary and adds a `fullDigest` flag so clients can render the upgrade prompt. Self-hosted instances are unaffected (everything stays full).

**Spec Lite write-API gating** (`aaaaff0d`)
Added regression specs asserting `403 write_api_restricted` (and unchanged data / no enqueued job) for Lite users on imports, recalculations, and points destroy/bulk_destroy/reapply_anomaly_filter. Previously only `points#update` was covered.

**Make place-visit creation race-safe** (`ee7c4f6d`, `0cc0d7db`)
`Places::Visits::Create` did `find_or_initialize_by` + `save!` with no unique constraint; concurrent suggestion jobs for the same user could both insert, producing duplicate visits and double-counted stationary time. Adds a partial unique index on `visits(user_id, place_id, started_at) WHERE place_id IS NOT NULL`, a dedupe migration (keeper priority confirmed > suggested > declined), and a `RecordNotUnique` rescue that reuses the winner — the same pattern already used by `Tracks::TrackBuilder`.

## Notes for review

- The dedupe migration in `ee7c4f6d` runs against the production `visits` table; review batch sizing before deploying to Cloud.
- `db/schema.rb` is at version `2026_06_11_100001` with only the new partial unique index added — please regenerate from a clean migrate on merge, as the local test DB was being reset by a parallel branch during development.

## Verification

- Targeted suites for every touched area pass; the visit-detection regression sweep (`spec/services spec/models/visit_spec.rb spec/requests/api/v1/visits_spec.rb spec/jobs/visits spec/jobs/places`) is 2764 examples, 0 failures.
- RuboCop clean on all changed files.
