### PR TITLE
Open Poster Studio from trip pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- The Poster Studio can now be opened directly from a trip's page, pre-loaded with the trip's route, date range, and name.
+
 - Dawarich can now be installed to the phone home screen as a web app (PWA): all pages link the web app manifest and Apple touch icon, and the installed app opens straight into Map v2.
 
 ### Changed

--- a/app/controllers/concerns/poster_studio_context.rb
+++ b/app/controllers/concerns/poster_studio_context.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module PosterStudioContext
+  extend ActiveSupport::Concern
+
+  private
+
+  def load_poster_studio_context
+    @poster_themes = local_poster_themes
+    @recent_posters = current_user.posters.with_attached_image.order(created_at: :desc).limit(10)
+  end
+
+  # Poster theme tokens are vendored under public/poster_themes and read
+  # directly — they also power the map's custom-colour editor.
+  def local_poster_themes
+    Rails.cache.fetch('local_poster_themes', expires_in: 1.hour) do
+      Dir.glob(Rails.root.join('public/poster_themes/*.json')).sort.filter_map do |path|
+        data = JSON.parse(File.read(path))
+        data.merge('key' => File.basename(path, '.json'), 'route' => data['route'].presence || '#FF3B30')
+      rescue JSON::ParserError
+        nil
+      end
+    end
+  end
+end

--- a/app/controllers/map/maplibre_controller.rb
+++ b/app/controllers/map/maplibre_controller.rb
@@ -4,6 +4,7 @@ module Map
   class MaplibreController < ApplicationController
     include SafeTimestampParser
     include ImportTimeWindow
+    include PosterStudioContext
 
     before_action :authenticate_user!
     layout 'map'
@@ -27,27 +28,12 @@ module Map
       # Tag chips displayed in the rail; capped so the list doesn't explode.
       @timeline_tags = current_user.tags.order(:name).limit(8)
 
-      # Theme tokens power both the poster tab and the Appearance section's
+      # Theme tokens power both the poster studio and the Appearance section's
       # custom map colors.
-      @poster_themes = local_poster_themes
-
-      @recent_posters = current_user.posters.with_attached_image.order(created_at: :desc).limit(10)
+      load_poster_studio_context
     end
 
     private
-
-    # Poster theme tokens are vendored under public/poster_themes and read
-    # directly — they also power the map's custom-colour editor.
-    def local_poster_themes
-      Rails.cache.fetch('local_poster_themes', expires_in: 1.hour) do
-        Dir.glob(Rails.root.join('public/poster_themes/*.json')).sort.filter_map do |path|
-          data = JSON.parse(File.read(path))
-          data.merge('key' => File.basename(path, '.json'), 'route' => data['route'].presence || '#FF3B30')
-        rescue JSON::ParserError
-          nil
-        end
-      end
-    end
 
     # Reuses the same month-resolution rule as the calendar helper so the
     # filter pills are aligned with whatever month the calendar lands on

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -2,6 +2,7 @@
 
 class TripsController < ApplicationController
   include FlashStreamable
+  include PosterStudioContext
 
   before_action :authenticate_user!
   before_action :authenticate_active_user!, only: %i[new create recalculate]
@@ -19,6 +20,7 @@ class TripsController < ApplicationController
     @photos_by_day = @trip.photos_by_day(@timezone)
     @day_notes = @trip.notes.index_by(&:date)
     @day_stats = compute_day_stats
+    load_poster_studio_context
 
     return unless @trip.path.blank? || @trip.distance.blank? || @trip.visited_countries.blank?
 

--- a/app/javascript/controllers/poster_studio_editor_controller.js
+++ b/app/javascript/controllers/poster_studio_editor_controller.js
@@ -16,6 +16,7 @@ import {
   PRINT_PRODUCTS,
   printProductFor,
 } from "poster_studio/data/print_products"
