### PR TITLE
Claim pending imports on reverse-trial signup

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -30,16 +30,23 @@ class Users::RegistrationsController < Devise::RegistrationsController
     if resource.persisted?
       post_signup_setup(resource)
 
+      # The claim happens in every branch (not in after_sign_up_path_for):
+      # the reverse-trial redirect below never consults the sign-up path, and
+      # the ticket must not outlive the signup that owns it. It runs after
+      # each flash decision so the "Importing..." notice isn't overwritten.
       if @signup_variant == 'reverse_trial'
         resource.update!(status: :pending_payment)
+        claim_pending_import_for(resource)
         redirect_to manager_checkout_url(resource), allow_other_host: true
       elsif resource.active_for_authentication?
         set_flash_message!(:notice, :signed_up)
         sign_up(resource_name, resource)
+        claim_pending_import_for(resource)
         respond_with(resource, location: after_sign_up_path_for(resource))
       else
         set_flash_message!(:notice, :"signed_up_but_#{resource.inactive_message}")
         expire_data_after_sign_in!
+        claim_pending_import_for(resource)
         respond_with(resource, location: after_inactive_sign_up_path_for(resource))
       end
     else
@@ -108,8 +115,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def after_sign_up_path_for(resource)
-    claim_pending_import_for(resource)
-
     return family_path if @invitation&.family
 
     super(resource)

--- a/spec/requests/users/registrations_with_ticket_spec.rb
+++ b/spec/requests/users/registrations_with_ticket_spec.rb
@@ -26,6 +26,34 @@ RSpec.describe 'Signup with pending import ticket' do
     end
   end
 
+  describe 'reverse-trial signup (Cloud default variant)' do
+    let(:signup_params) do
+      {
+        user: {
+          email: "carryover-rt+#{SecureRandom.hex(4)}@example.com",
+          password: 'safepassword',
+          password_confirmation: 'safepassword'
+        }
+      }
+    end
+
+    before do
+      Flipper.enable(:reverse_trial_signup)
+      get "/users/sign_up?import_ticket=#{pending.claim_ticket}"
+    end
+
+    after { Flipper.disable(:reverse_trial_signup) }
+
+    it 'claims the import before redirecting to the manager checkout' do
+      expect { post '/users', params: signup_params }
+        .to change(Import, :count).by(1)
+
+      expect(response).to redirect_to(%r{\Ahttps://manager\.example\.com/checkout})
+      new_user = User.find_by(email: signup_params[:user][:email])
+      expect(pending.reload.claimed_by_user_id).to eq(new_user.id)
+    end
+  end
+
   describe 'claim failure resilience' do
     let(:signup_params) do
       {


### PR DESCRIPTION
Found during the staging end-to-end test of the tools handoff (#2808, #3069): the reverse-trial `create` branch redirects to the manager checkout **without ever consulting `after_sign_up_path_for`**, where the pending-import claim lived. Since reverse-trial is the variant nearly every real Cloud signup takes (759 vs 4 in the current experiment split), the stashed ticket was silently dropped for exactly the audience this feature targets.

The full staging run reproduced it end to end: dawarich.app tool → upload → 201 from staging → redirect with ticket → signup → Paddle sandbox checkout → back on /map/v2 — and **no import**.

The claim now runs in every `create` branch:
- **reverse_trial**: claim before the checkout redirect — the import processes while the user is at Paddle, and the "Importing…" flash survives (cross-domain hop doesn't consume it) to the post-payment page
- **active** (legacy/self-hosted): claim after `set_flash_message!` so the Importing notice isn't overwritten by "Welcome!"
- **inactive** (confirmable): same

Regression spec drives a reverse-trial signup with a stashed ticket and asserts the Import exists and the ticket is claimed before the checkout redirect. Full auth+handoff suite: 249 examples green.