### PR TITLE
fix: unify Google OAuth identity across web/mobile + connected-provider indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Upgrade notes:
 - Users signed in via Google will now be able to sign in with new password after setting it up, instead of being locked out by the old password being ignored.
 - Suggested visits now always show a Confirm and Delete control, including visits with no matched place — which previously rendered no action and got stuck with no way to confirm or remove them. #2917
 - Searching for a place by name now also matches your areas by name, so an area outside the nearby radius shows up in the results instead of being hidden. #2918
+- Signing in with Google resolves to a single account across web and mobile, and the account settings page shows which provider an OAuth account is connected with instead of offering a sign-in button. #2969
 
 ## [1.8.1] - 2026-06-11
 

--- a/app/controllers/api/v1/auth/google_controller.rb
+++ b/app/controllers/api/v1/auth/google_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::V1::Auth::GoogleController < Api::V1::Auth::BaseController
-  PROVIDER = 'google'
+  PROVIDER = 'google_oauth2'
   PROVIDER_LABEL = 'Google'
 
   def create

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -117,9 +117,7 @@ module ApplicationHelper
     case provider.to_s
     when 'google_oauth2', 'google' then 'Google'
     when 'apple' then 'Apple'
-    when 'github' then 'GitHub'
-    when 'openid_connect' then (defined?(OIDC_PROVIDER_NAME) ? OIDC_PROVIDER_NAME : 'OpenID Connect')
-    else oauth_provider_name(provider)
+    else oauth_provider_name(provider.to_sym)
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -115,7 +115,7 @@ module ApplicationHelper
 
   def oauth_provider_display_name(provider)
     case provider.to_s
-    when 'google_oauth2', 'google' then 'Google'
+    when 'google_oauth2' then 'Google'
     when 'apple' then 'Apple'
     else oauth_provider_name(provider.to_sym)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -113,6 +113,16 @@ module ApplicationHelper
     OmniAuth::Utils.camelize(provider)
   end
 
+  def oauth_provider_display_name(provider)
+    case provider.to_s
+    when 'google_oauth2', 'google' then 'Google'
+    when 'apple' then 'Apple'
+    when 'github' then 'GitHub'
+    when 'openid_connect' then (defined?(OIDC_PROVIDER_NAME) ? OIDC_PROVIDER_NAME : 'OpenID Connect')
+    else oauth_provider_name(provider)
+    end
+  end
+
   OAUTH_PROVIDERS = {
     google_oauth2: {
       icon_name: 'google',

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -15,6 +15,12 @@
               <p class="mt-1 text-sm text-base-content/70">Update your email address and password from one place.</p>
             </div>
 
+            <% if current_user.oauth_user? %>
+              <div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-sm font-medium">
+                Connected with <%= oauth_provider_display_name(current_user.provider) %>
+              </div>
+            <% end %>
+
             <%= form_for(resource, as: resource_name, url: registration_path(resource_name), class: 'form-body', method: :put, data: { turbo_method: :put, turbo: false }) do |f| %>
               <%= render "devise/shared/error_messages", resource: resource %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -29,7 +29,7 @@
     </div>
   <% end %>
 
-  <% if devise_mapping.omniauthable? %>
+  <% if devise_mapping.omniauthable? && !signed_in? %>
     <% visible_omniauth_providers.each do |provider| %>
       <% config = oauth_button_config(provider) %>
       <div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -356,6 +356,34 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe '#oauth_provider_display_name' do
+    it 'maps google_oauth2 to Google' do
+      expect(helper.oauth_provider_display_name('google_oauth2')).to eq('Google')
+    end
+
+    it 'maps the legacy google value to Google' do
+      expect(helper.oauth_provider_display_name('google')).to eq('Google')
+    end
+
+    it 'maps apple to Apple' do
+      expect(helper.oauth_provider_display_name('apple')).to eq('Apple')
+    end
+
+    it 'maps github to GitHub' do
+      expect(helper.oauth_provider_display_name('github')).to eq('GitHub')
+    end
+
+    it 'maps openid_connect to the configured OIDC provider name' do
+      stub_const('OIDC_PROVIDER_NAME', 'Authentik')
+
+      expect(helper.oauth_provider_display_name('openid_connect')).to eq('Authentik')
+    end
+
+    it 'falls back to a humanized name for unknown providers' do
+      expect(helper.oauth_provider_display_name('gitlab')).to eq('Gitlab')
+    end
+  end
+
   describe '#email_password_registration_enabled?' do
     context 'in cloud mode' do
       before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -691,6 +691,24 @@ subscription_source: :none)
         expect(user.email).to eq(email)
         expect(user.persisted?).to be true
       end
+
+      context 'when the same Google account was first registered via the mobile app' do
+        let!(:mobile_user) do
+          create(:user,
+                 email: email,
+                 provider: Api::V1::Auth::GoogleController::PROVIDER,
+                 uid: '123545')
+        end
+
+        it 'signs in the existing user by identity without prompting to link' do
+          user = nil
+          expect do
+            user = described_class.from_omniauth(auth_hash)
+          end.not_to change(User, :count)
+
+          expect(user).to eq(mobile_user)
+        end
+      end
     end
 
     context 'when email is blank or nil' do

--- a/spec/requests/api/v1/auth/google_spec.rb
+++ b/spec/requests/api/v1/auth/google_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'POST /api/v1/auth/google', type: :request do
       )
     end
 
