### PR TITLE
fix: keep pagination page when deleting a place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Cache preheating no longer times out for accounts with large location histories.
 - Users downgraded to Lite with more than a year of history now receive the archival warnings gradually (heads-up, then email, then archived notice over 30 days) instead of an immediate "Data has been archived" notification. Upgrading off Lite resets the warning state.
 - TCX and KML imports no longer fail when text fields contain raw ampersands.
+- Deleting a place from the Places list no longer jumps back to the first page — you stay on the page you were viewing (#3145)
 - Map v2 now applies the existing simplified point-rendering mode, so dense point streams are thinned on the map when that setting is selected. Only the points layer is thinned — heatmap, fog of war, scratch map, and routes are still built from the full point set (#946).
 
 

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -96,7 +96,7 @@ class PlacesController < ApplicationController
   def destroy
     @place.destroy!
 
-    redirect_to places_url, notice: 'Place was successfully destroyed.', status: :see_other
+    redirect_to places_url(page: params[:page]), notice: 'Place was successfully destroyed.', status: :see_other
   end
 
   private

--- a/app/views/places/index.html.erb
+++ b/app/views/places/index.html.erb
@@ -41,7 +41,7 @@
                 <td><%= human_datetime(place.created_at, current_user.safe_settings.timezone) %></td>
                 <td><%= "#{place.lat}, #{place.lon}" %></td>
                 <td>
-                  <%= link_to 'Delete', place, data: { turbo_confirm: "Are you sure? Deleting a place will result in deleting all visits for this place.", turbo_method: :delete }, class: "px-4 py-2 bg-red-500 text-white rounded-md" %>
+                  <%= link_to 'Delete', place_path(place, page: params[:page]), data: { turbo_confirm: "Are you sure? Deleting a place will result in deleting all visits for this place.", turbo_method: :delete }, class: "px-4 py-2 bg-red-500 text-white rounded-md" %>
                 </td>
               </tr>
             <% end %>

--- a/spec/regressions/place_delete_preserves_pagination_spec.rb
+++ b/spec/regressions/place_delete_preserves_pagination_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Deleting a place preserves the current pagination page', type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  it 'redirects back to the page the place was deleted from' do
+    places = create_list(:place, 21, user:)
+    target = places.last
+
+    delete place_url(target, page: 2)
+
+    expect(response).to redirect_to(places_url(page: 2))
+  end
+
+  it 'renders delete links that carry the current page' do
+    create_list(:place, 21, user:)
+
+    get places_url(page: 2)
+
+    delete_links = response.body.scan(%r{<a\b[^>]*>Delete</a>})
+    expect(delete_links).not_to be_empty
+    expect(delete_links).to all(include('page=2'))
+  end
+end


### PR DESCRIPTION
## Problem

On the Places page, deleting a place from any page other than the first returns you to page 1 (#3145). `PlacesController#destroy` redirected to the bare `places_url`, dropping `params[:page]`, and the delete link didn't carry the page in the first place.

## Fix

- Delete link now points to `place_path(place, page: params[:page])`.
- `destroy` redirects to `places_url(page: params[:page])`. When no page is present, `page: nil` is stripped, so the URL is identical to the old `/places` (no behavior change for page 1).

## Tests

- `spec/regressions/place_delete_preserves_pagination_spec.rb` — controller redirect preserves the page, and index delete links carry it. Verified red before the fix.
- All 27 existing `spec/requests/places_spec.rb` examples still pass.

Closes #3145
