### PR TITLE
fix: walk downgraded users through archival warnings gradually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.10.1] - Unreleased
 
+### Fixed
+
+- Users downgraded to Lite with more than a year of history now receive the archival warnings gradually (heads-up, then email, then archived notice over 30 days) instead of an immediate "Data has been archived" notification. Upgrading off Lite resets the warning state.
+
 ### Changed
 
 - The legacy `latitude`/`longitude` columns on `points` are dropped — the PostGIS `lonlat` column has been the single source of truth since 0.25.0. The migration copies any remaining legacy-only coordinates into `lonlat` before dropping, so upgrades from older versions are safe. To reclaim the freed disk space on large instances, run `pg_repack -t points` (optional).

--- a/app/jobs/lite/archival_warning_job.rb
+++ b/app/jobs/lite/archival_warning_job.rb
@@ -4,11 +4,16 @@ class Lite::ArchivalWarningJob < ApplicationJob
   queue_as :archival
 
   # Thresholds checked daily for all Lite users.
-  # Each threshold defines the cutoff duration and a dedup key.
+  # Each threshold defines the cutoff duration, a dedup key, and the minimum
+  # time the user must have been on Lite (so a fresh downgrade with old data
+  # walks through the warning sequence instead of jumping to "archived").
   THRESHOLDS = [
-    { duration: DawarichSettings::LITE_DATA_WINDOW - 1.month,            key: '11mo',   action: :notify_approaching },
-    { duration: DawarichSettings::LITE_DATA_WINDOW - 1.month + 15.days,  key: '11_5mo', action: :notify_email },
-    { duration: DawarichSettings::LITE_DATA_WINDOW,                      key: '12mo',   action: :notify_archived }
+    { duration: DawarichSettings::LITE_DATA_WINDOW - 1.month,            key: '11mo',   action: :notify_approaching,
+      min_lite_age: 0.days },
+    { duration: DawarichSettings::LITE_DATA_WINDOW - 1.month + 15.days,  key: '11_5mo', action: :notify_email,
+      min_lite_age: 15.days },
+    { duration: DawarichSettings::LITE_DATA_WINDOW,                      key: '12mo',   action: :notify_archived,
+      min_lite_age: 1.month }
   ].freeze
 
   def perform
@@ -28,10 +33,14 @@ class Lite::ArchivalWarningJob < ApplicationJob
     oldest_timestamp = user.points.minimum(:timestamp)
     return unless oldest_timestamp
 
+    lite_since = parse_lite_since(user)
+
     # Find all crossed thresholds that haven't been sent yet
     unsent_crossed = THRESHOLDS.select do |threshold|
       cutoff = threshold[:duration].ago.to_i
-      oldest_timestamp <= cutoff && warnings_sent[threshold[:key]].blank?
+      oldest_timestamp <= cutoff &&
+        warnings_sent[threshold[:key]].blank? &&
+        lite_long_enough?(lite_since, threshold[:min_lite_age])
     end
 
     return if unsent_crossed.empty?
@@ -65,6 +74,21 @@ class Lite::ArchivalWarningJob < ApplicationJob
                'Your archived data can be exported at any time. ' \
                'Upgrade to Pro to make it visible and interactive in-app again.'
     )
+  end
+
+  def parse_lite_since(user)
+    raw = user.settings&.dig('lite_since')
+    return nil if raw.blank?
+
+    Time.zone.parse(raw.to_s)
+  rescue ArgumentError
+    nil
+  end
+
+  def lite_long_enough?(lite_since, min_lite_age)
+    return true if lite_since.nil?
+
+    lite_since <= min_lite_age.ago
   end
 
   def mark_warning_sent(user, key)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,7 @@ class User < ApplicationRecord
   after_commit :trigger_creation_webhook, on: :create,
                                             if: -> { !DawarichSettings.self_hosted? && skip_auto_trial }
   after_update :invalidate_plan_rate_limit_cache, if: :saved_change_to_plan?
+  after_update :stamp_lite_transition, if: :saved_change_to_plan?
 
   before_save :sanitize_input
 
@@ -342,5 +343,12 @@ class User < ApplicationRecord
   def invalidate_plan_rate_limit_cache
     key = api_key_previously_was || api_key_was || api_key
     Rails.cache.delete("rack_attack/plan/#{key}") if key.present?
+  end
+
+  def stamp_lite_transition
+    updated_settings = (settings || {}).except('lite_since', 'archival_warnings')
+    updated_settings['lite_since'] = Time.zone.now.iso8601 if lite?
+
+    update_column(:settings, updated_settings)
   end
 end

--- a/spec/jobs/lite/archival_warning_job_spec.rb
+++ b/spec/jobs/lite/archival_warning_job_spec.rb
@@ -149,5 +149,52 @@ RSpec.describe Lite::ArchivalWarningJob, type: :job do
         expect { described_class.perform_now }.not_to change(Notification, :count)
       end
     end
