### PR TITLE
avoid renaming visit on cancelled place selection

### DIFF
--- a/app/javascript/maps_maplibre/components/visit_place_search.js
+++ b/app/javascript/maps_maplibre/components/visit_place_search.js
@@ -115,8 +115,7 @@ export class VisitPlaceSearch {
           `This place is ~${Math.round(distance)} m from the visit. Move the visit here?`,
         )
         if (!move) {
-          await this.patchVisit({ name: place.name })
-          return this.done()
+          return
         }
       }
       await this.postJson(`/api/v1/visits/${this.visitId}/select_place`, {


### PR DESCRIPTION
Fixes #3049

## Summary

Currently, when a user replaces a visited place with a location more than 100m away, a confirmation box appears to confirm that the visit should be moved. If the user presses Cancel, the visit is not moved, but the visit name is still overwritten with the name of the cancelled place.

This PR proposes changing the behaviour to keep the picker open, leaving the existing place name unchanged and allowing the user to continue where they left off.

## Demo

Before (from #3049):
https://github.com/user-attachments/assets/a2e5d0a0-30e2-442d-8535-4de76f8019fd

After:
https://github.com/user-attachments/assets/40cba91e-c9cc-43c3-955f-2b7cb517eb4e

Note: For the "After" clip, I temporarily adjusted `MOVE_THRESHOLD_M` to 10m to make the confirmation easier to trigger with the demo data. This PR does not actually modify the move threshold.

## Notes

Since this changes the current behaviour, I'm happy to adjust or close this PR as needed.
