### PR TITLE
Fix points cache staleness, mobile boolean reset, poster theme reads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,15 +33,6 @@ OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 # saturating the database and delaying point ingestion. Raise on large databases.
 PLACE_VISITS_THROTTLE_SECONDS=0.1
 
-# ─── Poster generation (optional) ────────────────────────────────────────────
-# The map poster tab renders client-side with no configuration. To use the
-# server-side renderer, point POSTER_SERVICE_URL at a running poster sidecar.
-# Set POSTER_NATIVE_RENDERER=true to render inside the app container instead of
-# the sidecar (the image ships the required headless GL stack).
-POSTER_SERVICE_URL=
-POSTER_SERVICE_TOKEN=
-POSTER_NATIVE_RENDERER=
-
 # ─── SMTP email (optional) ───────────────────────────────────────────────────
 # Configure outbound email. SMTP_SSL=true enables implicit TLS (port 465); it
 # turns on automatically when SMTP_PORT=465. STARTTLS is the default otherwise.

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,21 @@ OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 # Seconds the nightly place-visit job pauses between places, to keep it from
 # saturating the database and delaying point ingestion. Raise on large databases.
 PLACE_VISITS_THROTTLE_SECONDS=0.1
+
+# ─── Poster generation (optional) ────────────────────────────────────────────
+# The map poster tab renders client-side with no configuration. To use the
+# server-side renderer, point POSTER_SERVICE_URL at a running poster sidecar.
+# Set POSTER_NATIVE_RENDERER=true to render inside the app container instead of
+# the sidecar (the image ships the required headless GL stack).
+POSTER_SERVICE_URL=
+POSTER_SERVICE_TOKEN=
+POSTER_NATIVE_RENDERER=
+
+# ─── SMTP email (optional) ───────────────────────────────────────────────────
+# Configure outbound email. SMTP_SSL=true enables implicit TLS (port 465); it
+# turns on automatically when SMTP_PORT=465. STARTTLS is the default otherwise.
+SMTP_SERVER=
+SMTP_PORT=
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_SSL=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New API endpoints `GET`/`PATCH /api/v1/settings/mobile` for syncing mobile app settings between devices: settings are stored per user with a server-stamped `updated_at` so the most recent write wins. The existing settings API now also accepts `maps.distance_unit` and merges the `maps` hash instead of replacing it, so partial updates no longer wipe other map settings.
 - Cloud: free tools on dawarich.app can hand your uploaded file into signup — it's auto-imported into the new account (single-use claim ticket, 24h TTL). Adds a `pending_imports` table, the `rack-cors` gem, and a daily cleanup job; self-hosted instances are unaffected (the endpoint is disabled there).
 - Map v2 now reopens at your last viewport instead of the zoomed-out globe when the selected date range has no data to fit.
-- Poster Studio: a full-screen editor on Map v2 for turning your tracks into printable posters, with theme presets and a live preview. Rendering runs client-side by default; a server-side renderer can be enabled via `POSTER_SERVICE_URL` or `POSTER_NATIVE_RENDERER`.
 - Custom map colors: pick from theme presets or edit individual color tokens for the map, and a reorganized, collapsible Settings tab to manage them.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - New API endpoints `GET`/`PATCH /api/v1/settings/mobile` for syncing mobile app settings between devices: settings are stored per user with a server-stamped `updated_at` so the most recent write wins. The existing settings API now also accepts `maps.distance_unit` and merges the `maps` hash instead of replacing it, so partial updates no longer wipe other map settings.
 - Cloud: free tools on dawarich.app can hand your uploaded file into signup — it's auto-imported into the new account (single-use claim ticket, 24h TTL). Adds a `pending_imports` table, the `rack-cors` gem, and a daily cleanup job; self-hosted instances are unaffected (the endpoint is disabled there).
 - Map v2 now reopens at your last viewport instead of the zoomed-out globe when the selected date range has no data to fit.
