### PR TITLE
Fix family history returning nil coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Family location history now actually shows up on Map v2: the history endpoint read coordinates from the legacy `latitude`/`longitude` point columns, which are empty on instances where points only store the PostGIS `lonlat` value — every shared history point came back without coordinates, so nothing was drawn. Coordinates are now derived from `lonlat` (#2977)
 - Declining the "Move the visit here?" prompt when picking a distant place for a Map v2 visit no longer renames the visit to that place.
 - Place visit detection no longer leaves an empty duplicate visit behind when a newly added point bridges the gap between two previously separate visits at the same place (the two are now merged into one instead of orphaning the earlier suggestion). Confirmed visits are also left untouched by the nightly re-scan, so a new nearby point can no longer pull points out of a visit you have already confirmed.
 - Re-evaluating anomalous points now refreshes the map immediately instead of occasionally serving a cached copy of the points until the next change.

--- a/app/services/families/locations.rb
+++ b/app/services/families/locations.rb
@@ -80,7 +80,11 @@ class Families::Locations
         email: member.email,
         email_initial: member.email.first.upcase,
         sharing_since: member.family_sharing_started_at&.iso8601,
-        points: sampled.pluck(:latitude, :longitude, :timestamp)
+        points: sampled.pluck(
+          Arel.sql('ST_Y(lonlat::geometry)'),
+          Arel.sql('ST_X(lonlat::geometry)'),
+          :timestamp
+        )
       }
     end
   end

--- a/spec/services/families/locations_spec.rb
+++ b/spec/services/families/locations_spec.rb
@@ -79,6 +79,15 @@ RSpec.describe Families::Locations do
         expect(point_data.length).to eq(3)
       end
 
+      it 'derives coordinates from lonlat, not the legacy latitude/longitude columns' do
+        timestamp = 1.hour.ago.to_i
+        create(:point, user: other_user, timestamp: timestamp,
+                       latitude: nil, longitude: nil, lonlat: 'POINT(13.404954 52.520008)')
+
+        result = described_class.new(user).history(start_at: 1.day.ago, end_at: Time.current)
+        expect(result.first[:points].first).to eq([52.520008, 13.404954, timestamp])
+      end
+
       it 'does not include current user in results' do
         user.update_family_location_sharing!(true, duration: 'permanent')
         user.update!(


### PR DESCRIPTION
Fixes #2977

## Problem

`Families::Locations#history` plucked the legacy `latitude`/`longitude` decimal columns:

```ruby
points: sampled.pluck(:latitude, :longitude, :timestamp)
```

Those columns are nil in production (only `lonlat` is populated), so family history points came back as `[nil, nil, timestamp]`. The bug was invisible to the existing specs because the point factory fills the legacy columns alongside `lonlat`.

The `#call` path (latest locations) was unaffected — it uses `Point#lat`/`#lon`, which read from `lonlat`.

## Fix

Pluck coordinates from the `lonlat` geometry instead:

```ruby
points: sampled.pluck(
  Arel.sql('ST_Y(lonlat::geometry)'),
  Arel.sql('ST_X(lonlat::geometry)'),
  :timestamp
)
```

## Testing

Added a spec that creates a point with `lonlat` only (legacy columns nil) and asserts the returned `[lat, lon, timestamp]` tuple. It fails with `[nil, nil, timestamp]` before the fix and passes after. Full `spec/services/families/locations_spec.rb`: 10 examples, 0 failures. RuboCop clean.
