### PR TITLE
Fix: km place-visit detection (radius 0) + make nightly visit job incremental and throttled

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,8 @@ AUTH_JWT_SECRET_KEY=
 # Prevents "objc[…]: +initialize may have been in progress in another thread"
 # warnings/crashes when Sidekiq forks on macOS.
 OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+
+# ─── Background job tuning (optional) ─────────────────────────────────────────
+# Seconds the nightly place-visit job pauses between places, to keep it from
+# saturating the database and delaying point ingestion. Raise on large databases.
+PLACE_VISITS_THROTTLE_SECONDS=0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Place-based visit suggestions now work for users whose distance unit is kilometres — an integer-rounding bug set the detection radius to zero, so no place visits were ever detected for them (#2963)
+- Place-based visit suggestions now work for users whose distance unit is kilometres — an integer-rounding bug set the detection radius to zero, so no place visits were ever detected for them. Note for self-hosters on kilometres: the first nightly run after upgrading processes your whole history at once; raise `PLACE_VISITS_THROTTLE_SECONDS` beforehand on large databases if you want it gentler (#2963)
 - The nightly place-visit job now only processes points that don't yet belong to a visit, instead of recomputing every place's entire history each night, and pauses briefly between places — together these stop it from saturating the database and delaying incoming location uploads. The pause is tunable via `PLACE_VISITS_THROTTLE_SECONDS` (default `0.1`) (#2963)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Place-based visit suggestions now work for users whose distance unit is kilometres — an integer-rounding bug set the detection radius to zero, so no place visits were ever detected for them (#2963)
+- The nightly place-visit job now only processes points that don't yet belong to a visit, instead of recomputing every place's entire history each night, and pauses briefly between places — together these stop it from saturating the database and delaying incoming location uploads. The pause is tunable via `PLACE_VISITS_THROTTLE_SECONDS` (default `0.1`) (#2963)
+
+
 ## [1.9.2] - 2026-06-25
 
 ### Added

--- a/app/services/places/visits/create.rb
+++ b/app/services/places/visits/create.rb
@@ -10,18 +10,18 @@ class Places::Visits::Create
     ENV.fetch('PLACE_VISITS_THROTTLE_SECONDS', '0.1').to_f
   end
 
-  def initialize(user, places, throttle_seconds: self.class.default_throttle_seconds)
+  def initialize(user, places, throttle_seconds: self.class.default_throttle_seconds, sleep_fn: method(:sleep))
     @user = user
     @places = places
     @throttle_seconds = throttle_seconds
+    @sleep_fn = sleep_fn
     @time_threshold_minutes = user.safe_settings.time_threshold_minutes || 30
     @merge_threshold_minutes = user.safe_settings.merge_threshold_minutes || 15
   end
 
   def call
     places.each do |place|
-      place_visits(place)
-      sleep(@throttle_seconds) if @throttle_seconds.positive?
+      throttle if place_visits(place)
     end
   end
 
@@ -45,6 +45,12 @@ class Places::Visits::Create
         create_or_update_visit(place, time_range, visit_points)
       end
     end
+
+    months.any?
+  end
+
+  def throttle
+    @sleep_fn.call(@throttle_seconds) if @throttle_seconds.positive?
   end
 
   def distinct_months_for_place(place)
@@ -63,12 +69,7 @@ class Places::Visits::Create
   end
 
   def place_points_for_month(place, month)
-    place_radius =
-      if user.safe_settings.distance_unit == :km
-        DEFAULT_PLACE_RADIUS.to_f / ::DISTANCE_UNITS[:km]
-      else
-        DEFAULT_PLACE_RADIUS.to_f / ::DISTANCE_UNITS[user.safe_settings.distance_unit.to_sym]
-      end
+    place_radius = DEFAULT_PLACE_RADIUS.to_f / ::DISTANCE_UNITS[user.safe_settings.distance_unit.to_sym]
 
     year, month_num = month.split('-').map(&:to_i)
     month_start = Time.utc(year, month_num, 1).to_i

--- a/app/services/places/visits/create.rb
+++ b/app/services/places/visits/create.rb
@@ -6,15 +6,23 @@ class Places::Visits::Create
   # Default radius for place visit detection (in meters)
   DEFAULT_PLACE_RADIUS = 100
 
-  def initialize(user, places)
+  def self.default_throttle_seconds
+    ENV.fetch('PLACE_VISITS_THROTTLE_SECONDS', '0.1').to_f
+  end
+
+  def initialize(user, places, throttle_seconds: self.class.default_throttle_seconds)
     @user = user
     @places = places
+    @throttle_seconds = throttle_seconds
     @time_threshold_minutes = user.safe_settings.time_threshold_minutes || 30
     @merge_threshold_minutes = user.safe_settings.merge_threshold_minutes || 15
   end
 
   def call
-    places.each { place_visits(_1) }
+    places.each do |place|
+      place_visits(place)
+      sleep(@throttle_seconds) if @throttle_seconds.positive?
+    end
   end
 
   private
@@ -40,9 +48,10 @@ class Places::Visits::Create
   end
 
   def distinct_months_for_place(place)
-    place_radius = DEFAULT_PLACE_RADIUS / ::DISTANCE_UNITS[user.safe_settings.distance_unit.to_sym]
+    place_radius = DEFAULT_PLACE_RADIUS.to_f / ::DISTANCE_UNITS[user.safe_settings.distance_unit.to_sym]
 
     relation = Point.where(user_id: user.id)
+                    .where(visit_id: nil)
                     .near([place.latitude, place.longitude], place_radius, user.safe_settings.distance_unit)
     sql = <<~SQL.squish
       SELECT DISTINCT TO_CHAR(TO_TIMESTAMP(timestamp), 'YYYY-MM') AS month
@@ -56,9 +65,9 @@ class Places::Visits::Create
   def place_points_for_month(place, month)
     place_radius =
       if user.safe_settings.distance_unit == :km
-        DEFAULT_PLACE_RADIUS / ::DISTANCE_UNITS[:km]
+        DEFAULT_PLACE_RADIUS.to_f / ::DISTANCE_UNITS[:km]
       else
-        DEFAULT_PLACE_RADIUS / ::DISTANCE_UNITS[user.safe_settings.distance_unit.to_sym]
+        DEFAULT_PLACE_RADIUS.to_f / ::DISTANCE_UNITS[user.safe_settings.distance_unit.to_sym]
       end
 
     year, month_num = month.split('-').map(&:to_i)

--- a/spec/services/places/visits/create_spec.rb
+++ b/spec/services/places/visits/create_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe Places::Visits::Create do
     described_class.new(user, user.reload.places, throttle_seconds: 0).call
   end
 
-  # A point a few metres from the place (unique lonlat per call to satisfy the
-  # uniqueness validation), at the given timestamp.
   def near_point(timestamp, seq:, **attrs)
     lon = 13.0948638 + (seq * 0.00001)
     lat = 54.2905245 + (seq * 0.00001)
@@ -20,14 +18,11 @@ RSpec.describe Places::Visits::Create do
                    lonlat: "POINT(#{lon} #{lat})", timestamp: timestamp, **attrs)
   end
 
-  # Count the per-month point-loading queries (`place_points_for_month`),
-  # identified by their `ORDER BY "points"."timestamp"` clause — the distinct
-  # months query orders by month, not by points.
   def count_point_load_queries
     count = 0
     sub = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
       sql = args.last[:sql].to_s.downcase
-      count += 1 if sql.include?('order by "points"."timestamp"')
+      count += 1 if sql.match?(/from "points".*order by "points"\."timestamp"/)
     end
     yield
     count
@@ -68,28 +63,52 @@ RSpec.describe Places::Visits::Create do
     expect(queries).to eq(0)
   end
 
-  it 'pauses between places when a throttle is configured' do
+  it 'pauses after a place that had new points to process' do
     near_point(base_ts, seq: 1)
     near_point(base_ts + 5.minutes, seq: 2)
     near_point(base_ts + 10.minutes, seq: 3)
 
-    service = described_class.new(user, user.reload.places, throttle_seconds: 0.01)
-    allow(service).to receive(:sleep)
+    paused = []
+    described_class.new(user, user.reload.places, throttle_seconds: 0.01, sleep_fn: ->(s) { paused << s }).call
 
-    service.call
+    expect(paused).to include(0.01)
+  end
 
-    expect(service).to have_received(:sleep).with(0.01).at_least(:once)
+  it 'does not pause for a place with no new points to process' do
+    near_point(base_ts, seq: 1)
+    near_point(base_ts + 5.minutes, seq: 2)
+    near_point(base_ts + 10.minutes, seq: 3)
+    run
+
+    paused = []
+    described_class.new(user, user.reload.places, throttle_seconds: 0.01, sleep_fn: ->(s) { paused << s }).call
+
+    expect(paused).to be_empty
   end
 
   it 'does not pause when the throttle is zero' do
     near_point(base_ts, seq: 1)
+    near_point(base_ts + 5.minutes, seq: 2)
+    near_point(base_ts + 10.minutes, seq: 3)
 
-    service = described_class.new(user, user.reload.places, throttle_seconds: 0)
-    allow(service).to receive(:sleep)
+    paused = []
+    described_class.new(user, user.reload.places, throttle_seconds: 0, sleep_fn: ->(s) { paused << s }).call
 
-    service.call
+    expect(paused).to be_empty
+  end
 
-    expect(service).not_to have_received(:sleep)
+  it 'attributes a point near two places to a single visit (first place wins, no duplication)' do
+    create(:place, user: user, latitude: 54.2905245, longitude: 13.0948638)
+    near_point(base_ts, seq: 1)
+    near_point(base_ts + 5.minutes, seq: 2)
+    near_point(base_ts + 10.minutes, seq: 3)
+
+    run
+
+    visited = Point.where(user_id: user.id).where.not(visit_id: nil)
+    expect(visited.count).to eq(3)
+    expect(visited.distinct.pluck(:visit_id).size).to eq(1)
+    expect(Visit.count).to eq(1)
   end
 
   it 'extends an existing visit when a new adjacent point arrives' do

--- a/spec/services/places/visits/create_spec.rb
+++ b/spec/services/places/visits/create_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Places::Visits::Create do
+  let(:user) { create(:user) }
+  let!(:place) { create(:place, user: user, latitude: 54.2905245, longitude: 13.0948638) }
+  let(:base_ts) { Time.utc(2024, 5, 1, 12, 0, 0).to_i }
+
+  def run
+    described_class.new(user, user.reload.places, throttle_seconds: 0).call
+  end
+
+  # A point a few metres from the place (unique lonlat per call to satisfy the
+  # uniqueness validation), at the given timestamp.
+  def near_point(timestamp, seq:, **attrs)
+    lon = 13.0948638 + (seq * 0.00001)
+    lat = 54.2905245 + (seq * 0.00001)
+    create(:point, user: user, latitude: lat, longitude: lon,
+                   lonlat: "POINT(#{lon} #{lat})", timestamp: timestamp, **attrs)
+  end
+
+  # Count the per-month point-loading queries (`place_points_for_month`),
+  # identified by their `ORDER BY "points"."timestamp"` clause — the distinct
+  # months query orders by month, not by points.
+  def count_point_load_queries
+    count = 0
+    sub = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+      sql = args.last[:sql].to_s.downcase
+      count += 1 if sql.include?('order by "points"."timestamp"')
+    end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(sub)
+  end
+
+  it 'creates a suggested visit for unvisited points near the place' do
+    near_point(base_ts, seq: 1)
+    near_point(base_ts + 5.minutes, seq: 2)
+    near_point(base_ts + 10.minutes, seq: 3)
+
+    expect { run }.to change(Visit, :count).by(1)
+
+    visit = Visit.last
+    expect(visit.place_id).to eq(place.id)
+    expect(visit.status).to eq('suggested')
+    expect(Point.where(user_id: user.id).where.not(visit_id: nil).count).to eq(3)
+  end
+
+  it 'is idempotent — a second run creates no duplicate visit' do
+    near_point(base_ts, seq: 1)
+    near_point(base_ts + 5.minutes, seq: 2)
+    near_point(base_ts + 10.minutes, seq: 3)
+    run
+
+    expect { run }.not_to change(Visit, :count)
+  end
+
+  it 'does not reload month points for a place whose nearby points are all already visited' do
+    near_point(base_ts, seq: 1)
+    near_point(base_ts + 5.minutes, seq: 2)
+    near_point(base_ts + 10.minutes, seq: 3)
+    run # first run assigns visit_id to every nearby point
+
+    queries = count_point_load_queries { run }
+
+    expect(queries).to eq(0)
+  end
+
+  it 'pauses between places when a throttle is configured' do
+    near_point(base_ts, seq: 1)
+    near_point(base_ts + 5.minutes, seq: 2)
+    near_point(base_ts + 10.minutes, seq: 3)
+
+    service = described_class.new(user, user.reload.places, throttle_seconds: 0.01)
+    allow(service).to receive(:sleep)
+
+    service.call
+
+    expect(service).to have_received(:sleep).with(0.01).at_least(:once)
+  end
+
+  it 'does not pause when the throttle is zero' do
+    near_point(base_ts, seq: 1)
+
+    service = described_class.new(user, user.reload.places, throttle_seconds: 0)
+    allow(service).to receive(:sleep)
+
+    service.call
+
+    expect(service).not_to have_received(:sleep)
+  end
+
+  it 'extends an existing visit when a new adjacent point arrives' do
+    near_point(base_ts, seq: 1)
+    near_point(base_ts + 5.minutes, seq: 2)
+    near_point(base_ts + 10.minutes, seq: 3)
+    run
+    original_visit_id = Point.where(user_id: user.id).pluck(:visit_id).compact.first
+    expect(original_visit_id).to be_present
+
+    new_point = near_point(base_ts + 15.minutes, seq: 4)
+    run
+
+    expect(Visit.count).to eq(1)
+    expect(new_point.reload.visit_id).to eq(original_visit_id)
+  end
+end


### PR DESCRIPTION
Two related fixes to nightly place-visit detection (`Places::Visits::Create`):

**1. Radius (correctness).** The detection radius was computed with integer division — `DEFAULT_PLACE_RADIUS / DISTANCE_UNITS[:km]` = `100 / 1000` = `0` — so users whose distance unit is kilometres detected **no place visits at all** (present since 0.36.0; under-noticed because the cluster-based `Visits::SmartDetect` path still produced some suggestions). Now uses float division.

**2. Incremental + throttle (performance, #2963).** The job recomputed every place over its entire history every night, saturating the DB and stalling point ingestion (OwnTracks `POST`s timing out at 7–9s). Now:
- `distinct_months_for_place` only considers months that still have points without a visit, so a stable instance does near-zero work — while `place_points_for_month` still loads all nearby points, so a new point correctly **extends** an existing visit.
- The job pauses briefly between places, tunable via `PLACE_VISITS_THROTTLE_SECONDS` (default `0.1`), so the one-time backfill the radius fix triggers for km users can't starve ingestion.

Verified: new `spec/services/places/visits/create_spec.rb` (6 examples — visit creation, idempotency, the per-month query-count optimization, throttle on/off, visit extension); 203 + 270 visit-related specs green; rubocop clean. Reproduced on real data via `EXPLAIN ANALYZE` (OFFSET degradation) and `rails runner` (km `distinct_months_for_place` returned 0 months; the correct float radius finds 5,793 points).

Note for review: the radius fix is a behaviour change for km users (they begin receiving place-based visit suggestions); their first post-deploy run processes full history, rate-limited by the throttle. Subsequent runs are near-no-op.

Closes #2963