### PR TITLE
chore: target dependabot version updates at dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ version: 2
 updates:
   - package-ecosystem: 'bundler'
     directory: '/'
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
       day: 'monday'
@@ -16,6 +17,7 @@ updates:
 
   - package-ecosystem: 'docker'
     directory: '/docker'
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
       day: 'monday'
@@ -23,6 +25,7 @@ updates:
 
   - package-ecosystem: 'github-actions'
     directory: '/'
+    target-branch: 'dev'
     schedule:
       interval: 'weekly'
       day: 'monday'


### PR DESCRIPTION
Adds `target-branch: 'dev'` to the bundler, docker, and github-actions ecosystems in `.github/dependabot.yml` so dependabot opens version-update PRs against `dev` (the development/PR branch) instead of `master`.

The 13 currently-open dependabot PRs were also retargeted to `dev` manually.

Note: dependabot *security* PRs always open against the default branch and ignore `target-branch` — those can only be retargeted per-PR.