### PR TITLE
fix: convert Map v1 hover popup current speed to km/h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Upgrade notes:
 ### Fixed
 
 - Trip card preview on `/trips` and the per-day route layer on the trip page now split routes at the International Date Line, so transpacific trips no longer draw an impossible line across the globe. #2731
+- The "Current Speed" value in the Map v1 route hover popup was shown ~3.6x too low because the stored velocity (m/s) was not converted to km/h before formatting, unlike the point popup and the route click popup. The hover popup now converts to km/h (and mph) consistently. #1314
 
 ## [1.8.1] - 2026-06-11
 

--- a/app/javascript/maps/polylines.js
+++ b/app/javascript/maps/polylines.js
@@ -217,7 +217,8 @@ export function addHighlightOnHover(
 
         // Calculate speed if we have both markers
         if (startMarkerData && endMarkerData) {
-          speed = startMarkerData[5] || endMarkerData[5] || 0
+          const velocityMs = startMarkerData[5] || endMarkerData[5] || 0
+          speed = velocityMs * 3.6
         }
       }
     }


### PR DESCRIPTION
The "Current Speed" value in the Map v1 route hover popup was ~3.6× too low because the stored velocity (m/s) was not converted to km/h before formatting, unlike the point and route-click popups. The hover popup now converts to km/h (and mph) consistently.

Fixes #1314