+import { MapPageProvider } from "poster_studio/data/providers"
 import {
   extendTokens,
   loadThemeTokens,
@@ -120,7 +121,7 @@ export default class extends Controller {
       document.body.appendChild(this.element)
       return
     }
-    this.onOpen = () => this.open()
+    this.onOpen = (event) => this.open(event.detail?.provider)
     document.addEventListener("poster-studio:open", this.onOpen)
     this.onResize = () => this.resizeFrame()
     this.populateLayouts()
@@ -135,14 +136,18 @@ export default class extends Controller {
     if (this.backdropUrl) URL.revokeObjectURL(this.backdropUrl)
   }
 
-  async open() {
+  async open(provider = null) {
     if (!this.element.classList.contains("hidden")) return
+    this.provider =
+      provider ?? new MapPageProvider({ application: this.application })
     this.element.classList.remove("hidden")
     window.addEventListener("resize", this.onResize)
 
     try {
       this.hidden ??= new Set(DEFAULT_HIDDEN)
       if (!this.tokens) await this.seedTheme(this.initialThemeKey())
+      if (!this.titleInputTarget.value)
+        this.titleInputTarget.value = this.provider.defaultTitle()
       if (!this.subtitleInputTarget.value)
         this.subtitleInputTarget.value = this.dateRangeLabel()
       this.seedDateInputs()
@@ -173,7 +178,8 @@ export default class extends Controller {
 
   createMap() {
     this.teardown()
-    const bounds = trackBounds(this.trackGeojson) ?? this.mainMapBounds()
+    const bounds =
+      trackBounds(this.trackGeojson) ?? this.provider.fallbackBounds()
     this.previewMap = createPreviewMap({
       container: this.mapContainerTarget,
       style: this.posterStyle(),
@@ -432,11 +438,11 @@ export default class extends Controller {
   }
 
   dateRangeLabel() {
-    const controller = this.mapController
-    if (!controller?.startDateValue || !controller?.endDateValue) return ""
+    const { startAt, endAt } = this.provider?.dateRange() ?? {}
+    if (!startAt || !endAt) return ""
     const options = { day: "numeric", month: "short", year: "numeric" }
-    const start = new Date(controller.startDateValue)
-    const end = new Date(controller.endDateValue)
+    const start = new Date(startAt)
+    const end = new Date(endAt)
     return `${start.toLocaleDateString("en-GB", options)} – ${end.toLocaleDateString("en-GB", options)}`
   }
 
@@ -458,38 +464,26 @@ export default class extends Controller {
   // ===== Date range =====
 
   seedDateInputs() {
-    const controller = this.mapController
-    if (!controller?.startDateValue) return
-    this.dateStartTarget.value = toLocalInput(
-      new Date(controller.startDateValue),
-    )
-    this.dateEndTarget.value = toLocalInput(new Date(controller.endDateValue))
+    if (!this.hasDateStartTarget || !this.hasDateEndTarget) return
+    const { startAt, endAt } = this.provider.dateRange()
+    if (!startAt) return
+    this.dateStartTarget.value = toLocalInput(new Date(startAt))
+    this.dateEndTarget.value = toLocalInput(new Date(endAt))
   }
 
-  // SPA date change, same as the timeline: dispatch the shared event so the
-  // main map reloads its layers in place — the studio never closes. The URL
-  // is pushed for browser-state consistency.
+  // SPA date change delegated to the provider — the studio never closes.
   async applyDates() {
+    if (!this.provider?.supportsDateNavigation) return
     const start = this.dateStartTarget.value
     const end = this.dateEndTarget.value
-    if (!start || !end || !this.mapController) return
-
-    const params = new URLSearchParams(window.location.search)
-    params.set("start_at", start)
-    params.set("end_at", end)
-    window.history.pushState({}, "", `/map/v2?${params.toString()}`)
+    if (!start || !end) return
 
     const subtitleWasAuto =
       this.subtitleInputTarget.value === this.dateRangeLabel()
     this.setLoadBusy(true)
     this.setStatus("Loading tracks for the new range…")
     try {
-      document.dispatchEvent(
-        new CustomEvent("timeline-feed:date-navigated", {
-          detail: { startAt: start, endAt: end },
-        }),
-      )
-      await this.waitForTrackReload()
+      await this.provider.applyDates(start, end)
 
       if (subtitleWasAuto)
         this.subtitleInputTarget.value = this.dateRangeLabel()
@@ -507,35 +501,6 @@ export default class extends Controller {
     this.loadButtonTarget.disabled = value
     this.loadSpinnerTarget.classList.toggle("hidden", !value)
     this.loadLabelTarget.textContent = value ? "Loading…" : "Load"
-  }
-
-  // The reload replaces the layer data objects; wait for the identity to
-  // change and then stay stable for two polls (progressive loading lands
-  // in several passes), capped at ~16s.
-  async waitForTrackReload() {
-    const layerManager = this.mapController?.layerManager
-    const snapshot = () => ({
-      routes: layerManager?.getLayer("routes")?.data,
-      tracks: layerManager?.getLayer("tracks")?.data,
-    })
-    const before = snapshot()
-    let changed = false
-    let stable = 0
-    let last = before
-    for (let i = 0; i < 40; i++) {
-      await new Promise((resolve) => setTimeout(resolve, 400))
-      const current = snapshot()
-      if (current.routes !== before.routes || current.tracks !== before.tracks)
-        changed = true
-      if (changed) {
-        stable =
-          current.routes === last.routes && current.tracks === last.tracks
-            ? stable + 1
-            : 0
-        if (stable >= 2) return
-      }
-      last = current
-    }
   }
 
   presetRange(event) {
@@ -560,7 +525,8 @@ export default class extends Controller {
   // ===== Map interaction =====
 
   recenter() {
-    const bounds = trackBounds(this.trackGeojson) ?? this.mainMapBounds()
+    const bounds =
+      trackBounds(this.trackGeojson) ?? this.provider.fallbackBounds()
     if (bounds) this.previewMap?.fitBounds(bounds, { padding: 24 })
   }
 
@@ -758,9 +724,10 @@ export default class extends Controller {
     this.saveLatTarget.value = center.lat
     this.saveLonTarget.value = center.lng
     this.saveDistanceTarget.value = distance
-    this.saveStartAtTarget.value = this.mapController?.startDateValue || ""
-    this.saveEndAtTarget.value = this.mapController?.endDateValue || ""
-    this.saveSourceTarget.value = this.trackSource
+    const { startAt, endAt } = this.provider.dateRange()
+    this.saveStartAtTarget.value = startAt || ""
+    this.saveEndAtTarget.value = endAt || ""
+    this.saveSourceTarget.value = this.provider.trackSource()
     this.saveOpacityTarget.value = this.trackOpacityTarget.value
     this.saveFormTarget.requestSubmit()
     this.setStatus("Queued — rendering server-side into Recent posters…")
@@ -827,41 +794,12 @@ export default class extends Controller {
 
   // ===== Data plumbing =====
 
-  get trackSource() {
-    const layerManager = this.mapController?.layerManager
-    if (layerManager?.getLayer("routes")?.data?.features?.length)
-      return "routes"
-    if (layerManager?.getLayer("tracks")?.data?.features?.length)
-      return "tracks"
-    return "routes"
-  }
-
   get trackGeojson() {
     return (
-      this.mapController?.layerManager?.getLayer(this.trackSource)?.data ?? {
+      this.provider?.trackGeojson() ?? {
         type: "FeatureCollection",
         features: [],
       }
-    )
-  }
-
-  mainMapBounds() {
-    const bounds = this.mapController?.map?.getBounds()
-    if (!bounds) return null
-    return [
-      [bounds.getWest(), bounds.getSouth()],
-      [bounds.getEast(), bounds.getNorth()],
-    ]
-  }
-
-  get mapController() {
-    const container = document.getElementById("maps-maplibre-container")
-    return (
-      container &&
-      this.application.getControllerForElementAndIdentifier(
-        container,
-        "maps--maplibre",
-      )
     )
   }
 

--- a/app/javascript/controllers/trip_maplibre_controller.js
+++ b/app/javascript/controllers/trip_maplibre_controller.js
@@ -9,6 +9,7 @@ import { ReplayPanel } from "maps_maplibre/managers/replay_panel"
 import { ApiClient } from "maps_maplibre/services/api_client"
 import { featureToPhoto } from "maps_maplibre/utils/feature_to_photo"
 import { flightWindows } from "maps_maplibre/utils/flight_mask"
+import { TripProvider } from "poster_studio/data/providers"
 import Flash from "./flash_controller"
 
 /**
@@ -22,6 +23,7 @@ export default class extends Controller {
     "daysAccordion",
     "expandAllBtn",
     "loadingIndicator",
+    "posterBtn",
     // Photos button
     "photosToggleBtn",
     // Flights button
@@ -56,6 +58,7 @@ export default class extends Controller {
     startedAt: String,
     endedAt: String,
     tripId: Number,
+    tripName: String,
     pathData: String,
     mapStyle: { type: String, default: "light" },
   }
@@ -217,6 +220,7 @@ export default class extends Controller {
 
       this.dayRoutesLayer = new DayRoutesLayer(this.map)
       this.dayRoutesLayer.addDayRoutes(this.pointsByDay)
+      if (this.hasPosterBtnTarget) this.posterBtnTarget.disabled = false
 
       this.applyDayColors(dayKeys)
 
@@ -398,6 +402,52 @@ export default class extends Controller {
     if (this.hasLoadingIndicatorTarget) {
       this.loadingIndicatorTarget.classList.toggle("hidden", !show)
     }
+  }
+
+  // ===== Poster studio =====
+
+  openPosterStudio() {
+    document.dispatchEvent(
+      new CustomEvent("poster-studio:open", {
+        detail: { provider: this.posterProvider() },
+      }),
+    )
+  }
+
+  posterProvider() {
+    return new TripProvider({
+      geojson: this.posterGeojson(),
+      startAt: this.startedAtValue,
+      endAt: this.endedAtValue,
+      title: this.tripNameValue,
+    })
+  }
+
+  posterGeojson() {
+    const features = []
+    if (this.dayRoutesLayer) {
+      for (const dayRoute of this.dayRoutesLayer.dayRouteData.values()) {
+        features.push(...dayRoute.features)
+      }
+    }
+    if (!features.length) {
+      const pathData = this.getPathData()
+      if (pathData) {
+        try {
+          const coordinates = JSON.parse(pathData)
+          if (coordinates.length >= 2) {
+            features.push({
+              type: "Feature",
+              properties: {},
+              geometry: { type: "LineString", coordinates },
+            })
+          }
+        } catch {
+          // malformed path data falls through to an empty collection
+        }
+      }
+    }
+    return { type: "FeatureCollection", features }
   }
 
   // ===== Photos layer toggle (button-based) =====

--- a/app/javascript/controllers/trip_maplibre_controller.js
+++ b/app/javascript/controllers/trip_maplibre_controller.js
@@ -9,7 +9,7 @@ import { ReplayPanel } from "maps_maplibre/managers/replay_panel"
 import { ApiClient } from "maps_maplibre/services/api_client"
 import { featureToPhoto } from "maps_maplibre/utils/feature_to_photo"
 import { flightWindows } from "maps_maplibre/utils/flight_mask"
-import { TripProvider } from "poster_studio/data/providers"
+import { buildTripGeojson, TripProvider } from "poster_studio/data/providers"
 import Flash from "./flash_controller"
 
 /**
@@ -220,7 +220,6 @@ export default class extends Controller {
 
       this.dayRoutesLayer = new DayRoutesLayer(this.map)
       this.dayRoutesLayer.addDayRoutes(this.pointsByDay)
-      if (this.hasPosterBtnTarget) this.posterBtnTarget.disabled = false
 
       this.applyDayColors(dayKeys)
 
@@ -424,30 +423,12 @@ export default class extends Controller {
   }
 
   posterGeojson() {
-    const features = []
-    if (this.dayRoutesLayer) {
-      for (const dayRoute of this.dayRoutesLayer.dayRouteData.values()) {
-        features.push(...dayRoute.features)
-      }
-    }
-    if (!features.length) {
-      const pathData = this.getPathData()
-      if (pathData) {
-        try {
-          const coordinates = JSON.parse(pathData)
-          if (coordinates.length >= 2) {
-            features.push({
-              type: "Feature",
-              properties: {},
-              geometry: { type: "LineString", coordinates },
-            })
-          }
-        } catch {
-          // malformed path data falls through to an empty collection
-        }
-      }
-    }
-    return { type: "FeatureCollection", features }
+    return buildTripGeojson({
+      dayRouteCollections: this.dayRoutesLayer
+        ? [...this.dayRoutesLayer.dayRouteData.values()]
+        : [],
+      pathData: this.getPathData(),
+    })
   }
 
   // ===== Photos layer toggle (button-based) =====

--- a/app/javascript/poster_studio/data/providers.js
+++ b/app/javascript/poster_studio/data/providers.js
@@ -99,6 +99,31 @@ export class MapPageProvider {
   }
 }
 
+export function buildTripGeojson({
+  dayRouteCollections = [],
+  pathData = null,
+}) {
+  const features = []
+  for (const collection of dayRouteCollections) {
+    features.push(...(collection?.features ?? []))
+  }
+  if (!features.length && pathData) {
+    try {
+      const coordinates = JSON.parse(pathData)
+      if (Array.isArray(coordinates) && coordinates.length >= 2) {
+        features.push({
+          type: "Feature",
+          properties: {},
+          geometry: { type: "LineString", coordinates },
+        })
+      }
+    } catch {
+      // malformed path data falls through to an empty collection
+    }
+  }
+  return { type: "FeatureCollection", features }
+}
+
 export class TripProvider {
   constructor({ geojson, startAt, endAt, title }) {
     this.geojson = geojson ?? EMPTY_COLLECTION

--- a/app/javascript/poster_studio/data/providers.js
+++ b/app/javascript/poster_studio/data/providers.js
@@ -1,0 +1,130 @@
+const EMPTY_COLLECTION = { type: "FeatureCollection", features: [] }
+
+export class MapPageProvider {
+  constructor({ application }) {
+    this.application = application
+    this.supportsDateNavigation = true
+  }
+
+  get controller() {
+    const container = document.getElementById("maps-maplibre-container")
+    return (
+      container &&
+      this.application.getControllerForElementAndIdentifier(
+        container,
+        "maps--maplibre",
+      )
+    )
+  }
+
+  trackSource() {
+    const layerManager = this.controller?.layerManager
+    if (layerManager?.getLayer("routes")?.data?.features?.length)
+      return "routes"
+    if (layerManager?.getLayer("tracks")?.data?.features?.length)
+      return "tracks"
+    return "routes"
+  }
+
+  trackGeojson() {
+    return (
+      this.controller?.layerManager?.getLayer(this.trackSource())?.data ??
+      EMPTY_COLLECTION
+    )
+  }
+
+  dateRange() {
+    return {
+      startAt: this.controller?.startDateValue || "",
+      endAt: this.controller?.endDateValue || "",
+    }
+  }
+
+  fallbackBounds() {
+    const bounds = this.controller?.map?.getBounds()
+    if (!bounds) return null
+    return [
+      [bounds.getWest(), bounds.getSouth()],
+      [bounds.getEast(), bounds.getNorth()],
+    ]
+  }
+
+  defaultTitle() {
+    return ""
+  }
+
+  // SPA date change, same as the timeline: dispatch the shared event so the
+  // main map reloads its layers in place. The URL is pushed for
+  // browser-state consistency.
+  async applyDates(start, end) {
+    const params = new URLSearchParams(window.location.search)
+    params.set("start_at", start)
+    params.set("end_at", end)
+    window.history.pushState({}, "", `/map/v2?${params.toString()}`)
+    document.dispatchEvent(
+      new CustomEvent("timeline-feed:date-navigated", {
+        detail: { startAt: start, endAt: end },
+      }),
+    )
+    await this.waitForTrackReload()
+  }
+
+  // The reload replaces the layer data objects; wait for the identity to
+  // change and then stay stable for two polls (progressive loading lands
+  // in several passes), capped at ~16s.
+  async waitForTrackReload() {
+    const layerManager = this.controller?.layerManager
+    const snapshot = () => ({
+      routes: layerManager?.getLayer("routes")?.data,
+      tracks: layerManager?.getLayer("tracks")?.data,
+    })
+    const before = snapshot()
+    let changed = false
+    let stable = 0
+    let last = before
+    for (let i = 0; i < 40; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 400))
+      const current = snapshot()
+      if (current.routes !== before.routes || current.tracks !== before.tracks)
+        changed = true
+      if (changed) {
+        stable =
+          current.routes === last.routes && current.tracks === last.tracks
+            ? stable + 1
+            : 0
+        if (stable >= 2) return
+      }
+      last = current
+    }
+  }
+}
+
+export class TripProvider {
+  constructor({ geojson, startAt, endAt, title }) {
+    this.geojson = geojson ?? EMPTY_COLLECTION
+    this.startAt = startAt
+    this.endAt = endAt
+    this.title = title ?? ""
+    this.supportsDateNavigation = false
+  }
+
+  trackSource() {
+    return "routes"
+  }
+
+  trackGeojson() {
+    return this.geojson
+  }
+
+  dateRange() {
+    return { startAt: this.startAt, endAt: this.endAt }
+  }
+
+  fallbackBounds() {
+    return null
+  }
+
+  defaultTitle() {
+    return this.title
+  }
+}

--- a/app/services/posters/generate.rb
+++ b/app/services/posters/generate.rb
@@ -58,7 +58,7 @@ module Posters
     def route_opacity
       raw = @poster.settings['route_opacity'].to_f
       raw /= 100.0 if raw > 1
-      raw = 0.6 if raw <= 0
+      raw = 1.0 if raw <= 0
       raw.clamp(0.05, 1.0)
     end
 

--- a/app/views/map/maplibre/index.html.erb
+++ b/app/views/map/maplibre/index.html.erb
@@ -51,7 +51,7 @@
   <%= render 'map/maplibre/settings_panel' %>
 
   <!-- Poster studio (full-screen WYSIWYG editor) -->
-  <%= render 'map/maplibre/poster_studio' %>
+  <%= render 'posters/studio' %>
 
   <!-- Replay panel -->
   <%= render 'map/maplibre/replay_panel' %>

--- a/app/views/posters/_studio.html.erb
+++ b/app/views/posters/_studio.html.erb
@@ -1,3 +1,4 @@
+<% show_date_controls = local_assigns.fetch(:show_date_controls, true) %>
 <% poster_font_urls = %w[inter oswald playfair-display jetbrains-mono].flat_map do |key|
      %w[400 700].map { |weight| ["#{key}-#{weight}", asset_path("poster/#{key}-#{weight}.woff2")] }
    end.to_h %>
@@ -16,30 +17,35 @@
         <%= icon 'map', class: 'h-4 w-4 opacity-70' %>
         Poster Studio
       </h2>
-      <%# Changing dates reloads the map page (that's how track data loads);
-          the studio stashes its state and reopens itself afterwards. %>
-      <div class="flex items-center gap-2 min-w-0">
-        <input type="datetime-local" class="input input-bordered input-sm"
-               data-poster-studio-editor-target="dateStart">
-        <span class="text-xs opacity-60">–</span>
-        <input type="datetime-local" class="input input-bordered input-sm"
-               data-poster-studio-editor-target="dateEnd">
-        <button type="button" class="btn btn-sm btn-primary"
-                data-poster-studio-editor-target="loadButton"
-                data-action="poster-studio-editor#applyDates">
-          <span class="hidden h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-r-transparent"
-                data-poster-studio-editor-target="loadSpinner"></span>
-          <span data-poster-studio-editor-target="loadLabel">Load</span>
-        </button>
-        <div class="hidden items-center gap-1 lg:flex">
-          <button type="button" class="btn btn-sm btn-ghost"
-                  data-range="today" data-action="poster-studio-editor#presetRange">Today</button>
-          <button type="button" class="btn btn-sm btn-ghost"
-                  data-range="week" data-action="poster-studio-editor#presetRange">Last 7 days</button>
-          <button type="button" class="btn btn-sm btn-ghost"
-                  data-range="month" data-action="poster-studio-editor#presetRange">Last month</button>
+      <% if show_date_controls %>
+        <div class="flex items-center gap-2 min-w-0">
+          <input type="datetime-local" class="input input-bordered input-sm"
+                 data-poster-studio-editor-target="dateStart">
+          <span class="text-xs opacity-60">–</span>
+          <input type="datetime-local" class="input input-bordered input-sm"
+                 data-poster-studio-editor-target="dateEnd">
+          <button type="button" class="btn btn-sm btn-primary"
+                  data-poster-studio-editor-target="loadButton"
+                  data-action="poster-studio-editor#applyDates">
+            <span class="hidden h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-r-transparent"
+                  data-poster-studio-editor-target="loadSpinner"></span>
+            <span data-poster-studio-editor-target="loadLabel">Load</span>
+          </button>
+          <div class="hidden items-center gap-1 lg:flex">
+            <button type="button" class="btn btn-sm btn-ghost"
+                    data-range="today" data-action="poster-studio-editor#presetRange">Today</button>
+            <button type="button" class="btn btn-sm btn-ghost"
+                    data-range="week" data-action="poster-studio-editor#presetRange">Last 7 days</button>
+            <button type="button" class="btn btn-sm btn-ghost"
+                    data-range="month" data-action="poster-studio-editor#presetRange">Last month</button>
+          </div>
         </div>
-      </div>
+      <% else %>
+        <div class="flex items-center gap-2 min-w-0 text-sm opacity-70">
+          <%= icon 'calendar-clock', class: 'h-4 w-4' %>
+          <span><%= local_assigns[:date_range_label] %></span>
+        </div>
+      <% end %>
       <button type="button" class="btn btn-ghost btn-sm btn-circle shrink-0" title="Close studio"
               data-action="poster-studio-editor#close">
         <%= icon 'x' %>

--- a/app/views/posters/_studio.html.erb
+++ b/app/views/posters/_studio.html.erb
@@ -221,7 +221,7 @@
                   <span class="text-xs font-medium tabular-nums opacity-80"
                         data-poster-studio-editor-target="trackOpacityLabel"></span>
                 </div>
-                <input type="range" min="10" max="100" step="5" value="30"
+                <input type="range" min="10" max="100" step="5" value="100"
                        class="range range-primary range-xs"
                        data-poster-studio-editor-target="trackOpacity"
                        data-action="input->poster-studio-editor#layersChanged">

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -137,7 +137,7 @@
                 class="btn btn-sm btn-outline gap-1"
                 data-trip-maplibre-target="posterBtn"
                 data-action="click->trip-maplibre#openPosterStudio"
-                title="Create a poster of this trip"
+                title="<%= @trip.path.blank? ? 'Available once the trip route is calculated' : 'Create a poster of this trip' %>"
                 <% if @trip.path.blank? %>disabled<% end %>>
           <%= icon 'image', class: 'w-4 h-4' %>
           <span class="hidden sm:inline">Poster</span>

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -8,6 +8,7 @@
      data-trip-maplibre-started-at-value="<%= @trip.started_at.iso8601 %>"
      data-trip-maplibre-ended-at-value="<%= @trip.ended_at.iso8601 %>"
      data-trip-maplibre-trip-id-value="<%= @trip.id %>"
+     data-trip-maplibre-trip-name-value="<%= @trip.name %>"
      data-trip-maplibre-path-data-value="<%= @trip.path&.coordinates&.to_json %>"
      data-trip-maplibre-map-style-value="<%= current_user.safe_settings.settings['maps_maplibre_style'] || 'light' %>">
 
@@ -132,6 +133,16 @@
           <span class="hidden sm:inline">Show all days</span>
         </button>
 
+        <button type="button"
+                class="btn btn-sm btn-outline gap-1"
+                data-trip-maplibre-target="posterBtn"
+                data-action="click->trip-maplibre#openPosterStudio"
+                title="Create a poster of this trip"
+                <% if @trip.path.blank? %>disabled<% end %>>
+          <%= icon 'image', class: 'w-4 h-4' %>
+          <span class="hidden sm:inline">Poster</span>
+        </button>
+
         <%= render "trips/recalculate_button", trip: @trip %>
       </div>
 
@@ -227,3 +238,7 @@
   </div>
 
 </div>
+
+<%= render 'posters/studio',
+           show_date_controls: false,
+           date_range_label: "#{human_date(@trip.started_at)} – #{human_date(@trip.ended_at)}" %>

--- a/spec/javascript/poster_providers_test.mjs
+++ b/spec/javascript/poster_providers_test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const source = await readFile(
+  new URL(
+    "../../app/javascript/poster_studio/data/providers.js",
+    import.meta.url,
+  ),
+  "utf8",
+)
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+const { MapPageProvider, TripProvider } = await import(moduleUrl)
+
+const lineString = (coordinates) => ({
+  type: "Feature",
+  properties: {},
+  geometry: { type: "LineString", coordinates },
+})
+
+test("TripProvider returns the snapshot it was built with", () => {
+  const geojson = {
+    type: "FeatureCollection",
+    features: [
+      lineString([
+        [13.4, 52.5],
+        [13.5, 52.6],
+      ]),
+    ],
+  }
+  const provider = new TripProvider({
+    geojson,
+    startAt: "2026-05-01T00:00:00Z",
+    endAt: "2026-05-09T23:59:59Z",
+    title: "Berlin Trip",
+  })
+  assert.equal(provider.trackGeojson(), geojson)
+  assert.deepEqual(provider.dateRange(), {
+    startAt: "2026-05-01T00:00:00Z",
+    endAt: "2026-05-09T23:59:59Z",
+  })
+  assert.equal(provider.defaultTitle(), "Berlin Trip")
+  assert.equal(provider.trackSource(), "routes")
+  assert.equal(provider.supportsDateNavigation, false)
+  assert.equal(provider.fallbackBounds(), null)
+})
+
+test("TripProvider defaults to an empty collection and blank title", () => {
+  const provider = new TripProvider({ startAt: "a", endAt: "b" })
+  assert.deepEqual(provider.trackGeojson(), {
+    type: "FeatureCollection",
+    features: [],
+  })
+  assert.equal(provider.defaultTitle(), "")
+})
+
+test("MapPageProvider reads layers and dates from the maps controller", (t) => {
+  const layers = {
+    routes: { data: { type: "FeatureCollection", features: [] } },
+    tracks: {
+      data: { type: "FeatureCollection", features: [lineString([[0, 0]])] },
+    },
+  }
+  const fakeController = {
+    layerManager: { getLayer: (name) => layers[name] },
+    startDateValue: "2026-01-01T00:00",
+    endDateValue: "2026-01-31T23:59",
+  }
+  const originalDocument = globalThis.document
+  globalThis.document = { getElementById: () => ({}) }
+  t.after(() => {
+    globalThis.document = originalDocument
+  })
+  const provider = new MapPageProvider({
+    application: { getControllerForElementAndIdentifier: () => fakeController },
+  })
+
+  assert.equal(provider.trackSource(), "tracks")
+  assert.equal(provider.trackGeojson(), layers.tracks.data)
+  assert.deepEqual(provider.dateRange(), {
+    startAt: "2026-01-01T00:00",
+    endAt: "2026-01-31T23:59",
+  })
+  assert.equal(provider.defaultTitle(), "")
+  assert.equal(provider.supportsDateNavigation, true)
+
+  layers.routes.data.features.push(lineString([[1, 1]]))
+  assert.equal(provider.trackSource(), "routes")
+})
+
+test("MapPageProvider degrades to empty data without a maps controller", (t) => {
+  const originalDocument = globalThis.document
+  globalThis.document = { getElementById: () => null }
+  t.after(() => {
+    globalThis.document = originalDocument
+  })
+  const provider = new MapPageProvider({
+    application: { getControllerForElementAndIdentifier: () => null },
+  })
+  assert.deepEqual(provider.trackGeojson(), {
+    type: "FeatureCollection",
+    features: [],
+  })
+  assert.deepEqual(provider.dateRange(), { startAt: "", endAt: "" })
+  assert.equal(provider.fallbackBounds(), null)
+})

--- a/spec/javascript/poster_providers_test.mjs
+++ b/spec/javascript/poster_providers_test.mjs
@@ -10,7 +10,9 @@ const source = await readFile(
   "utf8",
 )
 const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
-const { MapPageProvider, TripProvider } = await import(moduleUrl)
+const { buildTripGeojson, MapPageProvider, TripProvider } = await import(
+  moduleUrl
+)
 
 const lineString = (coordinates) => ({
   type: "Feature",
@@ -86,6 +88,43 @@ test("MapPageProvider reads layers and dates from the maps controller", (t) => {
 
   layers.routes.data.features.push(lineString([[1, 1]]))
   assert.equal(provider.trackSource(), "routes")
+})
+
+test("buildTripGeojson merges day-route collections when present", () => {
+  const day1 = { features: [lineString([[13.4, 52.5]])] }
+  const day2 = { features: [lineString([[13.5, 52.6]])] }
+  const geojson = buildTripGeojson({
+    dayRouteCollections: [day1, day2],
+    pathData: JSON.stringify([
+      [1, 1],
+      [2, 2],
+    ]),
+  })
+  assert.equal(geojson.features.length, 2)
+  assert.deepEqual(geojson.features[0], day1.features[0])
+})
+
+test("buildTripGeojson falls back to the path overview line", () => {
+  const geojson = buildTripGeojson({
+    dayRouteCollections: [{ features: [] }],
+    pathData: JSON.stringify([
+      [13.4, 52.5],
+      [13.5, 52.6],
+    ]),
+  })
+  assert.equal(geojson.features.length, 1)
+  assert.equal(geojson.features[0].geometry.type, "LineString")
+  assert.deepEqual(geojson.features[0].geometry.coordinates, [
+    [13.4, 52.5],
+    [13.5, 52.6],
+  ])
+})
+
+test("buildTripGeojson yields an empty collection for degenerate input", () => {
+  for (const pathData of [null, "not json", JSON.stringify([[1, 1]])]) {
+    const geojson = buildTripGeojson({ dayRouteCollections: [], pathData })
+    assert.deepEqual(geojson, { type: "FeatureCollection", features: [] })
+  }
 })
 
 test("MapPageProvider degrades to empty data without a maps controller", (t) => {

--- a/spec/requests/map/maplibre_spec.rb
+++ b/spec/requests/map/maplibre_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe 'Map v2 (maplibre)', type: :request do
 
       expect(response.body).to include('Blueprint')
     end
+
+    it 'renders the studio date controls on the map page' do
+      get map_v2_path
+
+      expect(response.body).to include('data-poster-studio-editor-target="dateStart"')
+    end
   end
 
   describe 'print ordering' do

--- a/spec/requests/map/maplibre_spec.rb
+++ b/spec/requests/map/maplibre_spec.rb
@@ -25,6 +25,13 @@ RSpec.describe 'Map v2 (maplibre)', type: :request do
 
       expect(response.body).to include('data-poster-studio-editor-target="dateStart"')
     end
+
+    it 'defaults the track opacity slider to 100%' do
+      get map_v2_path
+
+      slider = Nokogiri::HTML(response.body).at_css('[data-poster-studio-editor-target="trackOpacity"]')
+      expect(slider['value']).to eq('100')
+    end
   end
 
   describe 'print ordering' do

--- a/spec/requests/trips_spec.rb
+++ b/spec/requests/trips_spec.rb
@@ -66,6 +66,46 @@ RSpec.describe '/trips', type: :request do
       expect(response.body).to include('Delete this trip')
     end
 
+    describe 'poster studio' do
+      it 'renders the studio without date controls' do
+        get trip_url(trip)
+
+        expect(response.body).to include('id="poster-studio"')
+        expect(response.body).not_to include('data-poster-studio-editor-target="dateStart"')
+      end
+
+      it 'passes the trip name to the map controller' do
+        get trip_url(trip)
+
+        expect(response.body).to include("data-trip-maplibre-trip-name-value=\"#{trip.name}\"")
+      end
+
+      it 'renders an enabled poster button when the path exists' do
+        get trip_url(trip)
+
+        button = Nokogiri::HTML(response.body).at_css('[data-trip-maplibre-target="posterBtn"]')
+        expect(button).to be_present
+        expect(button['disabled']).to be_nil
+      end
+
+      it 'renders a disabled poster button while the path is calculating' do
+        trip.update_columns(path: nil)
+
+        get trip_url(trip)
+
+        button = Nokogiri::HTML(response.body).at_css('[data-trip-maplibre-target="posterBtn"]')
+        expect(button['disabled']).to be_present
+      end
+
+      it 'renders the poster gallery list' do
+        create(:poster, user:)
+
+        get trip_url(trip)
+
+        expect(response.body).to include('poster-gallery-list')
+      end
+    end
+
     context 'with photos grouped by day' do
       let(:photo) do
         { id: 7, url: '/api/v1/photos/7/thumbnail.jpg?api_key=x&source=immich',

--- a/spec/requests/trips_spec.rb
+++ b/spec/requests/trips_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe '/trips', type: :request do
 
         button = Nokogiri::HTML(response.body).at_css('[data-trip-maplibre-target="posterBtn"]')
         expect(button['disabled']).to be_present
+        expect(button['title']).to eq('Available once the trip route is calculated')
       end
 
       it 'renders the poster gallery list' do

--- a/spec/services/posters/generate_spec.rb
+++ b/spec/services/posters/generate_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Posters::Generate do
 
     it 'renders with the poster distance, opacity, subtitle and track' do
       expect(Posters::NativeRenderer).to receive(:new).with(
-        poster: poster, track: track, distance: 6000, route_opacity: 0.6,
+        poster: poster, track: track, distance: 6000, route_opacity: 1.0,
         subtitle: '1 Apr 2026 – 30 Apr 2026'
       ).and_return(renderer)
 


### PR DESCRIPTION
## What

A user suggested making the Poster Studio available from trip pages. This adds a **Poster** button to the trip toolbar that opens the existing studio locked to that trip: the poster track is the trip's route, the date range is fixed to the trip's dates (static label instead of the date-navigation header), and the title is pre-seeded with the trip name. Download, Save to gallery, and print ordering all work unchanged.

## How

- **Provider seam** (`app/javascript/poster_studio/data/providers.js`): the studio's map-page coupling (layerManager reads, date values, SPA date navigation + reload polling) moved behind a small data-provider interface. `MapPageProvider` is a behaviour-preserving extraction of the existing code; `TripProvider` is a static snapshot built by the trip page from data it already fetches (per-day routes, `trip.path` as fallback while points load).
- The `poster-studio:open` event gains an optional `detail.provider`; without it the studio falls back to `MapPageProvider`, so the map page is unchanged.
- The studio partial moved to `app/views/posters/_studio.html.erb` (shared by both pages) with a `show_date_controls` local; `@poster_themes`/`@recent_posters` loading extracted into a `PosterStudioContext` concern.
- No changes to `Posters::Generate` — Save to gallery posts the trip's date range and the server rebuilds the track exactly as for map-page saves.

## Testing

- Request specs: trip page renders the studio without date controls, button disabled while the trip path is calculating, gallery present; map page keeps its date controls (regression guard).
- `spec/javascript/poster_providers_test.mjs` covers both providers (node --test).
- Verified live on both pages: A3 PNG export pixel-exact, Save to gallery rendered server-side with the trip's exact range, map-page date navigation regression-tested.
- New Playwright spec in the e2e suite (`v2/trip-poster-studio.spec.js`) passes alongside the existing 9 map-page poster-studio tests.