### PR TITLE
fix: unify suggested-visit confirm UI; confirm visits with no place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Upgrade notes:
 ### Fixed
 
 - Trip card preview on `/trips` and the per-day route layer on the trip page now split routes at the International Date Line, so transpacific trips no longer draw an impossible line across the globe. #2731
+- Suggested visits that have no candidate places now show a Confirm (and Delete) button, so they can be confirmed instead of getting stuck with no way to act on them. #2917
 
 ## [1.8.1] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Upgrade notes:
 ### Fixed
 
 - Trip card preview on `/trips` and the per-day route layer on the trip page now split routes at the International Date Line, so transpacific trips no longer draw an impossible line across the globe. #2731
-- Suggested visits that have no candidate places now show a Confirm (and Delete) button, so they can be confirmed instead of getting stuck with no way to act on them. #2917
+- Suggested visits now always show a Confirm and Delete control, including visits with no matched place — which previously rendered no action and got stuck with no way to confirm or remove them. #2917
 
 ## [1.8.1] - 2026-06-11
 

--- a/app/assets/stylesheets/maps_maplibre_suggested_picker.css
+++ b/app/assets/stylesheets/maps_maplibre_suggested_picker.css
@@ -30,8 +30,8 @@
 }
 
 /* Header: badge + prompt on the left, Confirm anchored right.
-   Kept at the top (not below the list) so the primary action never
-   scrolls off-screen when the list is tall or partly expanded. */
+   Kept at the top (not below the note) so the primary action never
+   scrolls off-screen. */
 .suggested-picker__header {
   display: flex;
   align-items: center;
@@ -98,153 +98,16 @@
   outline-offset: 2px;
 }
 
