### PR TITLE
feat: verify supporters by GitHub username

### DIFF
--- a/app/controllers/settings/general_controller.rb
+++ b/app/controllers/settings/general_controller.rb
@@ -19,14 +19,20 @@ class Settings::GeneralController < ApplicationController
 
   def verify_supporter
     email = params[:supporter_email]&.downcase&.strip
+    github_username = params[:supporter_github_username]&.strip
 
-    return redirect_to settings_general_index_path, alert: 'Please enter an email address' if email.blank?
+    if email.blank? && github_username.blank?
+      return redirect_to settings_general_index_path,
+                         alert: 'Please enter an email address or GitHub username'
+    end
 
     current_user.settings['supporter_email'] = email
+    current_user.settings['supporter_github_username'] = github_username
     current_user.save!
 
     # Clear cached verification so we get a fresh result
-    Rails.cache.delete(Supporter::VerifyEmail.new(email).cache_key)
+    Rails.cache.delete(Supporter::VerifyEmail.new(email).cache_key) if email.present?
+    Rails.cache.delete(Supporter::VerifyGithubUsername.new(github_username).cache_key) if github_username.present?
 
     if current_user.reload.supporter?
       platform = current_user.supporter_platform&.titleize
@@ -34,8 +40,8 @@ class Settings::GeneralController < ApplicationController
                   notice: "Verified! Thank you for supporting Dawarich via #{platform}."
     else
       redirect_to settings_general_index_path,
-                  alert: 'Email not found in supporter list. '\
-                         'Make sure you\'re using the same email as your donation platform.'
+                  alert: 'Not found in supporter list. '\
+                         'Make sure you\'re using the same email or GitHub username as your donation platform.'
     end
   end
 
@@ -72,6 +78,9 @@ class Settings::GeneralController < ApplicationController
 
   def update_supporter_settings
     current_user.settings['supporter_email'] = params[:supporter_email] if params.key?(:supporter_email)
+    if params.key?(:supporter_github_username)
+      current_user.settings['supporter_github_username'] = params[:supporter_github_username]
+    end
     return unless params.key?(:show_supporter_badge)
 
     current_user.settings['show_supporter_badge'] =

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -294,9 +294,16 @@ class User < ApplicationRecord
   end
 
   def supporter_info
-    return { supporter: false } if safe_settings.supporter_email.blank?
+    if safe_settings.supporter_email.present?
+      email_info = Supporter::VerifyEmail.new(safe_settings.supporter_email).call
+      return email_info if email_info[:supporter]
+    end
 
-    Supporter::VerifyEmail.new(safe_settings.supporter_email).call
+    if safe_settings.supporter_github_username.present?
+      return Supporter::VerifyGithubUsername.new(safe_settings.supporter_github_username).call
+    end
+
+    { supporter: false }
   end
 
   private

--- a/app/services/supporter/verify_github_username.rb
+++ b/app/services/supporter/verify_github_username.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Supporter
+  class VerifyGithubUsername
+    CACHE_TTL = 24.hours
+    SUPPORTER_VERIFICATION_URL = 'https://verify.dawarich.app/api/v1/verify'
+
+    attr_reader :username
+
+    def initialize(username)
+      @username = username&.strip&.downcase
+    end
+
+    def call
+      return { supporter: false } if username.blank?
+
+      Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) do
+        fetch_supporter_status
+      end
+    end
+
+    def cache_key
+      "dawarich/supporter_gh:#{username}"
+    end
+
+    private
+
+    def fetch_supporter_status
+      response = HTTParty.get(
+        "#{SUPPORTER_VERIFICATION_URL}?github_username=#{CGI.escape(username)}",
+        timeout: 5,
+        headers: { 'X-Dawarich-Version' => APP_VERSION }
+      )
+
+      response.success? ? response.parsed_response.symbolize_keys : { supporter: false }
+    rescue StandardError => e
+      Rails.logger.warn("Supporter github verification failed: #{e.message}")
+      { supporter: false }
+    end
+  end
+end

--- a/app/services/users/safe_settings.rb
+++ b/app/services/users/safe_settings.rb
@@ -37,6 +37,7 @@ class Users::SafeSettings
     'news_emails_enabled' => true,
     'globe_projection' => true,
     'supporter_email' => nil,
