### PR TITLE
Surface family location history and warn about Map v1 sunset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Cloud: free tools on dawarich.app can hand your uploaded file into signup — it's auto-imported into the new account (single-use claim ticket, 24h TTL). Adds a `pending_imports` table, the `rack-cors` gem, and a daily cleanup job; self-hosted instances are unaffected (the endpoint is disabled there).
 - Map v2 now reopens at your last viewport instead of the zoomed-out globe when the selected date range has no data to fit.
 - Custom map colors: pick from theme presets or edit individual color tokens for the map, and a reorganized, collapsible Settings tab to manage them.
+- The classic map (v1) now shows a dismissible banner announcing it will be retired in August 2026, plus a second banner — shown when your family is sharing location — pointing out that family location history is only visible on the new map (v2). Both dismissals are remembered per browser.
 
 ### Changed
 
@@ -31,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Creating, updating, or deleting a user in Settings no longer shows a blank "HTTP ERROR 422" page when validation fails — the admin is redirected back with a message explaining what went wrong (e.g. password too short) (#3051)
 - Email delivery no longer times out with providers that use implicit TLS (SMTP port 465, e.g. many hosted mail services): set `SMTP_SSL=true` to enable it, and it is enabled automatically when `SMTP_PORT=465`. STARTTLS remains the default for all other ports (#3068)
 - Points on Map v2 can no longer be moved by accident: dragging a point now requires enabling the new "Edit points" toggle in the layers panel. The toggle resets on every page load, so points stay put unless you deliberately turn editing on (#3060)
+- Family location sharing now makes the separate "Location history" toggle clearer — the family settings page explains it is distinct from live location, that it powers the recent-track view on Map v2, and that only points recorded after you enable it are shared. The default history window is now 7 days instead of 24 hours, so newly-shared members show a useful track instead of an almost-empty one.
 - Place-based visit suggestions now work for users whose distance unit is kilometres — an integer-rounding bug set the detection radius to zero, so no place visits were ever detected for them. Note for self-hosters on kilometres: the first nightly run after upgrading processes your whole history at once; raise `PLACE_VISITS_THROTTLE_SECONDS` beforehand on large databases if you want it gentler (#2963)
 - The nightly place-visit job now only processes points that don't yet belong to a visit, instead of recomputing every place's entire history each night, and pauses briefly between places — together these stop it from saturating the database and delaying incoming location uploads. The pause is tunable via `PLACE_VISITS_THROTTLE_SECONDS` (default `0.1`) (#2963)
 - Opening "View on map" for an import on Map v2 now shows only that import's points, instead of every point within the import's date range (#2734)

--- a/app/controllers/map/leaflet_controller.rb
+++ b/app/controllers/map/leaflet_controller.rb
@@ -17,6 +17,8 @@ class Map::LeafletController < ApplicationController
     @points_number = points_count
     @features = DawarichSettings.features
     @home_coordinates = current_user.home_place_coordinates
+    @family_map_sharing_active = DawarichSettings.family_feature_enabled? &&
+                                 current_user.family_map_sharing_active?
   end
 
   private

--- a/app/javascript/controllers/dismissible_controller.js
+++ b/app/javascript/controllers/dismissible_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Hides its element and remembers the dismissal per-browser via localStorage.
+// Usage: data-controller="dismissible" data-dismissible-key-value="unique_key"
+//        <button data-action="dismissible#dismiss">
+export default class extends Controller {
+  static values = { key: String }
+
+  connect() {
+    if (this.dismissed) this.element.remove()
+  }
+
+  dismiss() {
+    if (this.keyValue) {
+      try {
+        localStorage.setItem(this.storageKey, "1")
+      } catch (_e) {
+        // localStorage unavailable (private mode) — dismissal just won't persist
+      }
+    }
+    this.element.remove()
+  }
+
+  get dismissed() {
+    if (!this.keyValue) return false
+    try {
+      return localStorage.getItem(this.storageKey) === "1"
+    } catch (_e) {
+      return false
+    }
+  }
+
+  get storageKey() {
+    return `dismissed:${this.keyValue}`
+  }
+}

--- a/app/models/concerns/user_family.rb
+++ b/app/models/concerns/user_family.rb
@@ -19,8 +19,16 @@ module UserFamily
              inverse_of: :target_user, dependent: :destroy
   end
 
+  DEFAULT_HISTORY_WINDOW = '7d'
+
   def in_family?
     family_membership.present?
+  end
+
+  def family_map_sharing_active?
+    return false unless in_family?
+
+    family.members.any?(&:family_sharing_enabled?)
   end
 
   def family_owner?
@@ -112,7 +120,7 @@ module UserFamily
   end
 
   def family_history_window
-    settings.dig('family', 'location_sharing', 'history_window') || '24h'
+    settings.dig('family', 'location_sharing', 'history_window') || DEFAULT_HISTORY_WINDOW
   end
 
   # Returns points within the given date range, scoped by sharing start time,
@@ -131,7 +139,7 @@ module UserFamily
                    when '7d' then 7.days.ago
                    when '30d' then 30.days.ago
                    when 'all' then 1.year.ago
-                   else 24.hours.ago
+                   else 7.days.ago
                    end
 
     effective_start = [start_at, started_at, window_start].max
@@ -169,6 +177,6 @@ module UserFamily
   private
 
   def validate_history_window(window)
-    VALID_HISTORY_WINDOWS.include?(window) ? window : '24h'
+    VALID_HISTORY_WINDOWS.include?(window) ? window : DEFAULT_HISTORY_WINDOW
   end
 end

--- a/app/views/families/_location_sharing_toggle.html.erb
+++ b/app/views/families/_location_sharing_toggle.html.erb
@@ -89,6 +89,12 @@
             </select>
           </div>
 
+          <p class="col-span-full text-xs text-base-content/50 leading-snug">
+            A separate setting from live location. When on, family can view your recent
+            track — not just your current position — on the new map (v2). Only points
+            recorded after you enable this are ever shared.
+          </p>
+
         </div>
 
       </div>

--- a/app/views/map/leaflet/_sunset_banners.html.erb
+++ b/app/views/map/leaflet/_sunset_banners.html.erb
@@ -1,0 +1,28 @@
+<% if family_map_sharing_active %>
+  <div class="pointer-events-auto alert alert-info shadow-lg py-2 px-3 text-sm flex items-start gap-2"
+       data-controller="dismissible"
+       data-dismissible-key-value="map_v1_family_history_v2_only">
+    <span class="flex-1">
+      Family location history is only shown on the new map (v2).
+      <%= link_to 'Open the new map', map_v2_path, class: 'link link-primary font-medium' %>
+      to see where your family has been.
+    </span>
+    <button type="button"
+            class="btn btn-ghost btn-xs btn-circle"
+            data-action="dismissible#dismiss"
+            aria-label="Dismiss">✕</button>
+  </div>
+<% end %>
+
+<div class="pointer-events-auto alert alert-warning shadow-lg py-2 px-3 text-sm flex items-start gap-2"
+     data-controller="dismissible"
+     data-dismissible-key-value="map_v1_sunset_aug_2026">
+  <span class="flex-1">
+    You're using the classic map (v1), which will be retired in <strong>August 2026</strong>.
+    <%= link_to 'Switch to the new map', map_v2_path, class: 'link link-primary font-medium' %>.
+  </span>
+  <button type="button"
+          class="btn btn-ghost btn-xs btn-circle"
+          data-action="dismissible#dismiss"
+          aria-label="Dismiss">✕</button>
+</div>

--- a/app/views/map/leaflet/index.html.erb
+++ b/app/views/map/leaflet/index.html.erb
@@ -3,7 +3,11 @@
 <%= render 'shared/map/date_navigation', start_at: @start_at, end_at: @end_at %>
 
 <!-- Map Container - Fills remaining space -->
-<div class="w-full h-full">
+<div class="w-full h-full relative">
+  <div class="absolute top-2 left-1/2 -translate-x-1/2 w-full max-w-2xl px-2 space-y-2 pointer-events-none"
+       style="z-index: 1200;">
+    <%= render 'map/leaflet/sunset_banners', family_map_sharing_active: @family_map_sharing_active %>
+  </div>
   <div
     id='map'
     class="w-full h-full relative"

--- a/spec/models/concerns/user_family_spec.rb
+++ b/spec/models/concerns/user_family_spec.rb
@@ -156,20 +156,46 @@ RSpec.describe UserFamily do
       end
     end
 
-    it 'rejects invalid history_window and falls back to 24h' do
+    it 'rejects invalid history_window and falls back to the default window' do
       user.update_family_location_sharing!(true, duration: 'permanent', history_window: 'invalid')
-      expect(user.family_history_window).to eq('24h')
+      expect(user.family_history_window).to eq(UserFamily::DEFAULT_HISTORY_WINDOW)
     end
 
     it 'rejects XSS payloads in history_window' do
       user.update_family_location_sharing!(true, duration: 'permanent', history_window: '<script>alert(1)</script>')
-      expect(user.family_history_window).to eq('24h')
+      expect(user.family_history_window).to eq(UserFamily::DEFAULT_HISTORY_WINDOW)
     end
 
     it 'preserves existing valid window when nil is passed' do
       user.update_family_location_sharing!(true, duration: 'permanent', history_window: '30d')
       user.update_family_location_sharing!(true, duration: 'permanent', history_window: nil)
       expect(user.family_history_window).to eq('30d')
+    end
+  end
+
+  describe '#family_history_window default' do
+    it 'defaults to 7 days when never configured' do
+      expect(user.family_history_window).to eq('7d')
+    end
+
+    it 'uses the default window on first enable without an explicit window' do
+      user.update_family_location_sharing!(true, duration: 'permanent')
+      expect(user.family_history_window).to eq(UserFamily::DEFAULT_HISTORY_WINDOW)
+    end
+  end
+
+  describe '#family_map_sharing_active?' do
+    it 'is false when the user is not in a family' do
+      expect(create(:user).family_map_sharing_active?).to be(false)
+    end
+
+    it 'is false when in a family but nobody is sharing' do
+      expect(user.family_map_sharing_active?).to be(false)
+    end
+
+    it 'is true when a family member has sharing enabled' do
+      user.update_family_location_sharing!(true, duration: 'permanent')
+      expect(user.reload.family_map_sharing_active?).to be(true)
     end
   end
 end

--- a/spec/regressions/map_v1_sunset_banners_spec.rb
+++ b/spec/regressions/map_v1_sunset_banners_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Map v1 sunset banners', type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  it 'always shows the general v1 sunset banner on the classic map' do
+    get map_v1_path
+
+    expect(response.body).to include('map_v1_sunset_aug_2026')
+    expect(response.body).to include('August 2026')
+  end
+
+  context 'when family location sharing is active in the user\'s family' do
+    let(:family) { create(:family, creator: user) }
+    let(:sharer) { create(:user) }
+
+    before do
+      allow(DawarichSettings).to receive(:family_feature_enabled?).and_return(true)
+      create(:family_membership, :owner, family: family, user: user)
+      create(:family_membership, family: family, user: sharer)
+      sharer.update_family_location_sharing!(true, duration: 'permanent')
+    end
+
+    it 'shows the family-history-on-v2 banner' do
+      get map_v1_path
+
+      expect(response.body).to include('map_v1_family_history_v2_only')
+      expect(response.body).to include('Family location history is only shown on the new map')
+    end
+  end
+
+  context 'when no family member is sharing' do
+    it 'does not show the family banner' do
+      get map_v1_path
+
+      expect(response.body).not_to include('map_v1_family_history_v2_only')
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Family members who enabled location sharing only saw each other's **live** position on the map, never their **history track** — as reported on the forum: https://discourse.dawarich.app/t/family-location-history/82

Investigation found three overlapping causes:

1. **The "Location history" toggle is a separate setting from live sharing** and defaults off — it's only revealed after live sharing is enabled, so it's easy to miss.
2. **The default history window was 24h**, and history is scoped to points recorded *after* opt-in — so a freshly-shared member showed an almost-empty track.
3. **Map v1 (Leaflet) never renders family history at all** — only Map v2 (`loadFamilyHistory` → `/families/locations/history`) does. Users on `preferred_version: 'v1'` only ever see live markers.

## Changes

- **Toggle discoverability:** hint text under the family "Location history" toggle explaining it's distinct from live location, powers the Map v2 recent-track view, and only shares points recorded after enabling.
- **Default window 24h → 7d** (`UserFamily::DEFAULT_HISTORY_WINDOW`), so newly-shared members show a useful track. Invalid/missing windows fall back to the same default.
- **Two dismissible Map v1 banners:**
  - General: "classic map (v1) will be retired in August 2026 → switch to the new map".
  - Family-conditional (`family_map_sharing_active?`): "family location history is only shown on Map v2".
  - Dismissals persist per-browser via `localStorage` (reusable `dismissible` Stimulus controller).

## Tests

- `spec/models/concerns/user_family_spec.rb` — default-window + `family_map_sharing_active?` coverage.
- `spec/regressions/map_v1_sunset_banners_spec.rb` — general banner always present, family banner only when sharing is active.
- Existing `spec/integration/family_privacy_spec.rb` still green. Verified in-browser: both banners render above the Leaflet map, and per-banner dismissal persists across reloads.

## Notes

- Self-hosted only surfaces the family feature (`family_feature_enabled? == self_hosted?`), so the family banner never shows on Cloud unless the feature is enabled there.
- Banner overlay uses an inline `z-index` so it renders above Leaflet controls regardless of Tailwind build state.
