### PR TITLE
feat: lead web onboarding with the start-tracking path

### DIFF
--- a/app/views/map/_onboarding_modal.html.erb
+++ b/app/views/map/_onboarding_modal.html.erb
@@ -16,17 +16,32 @@
         <div class="text-center mb-6">
           <h3 class="text-2xl font-bold text-primary mb-2">Welcome to Dawarich!</h3>
           <p class="text-base-content/70">
-            Let's get your location data on the map.
+            Your map starts with your next step — literally.
           </p>
         </div>
 
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <%# Path A: Import %>
-          <button class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow cursor-pointer text-left border-2 border-transparent hover:border-primary"
+          <%# Path A: Track (primary) %>
+          <button class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow cursor-pointer text-left border-2 border-primary/40 hover:border-primary sm:col-span-2"
+                  data-action="onboarding-modal#showTrack">
+            <div class="card-body p-5">
+              <div class="flex items-center gap-2 mb-2">
+                <%= icon 'smartphone', class: 'w-6 h-6 text-primary' %>
+                <h4 class="text-lg font-semibold">Start tracking now</h4>
+                <span class="badge badge-primary badge-sm">2 minutes</span>
+              </div>
+              <p class="text-sm text-base-content/70">
+                Get the app, scan a QR code, and watch your first points appear on the map today.
+              </p>
+            </div>
+          </button>
+
+          <%# Path B: Import %>
+          <button class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow cursor-pointer text-left border-2 border-transparent hover:border-secondary"
                   data-action="onboarding-modal#showImport">
             <div class="card-body p-5">
               <div class="flex items-center gap-2 mb-2">
-                <%= icon 'file-up', class: 'w-6 h-6 text-primary' %>
+                <%= icon 'file-up', class: 'w-6 h-6 text-secondary' %>
                 <h4 class="text-lg font-semibold">I have data</h4>
               </div>
               <p class="text-sm text-base-content/70">
@@ -35,22 +50,8 @@
             </div>
           </button>
 
-          <%# Path B: Track %>
-          <button class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow cursor-pointer text-left border-2 border-transparent hover:border-secondary"
-                  data-action="onboarding-modal#showTrack">
-            <div class="card-body p-5">
-              <div class="flex items-center gap-2 mb-2">
-                <%= icon 'smartphone', class: 'w-6 h-6 text-secondary' %>
-                <h4 class="text-lg font-semibold">Start tracking</h4>
-              </div>
-              <p class="text-sm text-base-content/70">
-                Download the app and connect it to start recording your location.
-              </p>
-            </div>
-          </button>
-
           <%# Path C: Demo Data %>
-          <button class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow cursor-pointer text-left border-2 border-transparent hover:border-accent sm:col-span-2"
+          <button class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow cursor-pointer text-left border-2 border-transparent hover:border-accent"
                   data-action="onboarding-modal#loadDemoData"
                   data-onboarding-modal-target="demoButton">
             <div class="card-body p-5">
@@ -191,6 +192,11 @@
               and follow the
               <%= link_to 'setup guide', 'https://dawarich.app/docs/tutorials/track-your-location?utm_source=app&utm_medium=referral&utm_campaign=onboarding',
                   class: 'link link-primary font-medium', target: '_blank', rel: 'noopener' %>.
+            </p>
+
+            <p class="text-xs text-base-content/60">
+              Have old location history, like a Google Takeout? Tracking works right away —
+              you can <button type="button" class="link link-primary" data-action="onboarding-modal#showImport">import your history anytime</button>.
             </p>
           </div>
         </div>

--- a/spec/views/map/_onboarding_modal.html.erb_spec.rb
+++ b/spec/views/map/_onboarding_modal.html.erb_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'map/_onboarding_modal', type: :view do
+  let(:user) { create(:user) }
+
+  before do
+    allow(view).to receive_messages(
+      user_signed_in?: true,
+      current_user: user,
+      onboarding_modal_showable?: true
+    )
+  end
+
+  def rendered_modal
+    render partial: 'map/onboarding_modal'
+    rendered
+  end
+
+  it 'leads with the tracking path before the import path' do
+    html = rendered_modal
+
+    tracking_index = html.index('Start tracking now')
+    import_index = html.index('I have data')
+
+    expect(tracking_index).not_to be_nil
+    expect(import_index).not_to be_nil
+    expect(tracking_index).to be < import_index
+  end
+
+  it 'reassures that importing history can happen later' do
+    expect(rendered_modal).to include('import your history anytime')
+  end
+
+  it 'keeps all three paths available' do
+    html = rendered_modal
+
+    expect(html).to include('Start tracking now')
+    expect(html).to include('I have data')
+    expect(html).to include('demo data')
+  end
+end


### PR DESCRIPTION
## Problem

The onboarding modal leads with "I have data" (file import). For Google Timeline switchers that means generating a Takeout first — hours of waiting the activation funnel doesn't survive. Signup→activation is the funnel's weakest stage, and the fastest path to a first point on the map (app + QR, minutes) is visually secondary.

## Changes

- **"Start tracking now"** is now the primary, full-width card (with a "2 minutes" badge); it opens the existing track screen with store badges + API-key QR connect.
- **"I have data"** (import) moves to second position — unchanged functionally.
- The track screen gains a reassurance line: tracking works right away, and history (Takeout, GPX) can be **imported anytime later** — with an inline jump to the import screen.
- Modal subtitle: "Your map starts with your next step — literally."

No Stimulus controller changes — same targets and actions, ERB-only reorder + copy.

## Verification

- New view spec (`spec/views/map/_onboarding_modal.html.erb_spec.rb`, first view spec in the repo): tracking path precedes import, all three paths present, import-later reassurance rendered — 3/3 green.
- RuboCop clean.