### PR TITLE
fix: preserve trailing slash in OIDC issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Upgrade notes:
 
 ### Fixed
 
+- OIDC login no longer fails with an "Issuer mismatch" error when the provider's issuer ends in a trailing slash (e.g. Authentik); the trailing slash is now preserved instead of being stripped. (#2925)
 - Trip card preview on `/trips` and the per-day route layer on the trip page now split routes at the International Date Line, so transpacific trips no longer draw an impossible line across the globe. #2731
 
 ## [1.8.1] - 2026-06-11

--- a/lib/oidc_config.rb
+++ b/lib/oidc_config.rb
@@ -40,7 +40,7 @@ module OidcConfig
   # itself. Configs pasting the full discovery URL would otherwise request a
   # doubled path and fail with an opaque NoMethodError.
   def self.normalize_issuer(issuer)
-    issuer.strip.sub(%r{/\.well-known/openid-configuration\z}, '').chomp('/')
+    issuer.strip.sub(%r{/\.well-known/openid-configuration/?\z}, '')
   end
 
   def self.pkce_enabled?(env = ENV)

--- a/spec/lib/oidc_config_spec.rb
+++ b/spec/lib/oidc_config_spec.rb
@@ -47,10 +47,12 @@ RSpec.describe OidcConfig do
       expect(config[:discovery]).to be true
     end
 
-    it 'strips a trailing slash from the issuer' do
-      config = described_class.build(base_env.merge('OIDC_ISSUER' => 'https://auth.example.com/'))
+    it 'preserves a trailing slash that is part of the issuer' do
+      config = described_class.build(
+        base_env.merge('OIDC_ISSUER' => 'https://auth.example.com/application/o/dawarich/')
+      )
 
-      expect(config[:issuer]).to eq('https://auth.example.com')
+      expect(config[:issuer]).to eq('https://auth.example.com/application/o/dawarich/')
     end
 
     it 'keeps a path-based issuer intact apart from the well-known suffix' do
@@ -59,6 +61,14 @@ RSpec.describe OidcConfig do
       )
 
       expect(config[:issuer]).to eq('https://idp.example.com/realms/main')
+    end
+
+    it 'strips a well-known suffix that itself has a trailing slash' do
+      config = described_class.build(
+        base_env.merge('OIDC_ISSUER' => 'https://auth.example.com/.well-known/openid-configuration/')
+      )
+
+      expect(config[:issuer]).to eq('https://auth.example.com')
     end
 
     it 'builds a manual-mode config when host is present without issuer' do


### PR DESCRIPTION
OIDC login no longer fails with an "Issuer mismatch" error when the provider's issuer ends in a trailing slash (e.g. Authentik); the trailing slash is now preserved instead of being stripped.

Fixes #2925
