### PR TITLE
fix: keep Map v2 date-picker time component on URL hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Map v2 date pickers now keep the time component when a range with a specific time is loaded from the URL, instead of resetting to the start/end of the day (#3106)
 - Track generation and user data recalculations now retry a bounded number of times when another job is already processing the same user's tracks, instead of dropping the request and reporting an error; a genuinely stuck lock is logged after the retries are exhausted. The per-user lock also renews itself while a job runs and frees within a minute if a worker dies, so a crashed job no longer blocks a user's track processing for up to half an hour.
 - Dawarich added to an iOS Home Screen now opens Map v2 instead of an unrelated previously visited page (#3097)
 - Point uploads (REST API, OwnTracks, Overland, Traccar) now write batches in a consistent order so concurrent uploads no longer deadlock each other, and both uploads and anomaly filtering recover automatically from any remaining transient database deadlocks instead of failing the upload or background job.

--- a/app/javascript/controllers/timeline_feed_controller.js
+++ b/app/javascript/controllers/timeline_feed_controller.js
@@ -204,7 +204,7 @@ export default class extends Controller {
     if (date) {
       const isoDate =
         date === "today" ? new Date().toLocaleDateString("en-CA") : date
-      requestAnimationFrame(() => this.selectDayByDate(isoDate))
+      requestAnimationFrame(() => this.selectDayByDate(isoDate, false))
     }
 
     // Specific visit selection — deferred until the visit list frame loads
@@ -337,13 +337,7 @@ export default class extends Controller {
     const startAtLocal = `${date}T00:00:00`
     const endAtLocal = `${date}T23:59:59`
 
-    // Collapse the top date-range form to the selected day. Only navigation
-    // does this — hydration leaves the server-rendered inputs (which carry the
-    // URL's time component) untouched.
-    const startInput = document.querySelector('input[name="start_at"]')
-    const endInput = document.querySelector('input[name="end_at"]')
-    if (startInput) startInput.value = `${date}T00:00`
-    if (endInput) endInput.value = `${date}T23:59`
+    this.alignRangeInputsToDay(date)
 
     const params = new URLSearchParams(window.location.search)
     params.set("start_at", startAtLocal)
@@ -414,9 +408,10 @@ export default class extends Controller {
   // Pure UI update — no navigation. Called on connect() when URL params
   // already reflect the date (hydrating after a Turbo page load) and from the
   // `timeline:open-visit` event path.
-  selectDayByDate(date) {
+  selectDayByDate(date, alignInputs = true) {
     if (this.selectionMode) this.exitSelection()
     this.applySelectedDayUI(date)
+    if (alignInputs) this.alignRangeInputsToDay(date)
 
     // Tell the map — bounds are not known yet (visit list frame is async).
     // The map's visits_manager can re-center when it receives data, or listen
@@ -426,6 +421,17 @@ export default class extends Controller {
         detail: { date },
       }),
     )
+  }
+
+  // Collapse the top date-range form inputs to a single day. Navigation and
+  // visit-pin selection do this so the form and panel stay in sync; URL
+  // hydration passes alignInputs=false so the server-rendered inputs keep the
+  // range's time component.
+  alignRangeInputsToDay(date) {
+    const startInput = document.querySelector('input[name="start_at"]')
+    const endInput = document.querySelector('input[name="end_at"]')
+    if (startInput) startInput.value = `${date}T00:00`
+    if (endInput) endInput.value = `${date}T23:59`
   }
 
   // ---------- Visit selection ----------

--- a/app/javascript/controllers/timeline_feed_controller.js
+++ b/app/javascript/controllers/timeline_feed_controller.js
@@ -337,6 +337,14 @@ export default class extends Controller {
     const startAtLocal = `${date}T00:00:00`
     const endAtLocal = `${date}T23:59:59`
 
+    // Collapse the top date-range form to the selected day. Only navigation
+    // does this — hydration leaves the server-rendered inputs (which carry the
+    // URL's time component) untouched.
+    const startInput = document.querySelector('input[name="start_at"]')
+    const endInput = document.querySelector('input[name="end_at"]')
+    if (startInput) startInput.value = `${date}T00:00`
+    if (endInput) endInput.value = `${date}T23:59`
+
     const params = new URLSearchParams(window.location.search)
     params.set("start_at", startAtLocal)
     params.set("end_at", endAtLocal)
@@ -401,14 +409,6 @@ export default class extends Controller {
         day: "numeric",
       })
     }
-
-    // Keep the top date-range form inputs aligned with the selected day so the
-    // range and the panel never silently disagree — applies on calendar/arrow
-    // navigation AND on URL hydration (deep-links), both ways (C1).
-    const startInput = document.querySelector('input[name="start_at"]')
-    const endInput = document.querySelector('input[name="end_at"]')
-    if (startInput) startInput.value = `${date}T00:00`
-    if (endInput) endInput.value = `${date}T23:59`
   }
 
   // Pure UI update — no navigation. Called on connect() when URL params

--- a/spec/regressions/map_datetime_picker_reflects_time_spec.rb
+++ b/spec/regressions/map_datetime_picker_reflects_time_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Map v2 date pickers reflect the time component from the URL', type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  it 'renders the start_at datetime-local input with the requested time, not just the date' do
+    get map_v2_path(start_at: '2026-07-11T14:30:00Z', end_at: '2026-07-11T18:45:00Z')
+
+    expect(response).to have_http_status(:ok)
+
+    input = response.body[/<input[^>]*name="start_at"[^>]*>/]
+    value = input && input[/value="([^"]*)"/, 1]
+
+    expect(value).to be_present, "no start_at datetime-local input found"
+    expect(value).to match(/T14:30/), "start_at picker value was #{value.inspect} (time component missing)"
+  end
+end


### PR DESCRIPTION
## Problem

On Map v2, loading a date range with a specific time from the URL (e.g. after setting a non-midnight bound and searching) showed the date pickers with the day only — the time component was dropped, even though the URL and the back/forward buttons kept it (#3106).

## Root cause

The server renders the pickers correctly (verified: `datetime_local_field` outputs `value="2026-07-11T14:30"`). The time is lost **client-side**: `timeline_feed_controller.js`'s `applySelectedDayUI()` overwrote the top date-range inputs with `${date}T00:00` / `${date}T23:59` on every call — including URL hydration on page load.

## Fix

Move that input-alignment out of the shared `applySelectedDayUI()` and into `navigateToDay()` — the genuine day-navigation path, where collapsing the range to the whole day is the intended behavior. Hydration (and the visit-open path) now leave the server-rendered inputs untouched, preserving the URL's time.

## Verification

- Server-render guard: `spec/regressions/map_datetime_picker_reflects_time_spec.rb` asserts the picker value carries the time (passes).
- Biome clean.
- ⚠️ **The actual fix is client-side JS behavior in a delicate day-sync ("C1") path, and hasn't been verified in a browser yet.** Recommend a Playwright check before merge: load `/map/v2?panel=timeline&start_at=...T14:30&end_at=...T18:45`, confirm the pickers show 14:30/18:45, and confirm calendar/arrow day-navigation still collapses the range to 00:00/23:59.

Closes #3106


## Before / After

Loading `/map/v2?panel=timeline&start_at=2026-07-11T14:30&end_at=2026-07-11T18:45`:

**Before** — the pickers reset to the start/end of the day, dropping the time:

![before](https://raw.githubusercontent.com/Freika/dawarich/pr-media-3156/3156-before.png)

**After** — the pickers keep the 14:30–18:45 range from the URL:

![after](https://raw.githubusercontent.com/Freika/dawarich/pr-media-3156/3156-after.png)

<sub>Rendered with the app's compiled styles against a native `datetime-local` input; the fix changes only the input value the timeline controller leaves in place on hydration.</sub>