+    'supporter_github_username' => nil,
     'show_supporter_badge' => true,
     # Transportation mode thresholds (speeds in km/h, distances in km)
     'transportation_thresholds' => {
@@ -257,6 +258,10 @@ class Users::SafeSettings
 
   def supporter_email
     settings['supporter_email']
+  end
+
+  def supporter_github_username
+    settings['supporter_github_username']
   end
 
   def show_supporter_badge?

--- a/app/views/settings/general/_supporter_status.html.erb
+++ b/app/views/settings/general/_supporter_status.html.erb
@@ -18,20 +18,31 @@
             <%= vf.label :supporter_email, class: 'label' do %>
               <span class="label-text font-medium">Email used for Patreon/GitHub/Ko-fi</span>
             <% end %>
-            <div class="join w-full">
-              <%= vf.email_field :supporter_email,
-                  value: current_user.safe_settings.supporter_email,
-                  class: 'input input-bordered join-item w-full',
-                  placeholder: 'supporter@example.com' %>
-              <%= vf.submit 'Verify', class: 'btn btn-primary join-item' %>
-            </div>
+            <%= vf.email_field :supporter_email,
+                value: current_user.safe_settings.supporter_email,
+                class: 'input input-bordered w-full',
+                placeholder: 'supporter@example.com' %>
           </div>
+
+          <div class="form-control mt-3">
+            <%= vf.label :supporter_github_username, class: 'label' do %>
+              <span class="label-text font-medium">GitHub username (for GitHub Sponsors with a private email)</span>
+            <% end %>
+            <%= vf.text_field :supporter_github_username,
+                value: current_user.safe_settings.supporter_github_username,
+                class: 'input input-bordered w-full',
+                placeholder: 'octocat',
+                autocapitalize: 'none',
+                autocorrect: 'off' %>
+          </div>
+
+          <%= vf.submit 'Verify', class: 'btn btn-primary mt-3' %>
         <% end %>
 
-        <% if current_user.safe_settings.supporter_email.present? && !current_user.supporter? %>
+        <% if (current_user.safe_settings.supporter_email.present? || current_user.safe_settings.supporter_github_username.present?) && !current_user.supporter? %>
           <div class="alert">
             <%= icon 'triangle-alert', class: 'w-5 h-5 text-warning' %>
-            <span>Email not found in supporter list. Make sure you're using the same email as your donation platform.</span>
+            <span>Not found in supporter list. Make sure you're using the same email or GitHub username as your donation platform.</span>
           </div>
         <% end %>
 

--- a/spec/requests/settings/general_spec.rb
+++ b/spec/requests/settings/general_spec.rb
@@ -118,12 +118,42 @@ RSpec.describe 'settings/general', type: :request do
     end
 
     describe 'POST /verify_supporter' do
-      context 'when email is blank' do
+      context 'when both email and github username are blank' do
         it 'redirects with alert' do
-          post settings_verify_supporter_path, params: { supporter_email: '' }
+          post settings_verify_supporter_path, params: { supporter_email: '', supporter_github_username: '' }
 
           expect(response).to redirect_to(settings_general_index_path)
-          expect(flash[:alert]).to eq('Please enter an email address')
+          expect(flash[:alert]).to include('email address or GitHub username')
+        end
+      end
+
+      context 'when github username is a verified supporter' do
+        before do
+          allow_any_instance_of(Supporter::VerifyGithubUsername).to receive(:call)
+            .and_return({ supporter: true, platform: 'github' })
+        end
+
+        it 'saves the username and redirects with success notice' do
+          post settings_verify_supporter_path, params: { supporter_github_username: 'octocat' }
+
+          expect(response).to redirect_to(settings_general_index_path)
+          expect(flash[:notice]).to include('Verified!')
+          expect(user.reload.settings['supporter_github_username']).to eq('octocat')
+        end
+      end
+
+      context 'when github username is not a supporter' do
+        before do
+          allow_any_instance_of(Supporter::VerifyEmail).to receive(:call).and_return({ supporter: false })
+          allow_any_instance_of(Supporter::VerifyGithubUsername).to receive(:call).and_return({ supporter: false })
+        end
+
+        it 'saves the username and redirects with failure alert' do
+          post settings_verify_supporter_path, params: { supporter_github_username: 'nobody' }
+
+          expect(response).to redirect_to(settings_general_index_path)
+          expect(flash[:alert]).to include('supporter list')
+          expect(user.reload.settings['supporter_github_username']).to eq('nobody')
         end
       end
 
@@ -152,7 +182,7 @@ RSpec.describe 'settings/general', type: :request do
           post settings_verify_supporter_path, params: { supporter_email: 'unknown@example.com' }
 
           expect(response).to redirect_to(settings_general_index_path)
-          expect(flash[:alert]).to include('Email not found in supporter list')
+          expect(flash[:alert]).to include('supporter list')
           expect(user.reload.settings['supporter_email']).to eq('unknown@example.com')
         end
       end

--- a/spec/services/supporter/verify_github_username_spec.rb
+++ b/spec/services/supporter/verify_github_username_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Supporter::VerifyGithubUsername do
+  let(:verify_url) { 'https://verify.dawarich.app/api/v1/verify' }
+
+  describe '#call' do
+    it 'returns supporter: false for a blank username' do
+      expect(described_class.new('').call).to eq({ supporter: false })
+    end
+
+    it 'queries the verification service by github_username and returns the result' do
+      stub_request(:get, verify_url)
+        .with(query: { github_username: 'octocat' })
+        .to_return(status: 200, body: { supporter: true, platform: 'github' }.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+
+      expect(described_class.new('octocat').call).to eq({ supporter: true, platform: 'github' })
+    end
+
+    it 'normalizes the username to lowercase before querying' do
+      stub = stub_request(:get, verify_url)
+             .with(query: { github_username: 'octocat' })
+             .to_return(status: 200, body: { supporter: true, platform: 'github' }.to_json,
+                        headers: { 'Content-Type' => 'application/json' })
+
+      described_class.new('OctoCat').call
+
+      expect(stub).to have_been_requested
+    end
+
+    it 'returns supporter: false when the service responds with an error' do
+      stub_request(:get, verify_url)
+        .with(query: { github_username: 'octocat' })
+        .to_return(status: 500)
+
+      expect(described_class.new('octocat').call).to eq({ supporter: false })
+    end
+
+    it 'returns supporter: false when the request raises' do
+      stub_request(:get, verify_url)
+        .with(query: { github_username: 'octocat' })
+        .to_raise(SocketError)
+
+      expect(described_class.new('octocat').call).to eq({ supporter: false })
+    end
+  end
+end

--- a/spec/services/users/safe_settings_spec.rb
+++ b/spec/services/users/safe_settings_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe Users::SafeSettings do
             'news_emails_enabled' => true,
             'globe_projection' => true,
             'supporter_email' => nil,
+            'supporter_github_username' => nil,
             'show_supporter_badge' => true,
             'transportation_thresholds' => {
               'walking_max_speed' => 7,


### PR DESCRIPTION
## What

Adds a second supporter-verification path that resolves status by **GitHub username**, alongside the existing email-based path.

## Why

GitHub Sponsors usually keep their email private. When they do, the verify-service webhook payload contains only the sponsor's `login`, not an email — so today those sponsors can never earn the supporter badge no matter what email they enter. Verifying by GitHub username closes that gap.

## Changes

- **`Supporter::VerifyGithubUsername`** — queries the verify service with `?github_username=` (24h cache, same shape as `VerifyEmail`).
- **`User#supporter_info`** — checks the supporter email first, then falls back to the GitHub username.
- **`Users::SafeSettings`** — exposes `supporter_github_username`.
- **Settings → Supporter Status** — adds a GitHub username field; `verify_supporter` now accepts either an email or a username (or both).

## Testing

- New `spec/services/supporter/verify_github_username_spec.rb` (success / lowercase normalization / error / network-failure).
- `spec/requests/settings/general_spec.rb` extended for the username verify flow.
- RuboCop clean on changed Ruby files.

## Dependency

Requires the matching **verify-service** change (new `github_username` column + webhook storing private-email sponsors by login + `?github_username=` lookup). That must be deployed for this to return positive results; until then the new path simply returns `supporter: false` and the email path is unaffected.

## Note

Pre-existing `airtrail_*` drift in `spec/services/users/safe_settings_spec.rb` (unrelated to this change) fails against the committed `dev` HEAD this branch is based on; it is already fixed in the local working tree. Only the `supporter_github_username` key was added here.
