### PR TITLE
Support implicit TLS (SMTP port 465) for email delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Email delivery no longer times out with providers that use implicit TLS (SMTP port 465, e.g. many hosted mail services): set `SMTP_SSL=true` to enable it, and it is enabled automatically when `SMTP_PORT=465`. STARTTLS remains the default for all other ports (#3068)
 - Place-based visit suggestions now work for users whose distance unit is kilometres — an integer-rounding bug set the detection radius to zero, so no place visits were ever detected for them. Note for self-hosters on kilometres: the first nightly run after upgrading processes your whole history at once; raise `PLACE_VISITS_THROTTLE_SECONDS` beforehand on large databases if you want it gentler (#2963)
 - The nightly place-visit job now only processes points that don't yet belong to a visit, instead of recomputing every place's entire history each night, and pauses briefly between places — together these stop it from saturating the database and delaying incoming location uploads. The pause is tunable via `PLACE_VISITS_THROTTLE_SECONDS` (default `0.1`) (#2963)
 - Opening "View on map" for an import on Map v2 now shows only that import's points, instead of every point within the import's date range (#2734)

--- a/lib/smtp_config.rb
+++ b/lib/smtp_config.rb
@@ -4,7 +4,11 @@ module SmtpConfig
   ALLOWED_AUTHENTICATIONS = %i[plain login cram_md5 digest_md5 gssapi ntlm xoauth2].freeze
   DEFAULT_TIMEOUT = 5
 
+  IMPLICIT_TLS_PORT = 465
+
   def self.smtp_settings(env = ENV)
+    ssl = ssl?(env)
+
     {
       address:         env['SMTP_SERVER'],
       port:            env['SMTP_PORT']&.to_i,
@@ -12,7 +16,8 @@ module SmtpConfig
       user_name:       env['SMTP_USERNAME'],
       password:        env['SMTP_PASSWORD'],
       authentication:  authentication(env),
-      enable_starttls: env.fetch('SMTP_STARTTLS', 'true') == 'true',
+      ssl:             ssl,
+      enable_starttls: !ssl && env.fetch('SMTP_STARTTLS', 'true') == 'true',
       open_timeout:    timeout(env, 'SMTP_OPEN_TIMEOUT'),
       read_timeout:    timeout(env, 'SMTP_READ_TIMEOUT')
     }
@@ -36,6 +41,14 @@ module SmtpConfig
           "SMTP_AUTHENTICATION=#{raw.inspect} is not supported; expected one of #{ALLOWED_AUTHENTICATIONS.inspect}"
   end
   private_class_method :authentication
+
+  def self.ssl?(env)
+    raw = env['SMTP_SSL'].to_s.strip
+    return raw == 'true' unless raw.empty?
+
+    env['SMTP_PORT']&.to_i == IMPLICIT_TLS_PORT
+  end
+  private_class_method :ssl?
 
   def self.timeout(env, key)
     raw = env[key]

--- a/spec/regressions/smtp_implicit_tls_spec.rb
+++ b/spec/regressions/smtp_implicit_tls_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SmtpConfig do
+  describe '.smtp_settings' do
+    let(:base_env) do
+      {
+        'SMTP_SERVER' => 'mail.example.com',
+        'SMTP_DOMAIN' => 'example.com',
+        'SMTP_USERNAME' => 'user',
+        'SMTP_PASSWORD' => 'secret'
+      }
+    end
+
+    context 'when SMTP_SSL is enabled' do
+      let(:env) { base_env.merge('SMTP_PORT' => '2465', 'SMTP_SSL' => 'true') }
+
+      it 'uses implicit TLS and disables STARTTLS' do
+        settings = described_class.smtp_settings(env)
+
+        expect(settings[:ssl]).to be(true)
+        expect(settings[:enable_starttls]).to be(false)
+      end
+    end
+
+    context 'when SMTP_PORT is 465 and SMTP_SSL is not set' do
+      let(:env) { base_env.merge('SMTP_PORT' => '465') }
+
+      it 'defaults to implicit TLS so the connection does not hang in STARTTLS' do
+        settings = described_class.smtp_settings(env)
+
+        expect(settings[:ssl]).to be(true)
+        expect(settings[:enable_starttls]).to be(false)
+      end
+    end
+
+    context 'when SMTP_SSL is explicitly disabled on port 465' do
+      let(:env) { base_env.merge('SMTP_PORT' => '465', 'SMTP_SSL' => 'false') }
+
+      it 'respects the override' do
+        settings = described_class.smtp_settings(env)
+
+        expect(settings[:ssl]).to be(false)
+        expect(settings[:enable_starttls]).to be(true)
+      end
+    end
+
+    context 'when using a STARTTLS provider (port 587)' do
+      let(:env) { base_env.merge('SMTP_PORT' => '587') }
+
+      it 'keeps the existing STARTTLS behavior' do
+        settings = described_class.smtp_settings(env)
+
+        expect(settings[:ssl]).to be(false)
+        expect(settings[:enable_starttls]).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3068

## Problem

`SmtpConfig` only exposed `enable_starttls` — there was no way to enable implicit TLS. Providers that use implicit TLS (port 465) expect a TLS handshake immediately on connect, so every delivery attempt hung in plain-text STARTTLS negotiation until `Net::ReadTimeout`. The reporter validated that merging `ssl: true` into the settings fixes delivery.

## Fix

- New `SMTP_SSL` env var enables implicit TLS.
- When `SMTP_SSL` is unset, it defaults to **on** when `SMTP_PORT=465` (the standard implicit-TLS port), so the common case needs zero configuration. `SMTP_SSL=false` opts out.
- `enable_starttls` is forced off while SSL is active, since `Net::SMTP` rejects both at once. STARTTLS behavior on all other ports is unchanged.

## Testing

- New regression spec `spec/regressions/smtp_implicit_tls_spec.rb` (4 examples: explicit `SMTP_SSL`, port-465 default, explicit opt-out, unchanged port-587 behavior) — all failed before the fix, all pass now.
- RuboCop clean on changed files.

## Follow-up

The self-hosting docs (dawarich-app/site) should document `SMTP_SSL` alongside the other SMTP variables.