### PR TITLE
fix: always use HTTPS for hosted photon reverse geocoding (#2982)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Reverse geocoding against the hosted `photon.dawarich.app` (and `photon.komoot.io`) now always uses HTTPS, even when `PHOTON_API_USE_HTTPS` is unset or not exactly `true`, fixing the `Geocoder::ResponseParseError` caused by Cloudflare's HTTP→HTTPS redirect (#2982)
+
 ## [1.9.0] - 2026-06-21
 
 ### Added

--- a/config/initializers/01_constants.rb
+++ b/config/initializers/01_constants.rb
@@ -16,6 +16,7 @@ APP_VERSION = File.read('.app_version').strip
 PHOTON_API_HOST = ENV.fetch('PHOTON_API_HOST', nil)
 PHOTON_API_KEY = ENV.fetch('PHOTON_API_KEY', nil)
 PHOTON_API_USE_HTTPS = ENV.fetch('PHOTON_API_USE_HTTPS', 'false') == 'true'
+PHOTON_HTTPS_ONLY_HOSTS = %w[photon.dawarich.app photon.komoot.io].freeze
 
 NOMINATIM_API_HOST = ENV.fetch('NOMINATIM_API_HOST', nil)
 NOMINATIM_API_KEY = ENV.fetch('NOMINATIM_API_KEY', nil)

--- a/config/initializers/03_dawarich_settings.rb
+++ b/config/initializers/03_dawarich_settings.rb
@@ -17,6 +17,14 @@ class DawarichSettings
       @photon_uses_komoot_io ||= PHOTON_API_HOST == 'photon.komoot.io'
     end
 
+    def photon_https_only_host?
+      @photon_https_only_host ||= PHOTON_HTTPS_ONLY_HOSTS.include?(PHOTON_API_HOST)
+    end
+
+    def photon_use_https?
+      @photon_use_https ||= PHOTON_API_USE_HTTPS || photon_https_only_host?
+    end
+
     def geoapify_enabled?
       @geoapify_enabled ||= GEOAPIFY_API_KEY.present?
     end

--- a/config/initializers/03_dawarich_settings.rb
+++ b/config/initializers/03_dawarich_settings.rb
@@ -18,7 +18,11 @@ class DawarichSettings
     end
 
     def photon_https_only_host?
-      @photon_https_only_host ||= PHOTON_HTTPS_ONLY_HOSTS.include?(PHOTON_API_HOST)
+      @photon_https_only_host ||= PHOTON_HTTPS_ONLY_HOSTS.include?(normalized_photon_host)
+    end
+
+    def normalized_photon_host
+      PHOTON_API_HOST.to_s.strip.downcase.split(':').first
     end
 
     def photon_use_https?

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -16,7 +16,7 @@ settings = {
 
 if PHOTON_API_HOST.present?
   settings[:lookup] = :photon
-  settings[:use_https] = PHOTON_API_USE_HTTPS
+  settings[:use_https] = DawarichSettings.photon_use_https?
   settings[:photon] = { host: PHOTON_API_HOST }
   settings[:http_headers]['X-Api-Key'] = PHOTON_API_KEY if PHOTON_API_KEY.present?
 elsif GEOAPIFY_API_KEY.present?

--- a/spec/regressions/photon_https_for_public_host_spec.rb
+++ b/spec/regressions/photon_https_for_public_host_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DawarichSettings do
+  before do
+    described_class.instance_variables.each do |ivar|
+      described_class.remove_instance_variable(ivar)
+    end
+  end
+
+  describe '.photon_use_https?' do
+    context 'when the host is a known HTTPS-only public host and the flag is off' do
+      before do
+        stub_const('PHOTON_API_HOST', 'photon.dawarich.app')
+        stub_const('PHOTON_API_USE_HTTPS', false)
+      end
+
+      it 'forces HTTPS regardless of the flag' do
+        expect(described_class.photon_use_https?).to be true
+      end
+    end
+
+    context 'when the host is photon.komoot.io and the flag is off' do
+      before do
+        stub_const('PHOTON_API_HOST', 'photon.komoot.io')
+        stub_const('PHOTON_API_USE_HTTPS', false)
+      end
+
+      it 'forces HTTPS' do
+        expect(described_class.photon_use_https?).to be true
+      end
+    end
+
+    context 'when the host is a self-hosted photon and the flag is off' do
+      before do
+        stub_const('PHOTON_API_HOST', 'localhost:2322')
+        stub_const('PHOTON_API_USE_HTTPS', false)
+      end
+
+      it 'leaves HTTP in place' do
+        expect(described_class.photon_use_https?).to be false
+      end
+    end
+
+    context 'when the host is a self-hosted photon and the flag is on' do
+      before do
+        stub_const('PHOTON_API_HOST', 'photon.internal.example')
+        stub_const('PHOTON_API_USE_HTTPS', true)
+      end
+
+      it 'honors the flag' do
+        expect(described_class.photon_use_https?).to be true
+      end
+    end
+  end
+end

--- a/spec/regressions/photon_https_for_public_host_spec.rb
+++ b/spec/regressions/photon_https_for_public_host_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe DawarichSettings do
       end
     end
 
+    context 'when the public host carries a port and surrounding whitespace' do
+      before do
+        stub_const('PHOTON_API_HOST', '  Photon.Dawarich.App:443 ')
+        stub_const('PHOTON_API_USE_HTTPS', false)
+      end
+
+      it 'still forces HTTPS' do
+        expect(described_class.photon_use_https?).to be true
+      end
+    end
+
     context 'when the host is a self-hosted photon and the flag is off' do
       before do
         stub_const('PHOTON_API_HOST', 'localhost:2322')


### PR DESCRIPTION
Reverse geocoding against the hosted `photon.dawarich.app` (and `photon.komoot.io`) now always uses HTTPS, even when `PHOTON_API_USE_HTTPS` is unset or not exactly `true`. This fixes the `Geocoder::ResponseParseError` caused by Cloudflare's HTTP→HTTPS redirect.

Closes #2982.