### PR TITLE
feat: mobile settings sync API + distance unit via API

### DIFF
--- a/app/controllers/api/v1/settings/mobile_controller.rb
+++ b/app/controllers/api/v1/settings/mobile_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class Api::V1::Settings::MobileController < ApiController
+  before_action :authenticate_active_api_user!, only: %i[update]
+
+  TRACKING_MODES = %w[precise significant].freeze
+  BOOLEAN_KEYS = %w[
+    tracking_visits track_visits_independently auto_start
+    show_background_location_indicator upload_automatically
+    upload_all_on_tracking_stop
+  ].freeze
+  NUMERIC_CLAMPS = {
+    'distance_filter' => (1..10_000),
+    'time_filter' => (1..3600),
+    'track_break' => (1..1440),
+    'accuracy' => (1..6),
+    'batch_size' => (1..1000)
+  }.freeze
+
+  def show
+    render json: mobile_settings_response, status: :ok
+  end
+
+  def update
+    settings = current_api_user.settings || {}
+    existing = settings['mobile'] || {}
+    settings['mobile'] = existing
+                         .merge(sanitized_params)
+                         .merge('updated_at' => Time.current.iso8601)
+
+    if current_api_user.update(settings: settings)
+      render json: mobile_settings_response.merge(message: 'Settings updated'), status: :ok
+    else
+      render json: {
+        message: 'Something went wrong',
+        errors: current_api_user.errors.full_messages
+      }, status: :unprocessable_content
+    end
+  end
+
+  private
+
+  def mobile_settings_response
+    mobile = current_api_user.settings&.fetch('mobile', nil) || {}
+
+    {
+      settings: mobile.except('updated_at'),
+      updated_at: mobile['updated_at'],
+      status: 'success'
+    }
+  end
+
+  def mobile_params
+    params.require(:settings).permit(
+      :tracking_mode, :tracking_visits, :track_visits_independently,
+      :auto_start, :distance_filter, :time_filter, :track_break,
+      :accuracy, :show_background_location_indicator,
+      :upload_automatically, :upload_all_on_tracking_stop, :batch_size
+    )
+  end
+
+  def sanitized_params
+    sanitized = mobile_params.to_h
+
+    sanitized.delete('tracking_mode') unless TRACKING_MODES.include?(sanitized['tracking_mode'])
+
+    NUMERIC_CLAMPS.each do |key, range|
+      sanitized[key] = sanitized[key].to_i.clamp(range.min, range.max) if sanitized.key?(key)
+    end
+
+    BOOLEAN_KEYS.each do |key|
+      sanitized[key] = ActiveModel::Type::Boolean.new.cast(sanitized[key]) if sanitized.key?(key)
+    end
+
+    sanitized
+  end
+end

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -49,6 +49,7 @@ class Api::V1::SettingsController < ApiController
   end
 
   PRO_ONLY_KEYS = %i[immich_url immich_api_key photoprism_url photoprism_api_key].freeze
+  VALID_DISTANCE_UNITS = %w[km mi].freeze
 
   def settings_params
     permitted = params.require(:settings).permit(
@@ -71,6 +72,10 @@ class Api::V1::SettingsController < ApiController
                                            train_min_speed min_segment_duration time_gap_threshold
                                            min_flight_distance_km]
     )
+
+    if permitted[:maps] && !VALID_DISTANCE_UNITS.include?(permitted[:maps][:distance_unit])
+      permitted[:maps].delete(:distance_unit)
+    end
 
     # Strip Pro-only integration keys for Lite cloud users. Self-hosted
     # users always have full access (`plan_restricted?` returns false).

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -65,6 +65,7 @@ class Api::V1::SettingsController < ApiController
       :gps_filtering_enabled, :gps_accuracy_threshold,
       enabled_map_layers: [],
       enabled_transportation_modes: [],
