### PR TITLE
fix: select visit_id when building visit hashes (DAWARICH-5K)

### DIFF
--- a/app/services/visits/smart_detect.rb
+++ b/app/services/visits/smart_detect.rb
@@ -146,7 +146,7 @@ module Visits
     def build_visit_hashes(clusters)
       all_point_ids = clusters.flat_map { |c| c[:point_ids] }.select(&:positive?)
       points_by_id = Point.where(id: all_point_ids)
-                          .select(:id, :lonlat, :timestamp, :accuracy, :geodata)
+                          .select(:id, :visit_id, :lonlat, :timestamp, :accuracy, :geodata)
                           .index_by(&:id)
 
       clusters.filter_map do |cluster|

--- a/spec/services/visits/smart_detect_spec.rb
+++ b/spec/services/visits/smart_detect_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe Visits::SmartDetect do
 
       expect(visits.size).to be >= 1
     end
+
+    it 'loads visit_id so confirmed-visit ownership checks do not raise MissingAttributeError' do
+      points = Array.new(6) do |i|
+        create(:point, user: user, latitude: 52.5, longitude: 13.4, lonlat: 'POINT(13.4 52.5)',
+                       timestamp: base_ts + i * 60, accuracy: 10, visit_id: nil)
+      end
+
+      visits = described_class.new(user, start_at: base_ts - 1, end_at: base_ts + 600).call
+
+      expect(visits.size).to eq(1)
+      expect(points.map { |p| p.reload.visit_id }.uniq).to eq([visits.first.id])
+    end
   end
 
   describe 'detector selection (stay_point_detection flag)' do


### PR DESCRIPTION
## Problem

`ActiveModel::MissingAttributeError: missing attribute 'visit_id' for Point` — 12,478 occurrences since 2026-06-22 (GlitchTip DAWARICH-5K).

`Visits::Creator#confirmed_visit_owning_points` (added in #2952 to skip suggesting visits for points already owned by a confirmed visit) reads `point.visit_id`:

```ruby
visit_ids = Array(visit_data[:points]).filter_map(&:visit_id).uniq
```

But those points come from `Visits::SmartDetect#build_visit_hashes`, which loaded them with a partial `select` that omitted `visit_id`. Reading an unselected attribute raises `MissingAttributeError` — even when the value would be `nil` — so it fired on every detection run that produced clusters.

## Fix

Add `:visit_id` to the `select` in `build_visit_hashes` so the consumer gets the column it needs.

## Tests

- Added a regression spec in `smart_detect_spec.rb` (proven RED→GREEN: fails with the exact `MissingAttributeError` without the fix).
- Full `spec/services/visits/` suite: 214 examples, 0 failures.
- RuboCop clean.