### PR TITLE
feat: AirTrail flight arcs and flight masking on trip show pages

### DIFF
--- a/app/javascript/controllers/trip_maplibre_controller.js
+++ b/app/javascript/controllers/trip_maplibre_controller.js
@@ -2,11 +2,13 @@ import { Controller } from "@hotwired/stimulus"
 import { MapInitializer } from "controllers/maps/maplibre/map_initializer"
 import maplibregl from "maplibre-gl"
 import { DayRoutesLayer } from "maps_maplibre/layers/day_routes_layer"
+import { FlightsLayer } from "maps_maplibre/layers/flights_layer"
 import { PhotosLayer } from "maps_maplibre/layers/photos_layer"
 import { ReplayManager } from "maps_maplibre/managers/replay_manager"
 import { ReplayPanel } from "maps_maplibre/managers/replay_panel"
 import { ApiClient } from "maps_maplibre/services/api_client"
 import { featureToPhoto } from "maps_maplibre/utils/feature_to_photo"
+import { flightWindows } from "maps_maplibre/utils/flight_mask"
 
 /**
  * Trip MapLibre Controller
@@ -21,6 +23,8 @@ export default class extends Controller {
     "loadingIndicator",
     // Photos button
     "photosToggleBtn",
+    // Flights button
+    "flightsToggleBtn",
     // Replay toggle button
     "replayToggleBtn",
     // Replay panel
@@ -61,6 +65,9 @@ export default class extends Controller {
     this.photosLayer = null
     this.photosGeoJSON = null
     this.photosActive = false
+    this.flightsLayer = null
+    this.flightsGeoJSON = null
+    this.flightsActive = false
     this.mapInitializing = false
     this.overviewSourceId = "trip-overview-source"
     this.overviewLayerId = "trip-overview-layer"
@@ -79,6 +86,10 @@ export default class extends Controller {
     if (this.photosLayer) {
       this.photosLayer.remove()
       this.photosLayer = null
+    }
+    if (this.flightsLayer) {
+      this.flightsLayer.remove()
+      this.flightsLayer = null
     }
     if (this.dayRoutesLayer) {
       this.dayRoutesLayer.remove()
@@ -215,6 +226,10 @@ export default class extends Controller {
       if (fullBounds) {
         this.map.fitBounds(fullBounds, { padding: 50, maxZoom: 15 })
       }
+
+      // Re-apply flight masking in case flights were toggled on before the
+      // day routes finished loading.
+      this.applyFlightMask()
 
       // Store all points for replay use
       this.allPoints = allPoints
@@ -446,6 +461,59 @@ export default class extends Controller {
         }
       }),
     }
+  }
+
+  // ===== Flights layer toggle (button-based) =====
+
+  async toggleFlights() {
+    this.flightsActive = !this.flightsActive
+
+    if (!this.flightsActive) {
+      this.flightsLayer?.hide()
+      this.applyFlightMask()
+      this._setButtonActive(this.flightsToggleBtnTarget, false)
+      return
+    }
+
+    if (!this.flightsGeoJSON) {
+      const apiClient = new ApiClient(this.apiKeyValue)
+      try {
+        this.flightsGeoJSON = await apiClient.fetchFlights({
+          start_at: this.startedAtValue,
+          end_at: this.endedAtValue,
+        })
+      } catch (e) {
+        console.error("[TripMapLibre] Error fetching flights:", e)
+        this.flightsActive = false
+        return
+      }
+    }
+
+    if (!this.flightsGeoJSON.features?.length) {
+      this.flightsActive = false
+      return
+    }
+
+    if (!this.flightsLayer) {
+      this.flightsLayer = new FlightsLayer(this.map, {
+        style: this.mapStyleValue,
+      })
+      this.flightsLayer.add(this.flightsGeoJSON)
+    } else {
+      this.flightsLayer.update(this.flightsGeoJSON)
+      this.flightsLayer.show()
+    }
+
+    this.applyFlightMask()
+    this._setButtonActive(this.flightsToggleBtnTarget, true)
+  }
+
+  applyFlightMask() {
+    const windows =
+      this.flightsActive && this.flightsLayer?.visible
+        ? flightWindows(this.flightsGeoJSON)
+        : []
+    this.dayRoutesLayer?.maskRoutes(windows)
   }
 
   // ===== Note form toggling =====

--- a/app/javascript/maps_maplibre/layers/day_routes_layer.js
+++ b/app/javascript/maps_maplibre/layers/day_routes_layer.js
@@ -1,4 +1,5 @@
 import maplibregl from "maplibre-gl"
+import { maskLines } from "../utils/flight_mask"
 import { RouteSegmenter } from "../utils/route_segmenter"
 
 /**
@@ -12,6 +13,7 @@ export class DayRoutesLayer {
     this.daySources = new Map() // dayKey -> sourceId
     this.dayLayers = new Map() // dayKey -> layerId
     this.dayColors = new Map() // dayKey -> color string
+    this.dayRouteData = new Map() // dayKey -> unmasked route GeoJSON
     this.dayBounds = new Map() // dayKey -> LngLatBounds
     this.fullBounds = null
     this.selectedDay = null
@@ -83,6 +85,7 @@ export class DayRoutesLayer {
 
       this.daySources.set(dayKey, sourceId)
       this.dayLayers.set(dayKey, layerId)
+      this.dayRouteData.set(dayKey, routeGeoJSON)
 
       // Add source
       if (!this.map.getSource(sourceId)) {
@@ -135,6 +138,24 @@ export class DayRoutesLayer {
       for (const coord of allCoords) {
         this.fullBounds.extend(coord)
       }
+    }
+  }
+
+  /**
+   * Give AirTrail flights render priority over day routes: hide route segments
+   * whose full time span is contained inside a flight window. Passing empty
+   * windows restores the unmasked routes. Reversible.
+   * @param {Array<[number, number]>} windows - Flight windows in Unix seconds
+   */
+  maskRoutes(windows) {
+    for (const [dayKey, sourceId] of this.daySources) {
+      const original = this.dayRouteData.get(dayKey)
+      if (!original) continue
+
+      const source = this.map.getSource(sourceId)
+      if (!source?.setData) continue
+
+      source.setData(windows?.length ? maskLines(original, windows) : original)
     }
   }
 