+      maps: [:distance_unit],
       transportation_thresholds: %i[walking_max_speed cycling_max_speed driving_max_speed flying_min_speed],
       transportation_expert_thresholds: %i[stationary_max_speed running_vs_cycling_accel cycling_vs_driving_accel
                                            train_min_speed min_segment_duration time_gap_threshold

--- a/app/services/users/transportation_thresholds_updater.rb
+++ b/app/services/users/transportation_thresholds_updater.rb
@@ -59,7 +59,11 @@ module Users
       @settings_params.each do |key, value|
         next if key.to_s == 'timezone' && !ActiveSupport::TimeZone[value]
 
-        @user.settings[key] = value
+        if key.to_s == 'maps'
+          @user.settings['maps'] = (@user.settings['maps'] || {}).merge(value.to_h)
+        else
+          @user.settings[key] = value
+        end
       end
 
       sanitize_gated_layers if @user.lite?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,6 +284,8 @@ Rails.application.routes.draw do
       patch 'settings', to: 'settings#update'
       get   'settings', to: 'settings#index'
       get   'settings/transportation_recalculation_status', to: 'settings#transportation_recalculation_status'
+      get   'settings/mobile', to: 'settings/mobile#show'
+      patch 'settings/mobile', to: 'settings/mobile#update'
       get   'users/me', to: 'users#me'
       delete 'users/me', to: 'users/destroy#destroy'
 

--- a/spec/requests/api/v1/settings/mobile_spec.rb
+++ b/spec/requests/api/v1/settings/mobile_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Settings::Mobile', type: :request do
+  let!(:user) { create(:user) }
+  let!(:api_key) { user.api_key }
+
+  describe 'GET /api/v1/settings/mobile' do
+    it 'returns empty settings when none stored' do
+      get "/api/v1/settings/mobile?api_key=#{api_key}"
+
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body['settings']).to eq({})
+      expect(response.parsed_body['updated_at']).to be_nil
+    end
+
+    it 'returns stored mobile settings with updated_at' do
+      user.settings['mobile'] = {
+        'tracking_mode' => 'significant',
+        'updated_at' => '2026-07-01T10:00:00Z'
+      }
+      user.save!
+
+      get "/api/v1/settings/mobile?api_key=#{api_key}"
+
+      expect(response.parsed_body['settings']).to eq('tracking_mode' => 'significant')
+      expect(response.parsed_body['updated_at']).to eq('2026-07-01T10:00:00Z')
+    end
+
+    it 'returns unauthorized without api key' do
+      get '/api/v1/settings/mobile'
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'PATCH /api/v1/settings/mobile' do
+    it 'stores permitted settings and stamps updated_at' do
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { tracking_mode: 'significant', batch_size: 50, auto_start: false } }
+
+      expect(response).to have_http_status(:success)
+
+      mobile = user.reload.settings['mobile']
+      expect(mobile['tracking_mode']).to eq('significant')
+      expect(mobile['batch_size']).to eq(50)
+      expect(mobile['auto_start']).to eq(false)
+      expect(Time.iso8601(mobile['updated_at'])).to be_within(5.seconds).of(Time.current)
+    end
+
+    it 'returns the stored settings and updated_at' do
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { batch_size: 300 } }
+
+      expect(response.parsed_body['settings']['batch_size']).to eq(300)
+      expect(response.parsed_body['updated_at']).to be_present
+    end
+
+    it 'merges with previously stored mobile settings' do
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { tracking_mode: 'significant' } }
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { batch_size: 10 } }
+
+      mobile = user.reload.settings['mobile']
+      expect(mobile['tracking_mode']).to eq('significant')
+      expect(mobile['batch_size']).to eq(10)
+    end
+
+    it 'strips unknown keys' do
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { tracking_mode: 'precise', bogus: 'nope' } }
+
+      expect(user.reload.settings['mobile']).not_to have_key('bogus')
+    end
+
+    it 'drops invalid tracking_mode values' do
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { tracking_mode: 'teleport', batch_size: 5 } }
+
+      mobile = user.reload.settings['mobile']
+      expect(mobile).not_to have_key('tracking_mode')
+      expect(mobile['batch_size']).to eq(5)
+    end
+
+    it 'clamps numeric values' do
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { batch_size: 99_999, distance_filter: 0 } }
+
+      mobile = user.reload.settings['mobile']
+      expect(mobile['batch_size']).to eq(1000)
+      expect(mobile['distance_filter']).to eq(1)
+    end
+
+    it 'casts boolean values' do
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { upload_automatically: 'true' } }
+
+      expect(user.reload.settings['mobile']['upload_automatically']).to eq(true)
+    end
+
+    it 'does not touch non-mobile settings' do
+      user.settings['route_opacity'] = 0.9
+      user.save!
+
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { batch_size: 5 } }
+
+      expect(user.reload.settings['route_opacity']).to eq(0.9)
+    end
+
+    it 'rejects inactive users' do
+      user.update(status: :inactive, active_until: 1.day.ago)
+
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { batch_size: 5 } }
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  describe 'mobile namespace isolation' do
+    it 'does not leak into the web settings response' do
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { tracking_mode: 'significant' } }
+
+      get "/api/v1/settings?api_key=#{api_key}"
+
+      expect(response.parsed_body['settings']).not_to have_key('mobile')
+    end
+  end
+end

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -228,4 +228,25 @@ RSpec.describe 'Api::V1::Settings', type: :request do
       expect(response.parsed_body['processed_tracks']).to eq(50)
     end
   end
