### PR TITLE
fix: serialize places without lonlat geometry

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -32,11 +32,11 @@ class Place < ApplicationRecord
   }
 
   def lon
-    lonlat.x
+    lonlat&.x || longitude
   end
 
   def lat
-    lonlat.y
+    lonlat&.y || latitude
   end
 
   def osm_id

--- a/spec/requests/api/v1/places_spec.rb
+++ b/spec/requests/api/v1/places_spec.rb
@@ -18,6 +18,25 @@ RSpec.describe 'Api::V1::Places', type: :request do
       expect(json.first['name']).to eq('Home')
     end
 
+    it 'serializes legacy places without lonlat geometry' do
+      legacy_place = create(
+        :place,
+        :without_lonlat,
+        user: user,
+        name: 'Legacy Import Place',
+        latitude: 52.52,
+        longitude: 13.405
+      )
+
+      get '/api/v1/places', params: { filter: 'all' }, headers: headers
+
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      serialized = json.find { |place_json| place_json['id'] == legacy_place.id }
+      expect(serialized['latitude'].to_f).to eq(52.52)
+      expect(serialized['longitude'].to_f).to eq(13.405)
+    end
+
     it 'filters by tag_ids' do
       tagged_place = create(:place, user: user)
       create(:tagging, taggable: tagged_place, tag: tag)


### PR DESCRIPTION
## Summary
- Fall back to stored latitude/longitude when a legacy place row has no lonlat geometry.
- Add a request spec covering the `/api/v1/places` serialization path for that legacy shape.

Fixes #2734.

## Verification
- `git diff --check upstream/dev...HEAD`
- Rebased onto current `dev` on 2026-06-21.

`bundle exec rspec spec/requests/api/v1/places_spec.rb` could not run locally because this machine only has macOS system Ruby 2.6.10, while the repo requires Ruby 3.4.6 / Bundler 2.5.21.
