### PR TITLE
Make print ordering discoverable from any layout

### DIFF
--- a/app/javascript/controllers/poster_studio_editor_controller.js
+++ b/app/javascript/controllers/poster_studio_editor_controller.js
@@ -11,7 +11,11 @@ import {
   layoutById,
   resolveLayoutGeometry,
 } from "poster_studio/data/layouts"
-import { printProductFor } from "poster_studio/data/print_products"
+import {
+  ORDERABLE_LAYOUT_IDS,
+  PRINT_PRODUCTS,
+  printProductFor,
+} from "poster_studio/data/print_products"
 import {
   extendTokens,
   loadThemeTokens,
@@ -37,7 +41,11 @@ const METERS_PER_DEGREE = 111320
 // Sidecar frame semantics: it renders ±distance/3 vertically, so covering
 // the studio's visible height needs distance = 3 × half-height in meters.
 const SIDECAR_DISTANCE_FACTOR = 1.5
-const SIDECAR_DISTANCE_RANGE = [500, 20000]
+// Max lifted so any single-view framing is saveable: the distance box is
+// calibrated to the visible frame, so a low cap made zoomed-out routes read as
+// "outside the frame" even while visible. The upper bound stays finite to keep
+// degenerate whole-globe requests off the sidecar.
+const SIDECAR_DISTANCE_RANGE = [500, 5_000_000]
 function toLocalInput(date) {
   const pad = (n) => String(n).padStart(2, "0")
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
@@ -89,7 +97,8 @@ export default class extends Controller {
     "dateStart",
     "dateEnd",
     "orderButton",
-    "orderHint",
+    "sizePicker",
+    "sizePickerOptions",
     "orderDialog",
     "orderSummary",
     "orderStatus",
@@ -110,6 +119,7 @@ export default class extends Controller {
     document.addEventListener("poster-studio:open", this.onOpen)
     this.onResize = () => this.resizeFrame()
     this.populateLayouts()
+    this.populateSizePicker()
     this.populateFonts()
   }
 
@@ -297,6 +307,27 @@ export default class extends Controller {
     select.value = DEFAULT_LAYOUT_ID
   }
 
+  populateSizePicker() {
+    const container = this.sizePickerOptionsTarget
+    container.innerHTML = ""
+    ORDERABLE_LAYOUT_IDS.forEach((id) => {
+      const layout = layoutById(id)
+      const button = document.createElement("button")
+      button.type = "button"
+      button.className = "btn btn-outline btn-sm w-full justify-between"
+      button.dataset.layoutId = id
+      button.dataset.action = "poster-studio-editor#pickPrintSize"
+
+      const name = document.createElement("span")
+      name.textContent = layout.name
+      const price = document.createElement("span")
+      price.className = "opacity-70"
+      price.textContent = PRINT_PRODUCTS[id].priceLabel
+      button.append(name, price)
+      container.appendChild(button)
+    })
+  }
+
   get layout() {
     return layoutById(this.layoutSelectTarget.value)
   }
@@ -305,6 +336,17 @@ export default class extends Controller {
     this.resizeFrame()
     this.updateSummary()
     this.syncOrderAvailability()
+    // Keep an open order view in sync with the new size: an orderable size
+    // refreshes the dialog (and its price); a non-orderable one falls back to
+    // the size picker.
+    if (this.orderViewOpen) this.openOrder()
+  }
+
+  get orderViewOpen() {
+    return (
+      !this.orderDialogTarget.classList.contains("hidden") ||
+      !this.sizePickerTarget.classList.contains("hidden")
+    )
   }
 
   resizeFrame() {
@@ -562,19 +604,28 @@ export default class extends Controller {
   }
 
   syncOrderAvailability() {
-    const product = printProductFor(this.layout?.id)
-    const available = Boolean(product) && this.printOrderUrlValue.length > 0
-    this.orderButtonTarget.classList.toggle("hidden", !available)
-    this.orderHintTarget.classList.toggle(
-      "hidden",
-      !(this.printOrderUrlValue.length > 0 && !product),
-    )
-    if (!available) this.orderDialogTarget.classList.add("hidden")
+    // The Order button is always available when ordering is configured — the
+    // current layout no longer gates it. A non-orderable layout routes through
+    // the size picker instead of being hidden.
+    const configured = this.printOrderUrlValue.length > 0
+    this.orderButtonTarget.classList.toggle("hidden", !configured)
+    if (!configured) {
+      this.orderDialogTarget.classList.add("hidden")
+      this.sizePickerTarget.classList.add("hidden")
+    }
   }
 
   openOrder() {
     const product = printProductFor(this.layout.id)
-    if (!product) return
+    if (product) {
+      this.showOrderDialog(product)
+    } else {
+      this.openSizePicker()
+    }
+  }
+
+  showOrderDialog(product) {
+    this.closeSizePicker()
     this.orderSummaryTarget.textContent = `${this.layout.name} poster — ${product.priceLabel}`
     this.orderErrorTarget.classList.add("hidden")
     this.orderStatusTarget.textContent = ""
@@ -583,6 +634,22 @@ export default class extends Controller {
 
   closeOrder() {
     this.orderDialogTarget.classList.add("hidden")
+  }
+
+  openSizePicker() {
+    this.orderDialogTarget.classList.add("hidden")
+    this.sizePickerTarget.classList.remove("hidden")
+  }
+
+  closeSizePicker() {
+    this.sizePickerTarget.classList.add("hidden")
+  }
+
+  pickPrintSize(event) {
+    const id = event.currentTarget.dataset.layoutId
+    this.layoutSelectTarget.value = id
+    // layoutChanged reopens the order view for the now-orderable size.
+    this.layoutChanged()
   }
 
   async confirmOrder() {

--- a/app/javascript/poster_studio/data/print_products.js
+++ b/app/javascript/poster_studio/data/print_products.js
@@ -5,6 +5,10 @@ export const PRINT_PRODUCTS = {
   "print-70x100": { sku: "poster-70x100", priceLabel: "€74.99" },
 }
 
+// Orderable layout ids, in display order — drives the size picker shown when
+// the current layout can't be ordered.
+export const ORDERABLE_LAYOUT_IDS = Object.keys(PRINT_PRODUCTS)
+
 export function printProductFor(layoutId) {
   return PRINT_PRODUCTS[layoutId] || null
 }

--- a/app/views/map/maplibre/_poster_studio.html.erb
+++ b/app/views/map/maplibre/_poster_studio.html.erb
@@ -271,9 +271,17 @@
                   data-poster-studio-editor-target="orderButton"
                   data-action="poster-studio-editor#openOrder">
             <%= icon 'package', class: 'h-4 w-4' %>
-            Order print
+            Order a printed poster
           </button>
-          <p class="text-xs opacity-60 hidden" data-poster-studio-editor-target="orderHint">Switch to a print format (30 × 40, 50 × 70, 70 × 100 cm) to order a printed poster.</p>
+
+          <div class="hidden rounded-lg border border-base-300 bg-base-100 p-3 space-y-2"
+               data-poster-studio-editor-target="sizePicker">
+            <p class="text-sm font-semibold">Choose a print size</p>
+            <p class="text-xs opacity-70">Printed &amp; shipped in the EU, shipping included.</p>
+            <div class="space-y-1" data-poster-studio-editor-target="sizePickerOptions"></div>
+            <button type="button" class="btn btn-ghost btn-xs w-full"
+                    data-action="poster-studio-editor#closeSizePicker">Cancel</button>
+          </div>
 
           <div class="hidden rounded-lg border border-base-300 bg-base-100 p-3 space-y-2"
                data-poster-studio-editor-target="orderDialog">


### PR DESCRIPTION
Follow-up to #3088 (already merged). Makes print ordering discoverable and fixes two UX gaps found while testing.

## Changes

- **Order button is always visible** (gated only on ordering being configured), not just on the three orderable sizes — so it shows on every layout.
- On a **non-orderable layout**, the button opens a **size picker** listing the orderable sizes with prices; choosing one switches the layout and opens the order dialog.
- **Live price sync:** changing the size while the order view is open refreshes the dialog price for an orderable size, or falls back to the picker for a non-orderable one (previously the dialog kept a stale price).
- **Save-to-gallery zoom-out cap lifted** (20 km → 5,000 km) so any framing visible in the preview is saveable; the distance box already tracks the visible frame, the low cap was the only thing excluding zoomed-out routes.

## Testing

- Request specs green (`spec/requests/map/maplibre_spec.rb`, 9 examples).
- Verified end-to-end in a browser via Playwright against the running app: order button visible on A3; picker opens with the three priced options; price updates live 30×40 → 70×100; size picker → dialog click path works; `sidecarDistance` exceeds the old cap when zoomed out and the gate covers frame-edge coordinates.
