### PR TITLE
fix: activate configured custom tile server as the Map v1 base layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Upgrade notes:
 
 ### Fixed
 
+- Map v1 (Leaflet) now uses a configured custom Tile Server as the active base layer instead of only adding it as a selectable option, so a saved custom tile URL takes effect on the map without manually switching layers. #1263
 - Trip card preview on `/trips` and the per-day route layer on the trip page now split routes at the International Date Line, so transpacific trips no longer draw an impossible line across the globe. #2731
 
 ## [1.8.1] - 2026-06-11

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -518,9 +518,13 @@ export default class extends BaseController {
         attribution: "&copy; OpenStreetMap contributors",
       })
 
-      // If this is the preferred layer, add it to the map immediately
-      if (selectedLayerName === this.userSettings.maps.name) {
-        // Remove any existing base layers first
+      const preferredIsCustom =
+        selectedLayerName === this.userSettings.maps.name
+      const preferredIsUnset =
+        !this.userSettings.preferred_map_layer ||
+        this.userSettings.preferred_map_layer === "OpenStreetMap"
+
+      if (preferredIsCustom || preferredIsUnset) {
         Object.values(maps).forEach((layer) => {
           if (this.map.hasLayer(layer)) {
             this.map.removeLayer(layer)


### PR DESCRIPTION
Map v1 (Leaflet) now uses a configured custom Tile Server as the active base layer instead of only adding it as a selectable option, so a saved custom tile URL takes effect without manually switching layers.

Fixes #1263