+
+  describe 'PATCH /update with maps.distance_unit' do
+    it 'updates the distance unit' do
+      patch "/api/v1/settings?api_key=#{api_key}",
+            params: { settings: { maps: { distance_unit: 'mi' } } }
+
+      expect(response).to have_http_status(:success)
+      expect(user.reload.settings.dig('maps', 'distance_unit')).to eq('mi')
+      expect(response.parsed_body['settings']['distance_unit']).to eq('mi')
+    end
+
+    it 'preserves other maps subkeys' do
+      user.settings['maps'] = { 'distance_unit' => 'km', 'hidden_tile_categories' => ['poi'] }
+      user.save!
+
+      patch "/api/v1/settings?api_key=#{api_key}",
+            params: { settings: { maps: { distance_unit: 'mi' } } }
+
+      expect(user.reload.settings.dig('maps', 'hidden_tile_categories')).to eq(['poi'])
+    end
+  end
 end

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -248,5 +248,16 @@ RSpec.describe 'Api::V1::Settings', type: :request do
 
       expect(user.reload.settings.dig('maps', 'hidden_tile_categories')).to eq(['poi'])
     end
+
+    it 'rejects invalid distance units' do
+      user.settings['maps'] = { 'distance_unit' => 'km' }
+      user.save!
+
+      patch "/api/v1/settings?api_key=#{api_key}",
+            params: { settings: { maps: { distance_unit: 'banana' } } }
+
+      expect(response).to have_http_status(:success)
+      expect(user.reload.settings.dig('maps', 'distance_unit')).to eq('km')
+    end
   end
 end

