### PR TITLE
Invalidate points ETag when anomaly flags change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Re-evaluating anomalous points now refreshes the map immediately instead of occasionally serving a cached copy of the points until the next change.
 - Raw data archival: reading archived `raw_data` back from encrypted archives works again (it silently returned nothing before), archive chunks are labeled with the points' actual month, and archives are verified at write time. Re-importing a duplicate point with different `raw_data` (same coordinates and timestamp) now detaches it from its stale archive so the newer data can't be cleared away. Clearing archived data now waits out a 7-day cooling window in the automated jobs and the `archive_full` rake task; the previously broken `points:raw_data:archive`/`archive_full` rake tasks work again. Restores are now reported under the `restored` metric label instead of `removed` — update dashboards reading `points_total{operation="removed"}` accordingly.
 - User data exports now include archived `raw_data` as plain gzip files, so an export can be imported on a different instance (previously the bundled archive files were encrypted with the exporting instance's key and unreadable anywhere else).
 - Creating, updating, or deleting a user in Settings no longer shows a blank "HTTP ERROR 422" page when validation fails — the admin is redirected back with a message explaining what went wrong (e.g. password too short) (#3051)

--- a/app/jobs/points/anomaly_backfill_user_job.rb
+++ b/app/jobs/points/anomaly_backfill_user_job.rb
@@ -27,7 +27,7 @@ class Points::AnomalyBackfillUserJob < ApplicationJob
   private
 
   def reset_existing_flags(user)
-    cleared = user.points.where(anomaly: true).update_all(anomaly: false)
+    cleared = user.points.where(anomaly: true).update_all(anomaly: false, updated_at: Time.current)
     Rails.logger.info("[AnomalyBackfill] User #{user.id}: cleared #{cleared} anomaly flags before re-evaluation")
   end
 

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -40,7 +40,7 @@ class Points::AnomalyFilter
          .not_anomaly
          .where.not(accuracy: nil)
          .where('accuracy > ?', accuracy_threshold)
-         .update_all(anomaly: true)
+         .update_all(anomaly: true, updated_at: Time.current)
   end
 
   # Pass 2: Speed-based sandwich test (chunked by month to handle large imports)
@@ -99,7 +99,7 @@ class Points::AnomalyFilter
 
     return 0 if anomaly_ids.empty?
 
-    Point.where(id: anomaly_ids).update_all(anomaly: true)
+    Point.where(id: anomaly_ids).update_all(anomaly: true, updated_at: Time.current)
   end
 
   def fetch_points_with_context(start_time, end_time)

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe Points::AnomalyFilter do
   let(:end_time) { Time.current.to_i }
 
   describe '#call' do
+    it 'bumps updated_at when flagging an anomaly so cached point reads invalidate' do
+      point = create(:point, user: user, accuracy: 500, timestamp: 30.minutes.ago.to_i,
+                             latitude: 52.52, longitude: 13.405, lonlat: 'POINT(13.405 52.52)')
+      point.update_column(:updated_at, 2.days.ago)
+      before_updated = point.reload.updated_at
+
+      described_class.new(user.id, start_time, end_time).call
+
+      expect(point.reload.anomaly).to be true
+      expect(point.updated_at).to be > before_updated
+    end
+
     context 'Pass 1: accuracy filter' do
       # Use nearby coordinates so Pass 2 speed filter does not interfere
       let(:base_lat) { 52.52 }


### PR DESCRIPTION
## Problem

`GET /api/v1/points` derives its ETag partly from `MAX(updated_at)` over the requested points. The anomaly filter flips the `anomaly` flag with `update_all(anomaly: true)` and the backfill reset uses `update_all(anomaly: false)` — neither bumps `updated_at`. So after "Re-evaluate anomalies", if a scope's row count is unchanged, the ETag can be identical and the map is served a stale `304`.

## Fix

Stamp `updated_at: Time.current` on the three `update_all(anomaly: …)` calls (`Points::AnomalyFilter` accuracy + speed passes, and `Points::AnomalyBackfillUserJob#reset_existing_flags`) so the points cache invalidates.

## Test

Regression spec: flagging a point as an anomaly moves its `updated_at` forward (verified red → green). `27` anomaly specs pass; rubocop clean.