-    it 'creates a new user in pending_payment with provider google and uid' do
+    it 'creates a new user in pending_payment with provider google_oauth2 and uid' do
       expect do
         post '/api/v1/auth/google', params: { id_token: 'fake_token' }
       end.to change(User, :count).by(1)
@@ -27,7 +27,7 @@ RSpec.describe 'POST /api/v1/auth/google', type: :request do
       user = User.find_by(email: 'google@example.com')
       expect(user.status).to eq('pending_payment')
       expect(user.subscription_source).to eq('none')
-      expect(user.provider).to eq('google')
+      expect(user.provider).to eq('google_oauth2')
       expect(user.uid).to eq('google-uid-123')
     end
 
@@ -39,7 +39,7 @@ RSpec.describe 'POST /api/v1/auth/google', type: :request do
   end
 
   context 'returning Google user' do
-    let!(:existing) { create(:user, email: 'google@example.com', provider: 'google', uid: 'google-uid-123') }
+    let!(:existing) { create(:user, email: 'google@example.com', provider: 'google_oauth2', uid: 'google-uid-123') }
 
     before do
       allow(verifier_double).to receive(:call).and_return(

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -900,4 +900,59 @@ RSpec.describe 'Users::Registrations', type: :request do
       end
     end
   end
+
+  describe 'GET /users/edit (account settings)' do
+    context 'when signed in as a Google OAuth user' do
+      let(:oauth_user) { create(:user, provider: 'google_oauth2', uid: '777', password: SecureRandom.hex(16)) }
+
+      # Providers stubbed so the shared partial would render the sign-in buttons
+      # for an unguarded (signed-in) user; the buttons must be hidden instead.
+      before do
+        allow(User).to receive(:omniauth_providers).and_return([:google_oauth2])
+        sign_in oauth_user
+      end
+
+      it 'renders without the "Sign in with Google" button' do
+        get edit_user_registration_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include('Sign in with Google')
+      end
+
+      it 'shows that the account is connected with Google' do
+        get edit_user_registration_path
+
+        expect(response.body).to include('Connected with Google')
+      end
+    end
+
+    context 'when signed in as an Apple OAuth user' do
+      let(:oauth_user) { create(:user, provider: 'apple', uid: '000.apple', password: SecureRandom.hex(16)) }
+
+      before { sign_in oauth_user }
+
+      it 'shows that the account is connected with Apple' do
+        get edit_user_registration_path
+
+        expect(response.body).to include('Connected with Apple')
+      end
+    end
+
+    context 'when signed in as an email/password user' do
+      let(:password_user) { create(:user, provider: nil, uid: nil) }
+
+      before do
+        allow(User).to receive(:omniauth_providers).and_return([:google_oauth2])
+        sign_in password_user
+      end
+
+      it 'renders without an OAuth sign-in button or a connected indicator' do
+        get edit_user_registration_path
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include('Sign in with Google')
+        expect(response.body).not_to include('Connected with')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Two related auth fixes around Google/OAuth sign-in.

### 1. Google account splits into two identities across platforms
The mobile Google endpoint (`Api::V1::Auth::GoogleController`) stored `provider='google'`, while the web OmniAuth flow stores `'google_oauth2'`. Identity is resolved by `(provider, uid)`, and the `uid` (Google's `sub`) is identical across platforms — so a user who registered with Google in the mobile app and later signed in with Google on the web missed the identity lookup, fell through to the email-collision path, and was prompted to "link" an account they already own.

Fix: normalize the mobile provider to the OmniAuth-canonical `google_oauth2` so a Google account resolves to a single user across platforms. Mobile Google auth is unreleased, so there are no `provider='google'` rows — no data backfill is needed. Apple already uses `'apple'` on both sides and is unaffected.

### 2. Account settings offered "Sign in with Google" to a signed-in user
The shared `devise/shared/_links.html.erb` partial rendered the OAuth sign-in buttons with no `signed_in?` guard, so an OAuth user saw a "Sign in with Google" button on their own settings page with no indication the account was already linked.

Fix: guard the omniauth buttons block with `!signed_in?` (covers Google, Apple, GitHub, OIDC), and render a "Connected with {provider}" indicator on the settings page for OAuth users.

## Changes
- `app/controllers/api/v1/auth/google_controller.rb` — `PROVIDER` `'google'` → `'google_oauth2'`
- `app/views/devise/shared/_links.html.erb` — guard OAuth buttons with `!signed_in?`
- `app/helpers/application_helper.rb` — add `oauth_provider_display_name`
- `app/views/devise/registrations/edit.html.erb` — render connected-provider indicator
- specs: cross-platform identity regression (`user_spec`), provider expectations (`google_spec`), settings guard + indicator (`registrations_spec`)

## Testing
- `RAILS_ENV=test bundle exec rspec spec/requests/api/v1/auth/google_spec.rb spec/models/user_spec.rb spec/requests/users/registrations_spec.rb spec/services/auth/find_or_create_oauth_user_spec.rb` — green (0 failures)
- Manually simulated mobile-create → web-lookup in a rolled-back console transaction: same user resolved, no link prompt.

## Follow-up
At mobile QA, confirm the app sends Google's `sub` as `uid` (matching web OmniAuth's `access_token.uid`) — the load-bearing assumption for cross-platform matching.