+- Poster Studio: a full-screen editor on Map v2 for turning your tracks into printable posters, with theme presets and a live preview. Rendering runs client-side by default; a server-side renderer can be enabled via `POSTER_SERVICE_URL` or `POSTER_NATIVE_RENDERER`.
+- Custom map colors: pick from theme presets or edit individual color tokens for the map, and a reorganized, collapsible Settings tab to manage them.
 
 ### Changed
 

--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -41,9 +41,10 @@ class Api::V1::PointsController < ApiController
       )
     end
 
-    cache_max_ts = points.maximum(:timestamp)
+    cache_count, cache_max_ts, cache_max_updated =
+      points.pick(Arel.sql('COUNT(*)'), Arel.sql('MAX(timestamp)'), Arel.sql('MAX(updated_at)'))
     fresh_when(
-      etag: points_index_etag(start_at, end_at, order, cache_max_ts),
+      etag: points_index_etag(start_at, end_at, order, cache_max_ts, cache_count, cache_max_updated),
       last_modified: cache_max_ts && Time.zone.at(cache_max_ts),
       public: false
     )
@@ -203,14 +204,14 @@ class Api::V1::PointsController < ApiController
     params[:slim] == 'true'
   end
 
-  def points_index_etag(start_at, end_at, order, max_timestamp)
+  def points_index_etag(start_at, end_at, order, max_timestamp, count, max_updated)
     [
       'points/index', current_api_user.id, start_at, end_at, order, slim_points?,
       params[:page], params[:per_page] || 100,
       params[:anomalies_only], params[:include_anomalies],
       params[:min_longitude], params[:max_longitude],
       params[:min_latitude], params[:max_latitude],
-      max_timestamp
+      max_timestamp, count, max_updated
     ]
   end
 

--- a/app/controllers/api/v1/settings/mobile_controller.rb
+++ b/app/controllers/api/v1/settings/mobile_controller.rb
@@ -73,7 +73,13 @@ class Api::V1::Settings::MobileController < ApiController
     end
 
     BOOLEAN_KEYS.each do |key|
-      sanitized[key] = ActiveModel::Type::Boolean.new.cast(sanitized[key]) if sanitized.key?(key)
+      next unless sanitized.key?(key)
+
+      if sanitized[key].to_s.strip.empty?
+        sanitized.delete(key)
+      else
+        sanitized[key] = ActiveModel::Type::Boolean.new.cast(sanitized[key])
+      end
     end
 
     sanitized

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,13 +10,20 @@ class ApplicationController < ActionController::Base
   around_action :set_user_time_zone
   before_action :unread_notifications, :set_self_hosted_status, :store_client_header
 
-  helper_method :current_user_safe_settings
+  helper_method :current_user_safe_settings, :posters_enabled?
 
   # Memoized per-request SafeSettings for the current user. Use this instead of
   # `current_user.safe_settings` in partials/helpers that may render many rows
   # — User#safe_settings allocates a fresh deep_dup'd hash on every call.
   def current_user_safe_settings
     @current_user_safe_settings ||= current_user&.safe_settings
+  end
+
+  def posters_enabled?
+    Flipper.enabled?(:posters, current_user)
+  rescue StandardError => e
+    Rails.logger.warn("[posters] Flipper unavailable: #{e.class}: #{e.message}")
+    false
   end
 
   protected

--- a/app/controllers/map/maplibre_controller.rb
+++ b/app/controllers/map/maplibre_controller.rb
@@ -28,10 +28,10 @@ module Map
       @timeline_tags = current_user.tags.order(:name).limit(8)
 
       # Theme tokens power both the poster tab and the Appearance section's
-      # custom map colors, so they load regardless of the poster service gate.
+      # custom map colors, so they load regardless of the posters feature gate.
       @poster_themes = cached_poster_themes
 
-      return unless DawarichSettings.poster_service_enabled?
+      return unless posters_enabled?
 
       @recent_posters = current_user.posters.with_attached_image.order(created_at: :desc).limit(10)
     end

