### PR TITLE
Fix malformed 'after' parameter in Photoprism API request

### DIFF
--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -31,21 +31,32 @@ class Api::V1::PointsController < ApiController
       bbox = parse_bbox(params)
       return render(json: { error: 'Invalid bounding box' }, status: :bad_request) unless bbox
 
+      envelope = 'ST_MakeEnvelope(?, ?, ?, ?, 4326)'
       points = points.where(
-        'lonlat && ST_MakeEnvelope(?, ?, ?, ?, 4326)::geography',
+        "lonlat && #{envelope}::geography AND ST_Intersects(lonlat::geometry, #{envelope})",
+        bbox[:min_lng], bbox[:min_lat], bbox[:max_lng], bbox[:max_lat],
         bbox[:min_lng], bbox[:min_lat], bbox[:max_lng], bbox[:max_lat]
-      ).where(
-        'ST_X(lonlat::geometry) BETWEEN ? AND ? AND ST_Y(lonlat::geometry) BETWEEN ? AND ?',
-        bbox[:min_lng], bbox[:max_lng], bbox[:min_lat], bbox[:max_lat]
       )
     end
+
+    cache_max_ts = points.maximum(:timestamp)
+    fresh_when(
+      etag: points_index_etag(start_at, end_at, order, cache_max_ts),
+      last_modified: cache_max_ts && Time.zone.at(cache_max_ts),
+      public: false
+    )
+    return if performed?
 
     points = points
              .order(timestamp: order)
              .page(params[:page])
              .per(params[:per_page] || 100)
 
-    serialized_points = points.map { |point| point_serializer.new(point).call }
+    serialized_points = if slim_points?
+                          Points::SlimCollectionQuery.new(points).call
+                        else
+                          points.map { |point| point_serializer.new(point).call }
+                        end
 
     response.set_header('X-Current-Page', points.current_page.to_s)
     response.set_header('X-Total-Pages', points.total_pages.to_s)
@@ -184,8 +195,23 @@ class Api::V1::PointsController < ApiController
     params.permit(point_ids: [])
   end
 
+  def slim_points?
+    params[:slim] == 'true'
+  end
+
+  def points_index_etag(start_at, end_at, order, max_timestamp)
+    [
+      'points/index', current_api_user.id, start_at, end_at, order, slim_points?,
+      params[:page], params[:per_page] || 100,
+      params[:anomalies_only], params[:include_anomalies],
+      params[:min_longitude], params[:max_longitude],
+      params[:min_latitude], params[:max_latitude],
+      max_timestamp
+    ]
+  end
+
   def point_serializer
-    params[:slim] == 'true' ? Api::SlimPointSerializer : Api::PointSerializer
+    slim_points? ? Api::SlimPointSerializer : Api::PointSerializer
   end
 
   # Validate and parse a bbox from request params. Rejects non-finite values

