### PR TITLE
Gate Map v2 point dragging behind an Edit points toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Points on Map v2 can no longer be moved by accident: dragging a point now requires enabling the new "Edit points" toggle in the layers panel. The toggle resets on every page load, so points stay put unless you deliberately turn editing on (#3060)
 - Place-based visit suggestions now work for users whose distance unit is kilometres — an integer-rounding bug set the detection radius to zero, so no place visits were ever detected for them. Note for self-hosters on kilometres: the first nightly run after upgrading processes your whole history at once; raise `PLACE_VISITS_THROTTLE_SECONDS` beforehand on large databases if you want it gentler (#2963)
 - The nightly place-visit job now only processes points that don't yet belong to a visit, instead of recomputing every place's entire history each night, and pauses briefly between places — together these stop it from saturating the database and delaying incoming location uploads. The pause is tunable via `PLACE_VISITS_THROTTLE_SECONDS` (default `0.1`) (#2963)
 - Opening "View on map" for an import on Map v2 now shows only that import's points, instead of every point within the import's date range (#2734)

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -1375,6 +1375,11 @@ export default class extends Controller {
   togglePoints(event) {
     return this.routesManager.togglePoints(event)
   }
+
+  togglePointsEditing(event) {
+    const pointsLayer = this.layerManager.getLayer("points")
+    pointsLayer?.setEditMode(event.currentTarget.checked)
+  }
   toggleRoutes(event) {
     return this.routesManager.toggleRoutes(event)
   }

--- a/app/javascript/maps_maplibre/layers/points_layer.js
+++ b/app/javascript/maps_maplibre/layers/points_layer.js
@@ -17,6 +17,7 @@ export class PointsLayer extends BaseLayer {
     this.justDragged = false
     this.draggedFeature = null
     this.canvas = null
+    this.editModeEnabled = false
 
     // Bind event handlers once and store references for proper cleanup
     this._onMouseEnter = this.onMouseEnter.bind(this)
@@ -56,6 +57,19 @@ export class PointsLayer extends BaseLayer {
         },
       },
     ]
+  }
+
+  /**
+   * Toggle edit mode: points are draggable only while it is on
+   */
+  setEditMode(enabled) {
+    this.editModeEnabled = enabled
+
+    if (enabled) {
+      this.enableDragging()
+    } else {
+      this.disableDragging()
+    }
   }
 
   /**
@@ -239,10 +253,12 @@ export class PointsLayer extends BaseLayer {
   }
 
   /**
-   * Override add method to enable dragging when layer is added
+   * Override add method to restore edit mode when layer is re-added
    */
   add(data) {
     super.add(data)
+
+    if (!this.editModeEnabled) return
 
     // Wait for next tick to ensure layers are fully added before enabling dragging
     setTimeout(() => {

--- a/app/javascript/maps_maplibre/layers/points_layer.js
+++ b/app/javascript/maps_maplibre/layers/points_layer.js
@@ -260,9 +260,13 @@ export class PointsLayer extends BaseLayer {
 
     if (!this.editModeEnabled) return
 
-    // Wait for next tick to ensure layers are fully added before enabling dragging
+    // Wait for next tick to ensure layers are fully added before enabling dragging.
+    // Re-check the flag inside the callback: edit mode may have been turned off
+    // while the timeout was pending.
     setTimeout(() => {
-      this.enableDragging()
+      if (this.editModeEnabled) {
+        this.enableDragging()
+      }
     }, 100)
   }
 

--- a/app/views/map/maplibre/_settings_panel.html.erb
+++ b/app/views/map/maplibre/_settings_panel.html.erb
@@ -70,6 +70,13 @@
               <span class="label-text font-medium">Points</span>
             </label>
             <p class="text-sm text-base-content/60 ml-14">Show individual location points</p>
+            <label class="label cursor-pointer justify-start gap-3 ml-14 mt-1">
+              <input type="checkbox"
+                     class="toggle toggle-primary toggle-sm"
+                     data-action="change->maps--maplibre#togglePointsEditing" />
+              <span class="label-text">Edit points</span>
+            </label>
+            <p class="text-sm text-base-content/60 ml-24">Allow dragging points to correct their position</p>
           </div>
 
           <div class="divider"></div>


### PR DESCRIPTION
Fixes #3060

## Problem

`PointsLayer.add()` unconditionally enabled point dragging whenever the points layer was added. Any click-hold-move on a point silently PATCHed the new position to the backend — no edit mode, no confirmation, no undo. Users editing visits or places kept displacing location points by accident with no way to restore the original position.

## Fix

Dragging now sits behind a new **Edit points** sub-toggle under the Points layer in the layers panel:

- `PointsLayer.setEditMode(enabled)` binds/unbinds the drag handlers; `add()` no longer auto-enables them and only restores dragging if edit mode is on when the layer is re-added.
- The toggle is deliberately **not persisted** — it resets on every page load, so points are read-only by default.
- Drag-to-fix-GPS still works exactly as before once the toggle is enabled.

## Testing

Verified end-to-end against a local instance: dragging a point without edit mode leaves the map feature, the API, and the database untouched (zero PATCH requests); with the toggle on, the drag persists as before. Biome clean on changed files.

Companion e2e coverage: Freika/e2e-dawarich-playwright — `fix/accidental-point-drag` adds `v2/map/point-drag-edit-mode.spec.js`, which fails against current `dev` and passes with this branch (verified in both directions). The two PRs ship together.

## Note

Maps v1 (Leaflet) markers are still always-draggable (`app/javascript/maps/marker_factory.js:90,126`) — the same accident vector exists on the legacy map. This PR scopes the gate to Map v2; happy to port it to v1 in a follow-up if desired.