### PR TITLE
feat: surface stay_max_gap_minutes in map settings panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Upgrade notes:
 
 ### Added
 
+- Map v2 settings panel: a **Visit Max Gap** slider to tune the stay-point visit detector's maximum gap (minutes) between points within a single visit. Shown only when stay-point detection is enabled.
 - Fog of War (Map v2) can now reveal explored areas per hexagon instead of per point, using precalculated monthly statistics. Switch between "Per point" and "Per hexagon" in the map settings panel. (#2899)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Upgrade notes:
 
 ### Added
 
-- Map v2 settings panel: a **Visit Max Gap** slider to tune the stay-point visit detector's maximum gap (minutes) between points within a single visit. Shown only when stay-point detection is enabled.
+- Map v2 settings panel: a **Visit Max Gap** slider to tune the stay-point visit detector's maximum gap (minutes) between points within a single visit. Only shown when the `stay_point_detection` feature flag is enabled (off by default).
 - Fog of War (Map v2) can now reveal explored areas per hexagon instead of per point, using precalculated monthly statistics. Switch between "Per point" and "Per hexagon" in the map settings panel. (#2899)
 
 ### Changed

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -61,6 +61,7 @@ class Api::V1::SettingsController < ApiController
       :maps_v2_style, :maps_maplibre_style, :globe_projection,
       :transportation_expert_mode,
       :min_minutes_spent_in_city, :max_gap_minutes_in_city,
+      :stay_max_gap_minutes,
       :gps_filtering_enabled, :gps_accuracy_threshold,
       enabled_map_layers: [],
       enabled_transportation_modes: [],

--- a/app/javascript/controllers/maps/maplibre/settings_manager.js
+++ b/app/javascript/controllers/maps/maplibre/settings_manager.js
@@ -1173,9 +1173,15 @@ export class SettingsController {
         10,
       ),
       maxGapMinutesInCity: parseInt(formData.get("maxGapMinutesInCity"), 10),
-      stayMaxGapMinutes: parseInt(formData.get("stayMaxGapMinutes"), 10),
       gpsFilteringEnabled: formData.get("gpsFilteringEnabled") === "on",
       gpsAccuracyThreshold: parseInt(formData.get("gpsAccuracyThreshold"), 10),
+    }
+
+    if (formData.has("stayMaxGapMinutes")) {
+      settings.stayMaxGapMinutes = parseInt(
+        formData.get("stayMaxGapMinutes"),
+        10,
+      )
     }
 
     // Collect transportation thresholds if present (convert from display units to metric)

--- a/app/javascript/controllers/maps/maplibre/settings_manager.js
+++ b/app/javascript/controllers/maps/maplibre/settings_manager.js
@@ -215,6 +215,17 @@ export class SettingsController {
       }
     }
 
+    // Sync visit detection settings
+    const stayMaxGapInput = controller.element.querySelector(
+      'input[name="stayMaxGapMinutes"]',
+    )
+    if (stayMaxGapInput) {
+      stayMaxGapInput.value = this.settings.stayMaxGapMinutes || 60
+      if (controller.hasStayMaxGapMinutesValueTarget) {
+        controller.stayMaxGapMinutesValueTarget.textContent = `${stayMaxGapInput.value} min`
+      }
+    }
+
     // Sync GPS noise filtering settings
     const gpsFilteringToggle = controller.element.querySelector(
       'input[name="gpsFilteringEnabled"]',
@@ -1162,6 +1173,7 @@ export class SettingsController {
         10,
       ),
       maxGapMinutesInCity: parseInt(formData.get("maxGapMinutesInCity"), 10),
+      stayMaxGapMinutes: parseInt(formData.get("stayMaxGapMinutes"), 10),
       gpsFilteringEnabled: formData.get("gpsFilteringEnabled") === "on",
       gpsAccuracyThreshold: parseInt(formData.get("gpsAccuracyThreshold"), 10),
     }
