### PR TITLE
feat: reveal trip photos along the replay playhead with privacy-zone masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Trip photos now appear on the Map v2 trip and replay views: thumbnails pop in one at a time as the replay playhead reaches each photo's timestamp, and the same photos are available on public shared-trip links. Photos that fall inside one of your privacy zones are masked from both the map and shared links.
+
 ## [1.9.0] - 2026-06-21
 
 ### Added

--- a/app/assets/stylesheets/maps_maplibre_replay.css
+++ b/app/assets/stylesheets/maps_maplibre_replay.css
@@ -433,6 +433,48 @@
   color: oklch(var(--bc) / 0.8);
 }
 
+/* Replay photo marker (HTML overlay revealed progressively as replay reaches each photo) */
+.replay-photo-marker {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  cursor: pointer;
+  background-size: cover;
+  background-position: center;
+  border: 3px solid white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transition:
+    transform 0.2s,
+    box-shadow 0.2s;
+}
+
+.replay-photo-marker:hover {
+  transform: scale(1.2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+}
+
+.replay-photo-marker.replay-photo-pop {
+  animation: replay-photo-pop 0.35s cubic-bezier(0.18, 0.89, 0.32, 1.28);
+}
+
+@keyframes replay-photo-pop {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .replay-photo-marker.replay-photo-pop {
+    animation: none;
+  }
+}
+
 /* Responsive: adjust replay panel shift for narrower side panels */
 @media (max-width: 1280px) {
   .maps-maplibre-container.panel-open ~ .replay-panel {

--- a/app/assets/stylesheets/maps_maplibre_replay.css
+++ b/app/assets/stylesheets/maps_maplibre_replay.css
@@ -434,11 +434,18 @@
 }
 
 /* Replay photo marker (HTML overlay revealed progressively as replay reaches each photo) */
+/* MapLibre positions the outer .replay-photo-marker via transform: translate(); keep all
+   visual transforms (pop animation, hover scale) on the inner element so they don't fight it. */
 .replay-photo-marker {
   width: 50px;
   height: 50px;
-  border-radius: 50%;
   cursor: pointer;
+}
+
+.replay-photo-marker-inner {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
   background-size: cover;
   background-position: center;
   border: 3px solid white;
@@ -449,12 +456,15 @@
 }
 
 .replay-photo-marker:hover {
-  transform: scale(1.2);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
   z-index: 1000;
 }
 
-.replay-photo-marker.replay-photo-pop {
+.replay-photo-marker:hover .replay-photo-marker-inner {
+  transform: scale(1.2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+}
+
+.replay-photo-marker-inner.replay-photo-pop {
   animation: replay-photo-pop 0.35s cubic-bezier(0.18, 0.89, 0.32, 1.28);
 }
 
@@ -470,7 +480,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .replay-photo-marker.replay-photo-pop {
+  .replay-photo-marker-inner.replay-photo-pop {
     animation: none;
   }
 }

--- a/app/controllers/api/v1/shared/base_controller.rb
+++ b/app/controllers/api/v1/shared/base_controller.rb
@@ -40,28 +40,7 @@ module Api
         end
 
         def privacy_zones
-          @privacy_zones ||= link.user.tags.privacy_zones.includes(:places).flat_map do |tag|
-            tag.places.map do |place|
-              { lon: place.longitude.to_f, lat: place.latitude.to_f, radius: tag.privacy_radius_meters }
-            end
-          end
-        end
-
-        def within_privacy_zone?(lat, lon)
-          return false if lat.blank? || lon.blank?
-
-          privacy_zones.any? do |zone|
-            haversine_meters(lat.to_f, lon.to_f, zone[:lat], zone[:lon]) <= zone[:radius]
-          end
-        end
-
-        def haversine_meters(lat1, lon1, lat2, lon2)
-          rad = Math::PI / 180
-          dlat = (lat2 - lat1) * rad
-          dlon = (lon2 - lon1) * rad
-          a = (Math.sin(dlat / 2)**2) +
-              (Math.cos(lat1 * rad) * Math.cos(lat2 * rad) * (Math.sin(dlon / 2)**2))
-          6_371_000 * 2 * Math.asin(Math.sqrt(a))
+          @privacy_zones ||= ::Users::PrivacyZones.new(link.user).call
         end
       end
     end

--- a/app/controllers/api/v1/shared/photos_controller.rb
+++ b/app/controllers/api/v1/shared/photos_controller.rb
@@ -4,8 +4,6 @@ module Api
   module V1
     module Shared
       class PhotosController < BaseController
-        MAX_PHOTOS = 100
-
         def index
           return render(json: []) unless ctx.show_photos?
 
@@ -49,9 +47,7 @@ module Api
         end
 
         def capped_geotagged(photos)
-          photos.select { |p| p[:latitude].present? && p[:longitude].present? }
-                .reject { |p| within_privacy_zone?(p[:latitude], p[:longitude]) }
-                .first(MAX_PHOTOS)
+          ::Photos::Mappable.new(photos, privacy_zones: privacy_zones).call
         end
 
         def allowed_ids_for(photos)
@@ -105,6 +101,7 @@ module Api
             latitude: photo[:latitude],
             longitude: photo[:longitude],
             source: photo[:source],
+            taken_at: photo[:capturedAt] || photo[:localDateTime],
             thumbnail_url: url_for(
               controller: 'api/v1/shared/photos',
               action: 'thumbnail',

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -13,10 +13,10 @@ class TripsController < ApplicationController
   end
 
   def show
-    @photo_previews = @trip.photo_previews
     @photo_sources = @trip.photo_sources
     @distance_unit = current_user.safe_settings.distance_unit
     @timezone = current_user.timezone_iana
+    @photos_by_day = @trip.photos_by_day(@timezone)
     @day_notes = @trip.notes.index_by(&:date)
     @day_stats = compute_day_stats
 

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -3,6 +3,7 @@ import { Toast } from "maps_maplibre/components/toast"
 import { ReplayPanel } from "maps_maplibre/managers/replay_panel"
 import { ApiClient } from "maps_maplibre/services/api_client"
 import { CleanupHelper } from "maps_maplibre/utils/cleanup_helper"
+import { featureToPhoto } from "maps_maplibre/utils/feature_to_photo"
 import { cancelAllPreviews } from "maps_maplibre/utils/layer_gate"
 import { performanceMonitor } from "maps_maplibre/utils/performance_monitor"
 import { SearchManager } from "maps_maplibre/utils/search_manager"
@@ -1950,6 +1951,21 @@ export default class extends Controller {
       highlightPoint: (point) => this._highlightReplayRouteSegment(point),
       clearHighlight: () => this._clearReplayRouteHighlight(),
       onPlayStateChange: (playing) => this._updateTrackReplayButton(playing),
+      getPhotos: () => {
+        const layer = this.layerManager?.getLayer("photos")
+        const features = layer?.visible ? layer.data?.features : null
+        return features?.length ? features.map(featureToPhoto) : []
+      },
+      onReplayPhotosActive: (active) => {
+        const layer = this.layerManager?.getLayer("photos")
+        if (!layer) return
+        if (active) {
+          this._photosWasVisible = layer.visible
+          layer.hide()
+        } else if (this._photosWasVisible) {
+          layer.show()
+        }
+      },
     })
   }
 

--- a/app/javascript/controllers/shared_trip_map_controller.js
+++ b/app/javascript/controllers/shared_trip_map_controller.js
@@ -38,6 +38,7 @@ export default class extends Controller {
   connect() {
     this.selectedDay = null
     this.allPoints = []
+    this.photoMarkers = []
     this.initializeMap()
   }
 
@@ -224,6 +225,20 @@ export default class extends Controller {
         element: this.element,
         timezone: this.timezoneValue,
         allPoints: this.allPoints,
+        getPhotos: () =>
+          (this.photoMarkers || []).map(({ photo }) => ({
+            id: photo.id,
+            taken_at: photo.taken_at,
+            thumbnail_url: photo.thumbnail_url,
+            latitude: photo.latitude,
+            longitude: photo.longitude,
+            source: photo.source,
+          })),
+        onReplayPhotosActive: (active) => {
+          for (const { marker } of this.photoMarkers || []) {
+            marker.getElement().style.display = active ? "none" : ""
+          }
+        },
       })
     }
     this.replayPanel.toggle()
@@ -272,6 +287,7 @@ export default class extends Controller {
     if (!res.ok) return
     const photos = await res.json()
 
+    this.photoMarkers = []
     for (const photo of photos) {
       if (photo.latitude == null || photo.longitude == null) continue
       const el = document.createElement("img")
@@ -281,9 +297,10 @@ export default class extends Controller {
       el.style.width = "32px"
       el.style.height = "32px"
       el.style.objectFit = "cover"
-      new maplibregl.Marker({ element: el })
+      const marker = new maplibregl.Marker({ element: el })
         .setLngLat([photo.longitude, photo.latitude])
         .addTo(this.map)
+      this.photoMarkers.push({ photo, marker })
     }
   }
 }

--- a/app/javascript/controllers/trip_maplibre_controller.js
+++ b/app/javascript/controllers/trip_maplibre_controller.js
@@ -6,6 +6,7 @@ import { PhotosLayer } from "maps_maplibre/layers/photos_layer"
 import { ReplayManager } from "maps_maplibre/managers/replay_manager"
 import { ReplayPanel } from "maps_maplibre/managers/replay_panel"
 import { ApiClient } from "maps_maplibre/services/api_client"
+import { featureToPhoto } from "maps_maplibre/utils/feature_to_photo"
 
 /**
  * Trip MapLibre Controller
@@ -434,7 +435,7 @@ export default class extends Controller {
           properties: {
             id: photo.id,
             thumbnail_url: thumbnailUrl,
-            taken_at: photo.localDateTime,
+            taken_at: photo.capturedAt || photo.localDateTime,
             filename: photo.originalFileName,
             city: photo.city,
             state: photo.state,
@@ -476,6 +477,18 @@ export default class extends Controller {
         element: this.element,
         timezone: this.timezoneValue,
         allPoints: this.allPoints,
+        getPhotos: () =>
+          this.photosActive && this.photosGeoJSON
+            ? this.photosGeoJSON.features.map(featureToPhoto)
+            : [],
+        onReplayPhotosActive: (active) => {
+          if (!this.photosLayer) return
+          if (active) {
+            this.photosLayer.hide()
+          } else {
+            this.photosLayer.show()
+          }
+        },
       })
     }
     this.replayPanel.toggle()

--- a/app/javascript/controllers/trip_maplibre_controller.js
+++ b/app/javascript/controllers/trip_maplibre_controller.js
@@ -484,8 +484,9 @@ export default class extends Controller {
         onReplayPhotosActive: (active) => {
           if (!this.photosLayer) return
           if (active) {
+            this._photosWasVisible = this.photosLayer.visible
             this.photosLayer.hide()
-          } else {
+          } else if (this._photosWasVisible) {
             this.photosLayer.show()
           }
         },

--- a/app/javascript/maps_maplibre/components/photo_popup.js
+++ b/app/javascript/maps_maplibre/components/photo_popup.js
@@ -1,4 +1,8 @@
-import { formatTimestamp } from "../utils/geojson_transformers"
+import { escapeHtml, formatTimestamp } from "../utils/geojson_transformers"
+
+function escapeAttr(value) {
+  return escapeHtml(value).replace(/"/g, "&quot;").replace(/'/g, "&#39;")
+}
 
 /**
  * Factory for creating photo popups
@@ -30,15 +34,15 @@ export class PhotoPopupFactory {
     return `
       <div class="photo-popup">
         <div class="photo-preview">
-          <img src="${thumbnail_url}"
-               alt="${filename}"
+          <img src="${escapeAttr(thumbnail_url)}"
+               alt="${escapeAttr(filename)}"
                loading="lazy">
         </div>
         <div class="photo-info">
-          <div class="filename">${filename}</div>
-          <div class="timestamp">Taken: ${takenDate}</div>
-          <div class="location">Location: ${location}</div>
-          <div class="source">Source: ${source}</div>
+          <div class="filename">${escapeHtml(filename)}</div>
+          <div class="timestamp">Taken: ${escapeHtml(takenDate)}</div>
+          <div class="location">Location: ${escapeHtml(location)}</div>
+          <div class="source">Source: ${escapeHtml(source)}</div>
           <div class="media-type">${mediaType}</div>
         </div>
       </div>

--- a/app/javascript/maps_maplibre/layers/replay_photo_layer.js
+++ b/app/javascript/maps_maplibre/layers/replay_photo_layer.js
@@ -1,0 +1,95 @@
+import maplibregl from "maplibre-gl"
+import { PhotoPopupFactory } from "maps_maplibre/components/photo_popup"
+
+/**
+ * Holds replay photos as DOM markers that are revealed one at a time as the
+ * replay playhead reaches each photo's timestamp. Markers are created lazily
+ * on first reveal (never pre-minted) and pop in with a scale-in animation.
+ */
+export class ReplayPhotoLayer {
+  constructor(map, options = {}) {
+    this.map = map
+    this.timezone = options.timezone || "UTC"
+    this.photos = new Map()
+    this.markers = new Map()
+    this.revealedIds = new Set()
+  }
+
+  setPhotos(photos) {
+    this.clear()
+    for (const photo of photos || []) {
+      if (!this._hasCoordinates(photo)) continue
+      this.photos.set(photo.id, photo)
+    }
+  }
+
+  reveal(id) {
+    if (this.markers.has(id)) return
+    const photo = this.photos.get(id)
+    if (!photo) return
+
+    const marker = this._createMarker(photo)
+    if (!marker) return
+
+    this.markers.set(id, marker)
+    this.revealedIds.add(id)
+  }
+
+  hide(id) {
+    const marker = this.markers.get(id)
+    if (!marker) return
+
+    marker.remove()
+    this.markers.delete(id)
+    this.revealedIds.delete(id)
+  }
+
+  hideAll() {
+    for (const [, marker] of this.markers) marker.remove()
+    this.markers.clear()
+    this.revealedIds.clear()
+  }
+
+  clear() {
+    this.hideAll()
+    this.photos.clear()
+  }
+
+  _hasCoordinates(photo) {
+    return (
+      photo &&
+      photo.id !== undefined &&
+      !Number.isNaN(Number(photo.lon)) &&
+      !Number.isNaN(Number(photo.lat))
+    )
+  }
+
+  _createMarker(photo) {
+    const lon = Number(photo.lon)
+    const lat = Number(photo.lat)
+    if (Number.isNaN(lon) || Number.isNaN(lat)) return null
+
+    const el = document.createElement("div")
+    el.className = "replay-photo-marker replay-photo-pop"
+    el.style.backgroundImage = `url('${photo.thumbnail_url}')`
+    el.addEventListener("click", (event) => {
+      event.stopPropagation()
+      this._showPopup(photo, lon, lat)
+    })
+
+    return new maplibregl.Marker({ element: el, anchor: "center" })
+      .setLngLat([lon, lat])
+      .addTo(this.map)
+  }
+
+  _showPopup(photo, lon, lat) {
+    new maplibregl.Popup({
+      closeButton: true,
+      closeOnClick: true,
+      maxWidth: "400px",
+    })
+      .setLngLat([lon, lat])
+      .setHTML(PhotoPopupFactory.createPhotoPopup(photo, this.timezone))
+      .addTo(this.map)
+  }
+}

--- a/app/javascript/maps_maplibre/layers/replay_photo_layer.js
+++ b/app/javascript/maps_maplibre/layers/replay_photo_layer.js
@@ -70,8 +70,13 @@ export class ReplayPhotoLayer {
     if (Number.isNaN(lon) || Number.isNaN(lat)) return null
 
     const el = document.createElement("div")
-    el.className = "replay-photo-marker replay-photo-pop"
-    el.style.backgroundImage = `url("${encodeURI(photo.thumbnail_url)}")`
+    el.className = "replay-photo-marker"
+
+    const inner = document.createElement("div")
+    inner.className = "replay-photo-marker-inner replay-photo-pop"
+    inner.style.backgroundImage = `url("${encodeURI(photo.thumbnail_url)}")`
+    el.appendChild(inner)
+
     el.addEventListener("click", (event) => {
       event.stopPropagation()
       this._showPopup(photo, lon, lat)

--- a/app/javascript/maps_maplibre/layers/replay_photo_layer.js
+++ b/app/javascript/maps_maplibre/layers/replay_photo_layer.js
@@ -71,7 +71,7 @@ export class ReplayPhotoLayer {
 
     const el = document.createElement("div")
     el.className = "replay-photo-marker replay-photo-pop"
-    el.style.backgroundImage = `url('${photo.thumbnail_url}')`
+    el.style.backgroundImage = `url("${encodeURI(photo.thumbnail_url)}")`
     el.addEventListener("click", (event) => {
       event.stopPropagation()
       this._showPopup(photo, lon, lat)

--- a/app/javascript/maps_maplibre/managers/replay_panel.js
+++ b/app/javascript/maps_maplibre/managers/replay_panel.js
@@ -1,5 +1,7 @@
 import { ReplayMarkerLayer } from "maps_maplibre/layers/replay_marker_layer"
+import { ReplayPhotoLayer } from "maps_maplibre/layers/replay_photo_layer"
 import { ReplayManager } from "maps_maplibre/managers/replay_manager"
+import { ReplayPhotoIndex } from "maps_maplibre/managers/replay_photo_index"
 
 export class ReplayPanel {
   constructor(opts) {
@@ -15,6 +17,10 @@ export class ReplayPanel {
     this._clearHighlight = opts.clearHighlight || null
     this.onDaySync = opts.onDaySync || null
     this.onPlayStateChange = opts.onPlayStateChange || null
+    this._getPhotos = opts.getPhotos || null
+    this._onReplayPhotosActive = opts.onReplayPhotosActive || (() => {})
+    this._replayPhotoLayer = null
+    this._photoIndex = null
   }
 
   get isOpen() {
@@ -46,6 +52,7 @@ export class ReplayPanel {
       this.c.replayPanelTarget.classList.add("hidden")
       this.clearMarker()
       this.clearHighlight()
+      this.teardownReplayPhotos()
       this.updateSpeedDisplay(null)
       this.setButtonActive(false)
     } else {
@@ -69,6 +76,7 @@ export class ReplayPanel {
     }
 
     this.bindFollowInterrupt()
+    this.setupReplayPhotos()
     this.updateDayDisplay()
     this.updateDayCount()
     this.updateDayButtons()
@@ -76,6 +84,61 @@ export class ReplayPanel {
     this.initPlayback()
     this.setInitialScrubberPosition()
     this.hideCycleControls()
+  }
+
+  setupReplayPhotos() {
+    if (!this._getPhotos) return
+
+    const photos = this._getPhotos()
+    if (!photos?.length) return
+
+    this._photoIndex = new ReplayPhotoIndex({
+      photos,
+      timezone: this.timezone,
+      getCoordinates: (photo) => this.replayManager.getCoordinates(photo),
+    })
+    if (!this._photoIndex.hasPhotos()) {
+      this._photoIndex = null
+      return
+    }
+
+    this._replayPhotoLayer = new ReplayPhotoLayer(this.map, {
+      timezone: this.timezone,
+    })
+    this._replayPhotoLayer.setPhotos(this._photoIndex.allPhotos())
+    this._onReplayPhotosActive(true)
+  }
+
+  updateRevealedPhotos(playheadMs) {
+    if (!this._replayPhotoLayer || !this._photoIndex) return
+    if (playheadMs === null || playheadMs === undefined) return
+
+    const day = this.replayManager?.getCurrentDay()
+    if (!day) return
+
+    const reveal = new Set(this._photoIndex.idsToReveal(day, playheadMs))
+    for (const photo of this._photoIndex.dayPhotos(day)) {
+      if (reveal.has(photo.id)) {
+        this._replayPhotoLayer.reveal(photo.id)
+      } else {
+        this._replayPhotoLayer.hide(photo.id)
+      }
+    }
+  }
+
+  resetReplayPhotos() {
+    if (this._replayPhotoLayer) this._replayPhotoLayer.hideAll()
+  }
+
+  teardownReplayPhotos() {
+    if (this._replayPhotoLayer) {
+      this._replayPhotoLayer.clear()
+      this._replayPhotoLayer = null
+    }
+    if (this._photoIndex) {
+      this._photoIndex = null
+      this._onReplayPhotosActive(false)
+    }
   }
 
   async ensureOpen() {
@@ -90,6 +153,7 @@ export class ReplayPanel {
     this.stopPlayback()
     this.clearMarker()
     this.clearHighlight()
+    this.teardownReplayPhotos()
     this.replayManager = null
   }
 
@@ -127,6 +191,7 @@ export class ReplayPanel {
     if (nearestMinute === null) {
       this.clearMarker()
       this.clearHighlight()
+      this.resetReplayPhotos()
       this.hideCycleControls()
       this.updateSpeedDisplay(null)
       return
@@ -140,6 +205,9 @@ export class ReplayPanel {
     if (!point) return
 
     this.showMarker(point)
+    this.updateRevealedPhotos(
+      this.parseTimestamp(this.replayManager.getTimestamp(point)),
+    )
     this.updateSpeedDisplay(this.getPointVelocity(point))
     this.flyToPoint(point, this.replayActive)
     this.highlightPoint(point)
@@ -206,6 +274,7 @@ export class ReplayPanel {
   }
 
   afterDayChange() {
+    this.resetReplayPhotos()
     this.updateDayDisplay()
     this.updateDayCount()
     this.updateDayButtons()
@@ -502,6 +571,18 @@ export class ReplayPanel {
       this.panToFollow(lon, lat)
     }
 
+    const revealCur = this.replayPoints?.[this.replayPointIndex]
+    const revealNext = this.replayPoints?.[this.replayPointIndex + 1]
+    if (revealCur) {
+      const curTs = this.parseTimestamp(
+        this.replayManager.getTimestamp(revealCur),
+      )
+      const nextTs = revealNext
+        ? this.parseTimestamp(this.replayManager.getTimestamp(revealNext))
+        : curTs
+      this.updateRevealedPhotos(curTs + (nextTs - curTs) * progress)
+    }
+
     if (elapsed >= intervalMs) {
       this.replayLastTime = now
       this.replayPointIndex++
@@ -517,6 +598,7 @@ export class ReplayPanel {
             this.replayManager.getCurrentDay(),
           )
           this.replayPointIndex = 0
+          this.resetReplayPhotos()
           if (this.replayPoints.length === 0) return this.stopPlayback()
         } else {
           return this.stopPlayback()
@@ -634,6 +716,7 @@ export class ReplayPanel {
     if (!this.replayManager || !this.isOpen) return
     this.stopPlayback()
     if (this.replayManager.goToDay(dayKey)) {
+      this.resetReplayPhotos()
       this.updateDayDisplay()
       this.updateDayCount()
       this.updateDayButtons()

--- a/app/javascript/maps_maplibre/managers/replay_photo_index.js
+++ b/app/javascript/maps_maplibre/managers/replay_photo_index.js
@@ -1,0 +1,78 @@
+/**
+ * Groups replay photos by day (in the replay timezone) and answers
+ * "which photos should be revealed at this playhead time?".
+ *
+ * Timestamps are treated as absolute instants: `taken_at` is the photo's UTC
+ * instant (capturedAt-preferred), compared directly against the UTC playhead.
+ * Day keys are derived in the configured timezone so photos land on the same
+ * calendar day as the track points (ReplayManager) and trip-day rows.
+ */
+export class ReplayPhotoIndex {
+  constructor({ photos, timezone, getCoordinates }) {
+    this.timezone = timezone || "UTC"
+    this.getCoordinates = getCoordinates
+    this.photosByDay = {}
+    this._build(photos || [])
+  }
+
+  allPhotos() {
+    return Object.values(this.photosByDay).flat()
+  }
+
+  dayPhotos(dayKey) {
+    return this.photosByDay[dayKey] || []
+  }
+
+  idsToReveal(dayKey, playheadMs) {
+    return this.dayPhotos(dayKey)
+      .filter((photo) => photo.tsMs <= playheadMs)
+      .map((photo) => photo.id)
+  }
+
+  hasPhotos() {
+    return Object.keys(this.photosByDay).length > 0
+  }
+
+  _build(photos) {
+    for (const photo of photos) {
+      const tsMs = this._parseMs(photo.taken_at)
+      if (tsMs === null) continue
+
+      const coords = this.getCoordinates ? this.getCoordinates(photo) : null
+      if (!coords) continue
+
+      const dayKey = this._dayKey(tsMs)
+      if (!dayKey) continue
+
+      const entry = { ...photo, tsMs, lon: coords.lon, lat: coords.lat }
+      if (!this.photosByDay[dayKey]) this.photosByDay[dayKey] = []
+      this.photosByDay[dayKey].push(entry)
+    }
+
+    for (const key of Object.keys(this.photosByDay)) {
+      this.photosByDay[key].sort((a, b) => a.tsMs - b.tsMs)
+    }
+  }
+
+  _parseMs(takenAt) {
+    if (!takenAt) return null
+    if (typeof takenAt === "number") {
+      return takenAt < 10000000000 ? takenAt * 1000 : takenAt
+    }
+    const ms = new Date(takenAt).getTime()
+    return Number.isNaN(ms) ? null : ms
+  }
+
+  _dayKey(tsMs) {
+    try {
+      return new Intl.DateTimeFormat("en-CA", {
+        timeZone: this.timezone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).format(new Date(tsMs))
+    } catch (_err) {
+      return new Date(tsMs).toISOString().slice(0, 10)
+    }
+  }
+}

--- a/app/javascript/maps_maplibre/utils/feature_to_photo.js
+++ b/app/javascript/maps_maplibre/utils/feature_to_photo.js
@@ -1,0 +1,8 @@
+/**
+ * Flatten a photo GeoJSON feature into the shape ReplayPhotoIndex expects:
+ * the feature's properties (id, taken_at, thumbnail_url, ...) plus its geometry,
+ * so ReplayManager.getCoordinates can extract coordinates from `geometry`.
+ */
+export function featureToPhoto(feature) {
+  return { ...(feature.properties || {}), geometry: feature.geometry }
+}

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -40,6 +40,17 @@ class Trip < ApplicationRecord
     @photo_sources ||= photos.map { _1[:source] }.uniq
   end
 
+  def photos_by_day(timezone)
+    zone = Time.find_zone(timezone) || Time.find_zone('UTC')
+
+    photos.each_with_object({}) do |photo, acc|
+      date = parse_photo_date(photo[:taken_at], zone)
+      next if date.nil?
+
+      (acc[date] ||= []) << photo
+    end
+  end
+
   def calculate_countries
     self.visited_countries = points.pluck(:country_name).uniq.compact
   end
@@ -54,6 +65,14 @@ class Trip < ApplicationRecord
 
   def photos
     @photos ||= Trips::Photos.new(self, user).call
+  end
+
+  def parse_photo_date(raw, zone)
+    return nil if raw.blank?
+
+    zone.parse(raw.to_s)&.to_date
+  rescue ArgumentError, TypeError
+    nil
   end
 
   def select_dominant_orientation(photos)

--- a/app/services/photos/mappable.rb
+++ b/app/services/photos/mappable.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Photos::Mappable
+  MAX_PHOTOS = 100
+
+  def initialize(photos, privacy_zones: [], max: MAX_PHOTOS)
+    @photos = photos
+    @privacy_zones = privacy_zones
+    @max = max
+  end
+
+  def call
+    @photos.select { |p| p[:latitude].present? && p[:longitude].present? }
+           .reject { |p| within_privacy_zone?(p[:latitude], p[:longitude]) }
+           .first(@max)
+  end
+
+  private
+
+  def within_privacy_zone?(lat, lon)
+    return false if lat.blank? || lon.blank?
+
+    @privacy_zones.any? do |zone|
+      haversine_meters(lat.to_f, lon.to_f, zone[:lat], zone[:lon]) <= zone[:radius]
+    end
+  end
+
+  def haversine_meters(lat1, lon1, lat2, lon2)
+    rad = Math::PI / 180
+    dlat = (lat2 - lat1) * rad
+    dlon = (lon2 - lon1) * rad
+    a = (Math.sin(dlat / 2)**2) +
+        (Math.cos(lat1 * rad) * Math.cos(lat2 * rad) * (Math.sin(dlon / 2)**2))
+    6_371_000 * 2 * Math.asin(Math.sqrt(a))
+  end
+end

--- a/app/services/photos/mappable.rb
+++ b/app/services/photos/mappable.rb
@@ -21,16 +21,11 @@ class Photos::Mappable
     return false if lat.blank? || lon.blank?
 
     @privacy_zones.any? do |zone|
-      haversine_meters(lat.to_f, lon.to_f, zone[:lat], zone[:lon]) <= zone[:radius]
+      distance_meters(lat.to_f, lon.to_f, zone[:lat], zone[:lon]) <= zone[:radius]
     end
   end
 
-  def haversine_meters(lat1, lon1, lat2, lon2)
-    rad = Math::PI / 180
-    dlat = (lat2 - lat1) * rad
-    dlon = (lon2 - lon1) * rad
-    a = (Math.sin(dlat / 2)**2) +
-        (Math.cos(lat1 * rad) * Math.cos(lat2 * rad) * (Math.sin(dlon / 2)**2))
-    6_371_000 * 2 * Math.asin(Math.sqrt(a))
+  def distance_meters(lat1, lon1, lat2, lon2)
+    Geocoder::Calculations.distance_between([lat1, lon1], [lat2, lon2], units: :km) * 1000
   end
 end

--- a/app/services/shared_links/trip_photos.rb
+++ b/app/services/shared_links/trip_photos.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module SharedLinks
+  class TripPhotos
+    def initialize(link, timezone:)
+      @link = link
+      @timezone = timezone.presence || 'UTC'
+    end
+
+    def call
+      zone = Time.find_zone(@timezone) || Time.find_zone('UTC')
+
+      mappable_photos.each_with_object({}) do |photo, acc|
+        raw = photo[:capturedAt] || photo[:localDateTime]
+        date = parse_date(raw, zone)
+        next if date.nil?
+
+        (acc[date] ||= []) << {
+          id: photo[:id],
+          source: photo[:source],
+          taken_at: raw
+        }
+      end
+    end
+
+    private
+
+    def mappable_photos
+      Photos::Mappable.new(search_photos, privacy_zones: Users::PrivacyZones.new(@link.user).call).call
+    end
+
+    def search_photos
+      trip = @link.resource
+      return [] if trip.nil?
+
+      Photos::Search.new(@link.user, start_date: trip.started_at.iso8601, end_date: trip.ended_at.iso8601).call
+    end
+
+    def parse_date(raw, zone)
+      return nil if raw.blank?
+
+      zone.parse(raw.to_s)&.to_date
+    rescue ArgumentError, TypeError
+      nil
+    end
+  end
+end

--- a/app/services/shared_links/trip_presenter.rb
+++ b/app/services/shared_links/trip_presenter.rb
@@ -64,6 +64,16 @@ module SharedLinks
       notes[day[:date]]
     end
 
+    def photos_by_day
+      return {} unless @ctx.show_photos?
+
+      @photos_by_day ||= SharedLinks::TripPhotos.new(@link, timezone: timezone).call
+    end
+
+    def photos_for(day)
+      photos_by_day[day[:date]] || []
+    end
+
     def interactive_class
       show_map? ? ' cursor-pointer transition-colors hover:bg-base-300' : ''
     end

--- a/app/services/trips/photos.rb
+++ b/app/services/trips/photos.rb
@@ -37,7 +37,8 @@ class Trips::Photos
       id: asset[:id],
       url: "/api/v1/photos/#{asset[:id]}/thumbnail.jpg?api_key=#{user.api_key}&source=#{asset[:source]}",
       source: asset[:source],
-      orientation: asset[:orientation]
+      orientation: asset[:orientation],
+      taken_at: asset[:capturedAt] || asset[:localDateTime]
     }
   end
 end

--- a/app/services/users/privacy_zones.rb
+++ b/app/services/users/privacy_zones.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Users::PrivacyZones
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    @user.tags.privacy_zones.includes(:places).flat_map do |tag|
+      tag.places.map do |place|
+        { lon: place.longitude.to_f, lat: place.latitude.to_f, radius: tag.privacy_radius_meters }
+      end
+    end
+  end
+end

--- a/app/views/shared/links/_trip.html.erb
+++ b/app/views/shared/links/_trip.html.erb
@@ -52,13 +52,29 @@
           <% trip.days.each do |day| %>
             <% day_key = day[:date].strftime('%Y-%m-%d') %>
             <% note = trip.note_for(day) %>
-            <% if trip.show_day_notes? && note&.body.present? %>
+            <% has_note = trip.show_day_notes? && note&.body.present? %>
+            <% day_photos = trip.photos_for(day) %>
+            <% if has_note || day_photos.any? %>
               <%= tag.details class: "collapse collapse-arrow bg-base-200 rounded-lg#{trip.interactive_class}", data: trip.row_data(day_key) do %>
                 <summary class="collapse-title flex items-center gap-2 text-sm font-medium min-h-0 cursor-pointer">
                   <%= render "shared/links/trip_day_header", day: day, day_key: day_key %>
                 </summary>
                 <div class="collapse-content">
-                  <p class="whitespace-pre-wrap text-sm text-base-content/80"><%= note.body %></p>
+                  <% if has_note %>
+                    <p class="whitespace-pre-wrap text-sm text-base-content/80"><%= note.body %></p>
+                  <% end %>
+                  <% if day_photos.any? %>
+                    <div class="grid grid-cols-3 gap-2 mt-3">
+                      <% day_photos.each do |photo| %>
+                        <div class="aspect-square overflow-hidden rounded-lg">
+                          <img src="<%= url_for(controller: 'api/v1/shared/photos', action: 'thumbnail', id: link.id, photo_id: photo[:id], source: photo[:source], only_path: true) %>"
+                               loading="lazy"
+                               alt=""
+                               class="h-full w-full object-cover">
+                        </div>
+                      <% end %>
+                    </div>
+                  <% end %>
                 </div>
               <% end %>
             <% else %>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -162,6 +162,19 @@
               <% else %>
                 <%= render "trips/notes/empty", trip: @trip, date: date %>
               <% end %>
+              <% day_photos = @photos_by_day[date] %>
+              <% if day_photos.present? %>
+                <div class="grid grid-cols-3 gap-2 mt-3">
+                  <% day_photos.each do |photo| %>
+                    <div class="aspect-square overflow-hidden rounded-lg transition-transform duration-200 hover:scale-105 hover:shadow-lg">
+                      <img src="<%= photo[:url] %>"
+                           loading="lazy"
+                           alt=""
+                           class="h-full w-full object-cover">
+                    </div>
+                  <% end %>
+                </div>
+              <% end %>
             </div>
           </details>
         <% end %>
@@ -177,32 +190,19 @@
         </div>
       <% end %>
 
-      <%# Photos %>
-      <% if @photo_previews.any? %>
+      <%# Photo sources %>
+      <% if @photo_sources.any? %>
         <div class="mb-6">
-          <h3 class="text-lg font-semibold mb-3">Photos</h3>
-          <div class="grid grid-cols-3 gap-2">
-            <% @photo_previews.each do |photo| %>
-              <div class="aspect-square overflow-hidden rounded-lg transition-transform duration-200 hover:scale-105 hover:shadow-lg">
-                <img src="<%= photo[:url] %>"
-                     loading="lazy"
-                     alt=""
-                     class="h-full w-full object-cover">
-              </div>
+          <div class="flex flex-wrap gap-2">
+            <% @photo_sources.each do |source| %>
+              <%= link_to photo_search_url(source, current_user.settings, @trip.started_at, @trip.ended_at),
+                  class: "btn btn-sm btn-outline gap-1",
+                  target: "_blank",
+                  rel: "noopener" do %>
+                <%= icon 'camera', class: 'w-4 h-4' %> More on <%= source.to_s.titleize %>
+              <% end %>
             <% end %>
           </div>
-          <% if @photo_sources.any? %>
-            <div class="flex flex-wrap gap-2 mt-3">
-              <% @photo_sources.each do |source| %>
-                <%= link_to photo_search_url(source, current_user.settings, @trip.started_at, @trip.ended_at),
-                    class: "btn btn-sm btn-outline gap-1",
-                    target: "_blank",
-                    rel: "noopener" do %>
-                  <%= icon 'camera', class: 'w-4 h-4' %> More on <%= source.to_s.titleize %>
-                <% end %>
-              <% end %>
-            </div>
-          <% end %>
         </div>
       <% end %>
 

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -96,13 +96,15 @@ RSpec.describe Trip, type: :model do
           id: '456',
           url: "/api/v1/photos/456/thumbnail.jpg?api_key=#{user.api_key}&source=immich",
           source: 'immich',
-          orientation: 'portrait'
+          orientation: 'portrait',
+          taken_at: '2024-01-02T01:00:00.000Z'
         },
         {
           id: '789',
           url: "/api/v1/photos/789/thumbnail.jpg?api_key=#{user.api_key}&source=immich",
           source: 'immich',
-          orientation: 'portrait'
+          orientation: 'portrait',
+          taken_at: '2024-01-02T02:00:00.000Z'
         }
       ]
     end
@@ -131,6 +133,69 @@ RSpec.describe Trip, type: :model do
         expect(trip.photo_previews).to include(expected_photos[0])
         expect(trip.photo_previews).to include(expected_photos[1])
         expect(trip.photo_previews.size).to eq(2)
+      end
+    end
+  end
+
+  describe '#photos_by_day' do
+    let(:user) { create(:user) }
+    let(:trip) { create(:trip, user: user) }
+
+    context 'when there are photos with timestamps' do
+      let(:photos) do
+        [
+          { id: 1, url: '/p/1', source: 'immich', orientation: 'landscape', taken_at: '2024-11-27T23:30:00Z' },
+          { id: 2, url: '/p/2', source: 'immich', orientation: 'landscape', taken_at: '2024-11-29T08:00:00Z' },
+          { id: 3, url: '/p/3', source: 'immich', orientation: 'landscape', taken_at: nil }
+        ]
+      end
+
+      before do
+        allow(Trips::Photos).to receive(:new).with(trip, user)
+                                             .and_return(instance_double(Trips::Photos, call: photos))
+      end
+
+      it 'buckets a photo by its UTC instant converted into the given timezone, not its UTC date' do
+        result = trip.photos_by_day('Europe/Berlin')
+
+        expect(result.keys).to contain_exactly(Date.new(2024, 11, 28), Date.new(2024, 11, 29))
+        expect(result[Date.new(2024, 11, 28)].map { _1[:id] }).to eq([1])
+        expect(result[Date.new(2024, 11, 29)].map { _1[:id] }).to eq([2])
+      end
+
+      it 'excludes photos with a blank taken_at' do
+        result = trip.photos_by_day('Europe/Berlin')
+
+        expect(result.values.flatten.map { _1[:id] }).not_to include(3)
+      end
+    end
+
+    context 'when a photo has a naive (no-offset) timestamp' do
+      let(:photos) do
+        [{ id: 9, url: '/p/9', source: 'immich', orientation: 'landscape', taken_at: '2024-11-30T00:30:00' }]
+      end
+
+      before do
+        allow(Trips::Photos).to receive(:new).with(trip, user)
+                                             .and_return(instance_double(Trips::Photos, call: photos))
+      end
+
+      it 'buckets it as wall-clock time in the given timezone' do
+        result = trip.photos_by_day('Europe/Berlin')
+
+        expect(result.keys).to contain_exactly(Date.new(2024, 11, 30))
+        expect(result[Date.new(2024, 11, 30)].map { _1[:id] }).to eq([9])
+      end
+    end
+
+    context 'when there are no photos' do
+      before do
+        allow(Trips::Photos).to receive(:new).with(trip, user)
+                                             .and_return(instance_double(Trips::Photos, call: []))
+      end
+
+      it 'returns an empty hash' do
+        expect(trip.photos_by_day('Europe/Berlin')).to eq({})
       end
     end
   end

--- a/spec/requests/api/v1/shared/photos_spec.rb
+++ b/spec/requests/api/v1/shared/photos_spec.rb
@@ -42,7 +42,10 @@ RSpec.describe 'Api::V1::Shared::Photos', type: :request do
       create(:shared_link, user: owner, resource_type: :trip, resource_id: trip.id,
                            settings: { 'show_photos' => true })
     end
-    let(:found_photos) { [{ id: 'asset-1', source: 'immich', latitude: 52.0, longitude: 13.0 }] }
+    let(:found_photos) do
+      [{ id: 'asset-1', source: 'immich', latitude: 52.0, longitude: 13.0,
+         localDateTime: '2026-04-02T14:30:00', capturedAt: '2026-04-02T13:30:00Z' }]
+    end
 
     before do
       allow(Photos::Search).to receive(:new).and_return(instance_double(Photos::Search, call: found_photos))
@@ -54,6 +57,12 @@ RSpec.describe 'Api::V1::Shared::Photos', type: :request do
       photo = JSON.parse(response.body).first
       expect(photo).to include('id' => 'asset-1', 'latitude' => 52.0, 'longitude' => 13.0)
       expect(photo['thumbnail_url']).to be_present
+    end
+
+    it 'includes taken_at so replay can reveal photos by timestamp' do
+      get "/api/v1/shared/#{link.id}/photos"
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).first['taken_at']).to eq('2026-04-02T13:30:00Z')
     end
 
     it 'serves thumbnails for photos belonging to the trip' do

--- a/spec/requests/shared/links_spec.rb
+++ b/spec/requests/shared/links_spec.rb
@@ -96,6 +96,24 @@ RSpec.describe 'Shared::Links', type: :request do
       get "/s/#{link.id}"
       expect(response.body).not_to include(owner.email)
     end
+
+    it "renders a day's photos inside the day collapse when show_photos is on" do
+      link = create(:shared_link, user: owner, resource_type: :trip, resource_id: trip.id,
+                                  settings: { 'show_days' => true, 'show_photos' => true })
+      allow(SharedLinks::TripPhotos).to receive(:new).and_return(
+        instance_double(SharedLinks::TripPhotos,
+                        call: { Date.new(2026, 4, 1) => [{ id: 'asset-9', source: 'immich',
+                                                           taken_at: '2026-04-01T10:00:00Z' }] })
+      )
+
+      get "/s/#{link.id}"
+
+      day = Nokogiri::HTML(response.body).at_css("details[data-day-key='2026-04-01']")
+      expect(day).to be_present
+      img = day.at_css('img')
+      expect(img['src']).to include("/api/v1/shared/#{link.id}/photos/asset-9/thumbnail")
+      expect(img['src']).to include('source=immich')
+    end
   end
 
   describe 'happy-path GET /s/:id for a track' do

--- a/spec/requests/trips_spec.rb
+++ b/spec/requests/trips_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '/trips', type: :request do
   let(:user) { create(:user) }
 
   before do
-    allow_any_instance_of(Trip).to receive(:photo_previews).and_return([])
+    allow_any_instance_of(Trip).to receive(:photos_by_day).and_return({})
 
     sign_in user
   end
@@ -64,6 +64,33 @@ RSpec.describe '/trips', type: :request do
 
       expect(response.body).to include(edit_trip_path(trip))
       expect(response.body).to include('Delete this trip')
+    end
+
+    context 'with photos grouped by day' do
+      let(:photo) do
+        { id: 7, url: '/api/v1/photos/7/thumbnail.jpg?api_key=x&source=immich',
+          source: 'immich', orientation: 'landscape' }
+      end
+
+      before do
+        allow_any_instance_of(Trip).to receive(:photos_by_day)
+          .and_return({ Date.new(2024, 11, 28) => [photo] })
+      end
+
+      it "renders a day's photos inside that day's collapse" do
+        get trip_url(trip)
+
+        day = Nokogiri::HTML(response.body).at_css("details[data-day-key='2024-11-28']")
+        expect(day.at_css("img[src='#{photo[:url]}']")).to be_present
+      end
+
+      it 'renders photo thumbnails only inside day collapses (no flat bottom grid)' do
+        get trip_url(trip)
+
+        imgs = Nokogiri::HTML(response.body).css("img[src*='/api/v1/photos/']")
+        expect(imgs).to be_present
+        expect(imgs).to all(satisfy { |img| img.ancestors('details').any? })
+      end
     end
 
     it 'computes day stats with PostGIS (no Ruby Geocoder fallback)' do

--- a/spec/services/photos/mappable_spec.rb
+++ b/spec/services/photos/mappable_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Photos::Mappable do
+  let(:photos) do
+    [
+      { id: 'a', latitude: 52.0, longitude: 13.0 },
+      { id: 'b', latitude: nil, longitude: 13.0 },
+      { id: 'c', latitude: 60.0, longitude: 10.0 }
+    ]
+  end
+
+  it 'keeps only geotagged photos' do
+    result = described_class.new(photos).call
+
+    expect(result.map { _1[:id] }).to contain_exactly('a', 'c')
+  end
+
+  it 'rejects photos inside a privacy zone' do
+    zones = [{ lat: 52.0, lon: 13.0, radius: 500 }]
+
+    result = described_class.new(photos, privacy_zones: zones).call
+
+    expect(result.map { _1[:id] }).to eq(['c'])
+  end
+
+  it 'caps the number of photos at the given max' do
+    many = Array.new(5) { |i| { id: i, latitude: 1.0, longitude: 1.0 } }
+
+    expect(described_class.new(many, max: 2).call.size).to eq(2)
+  end
+
+  it 'defaults the cap to MAX_PHOTOS' do
+    many = Array.new(Photos::Mappable::MAX_PHOTOS + 10) { |i| { id: i, latitude: 1.0, longitude: 1.0 } }
+
+    expect(described_class.new(many).call.size).to eq(Photos::Mappable::MAX_PHOTOS)
+  end
+end

--- a/spec/services/shared_links/trip_photos_spec.rb
+++ b/spec/services/shared_links/trip_photos_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SharedLinks::TripPhotos do
+  let(:owner) { create(:user) }
+  let(:trip) do
+    create(:trip, user: owner, started_at: Time.utc(2024, 11, 27), ended_at: Time.utc(2024, 11, 30))
+  end
+  let(:link) do
+    create(:shared_link, user: owner, resource_type: :trip, resource_id: trip.id,
+                         settings: { 'show_photos' => true })
+  end
+  let(:found_photos) do
+    [
+      { id: 'p1', source: 'immich', latitude: 52.0, longitude: 13.0,
+        capturedAt: '2024-11-27T23:30:00Z', localDateTime: '2024-11-28T00:30:00' },
+      { id: 'p2', source: 'immich', latitude: 60.0, longitude: 10.0,
+        capturedAt: '2024-11-29T08:00:00Z', localDateTime: '2024-11-29T09:00:00' }
+    ]
+  end
+
+  before do
+    allow(Photos::Search).to receive(:new).and_return(instance_double(Photos::Search, call: found_photos))
+  end
+
+  it 'groups trip photos by their day in the given timezone' do
+    result = described_class.new(link, timezone: 'Europe/Berlin').call
+
+    expect(result.keys).to contain_exactly(Date.new(2024, 11, 28), Date.new(2024, 11, 29))
+    expect(result[Date.new(2024, 11, 28)].map { _1[:id] }).to eq(['p1'])
+    expect(result[Date.new(2024, 11, 28)].first).to include(source: 'immich', taken_at: '2024-11-27T23:30:00Z')
+  end
+
+  it 'excludes photos inside a privacy zone' do
+    home = create(:place, user: owner, latitude: 52.0, longitude: 13.0)
+    tag = create(:tag, user: owner, privacy_radius_meters: 500)
+    create(:tagging, tag: tag, taggable: home)
+
+    result = described_class.new(link, timezone: 'Europe/Berlin').call
+
+    expect(result.values.flatten.map { _1[:id] }).to eq(['p2'])
+  end
+end

--- a/spec/services/shared_links/trip_presenter_spec.rb
+++ b/spec/services/shared_links/trip_presenter_spec.rb
@@ -70,4 +70,33 @@ RSpec.describe SharedLinks::TripPresenter do
       expect(presenter.notes).to eq({})
     end
   end
+
+  describe '#photos_by_day and #photos_for' do
+    context 'when show_photos is disabled' do
+      let(:settings) { { 'show_photos' => false } }
+
+      it 'returns an empty hash' do
+        expect(presenter.photos_by_day).to eq({})
+      end
+    end
+
+    context 'when show_photos is enabled' do
+      let(:settings) { { 'show_photos' => true } }
+      let(:grouped) { { Date.new(2024, 11, 28) => [{ id: 'p1', source: 'immich', taken_at: '2024-11-27T23:30:00Z' }] } }
+
+      before do
+        allow(SharedLinks::TripPhotos).to receive(:new)
+          .with(link, timezone: user.timezone_iana)
+          .and_return(instance_double(SharedLinks::TripPhotos, call: grouped))
+      end
+
+      it 'returns photos grouped by day' do
+        expect(presenter.photos_by_day).to eq(grouped)
+      end
+
+      it 'photos_for returns that day\'s photos' do
+        expect(presenter.photos_for({ date: Date.new(2024, 11, 28) }).map { _1[:id] }).to eq(['p1'])
+      end
+    end
+  end
 end

--- a/spec/services/trips/photos_spec.rb
+++ b/spec/services/trips/photos_spec.rb
@@ -27,15 +27,17 @@ RSpec.describe Trips::Photos do
         [
           {
             id: 1,
-            url: '/api/v1/photos/1/thumbnail.jpg?api_key=test-api-key&source=immich',
             source: 'immich',
-            orientation: 'landscape'
+            orientation: 'landscape',
+            localDateTime: '2024-01-02T14:30:00',
+            capturedAt: '2024-01-02T13:30:00Z'
           },
           {
             id: 2,
-            url: '/api/v1/photos/2/thumbnail.jpg?api_key=test-api-key&source=photoprism',
             source: 'photoprism',
-            orientation: 'portrait'
+            orientation: 'portrait',
+            localDateTime: '2024-01-03T09:00:00',
+            capturedAt: '2024-01-03T08:00:00Z'
           }
         ]
       end
@@ -57,13 +59,15 @@ RSpec.describe Trips::Photos do
             id: 1,
             url: '/api/v1/photos/1/thumbnail.jpg?api_key=test-api-key&source=immich',
             source: 'immich',
-            orientation: 'landscape'
+            orientation: 'landscape',
+            taken_at: '2024-01-02T13:30:00Z'
           },
           {
             id: 2,
             url: '/api/v1/photos/2/thumbnail.jpg?api_key=test-api-key&source=photoprism',
             source: 'photoprism',
-            orientation: 'portrait'
+            orientation: 'portrait',
+            taken_at: '2024-01-03T08:00:00Z'
           }
         ]
 

--- a/spec/services/users/privacy_zones_spec.rb
+++ b/spec/services/users/privacy_zones_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::PrivacyZones do
+  let(:user) { create(:user) }
+
+  it 'returns lon/lat/radius hashes for each place tagged as a privacy zone' do
+    place = create(:place, user: user, latitude: 52.5, longitude: 13.4)
+    tag = create(:tag, user: user, privacy_radius_meters: 300)
+    create(:tagging, tag: tag, taggable: place)
+
+    result = described_class.new(user).call
+
+    expect(result).to contain_exactly(
+      a_hash_including(lon: 13.4, lat: 52.5, radius: 300)
+    )
+  end
+
+  it 'returns an empty array when the user has no privacy zones' do
+    expect(described_class.new(user).call).to eq([])
+  end
+end


### PR DESCRIPTION
Trip and replay photos now pop in one at a time as the replay playhead reaches each photo's timestamp (markers minted lazily, never pre-rendered), with privacy-zone masking applied via a new `Users::PrivacyZones` service. Also wires shared-link trip photos through a dedicated presenter.