### PR TITLE
build: make Docker image build self-contained (npm ci in image)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,5 +15,8 @@ docs/
 screenshots/
 .ruby-lsp/
 
+# Node deps are installed inside the image (npm ci), never from the host
+node_modules/
+
 # Poster renderer deps are installed inside the image (platform binaries)
 vendor/poster_renderer/node_modules/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,6 +95,11 @@ RUN bundle config set --local path 'vendor/bundle' \
 
 COPY ../. ./
 
+# Node deps (tailwind plugins like daisyui) are needed by assets:precompile.
+# Install them here so the build does not depend on a host-side `npm install`
+# having populated node_modules in the build context.
+RUN npm ci --no-audit --no-fund && rm -rf ~/.npm
+
 # Poster renderer dependencies — prebuilt maplibre-native binaries exist for
 # x64/arm64 only (Debian's Node 20 = ABI 115, which the release ships). On
 # armv7 the renderer is skipped; server-side poster rendering is unavailable


### PR DESCRIPTION
## What

The `tailwindcss:build` step inside `assets:precompile` needs `node_modules` (the daisyui plugin), but the Dockerfile never installs root node deps — it silently relied on the build context containing a host-side `node_modules`. CI happens to run `npm install` before `docker build` (`build_and_push.yml`), so published images were fine, but **any build from a fresh clone fails** with:

```
Error: Cannot find module 'daisyui'
Tasks: TOP => assets:precompile => tailwindcss:build
```

## Changes

- **`docker/Dockerfile`**: run `npm ci --no-audit --no-fund` after copying the app, before `assets:precompile`. The existing `rm -rf node_modules tmp/cache` after precompile already strips it from the final image, so image size is unchanged (+~3 s build time).
- **`.dockerignore`**: exclude root `node_modules/` from the build context — deps are now always installed for the image's own platform (`linux/amd64|arm64`) instead of inheriting whatever the host had (e.g. darwin binaries), and the context upload shrinks accordingly.

## Verification

Built from a clean worktree with **no** host `node_modules` (previously the exact failing case): build succeeds (`npm ci` → `added 59 packages`, precompile passes), stack boots, `/api/v1/health` returns `{"status":"ok"}`, sign-in page renders with compiled assets.

## Notes

- The `npm install` step in `.github/workflows/build_and_push.yml` becomes redundant for the image build and can be removed later (left untouched here to keep this change minimal).
- Self-hosters building their own images from source no longer need Node/npm on the host at all.