--- a/spec/swagger/api/v1/settings/mobile_controller_spec.rb
+++ b/spec/swagger/api/v1/settings/mobile_controller_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+describe 'Mobile Settings API', type: :request do
+  path '/api/v1/settings/mobile' do
+    get 'Retrieves mobile app settings' do
+      tags 'Settings'
+      produces 'application/json'
+      parameter name: :api_key, in: :query, type: :string, required: true, description: 'API Key'
+
+      response '200', 'mobile settings found' do
+        schema type: :object,
+               properties: {
+                 settings: {
+                   type: :object,
+                   properties: {
+                     tracking_mode: { type: :string, example: 'precise', enum: %w[precise significant] },
+                     tracking_visits: { type: :boolean, example: true },
+                     track_visits_independently: { type: :boolean, example: false },
+                     auto_start: { type: :boolean, example: true },
+                     distance_filter: { type: :number, example: 100 },
+                     time_filter: { type: :number, example: 10 },
+                     track_break: { type: :number, example: 30 },
+                     accuracy: { type: :number, example: 3 },
+                     show_background_location_indicator: { type: :boolean, example: true },
+                     upload_automatically: { type: :boolean, example: true },
+                     upload_all_on_tracking_stop: { type: :boolean, example: false },
+                     batch_size: { type: :number, example: 100 }
+                   }
+                 },
+                 updated_at: { type: :string, nullable: true, example: '2026-07-01T10:00:00Z' },
+                 status: { type: :string, example: 'success' }
+               }
+
+        let(:api_key) { create(:user).api_key }
+
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        let(:api_key) { 'invalid' }
+
+        run_test!
+      end
+    end
+
+    patch 'Updates mobile app settings' do
+      request_body_example value: {
+        'settings': {
+          'tracking_mode': 'precise',
+          'tracking_visits': true,
+          'track_visits_independently': false,
+          'auto_start': true,
+          'distance_filter': 100,
+          'time_filter': 10,
+          'track_break': 30,
+          'accuracy': 3,
+          'show_background_location_indicator': true,
+          'upload_automatically': true,
+          'upload_all_on_tracking_stop': false,
+          'batch_size': 100
+        }
+      }
+      tags 'Settings'
+      consumes 'application/json'
+      produces 'application/json'
+      parameter name: :api_key, in: :query, type: :string, required: true, description: 'API Key'
+      parameter name: :settings, in: :body, schema: {
+        type: :object,
+        properties: {
+          tracking_mode: {
+            type: :string,
+            example: 'precise',
+            enum: %w[precise significant],
+            description: 'Location tracking mode'
+          },
+          tracking_visits: {
+            type: :boolean,
+            example: true,
+            description: 'Whether visit tracking is enabled'
+          },
+          track_visits_independently: {
+            type: :boolean,
+            example: false,
+            description: 'Whether visits are tracked independently of route tracking'
+          },
+          auto_start: {
+            type: :boolean,
+            example: true,
+            description: 'Whether tracking starts automatically'
+          },
+          distance_filter: {
+            type: :number,
+            example: 100,
+            description: 'Minimum distance between tracked points in meters (1-10000)'
+          },
+          time_filter: {
+            type: :number,
+            example: 10,
+            description: 'Minimum time between tracked points in seconds (1-3600)'
+          },
+          track_break: {
+            type: :number,
+            example: 30,
+            description: 'Minutes of inactivity before a track is split (1-1440)'
+          },
+          accuracy: {
+            type: :number,
+            example: 3,
+            description: 'Location accuracy level (1-6)'
+          },
+          show_background_location_indicator: {
+            type: :boolean,
+            example: true,
+            description: 'Whether the OS background-location indicator is shown (iOS)'
+          },
+          upload_automatically: {
+            type: :boolean,
+            example: true,
+            description: 'Whether points upload automatically while tracking'
+          },
+          upload_all_on_tracking_stop: {
+            type: :boolean,
+            example: false,
+            description: 'Whether pending points upload when tracking stops'
+          },
+          batch_size: {
+            type: :number,
+            example: 100,
+            description: 'Number of points per automatic upload batch (1-1000)'
+          }
+        }
+      }
+
+      response '200', 'mobile settings updated' do
+        let(:api_key) { create(:user).api_key }
+        let(:settings) { { settings: { tracking_mode: 'significant', batch_size: 50 } } }
+
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        let(:api_key) { 'invalid' }
+        let(:settings) { { settings: { tracking_mode: 'significant' } } }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -3765,6 +3765,168 @@ paths:
                     type: string
         '401':
           description: unauthorized
