### PR TITLE
fix: mobile settings API follow-ups (maps guard, docs, logging)

### DIFF
--- a/app/controllers/api/v1/settings/mobile_controller.rb
+++ b/app/controllers/api/v1/settings/mobile_controller.rb
@@ -22,13 +22,17 @@ class Api::V1::Settings::MobileController < ApiController
   end
 
   def update
+    sanitized = sanitized_params
     settings = current_api_user.settings || {}
     existing = settings['mobile'] || {}
     settings['mobile'] = existing
-                         .merge(sanitized_params)
+                         .merge(sanitized)
                          .merge('updated_at' => Time.current.iso8601)
 
     if current_api_user.update(settings: settings)
+      Rails.logger.info(
+        "Mobile settings updated for user #{current_api_user.id}: #{sanitized.keys.join(', ')}"
+      )
       render json: mobile_settings_response.merge(message: 'Settings updated'), status: :ok
     else
       render json: {

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -73,8 +73,10 @@ class Api::V1::SettingsController < ApiController
                                            min_flight_distance_km]
     )
 
-    if permitted[:maps] && !VALID_DISTANCE_UNITS.include?(permitted[:maps][:distance_unit])
-      permitted[:maps].delete(:distance_unit)
+    if permitted[:maps].is_a?(ActionController::Parameters)
+      permitted[:maps].delete(:distance_unit) unless VALID_DISTANCE_UNITS.include?(permitted[:maps][:distance_unit])
+    elsif permitted.key?(:maps)
+      permitted.delete(:maps)
     end
 
     # Strip Pro-only integration keys for Lite cloud users. Self-hosted

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -259,5 +259,16 @@ RSpec.describe 'Api::V1::Settings', type: :request do
       expect(response).to have_http_status(:success)
       expect(user.reload.settings.dig('maps', 'distance_unit')).to eq('km')
     end
+
+    it 'ignores maps sent as an array' do
+      user.settings['maps'] = { 'distance_unit' => 'km' }
+      user.save!
+
+      patch "/api/v1/settings?api_key=#{api_key}",
+            params: { settings: { maps: [{ distance_unit: 'mi' }] } }
+
+      expect(response).to have_http_status(:success)
+      expect(user.reload.settings['maps']).to eq('distance_unit' => 'km')
+    end
   end
 end

--- a/spec/swagger/api/v1/settings_controller_spec.rb
+++ b/spec/swagger/api/v1/settings_controller_spec.rb
@@ -22,7 +22,8 @@ describe 'Settings API', type: :request do
           'photoprism_url': 'https://photoprism.example.com',
           'photoprism_api_key': 'your-photoprism-api-key',
           'speed_color_scale': 'viridis',
-          'fog_of_war_threshold': 100
+          'fog_of_war_threshold': 100,
+          'maps': { 'distance_unit': 'km' }
         }
       }
       tags 'Settings'
@@ -109,6 +110,17 @@ describe 'Settings API', type: :request do
             type: :number,
             example: 100,
             description: 'Fog of war threshold value'
+          },
+          maps: {
+            type: :object,
+            properties: {
+              distance_unit: {
+                type: :string,
+                enum: %w[km mi],
+                example: 'km',
+                description: 'Distance unit used for displayed distances'
+              }
+            }
           }
         }
       }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -4014,6 +4014,16 @@ paths:
                   type: number
                   example: 100
                   description: Fog of war threshold value
+                maps:
+                  type: object
+                  properties:
+                    distance_unit:
+                      type: string
+                      enum:
+                      - km
+                      - mi
+                      example: km
+                      description: Distance unit used for displayed distances
             examples:
               '0':
                 summary: Updates user settings
@@ -4035,6 +4045,8 @@ paths:
                     photoprism_api_key: your-photoprism-api-key
                     speed_color_scale: viridis
                     fog_of_war_threshold: 100
+                    maps:
+                      distance_unit: km
     get:
       summary: Retrieves user settings
       tags:


### PR DESCRIPTION
Follow-ups to #3063 (merged) from its review round:

- `PATCH /api/v1/settings` no longer 500s when a malformed client sends `maps` as an array — the param is dropped instead of raising `TypeError`.
- `maps.distance_unit` is now documented in the settings OpenAPI schema (was only documented for `/settings/mobile`).
- Mobile settings updates log the changed keys, so "my settings didn't sync" reports are diagnosable.

## Testing

- New request spec: `maps` sent as an array → 200, settings unchanged
- `spec/requests/api/v1/settings*` + swagger specs: 253 examples, 0 failures; rubocop clean; swagger.yaml regenerated