### PR TITLE
fix: remove selective inline margin on navbar dropdown

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -88,8 +88,8 @@
         <details>
           <summary>My data</summary>
           <ul class="p-2 bg-base-100 rounded-box shadow-md z-[50]">
-            <li><%= link_to 'Points', points_url, class: "mx-1 #{active_class?(points_url)}" %></li>
-            <li><%= link_to 'Places', places_url, class: "mx-1 #{active_class?(places_url)}" %></li>
+            <li><%= link_to 'Points', points_url, class: "#{active_class?(points_url)}" %></li>
+            <li><%= link_to 'Places', places_url, class: "#{active_class?(places_url)}" %></li>
             <li><%= link_to 'Imports', imports_url, class: "#{active_class?(imports_url)}" %></li>
             <li><%= link_to 'Exports', exports_url, class: "#{active_class?(exports_url)}" %></li>
             <li><%= link_to 'Tags', tags_url, class: "#{active_class?(tags_url)}" %></li>


### PR DESCRIPTION
Just a tiny fix to align the items in the dropdown.

Before:
<img width="206" height="400" alt="Screenshot 2026-06-13 at 5  20 48" src="https://github.com/user-attachments/assets/5f0a5ef5-cbdf-41b6-9ea4-bc91f854a699" />

After:
<img width="214" height="380" alt="Screenshot 2026-06-13 at 5  20 27" src="https://github.com/user-attachments/assets/9bb09063-59b8-47f8-a205-1eded940086f" />