--- a/app/javascript/controllers/stat_page_controller.js
+++ b/app/javascript/controllers/stat_page_controller.js
@@ -107,7 +107,7 @@ export default class extends BaseController {
 
     while (true) {
       const response = await fetch(
-        `/api/v1/points?start_at=${encodeURIComponent(startDate)}&end_at=${encodeURIComponent(endDate)}&per_page=1000&page=${page}`,
+        `/api/v1/points?slim=true&start_at=${encodeURIComponent(startDate)}&end_at=${encodeURIComponent(endDate)}&per_page=1000&page=${page}`,
         {
           method: "GET",
           headers: {

--- a/app/queries/points/slim_collection_query.rb
+++ b/app/queries/points/slim_collection_query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Points::SlimCollectionQuery
+  def initialize(relation)
+    @relation = relation
+  end
+
+  def call
+    @relation
+      .joins('LEFT JOIN countries ON countries.id = points.country_id')
+      .pluck(
+        Arel.sql('points.id'),
+        Arel.sql('ST_Y(points.lonlat::geometry)'),
+        Arel.sql('ST_X(points.lonlat::geometry)'),
+        Arel.sql('points.timestamp'),
+        Arel.sql('points.velocity'),
+        Arel.sql("COALESCE(points.country_name, countries.name, points.country, '')"),
+        Arel.sql('points.tracker_id')
+      )
+      .map do |id, lat, lon, timestamp, velocity, country_name, tracker_id|
+        {
+          id: id,
+          latitude: lat.to_s,
+          longitude: lon.to_s,
+          timestamp: timestamp,
+          velocity: velocity,
+          country_name: country_name,
+          tracker_id: tracker_id
+        }
+      end
+  end
+end

--- a/app/services/photoprism/request_photos.rb
+++ b/app/services/photoprism/request_photos.rb
@@ -96,7 +96,7 @@ class Photoprism::RequestPhotos
       q: '',
       public: true,
       quality: 3,
-      after: start_date,
+      after: start_date.to_date.beginning_of_day.iso8601,
       count: 1000
     }
   end

--- a/spec/queries/points/slim_collection_query_spec.rb
+++ b/spec/queries/points/slim_collection_query_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Points::SlimCollectionQuery do
+  let(:user) { create(:user) }
+
+  it 'returns a payload byte-identical to Api::SlimPointSerializer' do
+    create_list(:point, 3, user: user)
+    relation = user.points.order(:timestamp)
+
+    expected = relation.map { |point| Api::SlimPointSerializer.new(point).call }
+
+    expect(described_class.new(relation).call).to eq(expected)
+  end
+
+  it 'resolves country_name through the country association when the column is blank' do
+    country = create(:country, name: 'Germany')
+    point = create(:point, user: user)
+    point.update_columns(country_name: nil, country: nil, country_id: country.id)
+
+    result = described_class.new(user.points.where(id: point.id)).call
+
+    expect(result.first[:country_name]).to eq('Germany')
+  end
+
+  it 'falls back to an empty string when no country information exists' do
+    point = create(:point, user: user)
+    point.update_columns(country_name: nil, country: nil, country_id: nil)
+
+    result = described_class.new(user.points.where(id: point.id)).call
+
+    expect(result.first[:country_name]).to eq('')
+  end
+
+  it 'preserves the relation order' do
+    p1 = create(:point, user: user, timestamp: 100)
+    p2 = create(:point, user: user, timestamp: 200)
+
+    result = described_class.new(user.points.order(timestamp: :desc)).call
+
+    expect(result.map { |row| row[:id] }).to eq([p2.id, p1.id])
+  end
+end

--- a/spec/requests/api/v1/points_caching_spec.rb
+++ b/spec/requests/api/v1/points_caching_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Points conditional GET caching', type: :request do
+  let(:user) { create(:user) }
+  let(:range) { "slim=true&start_at=#{2.days.ago.to_i}&end_at=#{Time.current.to_i}" }
+
+  before do
+    create_list(:point, 3, user: user, timestamp: 1.day.ago.to_i)
+  end
+
+  it 'returns an ETag on the points index' do
+    get "/api/v1/points?api_key=#{user.api_key}&#{range}"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.headers['ETag']).to be_present
+  end
+
+  it 'returns 304 Not Modified when the ETag matches and data is unchanged' do
+    get "/api/v1/points?api_key=#{user.api_key}&#{range}"
+    etag = response.headers['ETag']
+
+    get "/api/v1/points?api_key=#{user.api_key}&#{range}",
+        headers: { 'If-None-Match' => etag }
+
+    expect(response).to have_http_status(:not_modified)
+    expect(response.body).to be_empty
+  end
+
+  it 'does not run the point-row fetch on a 304 (skips serialization)' do
+    get "/api/v1/points?api_key=#{user.api_key}&#{range}"
+    etag = response.headers['ETag']
+
+    queries = []
+    callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+    ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+      get "/api/v1/points?api_key=#{user.api_key}&#{range}",
+          headers: { 'If-None-Match' => etag }
+    end
+
+    expect(response).to have_http_status(:not_modified)
+    expect(queries.none? { |sql| sql.include?('ST_Y') }).to be(true)
+  end
+
+  it 'returns a fresh 200 when a new point arrives' do
+    get "/api/v1/points?api_key=#{user.api_key}&#{range}"
+    etag = response.headers['ETag']
+
+    create(:point, user: user, timestamp: 1.hour.ago.to_i)
+
+    get "/api/v1/points?api_key=#{user.api_key}&#{range}",
+        headers: { 'If-None-Match' => etag }
+
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/services/photoprism/request_photos_spec.rb
+++ b/spec/services/photoprism/request_photos_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Photoprism::RequestPhotos do
         stub_request(
           :any,
           "#{user.settings['photoprism_url']}/api/v1/photos?" \
-            "after: expected_after_date&before=#{expected_before_date}&count=1000&public=true&q=&quality=3"
+            "after=#{expected_after_date}&before=#{expected_before_date}&count=1000&public=true&q=&quality=3"
         ).with(
           headers: {
             'Accept' => 'application/json',
@@ -188,7 +188,7 @@ RSpec.describe Photoprism::RequestPhotos do
         stub_request(
           :any,
           "#{user.settings['photoprism_url']}/api/v1/photos?" \
-            "after: expected_after_date&before=#{expected_before_date}&count=1000&public=true&q=&quality=3&offset=1000"
+            "after=#{expected_after_date}&before=#{expected_before_date}&count=1000&public=true&q=&quality=3&offset=1000"
         ).to_return(status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' })
       end
 
@@ -219,14 +219,14 @@ RSpec.describe Photoprism::RequestPhotos do
         stub_request(
           :get,
           "#{user.settings['photoprism_url']}/api/v1/photos?" \
-            "after: expected_after_date&before=#{expected_before_date}&count=1000&public=true&q=&quality=3"
+            "after=#{expected_after_date}&before=#{expected_before_date}&count=1000&public=true&q=&quality=3"
         ).to_return(status: 400, body: { status: 400, error: 'Unable to do that' }.to_json)
       end
 
       it 'logs the error' do
         expect(Rails.logger).to receive(:error).with('Photoprism photo fetch failed: Request failed: 400')
         expect(Rails.logger).to receive(:debug).with(
-          "Photoprism API request params: #{{ q: '', public: true, quality: 3, after: expected_after_date, count: 1000,
+          "Photoprism API request params: #{{ q: '', public: true, quality: 3, after=#{expected_after_date}, count: 1000,
 before: expected_before_date }}"
         )
 

--- a/spec/services/photoprism/request_photos_spec.rb
+++ b/spec/services/photoprism/request_photos_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Photoprism::RequestPhotos do
   let(:start_date) { '2024-01-01' }
   let(:end_date) { '2024-12-31' }
   let(:expected_before_date) { '2025-01-01T00:00:00Z' }
+  let(:expected_after_date) { '2024-01-01T00:00:00Z' }
   let(:service) { described_class.new(user, start_date: start_date, end_date: end_date) }
 
   around { |example| Time.use_zone('UTC') { example.run } }
@@ -169,7 +170,7 @@ RSpec.describe Photoprism::RequestPhotos do
         stub_request(
           :any,
           "#{user.settings['photoprism_url']}/api/v1/photos?" \
-            "after=#{start_date}&before=#{expected_before_date}&count=1000&public=true&q=&quality=3"
+            "after: expected_after_date&before=#{expected_before_date}&count=1000&public=true&q=&quality=3"
         ).with(
           headers: {
             'Accept' => 'application/json',
@@ -187,7 +188,7 @@ RSpec.describe Photoprism::RequestPhotos do
         stub_request(
           :any,
           "#{user.settings['photoprism_url']}/api/v1/photos?" \
-            "after=#{start_date}&before=#{expected_before_date}&count=1000&public=true&q=&quality=3&offset=1000"
+            "after: expected_after_date&before=#{expected_before_date}&count=1000&public=true&q=&quality=3&offset=1000"
         ).to_return(status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' })
       end
 
@@ -218,14 +219,14 @@ RSpec.describe Photoprism::RequestPhotos do
         stub_request(
           :get,
           "#{user.settings['photoprism_url']}/api/v1/photos?" \
-            "after=#{start_date}&before=#{expected_before_date}&count=1000&public=true&q=&quality=3"
+            "after: expected_after_date&before=#{expected_before_date}&count=1000&public=true&q=&quality=3"
         ).to_return(status: 400, body: { status: 400, error: 'Unable to do that' }.to_json)
       end
 
       it 'logs the error' do
         expect(Rails.logger).to receive(:error).with('Photoprism photo fetch failed: Request failed: 400')
         expect(Rails.logger).to receive(:debug).with(
-          "Photoprism API request params: #{{ q: '', public: true, quality: 3, after: start_date, count: 1000,
+          "Photoprism API request params: #{{ q: '', public: true, quality: 3, after: expected_after_date, count: 1000,
 before: expected_before_date }}"
         )
 
@@ -253,7 +254,7 @@ before: expected_before_date }}"
           .with(
             headers: common_headers,
             query: {
-              after: start_date,
+              after: expected_after_date,
               before: expected_before_date,
               count: '1000',
               public: 'true',
@@ -268,7 +269,7 @@ before: expected_before_date }}"
           .with(
             headers: common_headers,
             query: {
-              after: start_date,
+              after: expected_after_date,
               before: expected_before_date,
               count: '1000',
               public: 'true',
@@ -284,7 +285,7 @@ before: expected_before_date }}"
           .with(
             headers: common_headers,
             query: {
-              after: start_date,
+              after: expected_after_date,
               before: expected_before_date,
               count: '1000',
               public: 'true',

--- a/spec/services/photoprism/request_photos_spec.rb
+++ b/spec/services/photoprism/request_photos_spec.rb
@@ -151,6 +151,10 @@ RSpec.describe Photoprism::RequestPhotos do
     ]
   end
 
+  let(:expected_params) do
+  { q: '', public: true, quality: 3, after: expected_after_date, count: 1000, before: expected_before_date }
+  end
+
   describe '#call' do
     context 'when end_date is provided' do
       it 'sends before param as end_date + 1 day to include photos from end_date' do
@@ -225,11 +229,7 @@ RSpec.describe Photoprism::RequestPhotos do
 
       it 'logs the error' do
         expect(Rails.logger).to receive(:error).with('Photoprism photo fetch failed: Request failed: 400')
-        expect(Rails.logger).to receive(:debug).with(
-          "Photoprism API request params: #{{ q: '', public: true, quality: 3, after=#{expected_after_date}, count: 1000,
-before: expected_before_date }}"
-        )
-
+        expect(Rails.logger).to receive(:debug).with("Photoprism API request params: #{expected_params}")
         service.call
       end
     end

--- a/spec/services/photoprism/request_photos_spec.rb
+++ b/spec/services/photoprism/request_photos_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Photoprism::RequestPhotos do
   end
 
   let(:expected_params) do
-  { q: '', public: true, quality: 3, after: expected_after_date, count: 1000, before: expected_before_date }
+    { q: '', public: true, quality: 3, after: expected_after_date, count: 1000, before: expected_before_date }
   end
 
   describe '#call' do


### PR DESCRIPTION
## Problem
The `after` parameter sent to the PhotoPrism API was missing seconds in the 
ISO 8601 timestamp (e.g. `2026-06-21T00:00+02:00`), causing PhotoPrism to 
return HTTP 400 errors and no photos being retrieved.

## Root Cause
In `app/services/photoprism/request_photos.rb`, `default_params` passes 
`start_date` directly as the `after` parameter without formatting it as a 
full ISO 8601 timestamp with seconds.

## Fix
Changed `after: start_date` to `after: start_date.to_date.beginning_of_day.iso8601`,
which produces a valid timestamp (e.g. `2026-06-21T00:00:00+02:00`), consistent 
with the `before` parameter format.

Fixes #3034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lightweight “slim” point-loading mode for map/monthly views to reduce response payload size.
  * Enhanced `/api/v1/points` with conditional GET support using ETags.
* **Bug Fixes**
  * Improved geographic bounding-box filtering accuracy for area-based point results.
  * Standardized Photoprism photo requests so the `after` parameter uses day-precision ISO timestamps.
* **Tests**
  * Added specs for slim payload consistency and ETag/304 caching behavior, plus updated Photoprism request expectation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->