### PR TITLE
fix: declare changelog_consent attribute type so migrations load User

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,6 +59,7 @@ class User < ApplicationRecord
   enum :plan, { lite: 0, pro: 1 }, default: :pro
   # No default: nil means the user has not yet been prompted about the
   # changelog widget. prefix avoids `granted?`/`declined?` collisions.
+  attribute :changelog_consent, :integer
   enum :changelog_consent, { declined: 0, granted: 1 }, prefix: :changelog_consent
 
   MAX_FAILED_OTP_ATTEMPTS = 10

--- a/spec/regressions/changelog_consent_migration_order_spec.rb
+++ b/spec/regressions/changelog_consent_migration_order_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260508193900_dedupe_tracks_for_unique_index')
+
+RSpec.describe DedupeTracksForUniqueIndex do
+  let(:start_at) { Time.zone.parse('2026-04-01 10:00:00') }
+  let(:end_at) { Time.zone.parse('2026-04-01 10:30:00') }
+
+  def without_changelog_consent_column
+    connection = ActiveRecord::Base.connection
+    connection.remove_column(:users, :changelog_consent)
+    User.reset_column_information
+    yield
+  ensure
+    connection.add_column(:users, :changelog_consent, :integer, if_not_exists: true)
+    User.reset_column_information
+  end
+
+  def make_track(user)
+    Track.create!(
+      user_id: user.id,
+      start_at: start_at,
+      end_at: end_at,
+      original_path: 'LINESTRING(13.4 52.5, 13.41 52.51)',
+      distance: 100,
+      duration: (end_at - start_at).to_i,
+      avg_speed: 10
+    )
+  end
+
+  it 'loads the User model when the changelog_consent column is absent' do
+    without_changelog_consent_column do
+      expect { User.new }.not_to raise_error
+    end
+  end
+
+  it 'dedupes tracks when the changelog_consent column is absent' do
+    user = create(:user)
+    ActiveRecord::Base.connection.execute('DROP INDEX IF EXISTS index_tracks_on_user_start_end_unique')
+    ActiveRecord::Base.connection.execute('DROP INDEX IF EXISTS index_tracks_on_user_tracker_start_end_unique')
+    2.times { make_track(user) }
+
+    without_changelog_consent_column do
+      expect { described_class.new.up }.not_to raise_error
+    end
+
+    expect(user.tracks.count).to eq(1)
+  end
+end


### PR DESCRIPTION
## Problem

Upgrading **1.7.x → 1.8.1** fails during `db:migrate` with:

```
Undeclared attribute type for enum 'changelog_consent' in User.
Enums must be backed by a database column or declared with an explicit type via `attribute`.
```

(Reported via a user upgrade log.)

## Root cause

Two pending migrations run in timestamp order:

1. `20260508193900_dedupe_tracks_for_unique_index` (May 8) — runs `DedupeTracksForUniqueIndexJob`, which calls `User.find_by(...)`
2. `20260602125716_add_changelog_consent_to_users` (June 2) — adds the `changelog_consent` column

On a fresh jump from 1.7.x, both are pending and the **May** dedupe migration boots the current `User` model — which declares `enum :changelog_consent` — while the backing column is not added until the **June** migration. ActiveRecord 8.0 hard-fails on an enum with no column. (Instances that passed through an intermediate 1.8.0 escaped it, because the dedupe ran before the enum existed in the model.)

## Fix

Declare an explicit attribute type before the enum in `app/models/user.rb`:

```ruby
attribute :changelog_consent, :integer
enum :changelog_consent, { declined: 0, granted: 1 }, prefix: :changelog_consent
```

This keeps the enum valid when the column isn't present yet (during the earlier data migration); once the column exists the declaration is a no-op, so runtime behaviour is unchanged. No migration timestamps are touched.

## Tests

Added `spec/regressions/changelog_consent_migration_order_spec.rb`, which drops the `changelog_consent` column to simulate the mid-migration state and asserts both that `User` loads and that the dedupe migration dedupes tracks without raising. Verified RED→GREEN: both examples fail with the production error before the fix and pass after. Existing `user_spec`, `changelog_helper_spec`, and `dedupe_tracks_migration_spec` remain green.