### PR TITLE
Fix: Map v2 import view shows only the import's points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Place-based visit suggestions now work for users whose distance unit is kilometres — an integer-rounding bug set the detection radius to zero, so no place visits were ever detected for them. Note for self-hosters on kilometres: the first nightly run after upgrading processes your whole history at once; raise `PLACE_VISITS_THROTTLE_SECONDS` beforehand on large databases if you want it gentler (#2963)
 - The nightly place-visit job now only processes points that don't yet belong to a visit, instead of recomputing every place's entire history each night, and pauses briefly between places — together these stop it from saturating the database and delaying incoming location uploads. The pause is tunable via `PLACE_VISITS_THROTTLE_SECONDS` (default `0.1`) (#2963)
+- Opening "View on map" for an import on Map v2 now shows only that import's points, instead of every point within the import's date range (#2734)
 
 
 ## [1.9.2] - 2026-06-25

--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -67,7 +67,9 @@ class Api::V1::PointsController < ApiController
     # so the frontend can show how many points fall outside the 12-month data window.
     if !DawarichSettings.self_hosted? && current_api_user.lite?
       total_in_range = current_api_user.points
-                                       .where(timestamp: start_at..end_at).count
+                                       .where(timestamp: start_at..end_at)
+      total_in_range = total_in_range.where(import_id: params[:import_id]) if params[:import_id].present?
+      total_in_range = total_in_range.count
       scoped_count = points.total_count
       response.set_header('X-Total-Points-In-Range', total_in_range.to_s)
       response.set_header('X-Scoped-Points', scoped_count.to_s)

--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -26,6 +26,8 @@ class Api::V1::PointsController < ApiController
              .without_raw_data
              .where(timestamp: start_at..end_at)
 
+    points = points.where(import_id: params[:import_id]) if params[:import_id].present?
+
     if params[:min_longitude].present? && params[:max_longitude].present? &&
        params[:min_latitude].present? && params[:max_latitude].present?
       bbox = parse_bbox(params)

--- a/app/controllers/map/maplibre_controller.rb
+++ b/app/controllers/map/maplibre_controller.rb
@@ -11,6 +11,7 @@ module Map
     def index
       @start_at = parsed_start_at
       @end_at = parsed_end_at
+      @import_id = import_record&.id
 
       # Status counts shown in the Timeline tab's FILTER section — scoped to
       # the calendar's currently-visible month so the numbers reflect "what

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -33,6 +33,7 @@ export default class extends Controller {
     timezone: String,
     userPlan: { type: String, default: "pro" },
     upgradeUrl: { type: String, default: "" },
+    importId: { type: String, default: "" },
   }
 
   static targets = [
@@ -409,7 +410,7 @@ export default class extends Controller {
    * Initialize API client
    */
   initializeAPI() {
-    this.api = new ApiClient(this.apiKeyValue)
+    this.api = new ApiClient(this.apiKeyValue, this.importIdValue || null)
   }
 
   /**

--- a/app/javascript/maps_maplibre/services/api_client.js
+++ b/app/javascript/maps_maplibre/services/api_client.js
@@ -637,6 +637,8 @@ export class ApiClient {
       per_page: "10000", // Get all points in area (up to 10k)
     })
 
+    if (this.importId) params.append("import_id", this.importId)
+
     const response = await fetch(`${this.baseURL}/points?${params}`, {
       headers: this.getHeaders(),
     })

--- a/app/javascript/maps_maplibre/services/api_client.js
+++ b/app/javascript/maps_maplibre/services/api_client.js
@@ -3,9 +3,10 @@
  * Wraps all API endpoints with consistent error handling
  */
 export class ApiClient {
-  constructor(apiKey) {
+  constructor(apiKey, importId = null) {
     this.apiKey = apiKey
     this.baseURL = "/api/v1"
+    this.importId = importId
   }
 
   /**
@@ -22,6 +23,8 @@ export class ApiClient {
       slim: "true",
       order: "asc",
     })
+
+    if (this.importId) params.append("import_id", this.importId)
 
     const response = await fetch(`${this.baseURL}/points?${params}`, {
       headers: this.getHeaders(),

--- a/app/views/map/maplibre/index.html.erb
+++ b/app/views/map/maplibre/index.html.erb
@@ -9,6 +9,7 @@
      data-maps--maplibre-end-date-value="<%= @end_at.iso8601 %>"
      data-maps--maplibre-timezone-value="<%= current_user.timezone %>"
      data-maps--maplibre-user-plan-value="<%= current_user.plan %>"
+     data-maps--maplibre-import-id-value="<%= @import_id %>"
      data-maps--maplibre-upgrade-url-value="<%= upgrade_url(utm_medium: 'map', utm_content: 'maplibre') %>"
      data-maps--maplibre-realtime-enabled-value="true"
      data-maps--maplibre-realtime-live-mode-value="<%= current_user.safe_settings.live_map_enabled %>"

--- a/spec/requests/api/v1/points_spec.rb
+++ b/spec/requests/api/v1/points_spec.rb
@@ -156,6 +156,17 @@ RSpec.describe 'Api::V1::Points', type: :request do
         expect(json_response.map { |p| p['id'] }).to match_array(points_from_b.map(&:id))
         expect(json_response.map { |p| p['id'] }).not_to include(*points_from_a.map(&:id))
       end
+
+      it 'returns no points for an import_id owned by another user' do
+        other_user = create(:user)
+        other_import = create(:import, user: other_user)
+        create(:point, user: other_user, import: other_import, timestamp: 2.days.ago)
+
+        get api_v1_points_url(api_key: user.api_key, import_id: other_import.id, per_page: 1000)
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to be_empty
+      end
     end
 
     context 'when user is on lite plan and result spans multiple pages' do

--- a/spec/requests/api/v1/points_spec.rb
+++ b/spec/requests/api/v1/points_spec.rb
@@ -201,6 +201,23 @@ RSpec.describe 'Api::V1::Points', type: :request do
         expect(response.headers['X-Scoped-Points']).to eq('3')
       end
 
+      it 'import-scopes X-Total-Points-In-Range when import_id is provided' do
+        import = create(:import, user: lite_user)
+        create(:point, user: lite_user, import: import, timestamp: (window_start + 4.days).to_i)
+        create(:point, user: lite_user, import: import, timestamp: (window_start + 5.days).to_i)
+
+        get api_v1_points_url(
+          api_key: lite_user.api_key,
+          start_at: (window_start - 3.days).to_i,
+          end_at: Time.current.to_i,
+          import_id: import.id,
+          per_page: 10
+        )
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers['X-Total-Points-In-Range']).to eq('2')
+      end
+
       it 'does not set Lite headers for a pro user' do
         pro_user = create(:user)
         pro_user.update_columns(plan: User.plans[:pro])

--- a/spec/requests/api/v1/points_spec.rb
+++ b/spec/requests/api/v1/points_spec.rb
@@ -129,6 +129,35 @@ RSpec.describe 'Api::V1::Points', type: :request do
       end
     end
 
+    context 'when import_id param is provided' do
+      let!(:import_a) { create(:import, user:) }
+      let!(:import_b) { create(:import, user:) }
+      let!(:points_from_a) do
+        (1..3).map { |i| create(:point, user:, import: import_a, timestamp: 2.days.ago + i.minutes) }
+      end
+      let!(:points_from_b) do
+        (1..2).map { |i| create(:point, user:, import: import_b, timestamp: 2.days.ago + i.minutes) }
+      end
+
+      it 'returns only points belonging to that import' do
+        get api_v1_points_url(api_key: user.api_key, import_id: import_a.id, per_page: 1000)
+
+        expect(response).to have_http_status(:ok)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.map { |p| p['id'] }).to match_array(points_from_a.map(&:id))
+      end
+
+      it 'does not return points from another import' do
+        get api_v1_points_url(api_key: user.api_key, import_id: import_b.id, per_page: 1000)
+
+        json_response = JSON.parse(response.body)
+
+        expect(json_response.map { |p| p['id'] }).to match_array(points_from_b.map(&:id))
+        expect(json_response.map { |p| p['id'] }).not_to include(*points_from_a.map(&:id))
+      end
+    end
+
     context 'when user is on lite plan and result spans multiple pages' do
       let!(:lite_user) do
         u = create(:user)


### PR DESCRIPTION
The Map v2 "View on map" link for an import showed every point in the import's date range instead of only that import's points.

- Adds `import_id` filtering to `GET /api/v1/points` (ownership-scoped via `scoped_points`).
- Forwards `import_id` from the Map v2 controller → view data attribute → Stimulus value → `ApiClient` → `fetchPoints`, so the param rides every v2 point fetch.

Verified: request spec for the API filter (failing before, passing after); full points request spec green. Reproduced live on real data — the param was previously ignored (1044 points returned with and without `import_id`); with the fix it returns only the import's points.

Closes #2734