### PR TITLE
fix: align insights and statistics country counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Upgrade notes:
 
 ### Fixed
 
+- Insights and statistics now report the same number of countries visited, excluding fly-over countries without a qualifying city. (#2929)
 - Trip card preview on `/trips` and the per-day route layer on the trip page now split routes at the International Date Line, so transpacific trips no longer draw an impossible line across the globe. #2731
 
 ## [1.8.1] - 2026-06-11

--- a/app/services/insights/year_totals_calculator.rb
+++ b/app/services/insights/year_totals_calculator.rb
@@ -48,10 +48,9 @@ module Insights
 
         stat.toponyms.each do |toponym|
           next unless toponym.is_a?(Hash)
-
-          countries.add(toponym['country']) if toponym['country'].present?
-
           next unless toponym['cities'].is_a?(Array)
+
+          countries.add(toponym['country']) if toponym['country'].present? && toponym['cities'].any?
 
           toponym['cities'].each do |city|
             cities.add(city['city']) if city.is_a?(Hash) && city['city'].present?

--- a/spec/regressions/insights_statistics_countries_consistency_spec.rb
+++ b/spec/regressions/insights_statistics_countries_consistency_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Insights and statistics report the same countries visited' do
+  let(:user) { create(:user) }
+
+  let!(:stat) do
+    create(:stat, user: user, year: 2026, month: 4, distance: 100, toponyms: [
+             { 'country' => 'Germany', 'cities' => [{ 'city' => 'Berlin', 'stayed_for' => 480 }] },
+             { 'country' => 'France', 'cities' => [] },
+             { 'country' => 'Austria' }
+           ])
+  end
+
+  def insights_countries
+    Insights::YearTotalsCalculator.new(user.stats.where(year: 2026), distance_unit: 'km').call.countries_list
+  end
+
+  def statistics_countries
+    user.countries_visited_uncached
+  end
+
+  it 'excludes countries without qualifying cities from the insights count' do
+    expect(insights_countries).to eq(['Germany'])
+  end
+
+  it 'agrees with statistics on the set of countries visited' do
+    expect(insights_countries).to eq(statistics_countries)
+  end
+end

--- a/spec/services/insights/year_totals_calculator_spec.rb
+++ b/spec/services/insights/year_totals_calculator_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Insights::YearTotalsCalculator do
       it 'handles malformed data gracefully' do
         result = calculator.call
 
-        expect(result.countries_count).to eq(2) # Spain and Italy
+        expect(result.countries_count).to eq(1) # Italy only; Spain's cities is not an array
         expect(result.cities_count).to eq(0) # No valid cities
       end
     end


### PR DESCRIPTION
Insights and statistics now report the same number of countries visited, excluding fly-over countries without a qualifying city.

Fixes #2929