@@ -349,6 +370,7 @@ export class DayRoutesLayer {
     this.daySources.clear()
     this.dayLayers.clear()
     this.dayColors.clear()
+    this.dayRouteData.clear()
     this.dayBounds.clear()
     this.fullBounds = null
     this.selectedDay = null

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -104,6 +104,17 @@
           </button>
         <% end %>
 
+        <% if current_user.safe_settings.airtrail_url.present? %>
+          <button type="button"
+                  class="btn btn-sm btn-outline gap-1"
+                  data-trip-maplibre-target="flightsToggleBtn"
+                  data-action="click->trip-maplibre#toggleFlights"
+                  title="Toggle AirTrail flights on map">
+            <%= icon 'plane', class: 'w-4 h-4' %>
+            <span class="hidden sm:inline">Flights</span>
+          </button>
+        <% end %>
+
         <button type="button"
                 class="btn btn-sm btn-outline gap-1"
                 data-trip-maplibre-target="replayToggleBtn"


### PR DESCRIPTION
Brings trip show pages to parity with Map v2: trip pages now render flight arcs and apply flight masking, matching the day-routes / photos / replay treatment already on the main map.

## Changes

- **Flight arcs on trip maps** — render AirTrail flights as arcs on the trip show page (MapLibre).
- **Flight masking** — `DayRoutesLayer#maskRoutes` hides day-route segments whose full time span falls inside a flight window; reversible (empty windows restore unmasked routes).
- **Flights toggle** — a Flights button (shown only when `safe_settings.airtrail_url` is configured) wired to `trip-maplibre#toggleFlights`.

## Status

⚠️ Browser-unverified — needs a manual pass on a trip with AirTrail flights before merge.