+  "/api/v1/settings/mobile":
+    get:
+      summary: Retrieves mobile app settings
+      tags:
+      - Settings
+      parameters:
+      - name: api_key
+        in: query
+        required: true
+        description: API Key
+        schema:
+          type: string
+      responses:
+        '200':
+          description: mobile settings found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  settings:
+                    type: object
+                    properties:
+                      tracking_mode:
+                        type: string
+                        example: precise
+                        enum:
+                        - precise
+                        - significant
+                      tracking_visits:
+                        type: boolean
+                        example: true
+                      track_visits_independently:
+                        type: boolean
+                        example: false
+                      auto_start:
+                        type: boolean
+                        example: true
+                      distance_filter:
+                        type: number
+                        example: 100
+                      time_filter:
+                        type: number
+                        example: 10
+                      track_break:
+                        type: number
+                        example: 30
+                      accuracy:
+                        type: number
+                        example: 3
+                      show_background_location_indicator:
+                        type: boolean
+                        example: true
+                      upload_automatically:
+                        type: boolean
+                        example: true
+                      upload_all_on_tracking_stop:
+                        type: boolean
+                        example: false
+                      batch_size:
+                        type: number
+                        example: 100
+                  updated_at:
+                    type: string
+                    nullable: true
+                    example: '2026-07-01T10:00:00Z'
+                  status:
+                    type: string
+                    example: success
+        '401':
+          description: unauthorized
+    patch:
+      summary: Updates mobile app settings
+      tags:
+      - Settings
+      parameters:
+      - name: api_key
+        in: query
+        required: true
+        description: API Key
+        schema:
+          type: string
+      responses:
+        '200':
+          description: mobile settings updated
+        '401':
+          description: unauthorized
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tracking_mode:
+                  type: string
+                  example: precise
+                  enum:
+                  - precise
+                  - significant
+                  description: Location tracking mode
+                tracking_visits:
+                  type: boolean
+                  example: true
+                  description: Whether visit tracking is enabled
+                track_visits_independently:
+                  type: boolean
+                  example: false
+                  description: Whether visits are tracked independently of route tracking
+                auto_start:
+                  type: boolean
+                  example: true
+                  description: Whether tracking starts automatically
+                distance_filter:
+                  type: number
+                  example: 100
+                  description: Minimum distance between tracked points in meters (1-10000)
+                time_filter:
+                  type: number
+                  example: 10
+                  description: Minimum time between tracked points in seconds (1-3600)
+                track_break:
+                  type: number
+                  example: 30
+                  description: Minutes of inactivity before a track is split (1-1440)
+                accuracy:
+                  type: number
+                  example: 3
+                  description: Location accuracy level (1-6)
+                show_background_location_indicator:
+                  type: boolean
+                  example: true
+                  description: Whether the OS background-location indicator is shown
+                    (iOS)
+                upload_automatically:
+                  type: boolean
+                  example: true
+                  description: Whether points upload automatically while tracking
+                upload_all_on_tracking_stop:
+                  type: boolean
+                  example: false
+                  description: Whether pending points upload when tracking stops
+                batch_size:
+                  type: number
+                  example: 100
+                  description: Number of points per automatic upload batch (1-1000)
+            examples:
+              '0':
+                summary: Updates mobile app settings
+                value:
+                  settings:
+                    tracking_mode: precise
+                    tracking_visits: true
+                    track_visits_independently: false
+                    auto_start: true
+                    distance_filter: 100
+                    time_filter: 10
+                    track_break: 30
+                    accuracy: 3
+                    show_background_location_indicator: true
+                    upload_automatically: true
+                    upload_all_on_tracking_stop: false
+                    batch_size: 100
   "/api/v1/settings":
     patch:
       summary: Updates user settings


### PR DESCRIPTION
## What

- New `GET/PATCH /api/v1/settings/mobile` (`Api::V1::Settings::MobileController`): stores the mobile app's syncable settings under `user.settings['mobile']` (existing JSONB, no migration) with a server-stamped `updated_at` used for whole-blob last-write-wins sync across a user's devices. Permit-list of 12 snake_case keys with numeric clamping, boolean casting, and `tracking_mode` validation.
- Existing `PATCH /api/v1/settings` now permits `maps: [:distance_unit]` so the mobile app can change km/mi. `TransportationThresholdsUpdater#apply_settings` deep-merges the `maps` hash so `hidden_tile_categories`/`disabled_poi_groups` survive partial updates.

The `mobile` namespace never leaks into web settings responses (`SafeSettings#config` is an explicit allowlist; covered by spec). Auth mirrors the existing settings controller (`authenticate_active_api_user!` on update); does not go through the transportation-recalculation path.

Client side: companion PR in the multiplatform-app repo.

## Testing

- `spec/requests/api/v1/settings/mobile_spec.rb` — 13 examples (empty state, stamping, merging, unknown-key stripping, clamps, casts, auth, namespace isolation)
- 2 new examples in `spec/requests/api/v1/settings_spec.rb` (distance_unit update, maps subkey preservation)
- Full `spec/requests/api/v1/` suite: 595 examples, 0 failures
- Exercised live with curl: PATCH/GET round-trip, `updated_at` stamping, web isolation, mi↔km round-trip with maps preserved