-/* Candidate list — visually compact rows with enough vertical padding to
-   keep the 44px touch-target on coarse pointers. The radio is kept as a
-   real input for accessibility (arrow-key grouping + Space to select). */
-.suggested-picker__list {
-  list-style: none;
+.suggested-picker__note {
   margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.suggested-picker__list--overflow {
-  margin-top: 4px;
-}
-
-.suggested-picker__option {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  min-height: 32px;
-  border-radius: 5px;
-  cursor: pointer;
-  transition:
-    background 120ms ease,
-    box-shadow 120ms ease;
-}
-
-@media (pointer: coarse) {
-  .suggested-picker__option {
-    min-height: 44px;
-  }
-}
-
-.suggested-picker__option:hover {
-  background: oklch(var(--bc) / 0.05);
-}
-
-.suggested-picker__option:has(.suggested-picker__radio:checked) {
-  background: rgba(245, 158, 11, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.4);
-}
-
-.suggested-picker__option:has(.suggested-picker__radio:focus-visible) {
-  outline: 2px solid #f59e0b;
-  outline-offset: 1px;
-}
-
-.suggested-picker__radio {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 14px;
-  height: 14px;
-  min-width: 14px;
-  border-radius: 9999px;
-  border: 1.5px solid oklch(var(--bc) / 0.35);
-  background: transparent;
-  cursor: pointer;
-  position: relative;
-  margin: 0;
-  flex-shrink: 0;
-  transition:
-    border-color 120ms ease,
-    background 120ms ease;
-}
-
-.suggested-picker__radio:checked {
-  border-color: #f59e0b;
-  background: #f59e0b;
-  box-shadow: inset 0 0 0 2.5px oklch(var(--b1));
-}
-
-.suggested-picker__option-name {
-  flex: 1;
-  min-width: 0;
-  color: oklch(var(--bc) / 0.9);
-  /* Allow long place names ("1. FC Union Zapfstelle (Fuel)") to wrap inside
-     the narrow candidate row rather than overflow. `overflow-wrap: anywhere`
-     handles the no-space case; `word-break: break-word` is the widely
-     supported fallback. */
+  color: oklch(var(--bc) / 0.6);
+  font-size: 0.75rem;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
-/* "Show N more" disclosure — native <details>, so no extra Stimulus.
-   Styled as a subtle inline link so it doesn't compete with the candidates. */
-.suggested-picker__overflow {
-  margin-top: 2px;
-}
-
-.suggested-picker__overflow details {
-  margin: 0;
-}
-
-.suggested-picker__more {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  border-radius: 5px;
-  cursor: pointer;
-  font-size: 0.75rem;
-  color: oklch(var(--bc) / 0.65);
-  list-style: none;
-  user-select: none;
-}
-
-.suggested-picker__more::-webkit-details-marker {
-  display: none;
-}
-
-.suggested-picker__more:hover {
-  background: oklch(var(--bc) / 0.05);
-  color: oklch(var(--bc) / 0.9);
-}
-
-.suggested-picker__more-caret {
-  display: inline-block;
-  font-size: 0.625rem;
-  transition: transform 150ms ease;
-}
-
-.suggested-picker__overflow details[open] .suggested-picker__more-caret {
-  transform: rotate(90deg);
-}
-
-/* Summary text swaps between "Show N more" (closed) and "Hide N places"
-   (open) via the parent <details>[open] state. Keeps behavior server-side
-   + CSS only — no Stimulus needed. */
-.suggested-picker__more-text--open {
-  display: none;
-}
-
-.suggested-picker__overflow details[open] .suggested-picker__more-text--closed {
-  display: none;
-}
-
-.suggested-picker__overflow details[open] .suggested-picker__more-text--open {
-  display: inline;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .suggested-picker__confirm,
-  .suggested-picker__option,
-  .suggested-picker__radio,
-  .suggested-picker__more-caret {
+  .suggested-picker__confirm {
     transition: none;
   }
 }

--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -3,11 +3,6 @@
 module TimelineHelper
   WEEKDAY_HEADER_LABELS = %w[M T W T F S S].freeze
 
-  # Max suggested-place candidates shown before the "Show N more" disclosure
-  # kicks in. The assembler dedupes by name upstream; this just keeps the
-  # visible picker compact regardless of geocoder quality.
-  SUGGESTED_PICKER_VISIBLE_LIMIT = 3
-
   # "YYYY-MM" for the calendar's initial month. Prefers, in order:
   #   1. `params[:date]` (the selected day, e.g. "2025-12-11")
   #   2. `params[:start_at]` (range start, e.g. "2025-12-11T00:00:00")
@@ -115,16 +110,6 @@ module TimelineHelper
 
   def visit_entry_status(entry)
     entry[:status].presence || 'confirmed'
-  end
-
-  # Splits suggested places into [visible, overflow] for the picker UI.
-  # `visible` is rendered as selectable rows; `overflow` lives inside the
-  # <details> disclosure so the default footprint stays compact.
-  def split_suggested_places(places, limit: SUGGESTED_PICKER_VISIBLE_LIMIT)
-    list = Array(places)
-    return [list, []] if list.size <= limit
-
-    [list.first(limit), list.drop(limit)]
   end
 
   def day_label(day)

--- a/app/views/map/timeline_feeds/_suggested_picker.html.erb
+++ b/app/views/map/timeline_feeds/_suggested_picker.html.erb
@@ -1,4 +1,4 @@
-<% visible, overflow = split_suggested_places(entry[:suggested_places]) %>
+<% place_name = entry[:suggested_places]&.first&.dig(:name).presence %>
 <div class="suggested-picker" data-visit-id="<%= entry[:visit_id] %>">
   <%= form_with url: visit_path(entry[:visit_id]), method: :patch, local: false,
                 class: 'suggested-picker__form' do |f| %>
@@ -7,60 +7,20 @@
     <div class="suggested-picker__header">
       <div class="suggested-picker__heading">
         <span class="suggested-picker__badge">Needs review</span>
-        <span class="suggested-picker__prompt">Which place is this?</span>
+        <span class="suggested-picker__prompt">Confirm this visit?</span>
       </div>
       <%= f.submit 'Confirm',
                    data: { testid: 'visit-confirm' },
                    class: 'suggested-picker__confirm' %>
     </div>
 
-    <ul class="suggested-picker__list" role="radiogroup"
-        aria-label="Candidate places for this visit">
-      <% visible.each_with_index do |place, idx| %>
-        <li>
-          <label class="suggested-picker__option">
-            <%= f.radio_button 'visit[place_id]', place[:id],
-                               checked: place[:id] == entry[:place_id] || (entry[:place_id].nil? && idx.zero?),
-                               class: 'suggested-picker__radio' %>
-            <span class="suggested-picker__option-name"><%= place[:name] %></span>
-          </label>
-        </li>
+    <p class="suggested-picker__note" data-testid="visit-no-alternatives">
+      <% if place_name %>
+        Assigned to <%= place_name %>. Use the search button to pick a different place.
+      <% else %>
+        No place for this visit. Confirm to keep it as is.
       <% end %>
-
-      <% if overflow.any? %>
-        <li class="suggested-picker__overflow">
-          <details>
-            <summary class="suggested-picker__more" data-testid="visit-show-more-candidates">
-              <span class="suggested-picker__more-caret" aria-hidden="true">▸</span>
-              <span class="suggested-picker__more-text--closed">
-                Show <%= overflow.size %> more
-              </span>
-              <span class="suggested-picker__more-text--open">
-                Hide <%= pluralize(overflow.size, 'place') %>
-              </span>
-            </summary>
-            <ul class="suggested-picker__list suggested-picker__list--overflow">
-              <% overflow.each do |place| %>
-                <li>
-                  <label class="suggested-picker__option">
-                    <%= f.radio_button 'visit[place_id]', place[:id],
-                                       checked: place[:id] == entry[:place_id],
-                                       class: 'suggested-picker__radio' %>
-                    <span class="suggested-picker__option-name"><%= place[:name] %></span>
-                  </label>
-                </li>
-              <% end %>
-            </ul>
-          </details>
-        </li>
-      <% end %>
-    </ul>
-
-    <% if visible.size <= 1 && overflow.empty? %>
-      <p class="suggested-picker__note" data-testid="visit-no-alternatives">
-        Not the right place? Use the search button on this visit to find and assign another one.
-      </p>
-    <% end %>
+    </p>
   <% end %>
 
   <%= button_to 'Delete', visit_path(entry[:visit_id]),

--- a/app/views/map/timeline_feeds/_visit_entry.html.erb
+++ b/app/views/map/timeline_feeds/_visit_entry.html.erb
@@ -87,33 +87,9 @@
 
   <%# Suggested picker spans the full row width (grid-column: 1 / -1) so it
       doesn't squeeze into the narrow content column. %>
-  <% if status == 'suggested' && entry[:suggested_places].present? %>
+  <% if status == 'suggested' %>
     <div class="visit-row__suggested">
       <%= render partial: 'map/timeline_feeds/suggested_picker', locals: { entry: entry } %>
-    </div>
-  <% elsif status == 'suggested' %>
-    <div class="visit-row__suggested">
-      <div class="suggested-picker" data-visit-id="<%= entry[:visit_id] %>">
-        <%= form_with url: visit_path(entry[:visit_id]), method: :patch, local: false,
-                      class: 'suggested-picker__form' do |f| %>
-          <%= f.hidden_field 'visit[status]', value: 'confirmed' %>
-          <div class="suggested-picker__header">
-            <div class="suggested-picker__heading">
-              <span class="suggested-picker__badge">Needs review</span>
-              <span class="suggested-picker__prompt">Confirm this visit?</span>
-            </div>
-            <%= f.submit 'Confirm', data: { testid: 'visit-confirm' }, class: 'suggested-picker__confirm' %>
-          </div>
-          <p class="suggested-picker__note" data-testid="visit-no-alternatives">
-            No place suggestions for this visit. Confirm to keep it as is.
-          </p>
-        <% end %>
-
-        <%= button_to 'Delete', visit_path(entry[:visit_id]),
-                      method: :delete,
-                      data: { testid: 'visit-delete', turbo_confirm: 'Delete this visit? Your location points stay.' },
-                      class: 'suggested-picker__decline' %>
-      </div>
     </div>
   <% end %>
 </li>

--- a/app/views/map/timeline_feeds/_visit_entry.html.erb
+++ b/app/views/map/timeline_feeds/_visit_entry.html.erb
@@ -91,5 +91,29 @@
     <div class="visit-row__suggested">
       <%= render partial: 'map/timeline_feeds/suggested_picker', locals: { entry: entry } %>
     </div>
+  <% elsif status == 'suggested' %>
+    <div class="visit-row__suggested">
+      <div class="suggested-picker" data-visit-id="<%= entry[:visit_id] %>">
+        <%= form_with url: visit_path(entry[:visit_id]), method: :patch, local: false,
+                      class: 'suggested-picker__form' do |f| %>
+          <%= f.hidden_field 'visit[status]', value: 'confirmed' %>
+          <div class="suggested-picker__header">
+            <div class="suggested-picker__heading">
+              <span class="suggested-picker__badge">Needs review</span>
+              <span class="suggested-picker__prompt">Confirm this visit?</span>
+            </div>
+            <%= f.submit 'Confirm', data: { testid: 'visit-confirm' }, class: 'suggested-picker__confirm' %>
+          </div>
+          <p class="suggested-picker__note" data-testid="visit-no-alternatives">
+            No place suggestions for this visit. Confirm to keep it as is.
+          </p>
+        <% end %>
+
+        <%= button_to 'Delete', visit_path(entry[:visit_id]),
+                      method: :delete,
+                      data: { testid: 'visit-delete', turbo_confirm: 'Delete this visit? Your location points stay.' },
+                      class: 'suggested-picker__decline' %>
+      </div>
+    </div>
   <% end %>
 </li>

--- a/spec/helpers/timeline_helper_spec.rb
+++ b/spec/helpers/timeline_helper_spec.rb
@@ -310,34 +310,4 @@ RSpec.describe TimelineHelper, type: :helper do
       expect(helper.calendar_cell_classes(high)).to include('cal-cell--light-text')
     end
   end
-
-  describe '#split_suggested_places' do
-    it 'returns empty overflow when list fits the default limit' do
-      places = Array.new(3) { |i| { id: i, name: "P#{i}" } }
-      visible, overflow = helper.split_suggested_places(places)
-      expect(visible).to eq(places)
-      expect(overflow).to eq([])
-    end
-
-    it 'splits a longer list into visible + overflow using the default limit' do
-      places = Array.new(6) { |i| { id: i, name: "P#{i}" } }
-      visible, overflow = helper.split_suggested_places(places)
-      expect(visible.size).to eq(TimelineHelper::SUGGESTED_PICKER_VISIBLE_LIMIT)
-      expect(overflow.size).to eq(6 - TimelineHelper::SUGGESTED_PICKER_VISIBLE_LIMIT)
-      expect(visible + overflow).to eq(places)
-    end
-
-    it 'respects a custom limit' do
-      places = Array.new(5) { |i| { id: i, name: "P#{i}" } }
-      visible, overflow = helper.split_suggested_places(places, limit: 2)
-      expect(visible.size).to eq(2)
-      expect(overflow.size).to eq(3)
-    end
-
-    it 'handles nil input' do
-      visible, overflow = helper.split_suggested_places(nil)
-      expect(visible).to eq([])
-      expect(overflow).to eq([])
-    end
-  end
 end

--- a/spec/requests/map/timeline_feeds_spec.rb
+++ b/spec/requests/map/timeline_feeds_spec.rb
@@ -97,6 +97,29 @@ RSpec.describe 'Map::TimelineFeeds', type: :request do
         end
       end
 
+      context 'with a suggested visit that has a place' do
+        let(:suggested_place) { create(:place, name: 'Cafe Central') }
+        let!(:placed_suggested) do
+          create(:visit,
+                 user: user,
+                 place: suggested_place,
+                 name: 'Cafe Central',
+                 status: :suggested,
+                 started_at: day + 11.hours,
+                 ended_at: day + 12.hours,
+                 duration: 3600)
+        end
+
+        it 'renders a single confirm control without a place radio picker' do
+          get map_timeline_feeds_path(start_at: day.iso8601, end_at: (day + 1.day).iso8601)
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include('data-testid="visit-confirm"')
+          expect(response.body).not_to include('name="visit[place_id]"')
+          expect(response.body).not_to include('suggested-picker__radio')
+        end
+      end
+
       context 'with a track that crosses midnight in the user timezone' do
         let(:user) { create(:user, settings: { 'timezone' => 'Europe/Berlin' }) }
         let(:day_b) { Date.new(2026, 4, 28) }

--- a/spec/requests/map/timeline_feeds_spec.rb
+++ b/spec/requests/map/timeline_feeds_spec.rb
@@ -77,6 +77,26 @@ RSpec.describe 'Map::TimelineFeeds', type: :request do
         end
       end
 
+      context 'with a suggested visit that has no place suggestions' do
+        let!(:bare_suggested) do
+          create(:visit,
+                 user: user,
+                 place: nil,
+                 name: 'Mystery Stop',
+                 status: :suggested,
+                 started_at: day + 9.hours,
+                 ended_at: day + 10.hours,
+                 duration: 3600)
+        end
+
+        it 'still renders a confirm control' do
+          get map_timeline_feeds_path(start_at: day.iso8601, end_at: (day + 1.day).iso8601)
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include('data-testid="visit-confirm"')
+        end
+      end
+
       context 'with a track that crosses midnight in the user timezone' do
         let(:user) { create(:user, settings: { 'timezone' => 'Europe/Berlin' }) }
         let(:day_b) { Date.new(2026, 4, 28) }


### PR DESCRIPTION
Suggested visits that have no place (area-based or placeless detections) previously rendered no Confirm button in the timeline feed and got stuck. They now show a Confirm/Delete control.

While fixing this, unify the two suggested-visit UIs into one. Detection only ever attaches a **single** place (`place_id`) now — the multi-candidate `place_visits`/`suggested_places` list is no longer produced by any detector (only demo seeding writes those join rows). So the multi-place radio picker was permanently a one-option picker. Both branches now render one `Confirm` / `Delete` picker; place reassignment stays on the existing search button.

Removes the now-dead `split_suggested_places` helper + `SUGGESTED_PICKER_VISIBLE_LIMIT`, the radio/overflow markup, and the corresponding CSS (net −261 lines).

Fixes #2917
