### PR TITLE
fix: run automatic visit detection without a reverse geocoder (#3043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Automatic visit detection (nightly and realtime) now runs even when no reverse geocoder is configured; self-hosters without Photon/Nominatim/etc. now get visit suggestions, named by coordinates until geocoding is available (#3043).
+
 ## [1.9.2] - 2026-06-25
 
 ### Added

--- a/app/jobs/bulk_visits_suggesting_job.rb
+++ b/app/jobs/bulk_visits_suggesting_job.rb
@@ -8,8 +8,6 @@ class BulkVisitsSuggestingJob < ApplicationJob
 
   # Passing timespan of more than 3 years somehow results in duplicated Places
   def perform(start_at: 1.day.ago.beginning_of_day, end_at: 1.day.ago.end_of_day, user_ids: [], user_id: nil)
-    return unless DawarichSettings.reverse_geocoding_enabled?
-
     user_ids = (Array(user_ids) | Array(user_id)).compact
     users = user_ids.any? ? User.active.where(id: user_ids) : User.active
     start_at = start_at.to_datetime

--- a/app/services/visits/realtime_debouncer.rb
+++ b/app/services/visits/realtime_debouncer.rb
@@ -10,7 +10,6 @@ class Visits::RealtimeDebouncer
   end
 
   def trigger
-    return unless DawarichSettings.reverse_geocoding_enabled?
     return unless user_opted_in?
 
     redis_pool.with do |redis|

--- a/spec/jobs/bulk_visits_suggesting_job_spec.rb
+++ b/spec/jobs/bulk_visits_suggesting_job_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe BulkVisitsSuggestingJob, type: :job do
       create(:point, user: user_with_points)
     end
 
-    it 'does nothing if reverse geocoding is disabled' do
+    it 'schedules jobs even when reverse geocoding is disabled' do
       allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(false)
 
-      expect { described_class.perform_now }.not_to have_enqueued_job(VisitSuggestingJob)
+      expect { described_class.perform_now }.to have_enqueued_job(VisitSuggestingJob)
     end
 
     it 'schedules jobs only for active users with tracked points' do

--- a/spec/regressions/visit_detection_without_geocoder_spec.rb
+++ b/spec/regressions/visit_detection_without_geocoder_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Automatic visit detection without a reverse geocoder', type: :job do
+  before do
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(false)
+  end
+
+  describe BulkVisitsSuggestingJob do
+    let(:start_at) { 1.day.ago.beginning_of_day }
+    let(:end_at) { 1.day.ago.end_of_day }
+    let(:user) { create(:user) }
+
+    before do
+      allow_any_instance_of(Visits::TimeChunks).to receive(:call).and_return([[start_at, end_at]])
+      create(:point, user: user)
+    end
+
+    it 'schedules VisitSuggestingJob for users with tracked points' do
+      described_class.new.perform
+
+      expect(VisitSuggestingJob).to have_been_enqueued.with(
+        user_id: user.id, start_at: start_at, end_at: end_at
+      )
+    end
+  end
+
+  describe Visits::RealtimeDebouncer do
+    let(:user) { create(:user) }
+    let(:redis_key) { "visit_realtime:user:#{user.id}" }
+
+    before do
+      Sidekiq.redis { |redis| redis.del(redis_key) }
+    end
+
+    it 'schedules VisitSuggestingJob for the user' do
+      expect { described_class.new(user.id).trigger }
+        .to have_enqueued_job(VisitSuggestingJob).with(hash_including(user_id: user.id))
+    end
+  end
+end

--- a/spec/services/visits/realtime_debouncer_spec.rb
+++ b/spec/services/visits/realtime_debouncer_spec.rb
@@ -19,15 +19,15 @@ RSpec.describe Visits::RealtimeDebouncer do
         allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(false)
       end
 
-      it 'does not enqueue VisitSuggestingJob' do
-        expect { debouncer.trigger }.not_to have_enqueued_job(VisitSuggestingJob)
+      it 'enqueues VisitSuggestingJob' do
+        expect { debouncer.trigger }.to have_enqueued_job(VisitSuggestingJob)
       end
 
-      it 'does not set a Redis key' do
+      it 'sets a Redis key' do
         debouncer.trigger
 
         Sidekiq.redis do |redis|
-          expect(redis.exists(redis_key)).to eq(0)
+          expect(redis.exists(redis_key)).to eq(1)
         end
       end
     end


### PR DESCRIPTION
## Problem
On self-hosted instances with no reverse geocoder configured, automatic visit detection silently never runs — the nightly cron and the realtime path both no-op. Only the manual "re-evaluate whole history" and file imports produce visits.

Closes #3043.

## Root cause
`BulkVisitsSuggestingJob#perform` and `Visits::RealtimeDebouncer#trigger` both early-return on `return unless DawarichSettings.reverse_geocoding_enabled?`. After the detection rewrite, `Visits::SmartDetect` clusters visits without any geocoder — geocoding is enrichment only (it names places). So the guards gate detection on something detection no longer needs.

## Fix
Remove the geocoder guard from both entry points. Detection now runs regardless; `Visits::Suggest` still gates only the `ReverseGeocodingJob` enqueue, so no geocoding HTTP calls fire when none is configured. (Same change as the relevant part of the in-progress #2789, extracted as a standalone.)

## Behavior change
No-geocoder installs will now receive nightly + realtime visit suggestions, named by coordinates / `Place::DEFAULT_NAME` until a geocoder is configured.

## Test
`spec/regressions/visit_detection_without_geocoder_spec.rb` — with reverse geocoding disabled, both entry points still trigger detection (fails before, passes after). Existing specs updated to drop the old no-op assertions.
