### PR TITLE
Harden 1.9.1 notes backfill migration + stabilize confirmed-visit lookup

### DIFF
--- a/app/services/visits/creator.rb
+++ b/app/services/visits/creator.rb
@@ -107,7 +107,7 @@ module Visits
       visit_ids = Array(visit_data[:points]).filter_map(&:visit_id).uniq
       return nil if visit_ids.empty?
 
-      user.visits.confirmed.find_by(id: visit_ids)
+      user.visits.confirmed.order(:id).find_by(id: visit_ids)
     end
 
     def find_matching_area(visit_data)

--- a/db/migrate/20260622090000_backfill_notes_columns.rb
+++ b/db/migrate/20260622090000_backfill_notes_columns.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class BackfillNotesColumns < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  UNIQUE_INDEX_NAME = 'index_notes_on_attachable_and_noted_date'
+
   def up
     return unless table_exists?(:notes)
 
@@ -11,13 +15,37 @@ class BackfillNotesColumns < ActiveRecord::Migration[8.0]
     add_column :notes, :noted_at, :datetime unless column_exists?(:notes, :noted_at)
     add_column :notes, :lonlat, :st_point, geographic: true unless column_exists?(:notes, :lonlat)
 
-    add_index :notes, %i[attachable_type attachable_id], if_not_exists: true
-    add_index :notes, :lonlat, using: :gist, if_not_exists: true
+    add_index :notes, %i[attachable_type attachable_id], if_not_exists: true, algorithm: :concurrently
+    add_index :notes, :lonlat, using: :gist, if_not_exists: true, algorithm: :concurrently
+
+    return if index_name_exists?(:notes, UNIQUE_INDEX_NAME)
+
+    ensure_no_duplicate_attachable_dates!
 
     execute <<~SQL.squish
-      CREATE UNIQUE INDEX IF NOT EXISTS index_notes_on_attachable_and_noted_date
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS #{UNIQUE_INDEX_NAME}
       ON notes (attachable_type, attachable_id, (CAST(noted_at AS date)))
       WHERE attachable_id IS NOT NULL
     SQL
+  end
+
+  private
+
+  def ensure_no_duplicate_attachable_dates!
+    duplicate_groups = select_all(<<~SQL.squish).to_a
+      SELECT attachable_type, attachable_id, CAST(noted_at AS date) AS noted_date
+      FROM notes
+      WHERE attachable_id IS NOT NULL
+      GROUP BY attachable_type, attachable_id, CAST(noted_at AS date)
+      HAVING COUNT(*) > 1
+    SQL
+
+    return if duplicate_groups.empty?
+
+    raise <<~MSG.squish
+      Cannot create unique index #{UNIQUE_INDEX_NAME}: #{duplicate_groups.size} duplicate
+      (attachable_type, attachable_id, noted_at::date) group(s) exist in the notes table.
+      Resolve the duplicates and re-run this migration.
+    MSG
   end
 end

--- a/spec/regressions/notes_body_column_present_spec.rb
+++ b/spec/regressions/notes_body_column_present_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require Rails.root.join('db/migrate/20260622090000_backfill_notes_columns')
 
-RSpec.describe BackfillNotesColumns do
+RSpec.describe BackfillNotesColumns, :non_transactional do
   def column?(name)
     ActiveRecord::Base.connection.column_exists?(:notes, name)
   end
@@ -33,5 +33,30 @@ RSpec.describe BackfillNotesColumns do
     expect(column?(:body)).to be(true)
     expect { described_class.new.up }.not_to raise_error
     expect(column?(:body)).to be(true)
+  end
+
+  it 'raises a clear error when duplicate attachable dates would violate the unique index' do
+    connection = ActiveRecord::Base.connection
+    user = create(:user)
+    noted_at = Time.current
+
+    connection.execute("DROP INDEX IF EXISTS #{described_class::UNIQUE_INDEX_NAME}")
+    Note.insert_all(
+      Array.new(2) do
+        { user_id: user.id, body: 'dup', noted_at: noted_at, attachable_type: 'Trip',
+          attachable_id: 999_999, created_at: Time.current, updated_at: Time.current }
+      end
+    )
+
+    expect { described_class.new.up }.to raise_error(/duplicate/i)
+  ensure
+    Note.where(attachable_id: 999_999).delete_all
+    unless connection.index_name_exists?(:notes, described_class::UNIQUE_INDEX_NAME)
+      connection.execute(<<~SQL.squish)
+        CREATE UNIQUE INDEX IF NOT EXISTS #{described_class::UNIQUE_INDEX_NAME}
+        ON notes (attachable_type, attachable_id, (CAST(noted_at AS date)))
+        WHERE attachable_id IS NOT NULL
+      SQL
+    end
   end
 end


### PR DESCRIPTION
Follow-ups from a multi-perspective review of #3001 (1.9.1). Targets `dev`.

## Changes

**Notes backfill migration (`20260622090000_backfill_notes_columns.rb`)**
- Adds a duplicate precheck before the unique index. If a notes table holds duplicate `(attachable_type, attachable_id, noted_at::date)` rows, the migration now raises a descriptive error naming the duplicate count instead of failing mid-deploy with a cryptic `PG::UniqueViolation`. It does not delete user notes — resolving duplicates is left to the operator.
- Builds all three indexes with `algorithm: :concurrently` + `disable_ddl_transaction!`, matching the repo's migration conventions, so index creation never locks writes.

**`Visits::Creator#confirmed_visit_owning_points`**
- Orders the confirmed-visit lookup by `id` so the returned visit is deterministic for stable logs/tests when candidate points span more than one confirmed visit (behavior unchanged — truthiness is all the caller needs).

**Tests**
- New regression test covers the duplicate-data raise path. The migration spec is tagged `:non_transactional` (using the existing `spec/support/non_transactional_concurrency.rb` infra) because `CREATE INDEX CONCURRENTLY` cannot run inside RSpec's per-example transaction.

## Verification
- `5 examples, 0 failures` — `notes_body_column_present_spec.rb` (incl. new dedup test) + `visit_suggestion_skips_points_owned_by_confirmed_spec.rb`
- `rubocop` clean on all changed files

## Not changed
- `Trip#photos_by_day` timezone handling was reviewed and left as-is: `taken_at` is a UTC instant (`fileCreatedAt`/`TakenAt`), and the replay index documents the system-wide design of day-keying UTC instants in the configured timezone so photos align with track points and trip-day rows. Parsing the instant into the configured zone is correct and consistent.
