### PR TITLE
feat: support PUID/PGID for running containers as a non-root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Upgrade notes:
 
 ### Added
 
+- Run the app and Sidekiq containers under a custom user via `PUID`/`PGID` environment variables: the container starts as root, fixes ownership of the mounted volumes, then drops privileges. Use this instead of Compose `user:`, which cannot write to root-owned volumes (#1159).
 - Trip detail page redesigned around MapLibre v2: sticky map on the left, scrollable per-day accordion on the right with first/last point time and per-day distance, day-colored routes, photo overlay toggle, and a timeline replay scrubber.
 - Per-day **trip notes**: add a short plain-text note to any day of a trip directly from the accordion. Notes live in their own `notes` table and are also available via `GET/POST/PATCH/DELETE /api/v1/notes`.
 - Trip cards on `/trips` and the trip create/edit form now render their map with MapLibre instead of Leaflet, matching Map v2. The form map live-updates the route preview when the trip dates change.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update -qq \
     libjemalloc2 libjemalloc-dev \
     cmake \
     ca-certificates \
+    gosu \
     && mkdir -p $APP_PATH \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -67,6 +67,9 @@ services:
     restart: on-failure
     environment:
       RAILS_ENV: ${RAILS_ENV:-production}
+      ### To run under a non-root user, set PUID/PGID here (do NOT use `user:`).
+      # PUID: ${PUID:-1000}
+      # PGID: ${PGID:-1000}
       REDIS_URL: ${REDIS_URL:-redis://dawarich_redis:6379}
       DATABASE_HOST: ${DATABASE_HOST:-dawarich_db}
       DATABASE_PORT: ${DATABASE_PORT:-5432}
@@ -125,6 +128,9 @@ services:
     restart: on-failure
     environment:
       RAILS_ENV: ${RAILS_ENV:-production}
+      ### To run under a non-root user, set PUID/PGID here (do NOT use `user:`).
+      # PUID: ${PUID:-1000}
+      # PGID: ${PGID:-1000}
       REDIS_URL: ${REDIS_URL:-redis://dawarich_redis:6379}
       DATABASE_HOST: ${DATABASE_HOST:-dawarich_db}
       DATABASE_PORT: ${DATABASE_PORT:-5432}

--- a/docker/sidekiq-entrypoint.sh
+++ b/docker/sidekiq-entrypoint.sh
@@ -7,6 +7,24 @@ set -e
 
 echo "⚠️ Starting Sidekiq in $RAILS_ENV environment ⚠️"
 
+# Optional privilege drop. When PUID/PGID are set and the container starts as
+# root, fix ownership of the mounted writable paths, then re-exec as that user.
+# Prefer this over compose `user:`, which starts unprivileged and cannot chown
+# root-owned volumes.
+if [ "$(id -u)" = "0" ] && [ -n "${PUID}${PGID}" ]; then
+  TARGET_UID="${PUID:-1000}"
+  TARGET_GID="${PGID:-1000}"
+  for _dir in public storage tmp db log; do
+    _path="$APP_PATH/$_dir"
+    [ -d "$_path" ] || continue
+    if [ "$(stat -c '%u' "$_path")" != "$TARGET_UID" ]; then
+      echo "🔑 Adjusting ownership of $_path to $TARGET_UID:$TARGET_GID..."
+      chown -R "$TARGET_UID:$TARGET_GID" "$_path"
+    fi
+  done
+  exec gosu "$TARGET_UID:$TARGET_GID" "$0" "$@"
+fi
+
 # Parse DATABASE_URL if present, otherwise use individual variables
 if [ -n "$DATABASE_URL" ]; then
   # Strip scheme (postgres:// or postgresql://)

--- a/docker/web-entrypoint.sh
+++ b/docker/web-entrypoint.sh
@@ -7,6 +7,24 @@ set -e
 
 echo "⚠️ Starting Rails environment: $RAILS_ENV ⚠️"
 
+# Optional privilege drop. When PUID/PGID are set and the container starts as
+# root, fix ownership of the mounted writable paths, then re-exec as that user.
+# Prefer this over compose `user:`, which starts unprivileged and cannot chown
+# root-owned volumes.
+if [ "$(id -u)" = "0" ] && [ -n "${PUID}${PGID}" ]; then
+  TARGET_UID="${PUID:-1000}"
+  TARGET_GID="${PGID:-1000}"
+  for _dir in public storage tmp db log; do
+    _path="$APP_PATH/$_dir"
+    [ -d "$_path" ] || continue
+    if [ "$(stat -c '%u' "$_path")" != "$TARGET_UID" ]; then
+      echo "🔑 Adjusting ownership of $_path to $TARGET_UID:$TARGET_GID..."
+      chown -R "$TARGET_UID:$TARGET_GID" "$_path"
+    fi
+  done
+  exec gosu "$TARGET_UID:$TARGET_GID" "$0" "$@"
+fi
+
 # Parse DATABASE_URL if present, otherwise use individual variables
 if [ -n "$DATABASE_URL" ]; then
   # Strip scheme (postgres:// or postgresql://)


### PR DESCRIPTION
Run the app and Sidekiq containers under a custom user via `PUID`/`PGID`: the container starts as root, fixes ownership of the mounted volumes, then drops privileges. Use this instead of Compose `user:`, which cannot write to root-owned volumes.

Fixes #1159
