### PR TITLE
Configure SMTP certificate verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,8 +36,11 @@ PLACE_VISITS_THROTTLE_SECONDS=0.1
 # ─── SMTP email (optional) ───────────────────────────────────────────────────
 # Configure outbound email. SMTP_SSL=true enables implicit TLS (port 465); it
 # turns on automatically when SMTP_PORT=465. STARTTLS is the default otherwise.
+# SMTP_OPENSSL_VERIFY_MODE=none skips TLS certificate verification, for a LAN
+# mail server with a self-signed certificate. Leave unset to keep verifying.
 SMTP_SERVER=
 SMTP_PORT=
 SMTP_USERNAME=
 SMTP_PASSWORD=
 SMTP_SSL=
+SMTP_OPENSSL_VERIFY_MODE=

--- a/.env.example
+++ b/.env.example
@@ -44,11 +44,14 @@ VECTOR_TILES_QUERY_TIMEOUT_MS=5000
 # ─── SMTP email (optional) ───────────────────────────────────────────────────
 # Configure outbound email. SMTP_SSL=true enables implicit TLS (port 465); it
 # turns on automatically when SMTP_PORT=465. STARTTLS is the default otherwise.
+# SMTP_OPENSSL_VERIFY_MODE=none skips TLS certificate verification, for a LAN
+# mail server with a self-signed certificate. Leave unset to keep verifying.
 SMTP_SERVER=
 SMTP_PORT=
 SMTP_USERNAME=
 SMTP_PASSWORD=
 SMTP_SSL=
+SMTP_OPENSSL_VERIFY_MODE=
 
 # ─── Reverse geocoding / place search (optional) ─────────────────────────────
 # Optional. When any provider variable below is set, that provider applies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- New `SMTP_OPENSSL_VERIFY_MODE` environment variable (`none` or `peer`) lets self-hosters send mail through a LAN SMTP server that presents a self-signed certificate by skipping TLS certificate verification; leaving it unset keeps the default verifying behavior. Setting it to `none` logs a warning at startup. (#2681)
