### PR TITLE
fix: skip visit suggestions for points owned by a confirmed visit (#2952)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Re-running visit detection no longer creates duplicate suggestions for a visit you already confirmed, even after correcting its address moved the place marker away from the underlying points (#2952)
+
 ## [1.9.0] - 2026-06-21
 
 ### Added

--- a/app/services/visits/creator.rb
+++ b/app/services/visits/creator.rb
@@ -72,6 +72,9 @@ module Visits
 
     # Find if there's already a confirmed/suggested/declined visit at this location within a similar time
     def find_existing_visit(visit_data)
+      confirmed = confirmed_visit_owning_points(visit_data)
+      return confirmed if confirmed
+
       # Define time window to look for existing visits (slightly wider than the visit)
       start_time = Time.zone.at(visit_data[:start_time]) - 1.hour
       end_time = Time.zone.at(visit_data[:end_time]) + 1.hour
@@ -83,21 +86,28 @@ module Visits
             start: start_time, end: end_time
           )
           .find_each do |visit|
-            visit_lat, visit_lon = visit.center
-            next unless visit_lat && visit_lon
+        visit_lat, visit_lon = visit.center
+        next unless visit_lat && visit_lon
 
-            # Calculate distance between centers
-            distance = Geocoder::Calculations.distance_between(
-              [visit_data[:center_lat], visit_data[:center_lon]],
-              [visit_lat, visit_lon],
-              units: :km
-            )
+        # Calculate distance between centers
+        distance = Geocoder::Calculations.distance_between(
+          [visit_data[:center_lat], visit_data[:center_lon]],
+          [visit_lat, visit_lon],
+          units: :km
+        )
 
-            # If this visit is within 100 meters of the new suggestion
-            return visit if distance <= 0.1
+        # If this visit is within 100 meters of the new suggestion
+        return visit if distance <= 0.1
       end
 
       nil
+    end
+
+    def confirmed_visit_owning_points(visit_data)
+      visit_ids = Array(visit_data[:points]).filter_map(&:visit_id).uniq
+      return nil if visit_ids.empty?
+
+      user.visits.confirmed.find_by(id: visit_ids)
     end
 
     def find_matching_area(visit_data)

--- a/spec/regressions/visit_suggestion_skips_points_owned_by_confirmed_spec.rb
+++ b/spec/regressions/visit_suggestion_skips_points_owned_by_confirmed_spec.rb
@@ -46,4 +46,26 @@ RSpec.describe Visits::Creator do
       expect(user.visits.suggested.count).to eq(0)
     end
   end
+
+  describe '#create_visits when the candidate points are not owned by any visit' do
+    let(:visit_data) do
+      {
+        start_time: 2.hours.ago.to_i,
+        end_time: 1.hour.ago.to_i,
+        duration: 60.minutes.to_i,
+        center_lat: 40.7128,
+        center_lon: -74.0060,
+        radius: 50,
+        suggested_name: 'Fresh Place',
+        points: [point1, point2]
+      }
+    end
+
+    it 'creates a suggestion through the normal distance path' do
+      created = subject.create_visits([visit_data])
+
+      expect(created.size).to eq(1)
+      expect(user.visits.suggested.count).to eq(1)
+    end
+  end
 end

--- a/spec/regressions/visit_suggestion_skips_points_owned_by_confirmed_spec.rb
+++ b/spec/regressions/visit_suggestion_skips_points_owned_by_confirmed_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Visits::Creator do
+  let(:user) { create(:user) }
+  let(:point1) { create(:point, user: user) }
+  let(:point2) { create(:point, user: user) }
+
+  subject { described_class.new(user) }
+
+  describe '#create_visits when the candidate points already belong to a confirmed visit' do
+    let(:visit_data) do
+      {
+        start_time: 2.hours.ago.to_i,
+        end_time: 1.hour.ago.to_i,
+        duration: 60.minutes.to_i,
+        center_lat: 40.7128,
+        center_lon: -74.0060,
+        radius: 50,
+        suggested_name: 'Redetected Place',
+        points: [point1, point2]
+      }
+    end
+
+    let(:corrected_place) do
+      create(:place, name: 'Corrected Address', user_id: nil,
+                     latitude: 40.7128, longitude: -74.0300,
+                     lonlat: 'POINT(-74.0300 40.7128)')
+    end
+
+    let!(:confirmed_visit) do
+      create(:visit, user: user, place: corrected_place, area: nil, status: :confirmed,
+                     started_at: 2.hours.ago, ended_at: 1.hour.ago, duration: 60)
+    end
+
+    before do
+      [point1, point2].each { |p| p.update_column(:visit_id, confirmed_visit.id) }
+    end
+
+    it 'does not re-suggest a duplicate even though the corrected place moved far from the points' do
+      created = subject.create_visits([visit_data])
+
+      expect(created).to be_empty
+      expect(user.visits.reload.count).to eq(1)
+      expect(user.visits.suggested.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Re-running visit detection no longer creates duplicate suggestions for a visit you already confirmed, even after correcting its address moved the place marker away from the underlying points.

Closes #2952.