--- a/app/controllers/map/maplibre_controller.rb
+++ b/app/controllers/map/maplibre_controller.rb
@@ -50,11 +50,13 @@ module Map
     # Client-side renderer fallback: the browser poster path needs no sidecar, so
     # when the sidecar is unreachable we serve the vendored theme tokens directly.
     def local_poster_themes
-      Dir.glob(Rails.root.join('public/poster_themes/*.json')).sort.filter_map do |path|
-        data = JSON.parse(File.read(path))
-        data.merge('key' => File.basename(path, '.json'), 'route' => data['route'].presence || '#FF3B30')
-      rescue JSON::ParserError
-        nil
+      Rails.cache.fetch('local_poster_themes', expires_in: 1.hour) do
+        Dir.glob(Rails.root.join('public/poster_themes/*.json')).sort.filter_map do |path|
+          data = JSON.parse(File.read(path))
+          data.merge('key' => File.basename(path, '.json'), 'route' => data['route'].presence || '#FF3B30')
+        rescue JSON::ParserError
+          nil
+        end
       end
     end
 

--- a/app/controllers/posters_controller.rb
+++ b/app/controllers/posters_controller.rb
@@ -4,7 +4,7 @@ class PostersController < ApplicationController
   include FlashStreamable
 
   before_action :authenticate_user!
-  before_action :ensure_poster_service_enabled
+  before_action :ensure_posters_enabled
 
   def create
     poster = current_user.posters.create!(
@@ -55,9 +55,9 @@ class PostersController < ApplicationController
                                    :route_fill, :route_opacity)
   end
 
-  def ensure_poster_service_enabled
-    return if DawarichSettings.poster_service_enabled?
+  def ensure_posters_enabled
+    return if posters_enabled?
 
-    redirect_to root_path, alert: 'Poster service is not configured.'
+    redirect_to root_path, alert: 'Posters are not available.'
   end
 end

--- a/app/views/map/maplibre/_button_cluster.html.erb
+++ b/app/views/map/maplibre/_button_cluster.html.erb
@@ -54,7 +54,7 @@
     <%= icon 'play', class: 'w-5 h-5', aria: { hidden: true } %>
   </button>
 
-  <% if DawarichSettings.poster_service_enabled? %>
+  <% if posters_enabled? %>
     <button type="button"
             class="map-button-cluster__btn"
             data-action="click->map-panel#openPosterStudio"

--- a/app/views/map/maplibre/index.html.erb
+++ b/app/views/map/maplibre/index.html.erb
@@ -51,7 +51,7 @@
   <%= render 'map/maplibre/settings_panel' %>
 
   <!-- Poster studio (full-screen WYSIWYG editor) -->
-  <% if DawarichSettings.poster_service_enabled? %>
+  <% if posters_enabled? %>
     <%= render 'map/maplibre/poster_studio' %>
   <% end %>
 

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -6,6 +6,7 @@
 # aren't present yet (e.g. during `db:migrate` on a brand-new database).
 Rails.application.config.after_initialize do
   Flipper.add(:stay_point_detection) unless Flipper.exist?(:stay_point_detection)
+  Flipper.add(:posters) unless Flipper.exist?(:posters)
 rescue StandardError => e
   Rails.logger.warn("[feature_flags] could not register flags: #{e.class}: #{e.message}")
 end

--- a/spec/requests/api/v1/points_caching_spec.rb
+++ b/spec/requests/api/v1/points_caching_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::V1::Points conditional GET caching', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:user) { create(:user) }
   let(:range) { "slim=true&start_at=#{2.days.ago.to_i}&end_at=#{Time.current.to_i}" }
 