+
+    context 'when a Pro user with years of history is freshly downgraded to Lite' do
+      let!(:downgraded) { create(:user).tap { |u| u.update_column(:plan, User.plans[:pro]) } }
+
+      before do
+        create(:point, user: downgraded, timestamp: 14.months.ago.to_i)
+        downgraded.update!(plan: :lite)
+      end
+
+      it 'sends only the approaching warning on the first run' do
+        expect { described_class.perform_now }
+          .to change { Notification.where(user: downgraded).count }.by(1)
+
+        notification = Notification.where(user: downgraded).last
+        expect(notification.title).to include('30 days')
+      end
+
+      it 'does not enqueue the email on the first run' do
+        expect { described_class.perform_now }
+          .not_to have_enqueued_job(Users::MailerSendingJob)
+      end
+
+      it 'sends the email once the user has been Lite for 15 days' do
+        described_class.perform_now
+        set_lite_since(downgraded, 16.days.ago)
+
+        expect { described_class.perform_now }
+          .to have_enqueued_job(Users::MailerSendingJob)
+          .with(downgraded.id, 'archival_approaching')
+      end
+
+      it 'sends the archived notification once the user has been Lite for 30 days' do
+        described_class.perform_now
+        set_lite_since(downgraded, 31.days.ago)
+
+        expect { described_class.perform_now }
+          .to change { Notification.where(user: downgraded).count }.by(1)
+
+        notification = Notification.where(user: downgraded).order(:created_at).last
+        expect(notification.title).to include('archived')
+      end
+    end
+  end
+
+  def set_lite_since(user, time)
+    user.reload
+    user.update_column(:settings, user.settings.merge('lite_since' => time.iso8601))
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -42,6 +42,51 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe 'lite transition stamping' do
+    it 'stamps lite_since when the plan changes to lite' do
+      user = create(:user, skip_auto_trial: true)
+      user.update_column(:plan, User.plans[:pro])
+
+      user.update!(plan: :lite)
+
+      expect(Time.zone.parse(user.reload.settings['lite_since'])).to be_within(5.seconds).of(Time.zone.now)
+    end
+
+    it 'clears lite_since and archival warnings when the plan leaves lite' do
+      user = create(:user, skip_auto_trial: true)
+      user.update_column(:plan, User.plans[:lite])
+      user.update_column(:settings, user.settings.merge(
+                                      'lite_since' => 1.day.ago.iso8601,
+                                      'archival_warnings' => { '11mo' => 1.day.ago.iso8601 }
+                                    ))
+
+      user.update!(plan: :pro)
+
+      expect(user.reload.settings).not_to have_key('lite_since')
+      expect(user.settings).not_to have_key('archival_warnings')
+    end
+
+    it 'resets stale archival warnings when re-entering lite' do
+      user = create(:user, skip_auto_trial: true)
+      user.update_column(:plan, User.plans[:pro])
+      user.update_column(:settings, user.settings.merge('archival_warnings' => { '12mo' => 1.year.ago.iso8601 }))
+
+      user.update!(plan: :lite)
+
+      expect(user.reload.settings).not_to have_key('archival_warnings')
+      expect(user.settings['lite_since']).to be_present
+    end
+
+    it 'does not touch settings when the plan does not change' do
+      user = create(:user, skip_auto_trial: true)
+      user.update_column(:plan, User.plans[:lite])
+      user.update_column(:settings, user.settings.merge('lite_since' => 1.day.ago.iso8601))
+
+      expect { user.update!(email: 'new-address@example.com') }
+        .not_to(change { user.reload.settings['lite_since'] })
+    end
+  end
+
   describe 'changelog consent' do
     it 'defaults to nil (not yet prompted) and reports prompt pending' do
       user = create(:user)


### PR DESCRIPTION
## Summary

- stamp `settings['lite_since']` whenever a user's plan transitions to Lite; clear the stamp and any `archival_warnings` state when the plan leaves Lite
- gate each archival warning threshold on a minimum time-on-Lite (11mo → immediately, 11.5mo → 15 days, 12mo → 30 days), so a freshly downgraded user with years of history walks through the normal sequence — heads-up notification, then email, then the archived notice — instead of getting "Data has been archived" as their very first contact
- users without a `lite_since` stamp (long-time Lite users predating this change) keep the existing behavior

## Root cause

`Lite::ArchivalWarningJob` infers progress purely from the age of the oldest point. A Pro user with >12 months of history who is downgraded (legitimately or by a billing error, as happened with the Manager trial-sweep bug) crosses all three thresholds in a single daily run and receives the most severe notification immediately, skipping the 30-day warning and the email entirely.

## Verification

- new job specs: fresh downgrade → approaching warning only; +15 days → email; +30 days → archived notice (red before the fix, green after)
- new model specs: `lite_since` stamped on downgrade, stamp + warning state cleared on upgrade, stale warnings reset on re-entry
- `spec/jobs/lite/archival_warning_job_spec.rb` + `spec/models/user_spec.rb`: 160 examples, 0 failures
- subscription callback request specs + model concern specs: 166 examples, 0 failures
- RuboCop: no offenses on changed files