### PR TITLE
fix: prevent course_accuracy overflow from dropping point batches

### DIFF
--- a/app/services/points/params.rb
+++ b/app/services/points/params.rb
@@ -26,8 +26,8 @@ class Points::Params
         ssid:               point[:properties][:wifi],
         accuracy:           point[:properties][:horizontal_accuracy],
         vertical_accuracy:  point[:properties][:vertical_accuracy],
-        course_accuracy:    point[:properties][:course_accuracy],
-        course:             point[:properties][:course],
+        course_accuracy:    column_safe_decimal(point[:properties][:course_accuracy]),
+        course:             column_safe_decimal(point[:properties][:course]),
         motion_data:        Points::MotionDataExtractor.from_overland_properties(point[:properties]),
         raw_data:           point,
         user_id:            user_id
@@ -39,10 +39,21 @@ class Points::Params
 
   private
 
+  COURSE_COLUMN_LIMIT = 1000
+
   def battery_level(level)
     value = (level.to_f * 100).to_i
 
     value.positive? ? value : nil
+  end
+
+  def column_safe_decimal(value)
+    return nil if value.nil?
+
+    number = Float(value, exception: false)
+    return nil if number.nil? || !number.finite? || number.abs >= COURSE_COLUMN_LIMIT
+
+    value
   end
 
   def params_valid?(point)

--- a/spec/services/points/create_spec.rb
+++ b/spec/services/points/create_spec.rb
@@ -455,5 +455,49 @@ RSpec.describe Points::Create do
         expect(time_obj).to be_within(1.second).of(expected_time)
       end
     end
+
+    describe 'out-of-range course_accuracy from a near-stationary iOS fix' do
+      let(:user) { create(:user) }
+      let(:batch_params) do
+        {
+          locations: [
+            {
+              type: 'Feature',
+              geometry: { type: 'Point', coordinates: [7.300162333022016, 51.40863363359207] },
+              properties: {
+                timestamp: '2026-01-04T14:32:36.999Z',
+                speed: 0.01308945239267841,
+                course: 4.801180790801141,
+                course_accuracy: 1731.726995484005
+              }
+            },
+            {
+              type: 'Feature',
+              geometry: { type: 'Point', coordinates: [7.299433856659638, 51.40862237973182] },
+              properties: {
+                timestamp: '2026-01-04T14:36:40.999Z',
+                speed: 1.003747182282529,
+                course: 266.37909882602,
+                course_accuracy: 32.15991578317691
+              }
+            }
+          ]
+        }
+      end
+
+      it 'persists the whole batch instead of failing on the overflowing point' do
+        expect { described_class.new(user, batch_params).call }
+          .to change(user.points, :count).by(2)
+      end
+
+      it 'drops the overflowing course_accuracy and keeps the valid one' do
+        described_class.new(user, batch_params).call
+
+        accuracies = user.points.order(:timestamp).pluck(:course_accuracy)
+
+        expect(accuracies.first).to be_nil
+        expect(accuracies.last).to be_within(0.00001).of(32.15992)
+      end
+    end
   end
 end

--- a/spec/services/points/params_spec.rb
+++ b/spec/services/points/params_spec.rb
@@ -66,4 +66,43 @@ RSpec.describe Points::Params do
       expect(params.first).to eq(expected_json)
     end
   end
+
+  describe 'course sanitization' do
+    let(:user) { create(:user) }
+
+    def build_payload(course:, course_accuracy: 0)
+      {
+        locations: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [13.404954, 52.520008] },
+            properties: {
+              timestamp: '2026-06-13T09:03:57Z',
+              course: course,
+              course_accuracy: course_accuracy
+            }
+          }
+        ]
+      }
+    end
+
+    it 'nils out course whose absolute value exceeds the numeric(8,5) limit' do
+      result = described_class.new(build_payload(course: 1000.0), user.id).call
+
+      expect(result.first[:course]).to be_nil
+    end
+
+    it 'nils out course_accuracy whose absolute value exceeds the numeric(8,5) limit' do
+      result = described_class.new(build_payload(course: 27.07, course_accuracy: 9999.0), user.id).call
+
+      expect(result.first[:course_accuracy]).to be_nil
+    end
+
+    it 'keeps valid course and course_accuracy values' do
+      result = described_class.new(build_payload(course: 359.99, course_accuracy: 12.5), user.id).call
+
+      expect(result.first[:course]).to eq(359.99)
+      expect(result.first[:course_accuracy]).to eq(12.5)
+    end
+  end
 end


### PR DESCRIPTION
## Problem

`POST /api/v1/points` was returning **500** and **discarding the entire batch of points** for some iOS uploads. GlitchTip DAWARICH-10:

```
ActiveRecord::RangeError: PG::NumericValueOutOfRange — numeric field overflow
A field with precision 8, scale 5 must round to an absolute value less than 10^3
```

## Root cause

`course` and `course_accuracy` are `numeric(8,5)` columns (max abs value < 1000) and were passed straight from the client in `Points::Params` with no validation. A near-stationary iOS fix reports a very large `CLLocationDirectionAccuracy` — a real payload contained `course_accuracy: 1731.726995484005` (with `speed: 0.013`). Because `Points::Create` inserts a whole batch via a single `upsert_all`, that one out-of-range field raised `ActiveRecord::RangeError` and **every point in the request was lost**.

## Fix

`Points::Params` now routes `course` and `course_accuracy` through a `column_safe_decimal` guard: values that are non-numeric, non-finite, or whose absolute value reaches the column limit are stored as `nil`. Valid values pass through unchanged, so the point still persists — just without the unreliable bearing/accuracy — and the rest of the batch is no longer dropped.

## Tests

- `Points::Params` — out-of-range `course`/`course_accuracy` sanitize to `nil`; valid values preserved.
- `Points::Create` — regression test using the **actual production payload values**: a 2-point batch where one point carries `course_accuracy: 1731.7` now persists both points, with the overflowing accuracy nulled and the valid neighbor kept.

29 examples, 0 failures. RuboCop clean.