### PR TITLE
Show validation errors when admin user management forms fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Creating, updating, or deleting a user in Settings no longer shows a blank "HTTP ERROR 422" page when validation fails — the admin is redirected back with a message explaining what went wrong (e.g. password too short) (#3051)
 - Place-based visit suggestions now work for users whose distance unit is kilometres — an integer-rounding bug set the detection radius to zero, so no place visits were ever detected for them. Note for self-hosters on kilometres: the first nightly run after upgrading processes your whole history at once; raise `PLACE_VISITS_THROTTLE_SECONDS` beforehand on large databases if you want it gentler (#2963)
 - The nightly place-visit job now only processes points that don't yet belong to a visit, instead of recomputing every place's entire history each night, and pauses briefly between places — together these stop it from saturating the database and delaying incoming location uploads. The pause is tunable via `PLACE_VISITS_THROTTLE_SECONDS` (default `0.1`) (#2963)
 - Opening "View on map" for an import on Map v2 now shows only that import's points, instead of every point within the import's date range (#2734)

--- a/app/controllers/settings/users_controller.rb
+++ b/app/controllers/settings/users_controller.rb
@@ -27,7 +27,9 @@ class Settings::UsersController < ApplicationController
     if @user.update(update_params)
       redirect_to settings_users_url, notice: 'User was successfully updated.'
     else
-      redirect_to settings_users_url, notice: 'User could not be updated.', status: :unprocessable_content
+      redirect_to settings_users_url,
+                  alert: "User could not be updated: #{@user.errors.full_messages.to_sentence}",
+                  status: :see_other
     end
   end
 
@@ -41,7 +43,9 @@ class Settings::UsersController < ApplicationController
     if @user.save
       redirect_to settings_users_url, notice: 'User was successfully created'
     else
-      redirect_to settings_users_url, notice: 'User could not be created.', status: :unprocessable_content
+      redirect_to settings_users_url,
+                  alert: "User could not be created: #{@user.errors.full_messages.to_sentence}",
+                  status: :see_other
     end
   end
 
@@ -51,7 +55,7 @@ class Settings::UsersController < ApplicationController
     unless @user.can_delete_account?
       redirect_to settings_users_url,
                   alert: 'Cannot delete account while being owner of a family which has other members.',
-                  status: :unprocessable_content
+                  status: :see_other
       return
     end
 

--- a/spec/regressions/admin_user_form_error_feedback_spec.rb
+++ b/spec/regressions/admin_user_form_error_feedback_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin user management error feedback', type: :request do
+  let!(:admin) { create(:user, :admin) }
+
+  before do
+    allow(DawarichSettings).to receive(:self_hosted?).and_return(true)
+    sign_in admin
+  end
+
+  describe 'creating a user with an invalid password' do
+    it 'redirects with a followable status and explains the failure' do
+      post settings_users_url, params: { user: { email: 'new@user.com', password: 'short' } }
+
+      expect(response).to have_http_status(:see_other)
+
+      follow_redirect!
+
+      expect(response.body).to match(/password/i)
+    end
+  end
+
+  describe 'updating a user with an invalid email' do
+    it 'redirects with a followable status and explains the failure' do
+      user = create(:user)
+
+      patch settings_user_url(user), params: { user: { email: '' } }
+
+      expect(response).to have_http_status(:see_other)
+
+      follow_redirect!
+
+      expect(response.body).to match(/email/i)
+    end
+  end
+end

--- a/spec/requests/settings/users_spec.rb
+++ b/spec/requests/settings/users_spec.rb
@@ -113,10 +113,11 @@ RSpec.describe '/settings/users', type: :request do
               end.to change(User, :count).by(0)
             end
 
-            it 'renders a response with 422 status (i.e. to display the "new" template)' do
+            it 'redirects back with an alert explaining the failure' do
               post settings_users_url, params: { user: invalid_attributes }
 
-              expect(response).to have_http_status(:unprocessable_content)
+              expect(response).to have_http_status(:see_other)
+              expect(flash[:alert]).to include('User could not be created')
             end
           end
         end
@@ -372,10 +373,10 @@ RSpec.describe '/settings/users', type: :request do
               end.not_to(change { user.reload.deleted_at })
             end
 
-            it 'returns unprocessable content with error message' do
+            it 'redirects back with an error message' do
               delete settings_user_url(user)
 
-              expect(response).to have_http_status(:unprocessable_content)
+              expect(response).to have_http_status(:see_other)
               expect(flash[:alert]).to eq(
                 'Cannot delete account while being owner of a family which has other members.'
               )


### PR DESCRIPTION
Fixes #3051

## Problem

Creating or editing a user in Settings with invalid input (e.g. a password shorter than 12 characters) responded with a redirect carrying a 422 status. A `Location` header with a non-3xx status is a contradiction — browsers and Turbo only follow 3xx redirects — so the admin landed on a blank **HTTP ERROR 422** page with no explanation. The flash also used a generic `notice` that never said why the operation failed.

## Fix

Validation failure paths in `Settings::UsersController` (`create`, `update`, and the family-owner guard in `destroy`) now redirect with `303 See Other` and an `alert` containing the model's validation messages, so the admin sees e.g. *"User could not be created: Password is too short (minimum is 12 characters)"*.

## Testing

- New regression spec `spec/regressions/admin_user_form_error_feedback_spec.rb` — failed on the old code (empty body + unfollowable redirect), passes now.
- `spec/requests/settings/users_spec.rb` updated to the new behavior; full file green (45 examples).
- RuboCop clean on changed files.