### PR TITLE
build: drop ImageMagick from the Docker image

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,10 @@ module Dawarich
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks rubocop])
 
+    # No ActiveStorage variants are used anywhere (attachments are data files
+    # and pre-rendered poster images), so no image processor is installed.
+    config.active_storage.variant_processor = :disabled
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,6 @@ RUN apt-get update -qq \
     libyaml-dev \
     zlib1g-dev \
     libgeos-dev libgeos++-dev \
-    imagemagick \
     tzdata \
     less \
     libjemalloc2 libjemalloc-dev \


### PR DESCRIPTION
## What

Second slice of the Tier 2 memory/size work (follow-up to #3119, sibling of #3138).

Removes `imagemagick` from the Docker image. Nothing uses it:

- no ActiveStorage variants anywhere in the app
- no `mini_magick` / `image_processing` gems
- no shell-outs — poster images are rendered by the bundled maplibre-native/canvas renderer

`config.active_storage.variant_processor = :disabled` makes that explicit and silences the boot-time warning about the missing `image_processing` gem.

## Measured impact

Docker image shrinks by **~149 MB** (ImageMagick + its dependency tree in the final stage).

## Verification

- App boots cleanly with `variant_processor = :disabled` (verified via `rails runner`)
- Re-checked: zero `variant(` calls, zero mini_magick/image_processing references in Gemfile/app