### PR TITLE
fix: prevent Map v1 datepicker month navigation 404 on trailing-slash paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Upgrade notes:
 ### Fixed
 
 - Trip card preview on `/trips` and the per-day route layer on the trip page now split routes at the International Date Line, so transpacific trips no longer draw an impossible line across the globe. #2731
+- Leaflet map datepicker month selection no longer 404s when the app is served from a path with a trailing slash (#2869)
 
 ## [1.8.1] - 2026-06-11
 

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -2357,7 +2357,7 @@ export default class extends BaseController {
             const lastDay = new Date(selectedYear, index + 1, 0).getDate()
             const endDate = `${selectedYear}-${monthNum}-${lastDay}T23:59`
 
-            const href = `map?end_at=${encodeURIComponent(endDate)}&start_at=${encodeURIComponent(startDate)}`
+            const href = `/map?end_at=${encodeURIComponent(endDate)}&start_at=${encodeURIComponent(startDate)}`
             monthLink.setAttribute("href", href)
           } else {
             monthLink.classList.add("disabled")
@@ -2390,7 +2390,7 @@ export default class extends BaseController {
         const wholeYearLink = document.getElementById("whole-year-link")
         const startDate = `${selectedYear}-01-01T00:00`
         const endDate = `${selectedYear}-12-31T23:59`
-        const href = `map?end_at=${encodeURIComponent(endDate)}&start_at=${encodeURIComponent(startDate)}`
+        const href = `/map?end_at=${encodeURIComponent(endDate)}&start_at=${encodeURIComponent(startDate)}`
         wholeYearLink.setAttribute("href", href)
 
         updateMonthLinks(selectedYear, availableMonths)
@@ -2429,7 +2429,7 @@ export default class extends BaseController {
 
     const startDate = `${year}-01-01T00:00`
     const endDate = `${year}-12-31T23:59`
-    return `map?end_at=${encodeURIComponent(endDate)}&start_at=${encodeURIComponent(startDate)}`
+    return `/map?end_at=${encodeURIComponent(endDate)}&start_at=${encodeURIComponent(startDate)}`
   }
 
   async fetchAndDisplayVisitedCities() {


### PR DESCRIPTION
Leaflet map datepicker month selection no longer 404s when the app is served from a path with a trailing slash.

Fixes #2869