+
 ### Fixed
 
 - The Dawarich app and Sidekiq containers now restart automatically after a graceful (exit 0) shutdown instead of staying down, so a stray SIGHUP no longer takes an instance offline until manual intervention (#3099).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Self-hosters can configure SMTP certificate verification for a local mail relay (#2681).
+
 - Upgrades rebuild invalid statistics indexes left by interrupted migrations and restore duplicate protection (#2700)
 - Browser and API password sign-in now respect OIDC-only configuration (#2961)
 

--- a/lib/smtp_config.rb
+++ b/lib/smtp_config.rb
@@ -3,6 +3,7 @@
 module SmtpConfig
   ALLOWED_AUTHENTICATIONS = %i[plain login cram_md5 digest_md5 gssapi ntlm xoauth2].freeze
   NO_AUTHENTICATION_VALUES = %w[none nil false off disabled].freeze
+  ALLOWED_OPENSSL_VERIFY_MODES = %w[none peer].freeze
   DEFAULT_TIMEOUT = 5
 
   IMPLICIT_TLS_PORT = 465
@@ -10,7 +11,7 @@ module SmtpConfig
   def self.smtp_settings(env = ENV)
     ssl = ssl?(env)
 
-    {
+    settings = {
       address:         env['SMTP_SERVER'],
       port:            env['SMTP_PORT']&.to_i,
       domain:          env['SMTP_DOMAIN'],
@@ -22,6 +23,11 @@ module SmtpConfig
       open_timeout:    timeout(env, 'SMTP_OPEN_TIMEOUT'),
       read_timeout:    timeout(env, 'SMTP_READ_TIMEOUT')
     }
+
+    mode = openssl_verify_mode(env)
+    settings[:openssl_verify_mode] = mode if mode
+
+    settings
   end
 
   def self.mailer_url_options(env = ENV)
@@ -54,6 +60,29 @@ module SmtpConfig
     env['SMTP_PORT']&.to_i == IMPLICIT_TLS_PORT
   end
   private_class_method :ssl?
+
+  def self.openssl_verify_mode(env)
+    raw = env['SMTP_OPENSSL_VERIFY_MODE'].to_s.strip
+    return nil if raw.empty?
+
+    mode = raw.downcase
+    unless ALLOWED_OPENSSL_VERIFY_MODES.include?(mode)
+      raise ArgumentError,
+            "SMTP_OPENSSL_VERIFY_MODE=#{raw.inspect} is not supported; " \
+            "expected one of #{ALLOWED_OPENSSL_VERIFY_MODES.inspect}"
+    end
+
+    warn_unverified_tls if mode == 'none'
+
+    mode
+  end
+  private_class_method :openssl_verify_mode
+
+  def self.warn_unverified_tls
+    warn '[SMTP] SMTP_OPENSSL_VERIFY_MODE=none: TLS certificate verification is disabled. ' \
+         'Mail — including SMTP credentials — is sent over an unverified connection.'
+  end
+  private_class_method :warn_unverified_tls
 
   def self.timeout(env, key)
     raw = env[key]

--- a/lib/smtp_config.rb
+++ b/lib/smtp_config.rb
@@ -5,13 +5,14 @@ module SmtpConfig
   NO_AUTHENTICATION_VALUES = %w[none nil false off disabled].freeze
   DEFAULT_OPEN_TIMEOUT = 30
   DEFAULT_READ_TIMEOUT = 60
+  ALLOWED_OPENSSL_VERIFY_MODES = %w[none peer].freeze
 
   IMPLICIT_TLS_PORT = 465
 
   def self.smtp_settings(env = ENV)
     ssl = ssl?(env)
 
-    {
+    settings = {
       address:         env['SMTP_SERVER'],
       port:            env['SMTP_PORT']&.to_i,
       domain:          env['SMTP_DOMAIN'],
@@ -23,6 +24,11 @@ module SmtpConfig
       open_timeout:    timeout(env, 'SMTP_OPEN_TIMEOUT', DEFAULT_OPEN_TIMEOUT),
       read_timeout:    timeout(env, 'SMTP_READ_TIMEOUT', DEFAULT_READ_TIMEOUT)
     }
+
+    mode = openssl_verify_mode(env)
+    settings[:openssl_verify_mode] = mode if mode
+
+    settings
   end
 
   def self.mailer_url_options(env = ENV)
@@ -55,6 +61,29 @@ module SmtpConfig
     env['SMTP_PORT']&.to_i == IMPLICIT_TLS_PORT
   end
   private_class_method :ssl?
+
+  def self.openssl_verify_mode(env)
+    raw = env['SMTP_OPENSSL_VERIFY_MODE'].to_s.strip
+    return nil if raw.empty?
+
+    mode = raw.downcase
+    unless ALLOWED_OPENSSL_VERIFY_MODES.include?(mode)
+      raise ArgumentError,
+            "SMTP_OPENSSL_VERIFY_MODE=#{raw.inspect} is not supported; " \
+            "expected one of #{ALLOWED_OPENSSL_VERIFY_MODES.inspect}"
+    end
+
+    warn_unverified_tls if mode == 'none'
+
+    mode
+  end
+  private_class_method :openssl_verify_mode
+
+  def self.warn_unverified_tls
+    warn '[SMTP] SMTP_OPENSSL_VERIFY_MODE=none: TLS certificate verification is disabled. ' \
+         'Mail — including SMTP credentials — is sent over an unverified connection.'
+  end
+  private_class_method :warn_unverified_tls
 
   def self.timeout(env, key, default)
     raw = env[key]

--- a/spec/lib/smtp_config_spec.rb
+++ b/spec/lib/smtp_config_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SmtpConfig do
+  describe '.smtp_settings' do
+    def settings_for(value)
+      described_class.smtp_settings('SMTP_OPENSSL_VERIFY_MODE' => value)
+    end
+
+    it 'omits openssl_verify_mode when SMTP_OPENSSL_VERIFY_MODE is unset' do
+      expect(described_class.smtp_settings({})).not_to have_key(:openssl_verify_mode)
+    end
+
+    it 'omits openssl_verify_mode when the value is blank' do
+      expect(settings_for('   ')).not_to have_key(:openssl_verify_mode)
+    end
+
+    it 'passes through none' do
+      expect { expect(settings_for('none')[:openssl_verify_mode]).to eq('none') }
+        .to output(/SMTP_OPENSSL_VERIFY_MODE=none/).to_stderr
+    end
+
+    it 'passes through peer' do
+      expect(settings_for('peer')[:openssl_verify_mode]).to eq('peer')
+    end
+
+    it 'normalizes case and whitespace' do
+      expect { expect(settings_for('  NONE  ')[:openssl_verify_mode]).to eq('none') }
+        .to output.to_stderr
+    end
+
+    it 'warns that certificate verification is disabled when set to none' do
+      expect { settings_for('none') }
+        .to output(/TLS certificate verification is disabled/).to_stderr
+    end
+
+    it 'does not warn when set to peer' do
+      expect { settings_for('peer') }.not_to output.to_stderr
+    end
+
+    it 'raises on an unsupported value' do
+      expect { settings_for('bogus') }
+        .to raise_error(ArgumentError, /SMTP_OPENSSL_VERIFY_MODE/)
+    end
+
+    it 'leaves implicit TLS and STARTTLS resolution untouched' do
+      settings = described_class.smtp_settings(
+        'SMTP_PORT' => '465', 'SMTP_OPENSSL_VERIFY_MODE' => 'peer'
+      )
+
+      expect(settings).to include(ssl: true, enable_starttls: false, port: 465)
+    end
+  end
+end


### PR DESCRIPTION
Self-hosted administrators can configure SMTP certificate verification using SMTP_OPENSSL_VERIFY_MODE. The default keeps certificate verification enabled. The environment example documents the option.

Validation: 9 SMTP examples, 0 failures; complete combined suite: 9652 examples, 0 failures; changed Ruby files pass RuboCop.

Fixes #2681.

Final combined verification on dev 5eb0e15c: 9721 RSpec examples, 0 failures, using a freshly prepared disposable test database; 284 JavaScript tests passed. Current CI status is shown in the PR checks.