@@ -51,6 +53,32 @@ RSpec.describe 'Api::V1::Points conditional GET caching', type: :request do
 
     get "/api/v1/points?api_key=#{user.api_key}&#{range}",
         headers: { 'If-None-Match' => etag }
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'returns a fresh 200 when a point is deleted' do
+    get "/api/v1/points?api_key=#{user.api_key}&#{range}"
+    etag = response.headers['ETag']
+
+    user.points.order(:timestamp).first.destroy
+
+    get "/api/v1/points?api_key=#{user.api_key}&#{range}",
+        headers: { 'If-None-Match' => etag }
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'returns a fresh 200 when a point is edited without changing its timestamp' do
+    get "/api/v1/points?api_key=#{user.api_key}&#{range}"
+    etag = response.headers['ETag']
+
+    travel_to(1.minute.from_now) do
+      user.points.order(:timestamp).first.update!(lonlat: 'POINT(1.5 1.5)')
+
+      get "/api/v1/points?api_key=#{user.api_key}&#{range}",
+          headers: { 'If-None-Match' => etag }
+    end
 
     expect(response).to have_http_status(:ok)
   end

--- a/spec/requests/api/v1/settings/mobile_spec.rb
+++ b/spec/requests/api/v1/settings/mobile_spec.rb
@@ -100,6 +100,15 @@ RSpec.describe 'Api::V1::Settings::Mobile', type: :request do
       expect(user.reload.settings['mobile']['upload_automatically']).to eq(true)
     end
 
+    it 'does not overwrite a stored boolean with a blank value' do
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { upload_automatically: 'true' } }
+      patch "/api/v1/settings/mobile?api_key=#{api_key}",
+            params: { settings: { upload_automatically: '' } }
+
+      expect(user.reload.settings['mobile']['upload_automatically']).to eq(true)
+    end
+
     it 'does not touch non-mobile settings' do
       user.settings['route_opacity'] = 0.9
       user.save!

--- a/spec/requests/map/maplibre_spec.rb
+++ b/spec/requests/map/maplibre_spec.rb
@@ -15,22 +15,16 @@ RSpec.describe 'Map v2 (maplibre)', type: :request do
   end
 
   describe 'poster tab gating' do
-    it 'renders the poster tab button when the poster service is configured' do
-      stub_const('POSTER_SERVICE_URL', 'http://localhost:8123')
-      stub_const('POSTER_SERVICE_TOKEN', nil)
-      Rails.cache.delete('poster_service_themes')
-      stub_request(:get, 'http://localhost:8123/themes')
-        .to_return(status: 200, body: [{ key: 'blueprint', name: 'Blueprint', bg: '#1A3A5C',
-                                         text: '#E8F4FF', route: '#FF6B4A' }].to_json)
+    it 'renders the poster tab button when the posters flag is enabled' do
+      Flipper.enable(:posters)
 
       get map_v2_path
 
       expect(response.body).to include('map-button-poster')
-      expect(response.body).to include('Blueprint')
     end
 
-    it 'omits the poster tab when the poster service is not configured' do
-      stub_const('POSTER_SERVICE_URL', nil)
+    it 'omits the poster tab when the posters flag is disabled' do
+      Flipper.disable(:posters)
 
       get map_v2_path
 

--- a/spec/requests/posters_spec.rb
+++ b/spec/requests/posters_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Posters', type: :request do
     stub_const('POSTER_SERVICE_URL', 'http://localhost:8123')
     stub_const('POSTER_SERVICE_TOKEN', nil)
     Rails.cache.delete('poster_service_themes')
+    Flipper.enable(:posters)
     sign_in user
   end
 
@@ -47,8 +48,8 @@ RSpec.describe 'Posters', type: :request do
       expect(user.posters.last.name).to eq('My Poster')
     end
 
-    it 'redirects when the poster service is not configured' do
-      stub_const('POSTER_SERVICE_URL', nil)
+    it 'redirects when posters are not enabled' do
+      Flipper.disable(:posters)
 
       post posters_path, params: { poster: poster_attributes }
 


### PR DESCRIPTION
- points#index: derive the ETag from count and max(updated_at) alongside max(timestamp) in a single aggregate, so deleting or editing a point no longer serves a stale 304, and replace the separate maximum() query.
- settings/mobile: skip blank boolean values instead of casting them to nil, so a partial update can't wipe a previously stored setting.
- maps/maplibre: cache the vendored poster theme JSON reads instead of globbing and parsing them on every Map v2 render.
- Document Poster Studio and custom map colors in the changelog, and add the poster and SMTP env vars to .env.example.