### PR TITLE
Derive pending-import claim URL from the request host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,8 +32,3 @@ OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 # Seconds the nightly place-visit job pauses between places, to keep it from
 # saturating the database and delaying point ingestion. Raise on large databases.
 PLACE_VISITS_THROTTLE_SECONDS=0.1
-
-# ─── Tools → signup handoff (Cloud only) ──────────────────────────────────────
-# Host used to build the claim URL returned by POST /api/v1/imports/pending.
-# Irrelevant for self-hosted instances (the endpoint is disabled there).
-# DAWARICH_HOST=https://my.dawarich.app

--- a/app/controllers/api/v1/imports/pending_controller.rb
+++ b/app/controllers/api/v1/imports/pending_controller.rb
@@ -67,8 +67,9 @@ class Api::V1::Imports::PendingController < ApiController
     render json: { error: message }, status: status
   end
 
+  # The signup that claims the ticket lives on the same host that served
+  # this request — no configuration needed, works on any environment.
   def build_claim_url(ticket)
-    host = ENV.fetch('DAWARICH_HOST', 'https://my.dawarich.app')
-    "#{host}/users/sign_up?import_ticket=#{ticket}&utm_source=tool&utm_medium=save-to-account"
+    "#{request.base_url}/users/sign_up?import_ticket=#{ticket}&utm_source=tool&utm_medium=save-to-account"
   end
 end

--- a/spec/requests/api/v1/imports/pending_spec.rb
+++ b/spec/requests/api/v1/imports/pending_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe 'POST /api/v1/imports/pending' do
       expect(body).to include('claim_ticket', 'expires_at', 'claim_url')
       expect(body['claim_ticket']).to match(/\A[0-9a-f-]{36}\z/)
       expect(body['claim_url']).to include("import_ticket=#{body['claim_ticket']}")
+      expect(body['claim_url']).to start_with('http://www.example.com/users/sign_up')
     end
 
     it 'creates a PendingImport with attached file' do


### PR DESCRIPTION
Follow-up to #2808, found during the staging dark-launch test: the claim URL was built from a `DAWARICH_HOST` env var with a production fallback, so staging returned redirects pointing at `my.dawarich.app` (the ticket then lands on a host that doesn't have it).

The signup that claims a ticket always lives on the same host that served the pending-import POST — `request.base_url` provides it with zero configuration on any environment. Removes the env var, its `.env.example` entry, and the whole misconfiguration failure mode. Spec asserts the claim URL now carries the request host.