### PR TITLE
fix: skip family member route line when a location update lacks coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Upgrade notes:
 
 ### Fixed
 
+- Family Members map layer no longer draws a stray line to the map center when a member location update lacks coordinates (#2863)
 - Trip card preview on `/trips` and the per-day route layer on the trip page now split routes at the International Date Line, so transpacific trips no longer draw an impossible line across the globe. #2731
 
 ## [1.8.1] - 2026-06-11

--- a/app/javascript/maps_maplibre/layers/family_layer.js
+++ b/app/javascript/maps_maplibre/layers/family_layer.js
@@ -188,7 +188,18 @@ export class FamilyLayer extends BaseLayer {
   updateMember(member) {
     const features = this.data?.features || []
     const memberId = member.user_id || member.id
-    const coords = [member.longitude, member.latitude]
+    const lon = Number(member.longitude)
+    const lat = Number(member.latitude)
+
+    if (!this._isValidCoord(lon, lat)) {
+      console.warn(
+        "[FamilyLayer] Skipping member update with invalid coordinates:",
+        member,
+      )
+      return
+    }
+
+    const coords = [lon, lat]
     const color = member.color || this.getMemberColor(memberId)
 
     // Find existing or add new
@@ -273,6 +284,13 @@ export class FamilyLayer extends BaseLayer {
 
     this._historyFeatures = features
     source.setData({ type: "FeatureCollection", features })
+  }
+
+  _isValidCoord(lon, lat) {
+    if (!Number.isFinite(lon) || !Number.isFinite(lat)) return false
+    if (lon === 0 && lat === 0) return false
+    if (lon < -180 || lon > 180 || lat < -90 || lat > 90) return false
+    return true
   }
 
   /**


### PR DESCRIPTION
The Family Members map layer no longer draws a stray line to the map center when a member's location update is missing coordinates.

Fixes #2863
