### PR TITLE
fix: match areas by name in place search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Upgrade notes:
 ### Fixed
 
 - Trip card preview on `/trips` and the per-day route layer on the trip page now split routes at the International Date Line, so transpacific trips no longer draw an impossible line across the globe. #2731
+- Searching for a place by name now also matches your areas by name, so an area outside the nearby radius shows up in the results instead of being hidden. #2918
 
 ## [1.8.1] - 2026-06-11
 

--- a/app/controllers/api/v1/places_controller.rb
+++ b/app/controllers/api/v1/places_controller.rb
@@ -134,7 +134,9 @@ module Api
             Places::NearbySearch.new(latitude: lat, longitude: lon, radius: radius, limit: limit, cache: true).call
           end
 
-        areas = Areas::Nearby.new(user: current_api_user, latitude: lat, longitude: lon, radius: radius).call
+        areas = Areas::Nearby.new(
+          user: current_api_user, latitude: lat, longitude: lon, radius: radius, query: query
+        ).call
 
         render json: { places: places, areas: areas }
       end

--- a/app/services/areas/nearby.rb
+++ b/app/services/areas/nearby.rb
@@ -4,12 +4,15 @@ module Areas
   class Nearby
     MAX_RESULTS = 10
 
-    def initialize(user:, latitude:, longitude:, radius:, limit: MAX_RESULTS)
+    MIN_QUERY_LENGTH = 2
+
+    def initialize(user:, latitude:, longitude:, radius:, limit: MAX_RESULTS, query: nil)
       @user = user
       @latitude = latitude.to_f
       @longitude = longitude.to_f
       @radius = radius.to_f
       @limit = limit.to_i
+      @query = query.to_s.strip
     end
 
     def call
@@ -17,11 +20,15 @@ module Areas
       origin  = "ST_SetSRID(ST_MakePoint(#{@longitude}, #{@latitude}), 4326)::geography"
       area_pt = 'ST_SetSRID(ST_MakePoint(areas.longitude, areas.latitude), 4326)::geography'
 
-      @user.areas
-           .where(Arel.sql("ST_DWithin(#{area_pt}, #{origin}, #{radius_meters})"))
-           .order(Arel.sql("ST_Distance(#{area_pt}, #{origin}) ASC"))
-           .limit(@limit)
-           .map { |area| format(area) }
+      scope = @user.areas.where(Arel.sql("ST_DWithin(#{area_pt}, #{origin}, #{radius_meters})"))
+      if @query.length >= MIN_QUERY_LENGTH
+        scope = scope.or(@user.areas.where('name ILIKE ?', "%#{Area.sanitize_sql_like(@query)}%"))
+      end
+
+      scope
+        .order(Arel.sql("ST_Distance(#{area_pt}, #{origin}) ASC"))
+        .limit(@limit)
+        .map { |area| format(area) }
     end
 
     private

--- a/spec/services/areas/nearby_spec.rb
+++ b/spec/services/areas/nearby_spec.rb
@@ -27,6 +27,24 @@ RSpec.describe Areas::Nearby do
     expect(results).to eq([])
   end
 
+  it 'returns an area matched by name even when it is outside the radius' do
+    create(:area, user: user, name: 'Home', latitude: lat, longitude: lon, radius: 100)
+    far = create(:area, user: user, name: 'Grandma House', latitude: 48.137, longitude: 11.575, radius: 100)
+
+    results = described_class.new(user: user, latitude: lat, longitude: lon, radius: 1.0, query: 'grandma').call
+
+    expect(results.map { |r| r[:id] }).to include(far.id)
+  end
+
+  it 'does not match another user area by name' do
+    other = create(:user)
+    create(:area, user: other, name: 'Grandma House', latitude: 48.137, longitude: 11.575, radius: 100)
+
+    results = described_class.new(user: user, latitude: lat, longitude: lon, radius: 1.0, query: 'grandma').call
+
+    expect(results).to eq([])
+  end
+
   it 'caps results at MAX_RESULTS' do
     (Areas::Nearby::MAX_RESULTS + 2).times do |i|
       create(:area, user: user, name: "Spot #{i}", latitude: lat, longitude: lon, radius: 100)


### PR DESCRIPTION
Searching for a place by name now also matches your areas by name, so an area outside the nearby radius shows up in the results instead of being hidden.

Fixes #2918
