### PR TITLE
Fix integer division truncation in place visit radius calculation

### DIFF
--- a/app/services/places/visits/create.rb
+++ b/app/services/places/visits/create.rb
@@ -4,7 +4,7 @@ class Places::Visits::Create
   attr_reader :user, :places
 
   # Default radius for place visit detection (in meters)
-  DEFAULT_PLACE_RADIUS = 100
+  DEFAULT_PLACE_RADIUS = 100.0
 
   def initialize(user, places)
     @user = user


### PR DESCRIPTION
Fixes #3031

## What

`DEFAULT_PLACE_RADIUS = 100` (integer) divided by `DISTANCE_UNITS[:km] = 1000` (integer) uses Ruby integer division and truncates to `0`, causing place visit detection to query a 0-radius circle and find no nearby GPS points.

## Fix

Change the constant to a float so all divisions produce the correct result:

```ruby
# before
DEFAULT_PLACE_RADIUS = 100

# after
DEFAULT_PLACE_RADIUS = 100.0
```

## Impact

- **Broken:** users with `km` distance unit — place visits are never suggested
- **Unaffected:** `mi`, `ft`, `yd` users (those `DISTANCE_UNITS` values are already floats so Ruby uses float division), `m` users (`100 / 1 = 100`, coincidentally correct)