@@ -1343,6 +1355,12 @@ export class SettingsController {
   updateMaxGapMinutesDisplay(event) {
     if (this.controller.hasMaxGapMinutesValueTarget) {
       this.controller.maxGapMinutesValueTarget.textContent = `${event.target.value} min`
+    }
+  }
+
+  updateStayMaxGapMinutesDisplay(event) {
+    if (this.controller.hasStayMaxGapMinutesValueTarget) {
+      this.controller.stayMaxGapMinutesValueTarget.textContent = `${event.target.value} min`
     }
   }
 

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -51,6 +51,7 @@ export default class extends Controller {
     "minutesBetweenValue",
     "minMinutesInCityValue",
     "maxGapMinutesValue",
+    "stayMaxGapMinutesValue",
     "gpsAccuracyThresholdValue",
     "gpsFilteringToggle",
     // Search
@@ -1199,6 +1200,9 @@ export default class extends Controller {
   }
   updateMaxGapMinutesDisplay(event) {
     return this.settingsController.updateMaxGapMinutesDisplay(event)
+  }
+  updateStayMaxGapMinutesDisplay(event) {
+    return this.settingsController.updateStayMaxGapMinutesDisplay(event)
   }
   updateGpsAccuracyThresholdDisplay(event) {
     return this.settingsController.updateGpsAccuracyThresholdDisplay(event)

--- a/app/javascript/maps_maplibre/utils/settings_manager.js
+++ b/app/javascript/maps_maplibre/utils/settings_manager.js
@@ -18,6 +18,7 @@ const DEFAULT_SETTINGS = {
   globeProjection: false,
   minMinutesSpentInCity: 60,
   maxGapMinutesInCity: 120,
+  stayMaxGapMinutes: 60,
   gpsFilteringEnabled: true,
   gpsAccuracyThreshold: 100,
   transportationExpertMode: false,
@@ -83,6 +84,7 @@ const BACKEND_SETTINGS_MAP = {
   globeProjection: "globe_projection",
   minMinutesSpentInCity: "min_minutes_spent_in_city",
   maxGapMinutesInCity: "max_gap_minutes_in_city",
+  stayMaxGapMinutes: "stay_max_gap_minutes",
   gpsFilteringEnabled: "gps_filtering_enabled",
   gpsAccuracyThreshold: "gps_accuracy_threshold",
   transportationExpertMode: "transportation_expert_mode",
@@ -279,6 +281,11 @@ export class SettingsManager {
                 value,
                 DEFAULT_SETTINGS.maxGapMinutesInCity,
               )
+            } else if (frontendKey === "stayMaxGapMinutes") {
+              value = SettingsManager._parseIntOr(
+                value,
+                DEFAULT_SETTINGS.stayMaxGapMinutes,
+              )
             } else if (frontendKey === "gpsAccuracyThreshold") {
               value = SettingsManager._parseIntOr(
                 value,
@@ -382,7 +389,8 @@ export class SettingsManager {
               frontendKey === "metersBetweenRoutes" ||
               frontendKey === "minutesBetweenRoutes" ||
               frontendKey === "minMinutesSpentInCity" ||
-              frontendKey === "maxGapMinutesInCity"
+              frontendKey === "maxGapMinutesInCity" ||
+              frontendKey === "stayMaxGapMinutes"
             ) {
               value = parseInt(value, 10).toString()
             } else if (frontendKey === "speedColoredRoutes") {

--- a/app/views/map/maplibre/_settings_panel.html.erb
+++ b/app/views/map/maplibre/_settings_panel.html.erb
@@ -628,29 +628,31 @@
             <p class="text-xs text-base-content/60 mt-1">Max gap between points before assuming you left the city</p>
           </div>
 
-          <div class="divider"></div>
+          <% if Flipper.enabled?(:stay_point_detection, current_user) %>
+            <div class="divider"></div>
 
-          <!-- Visit Detection Settings -->
-          <div class="form-control w-full">
-            <label class="label">
-              <span class="label-text font-medium">Visit Max Gap</span>
-              <span class="label-text-alt" data-maps--maplibre-target="stayMaxGapMinutesValue">60 min</span>
-            </label>
-            <input type="range"
-                   name="stayMaxGapMinutes"
-                   min="5"
-                   max="720"
-                   step="5"
-                   value="60"
-                   class="range range-sm"
-                   data-action="input->maps--maplibre#updateStayMaxGapMinutesDisplay" />
-            <div class="w-full flex justify-between text-xs px-2 mt-1">
-              <span>5min</span>
-              <span>360min</span>
-              <span>720min</span>
+            <!-- Visit Detection Settings -->
+            <div class="form-control w-full">
+              <label class="label">
+                <span class="label-text font-medium">Visit Max Gap</span>
+                <span class="label-text-alt" data-maps--maplibre-target="stayMaxGapMinutesValue">60 min</span>
+              </label>
+              <input type="range"
+                     name="stayMaxGapMinutes"
+                     min="5"
+                     max="720"
+                     step="5"
+                     value="60"
+                     class="range range-sm"
+                     data-action="input->maps--maplibre#updateStayMaxGapMinutesDisplay" />
+              <div class="w-full flex justify-between text-xs px-2 mt-1">
+                <span>5min</span>
+                <span>360min</span>
+                <span>720min</span>
+              </div>
+              <p class="text-xs text-base-content/60 mt-1">Max time gap between points within one visit. Longer gaps (e.g. dead battery) split it into separate visits. Default 60.</p>
             </div>
-            <p class="text-xs text-base-content/60 mt-1">Max time gap between points within one visit. Longer gaps (e.g. dead battery) split it into separate visits. Default 60.</p>
-          </div>
+          <% end %>
 
           <div class="divider"></div>
 

--- a/app/views/map/maplibre/_settings_panel.html.erb
+++ b/app/views/map/maplibre/_settings_panel.html.erb
@@ -630,6 +630,30 @@
 
           <div class="divider"></div>
 
+          <!-- Visit Detection Settings -->
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text font-medium">Visit Max Gap</span>
+              <span class="label-text-alt" data-maps--maplibre-target="stayMaxGapMinutesValue">60 min</span>
+            </label>
+            <input type="range"
+                   name="stayMaxGapMinutes"
+                   min="5"
+                   max="720"
+                   step="5"
+                   value="60"
+                   class="range range-sm"
+                   data-action="input->maps--maplibre#updateStayMaxGapMinutesDisplay" />
+            <div class="w-full flex justify-between text-xs px-2 mt-1">
+              <span>5min</span>
+              <span>360min</span>
+              <span>720min</span>
+            </div>
+            <p class="text-xs text-base-content/60 mt-1">Max time gap between points within one visit. Longer gaps (e.g. dead battery) split it into separate visits. Default 60.</p>
+          </div>
+
+          <div class="divider"></div>
+
           <!-- Points Rendering Mode -->
           <div class="form-control w-full">
             <label class="label">

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -91,6 +91,18 @@ RSpec.describe 'Api::V1::Settings', type: :request do
         expect(response.parsed_body['settings']['stay_max_gap_minutes']).to eq(90)
       end
 
+      it 'clamps stay_max_gap_minutes above the maximum on read' do
+        patch "/api/v1/settings?api_key=#{api_key}", params: { settings: { stay_max_gap_minutes: 1000 } }
+
+        expect(response.parsed_body['settings']['stay_max_gap_minutes']).to eq(720)
+      end
+
+      it 'clamps stay_max_gap_minutes below the minimum on read' do
+        patch "/api/v1/settings?api_key=#{api_key}", params: { settings: { stay_max_gap_minutes: 1 } }
+
+        expect(response.parsed_body['settings']['stay_max_gap_minutes']).to eq(5)
+      end
+
       context 'when user is inactive' do
         before do
           user.update(status: :inactive, active_until: 1.day.ago)

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -103,6 +103,13 @@ RSpec.describe 'Api::V1::Settings', type: :request do
         expect(response.parsed_body['settings']['stay_max_gap_minutes']).to eq(5)
       end
 
+      it 'preserves stay_max_gap_minutes when a patch omits it' do
+        patch "/api/v1/settings?api_key=#{api_key}", params: { settings: { stay_max_gap_minutes: 90 } }
+        patch "/api/v1/settings?api_key=#{api_key}", params: { settings: { route_opacity: 0.3 } }
+
+        expect(user.reload.safe_settings.stay_max_gap_minutes).to eq(90)
+      end
+
       context 'when user is inactive' do
         before do
           user.update(status: :inactive, active_until: 1.day.ago)

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -78,6 +78,19 @@ RSpec.describe 'Api::V1::Settings', type: :request do
         expect(user.reload.safe_settings.fog_of_war_mode).to eq('points')
       end
 
+      it 'updates stay_max_gap_minutes' do
+        patch "/api/v1/settings?api_key=#{api_key}", params: { settings: { stay_max_gap_minutes: 90 } }
+
+        expect(response).to have_http_status(:success)
+        expect(user.reload.safe_settings.stay_max_gap_minutes).to eq(90)
+      end
+
+      it 'returns updated stay_max_gap_minutes in response' do
+        patch "/api/v1/settings?api_key=#{api_key}", params: { settings: { stay_max_gap_minutes: 90 } }
+
+        expect(response.parsed_body['settings']['stay_max_gap_minutes']).to eq(90)
+      end
+
       context 'when user is inactive' do
         before do
           user.update(status: :inactive, active_until: 1.day.ago)


### PR DESCRIPTION
## What

Adds a **Visit Max Gap** slider to the Map v2 settings panel so users can tune the stay-point detector's max gap (minutes) between consecutive points within a single visit.

The setting already existed in `Users::SafeSettings` (default `60`, clamped `5..720`) and is consumed by `Visits::StayPointDetector`, but it was **not editable from the UI** and **not permitted** by the settings API — so it was stuck at its default for everyone.

## Changes

- **API:** permit `:stay_max_gap_minutes` in `Api::V1::SettingsController` (persisted generically by `Users::TransportationThresholdsUpdater`).
- **View:** new range slider (5–720 min, step 5, default 60) in the Settings tab of `app/views/map/maplibre/_settings_panel.html.erb`, under City Statistics.
- **JS:** register the `stayMaxGapMinutesValue` target + `updateStayMaxGapMinutesDisplay` proxy; populate on load, collect on submit, live value display; camelCase↔snake_case mapping and load/save coercion in `SettingsManager`.

## Tests

- Request specs in `spec/requests/api/v1/settings_spec.rb` (TDD: RED → GREEN) covering persistence and the response payload.
- Full settings spec: 22 examples, 0 failures. RuboCop clean. Biome clean (only the project's accepted `noStaticOnlyClass` warning). ERB compiles.

## Notes

- Branched off `master` per request; retarget to `dev` if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a “Visit Detection Settings” block to Advanced Settings (enabled only when visit detection is available), including a **Visit Max Gap** slider (minutes) to control the maximum gap between points within a single visit.
  * The value updates live in the UI and is persisted via the settings API.

* **Tests**
  * Expanded API coverage to verify `stay_max_gap_minutes` is saved, returned in responses, clamped to allowed min/max bounds, and remains unchanged when omitted in a subsequent patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->