### PR TITLE
perf: cut default self-hosted memory footprint by ~20%

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,3 +17,6 @@ screenshots/
 
 # Poster renderer deps are installed inside the image (platform binaries)
 vendor/poster_renderer/node_modules/
+
+# Local git worktrees must never end up inside the image
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- The default self-hosted stack now idles about 20% lighter (measured: app container 452 → 325 MB, whole stack 843 → 690 MB). `docker-compose.yml` defaults to one Puma web worker (`WEB_CONCURRENCY=1`, plenty for a household instance) and 3 background job threads (`BACKGROUND_PROCESSING_CONCURRENCY=3`) — set the env vars to raise either for busier instances or large imports — and the Docker image now tunes jemalloc to return freed memory to the OS promptly instead of holding it. Existing installations that already set these variables are unaffected (#3119).
 - Deleting a point on Map v2 now removes it instantly and restores it if the delete request fails.
 - During replay, photos also stack up as a tilted, Polaroid-style pile in the top-left corner of the map as the playhead reaches each one (newest on top, up to five shown at once); click a photo in the pile to open it. The pile stays in sync with the on-map photo markers as you play, scrub, or rewind, and works on the map, trip, and public shared-trip replays.
 - Turning on the photos layer while a replay is already running now adds those photos to the replay (corner pile and map markers) and hides the static markers; turning it off removes them again — previously photos only appeared if the layer was enabled before starting replay.

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -40,6 +40,13 @@ workers ENV.fetch('WEB_CONCURRENCY', 2)
 #
 preload_app!
 
+# Compact the preloaded heap before forking so workers share as many
+# copy-on-write pages as possible. Only runs in cluster mode (workers > 0).
+before_fork do
+  3.times { GC.start }
+  GC.compact
+end
+
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,6 +75,10 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
     echo "/usr/lib/aarch64-linux-gnu/libjemalloc.so.2" > /etc/ld.so.preload; \
     fi
 
+# Return freed pages to the OS quickly instead of holding them in the
+# allocator, and cap arena count — keeps idle RSS low on small hosts.
+ENV MALLOC_CONF="narenas:2,dirty_decay_ms:1000,muzzy_decay_ms:1000"
+
 # Enable YJIT
 ENV RUBY_YJIT_ENABLE=1
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,6 +84,9 @@ services:
       RAILS_LOG_TO_STDOUT: ${RAILS_LOG_TO_STDOUT:-true}
       SELF_HOSTED: ${SELF_HOSTED:-true}
       STORE_GEODATA: ${STORE_GEODATA:-true}
+      # One preloaded Puma worker is plenty for a household instance and
+      # halves idle memory. Raise for busier instances.
+      WEB_CONCURRENCY: ${WEB_CONCURRENCY:-1}
       ### OTP encryption keys are required if you want to use 2FA
       # OTP_ENCRYPTION_PRIMARY_KEY: ${OTP_ENCRYPTION_PRIMARY_KEY:-}
       # OTP_ENCRYPTION_DETERMINISTIC_KEY: ${OTP_ENCRYPTION_DETERMINISTIC_KEY:-}
@@ -138,7 +141,9 @@ services:
       DATABASE_PASSWORD: ${DATABASE_PASSWORD:-password}
       DATABASE_NAME: ${DATABASE_NAME:-dawarich_development}
       APPLICATION_HOSTS: ${APPLICATION_HOSTS:-localhost,::1,127.0.0.1}
-      BACKGROUND_PROCESSING_CONCURRENCY: ${BACKGROUND_PROCESSING_CONCURRENCY:-5}
+      # 3 job threads keep idle memory and DB connections low; raise
+      # temporarily for large imports.
+      BACKGROUND_PROCESSING_CONCURRENCY: ${BACKGROUND_PROCESSING_CONCURRENCY:-3}
       APPLICATION_PROTOCOL: ${APPLICATION_PROTOCOL:-http}
       PROMETHEUS_EXPORTER_ENABLED: ${PROMETHEUS_EXPORTER_ENABLED:-false}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE:-"CHANGE_ME"}


### PR DESCRIPTION
## What

Four low-risk changes that reduce the default self-hosted stack's idle memory by ~150 MiB (~20% of the Rails processes' footprint):

1. **`WEB_CONCURRENCY` defaults to 1 in `docker-compose.yml`** (was 2 via the `puma.rb` fallback). One preloaded Puma worker with 5 threads is plenty for a household instance; the compose default only affects self-hosted — any deployment that sets the env var explicitly is untouched. Raise it back with `WEB_CONCURRENCY=2` for busier instances.
2. **`BACKGROUND_PROCESSING_CONCURRENCY` compose default 5 → 3.** Fewer idle job threads and DB connections; raise temporarily for large imports.
3. **jemalloc decay tuning in the Dockerfile** (`MALLOC_CONF=narenas:2,dirty_decay_ms:1000,muzzy_decay_ms:1000`). Freed pages are returned to the OS within ~1s instead of being held by the allocator, which is what inflates idle RSS numbers.
4. **`GC.compact` before Puma forks workers** — compacted preloaded heap shares more copy-on-write pages across workers (matters again the moment someone scales workers up).

Plus: `.worktrees/` excluded from the Docker build context (local git worktrees ended up inside locally-built images).

## Benchmark

Identical protocol for both runs: fresh volumes → migrate + seed → warmup (health, sign-in, login, map v2, stats, points, imports) → 2 min idle → 3× `docker stats` samples 30 s apart, averaged. Baseline is `dev` @ 2da756ee.

| container | baseline (avg) | this PR (avg) | delta |
|---|---|---|---|
| dawarich_app | 451.6 MiB | 324.9 MiB | **−126.7 MiB (−28%)** |
| dawarich_sidekiq | 307.5 MiB | 285.8 MiB | −21.7 MiB (−7%) |
| redis | 15.2 MiB | 14.4 MiB | −0.8 MiB |
| db (PostGIS) | 69.2 MiB | 64.7 MiB | −4.5 MiB |
| **app + sidekiq** | **759.0 MiB** | **610.7 MiB** | **−148.4 MiB (−20%)** |
| **whole stack** | **843.4 MiB** | **689.8 MiB** | **−153.7 MiB (−18%)** |

Per-process check: app container now runs 1 Puma worker (`[0 of 3 busy]` on Sidekiq confirms the concurrency default). App verified working after the change: login, Map v2, stats, points and imports pages all render (same flow as baseline).

## Notes

- Cloud/production deployments are unaffected: `puma.rb`'s `WEB_CONCURRENCY` fallback stays at 2, and the compose defaults only apply where the env vars aren't set.
- `MALLOC_CONF` applies to any consumer of the image; decay tuning trades a small amount of allocator work for significantly lower idle RSS.
- Follow-up candidates (separate PRs): gem boot-memory audit via derailed_benchmarks, vips instead of ImageMagick, Solid Queue to drop the Sidekiq container + Redis entirely.