### PR TITLE
fix: ignore OwnTracks waypoint payloads on the live ingest path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- OwnTracks `_type: waypoint` sync messages are no longer stored as location points, so syncing your saved OwnTracks places no longer creates phantom distance/track spikes (#3137)
 - Track generation and user data recalculations now retry a bounded number of times when another job is already processing the same user's tracks, instead of dropping the request and reporting an error; a genuinely stuck lock is logged after the retries are exhausted. The per-user lock also renews itself while a job runs and frees within a minute if a worker dies, so a crashed job no longer blocks a user's track processing for up to half an hour.
 - Dawarich added to an iOS Home Screen now opens Map v2 instead of an unrelated previously visited page (#3097)
 - Point uploads (REST API, OwnTracks, Overland, Traccar) now write batches in a consistent order so concurrent uploads no longer deadlock each other, and both uploads and anomaly filtering recover automatically from any remaining transient database deadlocks instead of failing the upload or background job.

--- a/app/services/own_tracks/importer.rb
+++ b/app/services/own_tracks/importer.rb
@@ -22,7 +22,10 @@ class OwnTracks::Importer
     points_data = parsed_data.map do |point|
       next unless point_valid?(point)
 
-      OwnTracks::Params.new(point, include_raw_data: false).call.merge(
+      attrs = OwnTracks::Params.new(point, include_raw_data: false).call
+      next unless attrs
+
+      attrs.merge(
         import_id: import.id,
         user_id: user_id,
         created_at: Time.current,

--- a/app/services/own_tracks/params.rb
+++ b/app/services/own_tracks/params.rb
@@ -90,6 +90,8 @@ class OwnTracks::Params
   end
 
   def valid_point?
+    return false if params[:_type].to_s == 'waypoint'
+
     params[:lon].present? && params[:lat].present? && params[:tst].present?
   end
 end

--- a/spec/regressions/owntracks_importer_skips_waypoints_spec.rb
+++ b/spec/regressions/owntracks_importer_skips_waypoints_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'tempfile'
+
+RSpec.describe 'OwnTracks .rec import is resilient to waypoint entries' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user:, source: :owntracks) }
+
+  it 'skips waypoint entries and imports only real location fixes without raising' do
+    rec = [
+      %(2024-03-01T09:03:09Z\t*\t{"_type":"location","lat":52.2,"lon":13.3,"tst":1709283789,"tid":"RO"}),
+      %(2024-03-01T18:40:09Z\t*\t{"_type":"waypoint","desc":"Home","lat":52.23,"lon":13.33,"tst":1717459768})
+    ].join("\n")
+
+    file = Tempfile.new(['owntracks', '.rec'])
+    file.write(rec)
+    file.rewind
+
+    expect do
+      OwnTracks::Importer.new(import, user.id, file.path).call
+    end.to change { import.points.count }.by(1)
+  ensure
+    file&.close
+    file&.unlink
+  end
+end

--- a/spec/regressions/owntracks_waypoint_not_stored_as_point_spec.rb
+++ b/spec/regressions/owntracks_waypoint_not_stored_as_point_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'OwnTracks waypoint payloads are not stored as location points', type: :request do
+  let(:user) { create(:user) }
+
+  def post_owntracks(payload)
+    post "/api/v1/owntracks/points?api_key=#{user.api_key}", params: payload
+  end
+
+  it 'ignores _type=waypoint config-sync payloads even when they carry coordinates' do
+    waypoint = { _type: 'waypoint', desc: 'Home', lat: 52.232, lon: 13.339, rad: 50, tst: 1_717_459_768 }
+
+    expect { post_owntracks(waypoint) }.not_to(change(Point, :count))
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'still stores _type=location fixes' do
+    location = { _type: 'location', lat: 52.225, lon: 13.332, tst: 1_709_283_789, tid: 'RO', topic: 'owntracks/u/d' }
+
+    expect { post_owntracks(location) }.to change(Point, :count).by(1)
+  end
+end


### PR DESCRIPTION
## Problem

OwnTracks republishes its entire saved-places (waypoint) list as `_type: "waypoint"` messages on certain client events (mode switch, app restart) — documented, intentional OwnTracks behavior. These payloads carry `lat`/`lon`/`tst`, so the live ingest path (`POST /api/v1/owntracks/points`) stored each one as a real GPS fix, timestamped at sync time. Result: phantom "visits" to every saved place, teleport spikes in tracks, and inflated distance stats (#3137, explains #1400).

## Root cause

`OwnTracks::Params#valid_point?` only checked `lon`/`lat`/`tst` presence — no `_type` filter. The `.rec` **import** path is already protected (`RecParser` keeps only the `*`/location column), but the **live POST** path was not.

## Fix

Reject `_type: "waypoint"` in `valid_point?`. Location and transition fixes (real positions) are unaffected; other config types (`lwt`, `card`, …) already lack coordinates and were already rejected.

## Tests

- `spec/regressions/owntracks_waypoint_not_stored_as_point_spec.rb` — a waypoint POST creates no point; a location POST still does. Verified red before the fix.
- All existing OwnTracks service/request/importer specs pass (import still yields 9 points from the fixture).

Closes #3137
