### PR TITLE
fix(imports): accept large activity archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- ZIP imports now accept large activity exports containing up to 25,000 files, while retaining file-count and expanded-size safety checks.
 - OwnTracks `_type: waypoint` sync messages are no longer stored as location points, so syncing your saved OwnTracks places no longer creates phantom distance/track spikes (#3137)
 - Map v2 date pickers now keep the time component when a range with a specific time is loaded from the URL, instead of resetting to the start/end of the day (#3106)
 - Track generation and user data recalculations now retry a bounded number of times when another job is already processing the same user's tracks, instead of dropping the request and reporting an error; a genuinely stuck lock is logged after the retries are exhausted. The per-user lock also renews itself while a job runs and frees within a minute if a worker dies, so a crashed job no longer blocks a user's track processing for up to half an hour.

--- a/app/services/imports/zip_extractor.rb
+++ b/app/services/imports/zip_extractor.rb
@@ -5,7 +5,7 @@ require 'zip'
 module Imports
   class ZipExtractor
     SUPPORTED_EXTENSIONS = %w[.gpx .json .geojson .kml .kmz .csv .tcx .fit .rec].freeze
-    MAX_FILES = 1000
+    MAX_FILES = 25_000
 
     GOOGLE_TAKEOUT_PATTERNS = {
       %r{Semantic Location History/\d{4}/\d{4}_\w+\.json}i => 'google_semantic_history',
@@ -55,17 +55,12 @@ module Imports
 
     def extract_files(temp_dir)
       total_size = 0
-      file_count = 0
 
       ::Zip::File.open(@stable_zip_path) do |zip_file|
-        zip_file.each do |entry|
-          next if entry.directory?
-          next if entry.name.include?('..')
-          next if entry.name.start_with?('/')
+        entries = zip_file.select { |entry| extractable_entry?(entry) }
+        raise "Too many files in archive (max #{MAX_FILES})" if entries.size > MAX_FILES
 
-          file_count += 1
-          raise "Too many files in archive (max #{MAX_FILES})" if file_count > MAX_FILES
-
+        entries.each do |entry|
           dest = File.join(temp_dir, entry.name)
           next unless File.expand_path(dest).start_with?("#{File.expand_path(temp_dir)}/")
 
@@ -74,6 +69,10 @@ module Imports
           raise "Archive too large (max #{@max_size} bytes)" if total_size > @max_size
         end
       end
+    end
+
+    def extractable_entry?(entry)
+      !entry.directory? && !entry.name.include?('..') && !entry.name.start_with?('/')
     end
 
     def extract_entry(entry, dest)

--- a/app/services/imports/zip_extractor.rb
+++ b/app/services/imports/zip_extractor.rb
@@ -112,26 +112,39 @@ module Imports
 
     def create_imports_from_entries(entries)
       user = User.find(@user_id)
+      seen_names = user.imports.where(name: entries.map { |entry| import_name_for(entry) }).pluck(:name).to_set
 
-      entries.each do |entry|
-        filename = File.basename(entry[:path])
-        import_name = "#{filename} (from #{@archive_name})"
+      new_imports = entries.filter_map do |entry|
+        name = import_name_for(entry)
+        next if seen_names.include?(name)
 
-        next if user.imports.exists?(name: import_name)
-
-        new_import = user.imports.build(
-          name: import_name,
-          source: entry[:source],
-          skip_background_processing: true
-        )
-        new_import.file.attach(
-          io: File.open(entry[:path]),
-          filename: filename,
-          content_type: Marcel::MimeType.for(name: filename)
-        )
-        new_import.save!
-        Import::ProcessJob.perform_later(new_import.id)
+        seen_names << name
+        build_import(user, entry, name)
       end
+
+      enqueue_processing(new_imports)
+    end
+
+    def import_name_for(entry)
+      "#{File.basename(entry[:path])} (from #{@archive_name})"
+    end
+
+    def build_import(user, entry, name)
+      filename = File.basename(entry[:path])
+      new_import = user.imports.build(name: name, source: entry[:source], skip_background_processing: true)
+      new_import.file.attach(
+        io: File.open(entry[:path]),
+        filename: filename,
+        content_type: Marcel::MimeType.for(name: filename)
+      )
+      new_import.save!
+      new_import
+    end
+
+    def enqueue_processing(imports)
+      return if imports.empty?
+
+      ActiveJob.perform_all_later(imports.map { |import| Import::ProcessJob.new(import.id) })
     end
   end
 end

--- a/spec/services/imports/zip_extractor_spec.rb
+++ b/spec/services/imports/zip_extractor_spec.rb
@@ -120,6 +120,49 @@ RSpec.describe Imports::ZipExtractor do
       end
     end
 
+    context 'with more than 1,000 files' do
+      let(:zip_path) do
+        path = Rails.root.join('tmp', "test_many_files_#{SecureRandom.hex(4)}.zip").to_s
+        ::Zip::File.open(path, create: true) do |zipfile|
+          1001.times do |index|
+            zipfile.get_output_stream("metadata/entry_#{index}.txt") { |file| file.write('metadata') }
+          end
+        end
+        path
+      end
+
+      after { File.delete(zip_path) if File.exist?(zip_path) }
+
+      it 'accepts exports larger than the previous file-count limit' do
+        expect { described_class.new(import, user.id, zip_path).call }.not_to raise_error
+        expect(Import.exists?(import.id)).to be(false)
+      end
+    end
+
+    context 'when the file-count safety limit is exceeded' do
+      let(:zip_path) do
+        path = Rails.root.join('tmp', "test_too_many_files_#{SecureRandom.hex(4)}.zip").to_s
+        ::Zip::File.open(path, create: true) do |zipfile|
+          3.times do |index|
+            zipfile.get_output_stream("entry_#{index}.txt") { |file| file.write('metadata') }
+          end
+        end
+        path
+      end
+
+      before { stub_const("#{described_class}::MAX_FILES", 2) }
+
+      after { File.delete(zip_path) if File.exist?(zip_path) }
+
+      it 'rejects the archive and reports the configured ceiling' do
+        expect do
+          described_class.new(import, user.id, zip_path).call
+        end.to raise_error('Too many files in archive (max 2)')
+
+        expect(import.reload).to be_failed
+      end
+    end
+
     context 'when extraction fails' do
       let(:zip_path) { '/nonexistent/path/to/archive.zip' }
 

--- a/spec/services/imports/zip_extractor_spec.rb
+++ b/spec/services/imports/zip_extractor_spec.rb
@@ -123,9 +123,13 @@ RSpec.describe Imports::ZipExtractor do
     context 'with more than 1,000 files' do
       let(:zip_path) do
         path = Rails.root.join('tmp', "test_many_files_#{SecureRandom.hex(4)}.zip").to_s
+        gpx_content = File.read(Rails.root.join('spec/fixtures/files/gpx/gpx_track_single_segment.gpx'))
         ::Zip::File.open(path, create: true) do |zipfile|
-          1001.times do |index|
+          1000.times do |index|
             zipfile.get_output_stream("metadata/entry_#{index}.txt") { |file| file.write('metadata') }
+          end
+          2.times do |index|
+            zipfile.get_output_stream("tracks/track_#{index}.gpx") { |file| file.write(gpx_content) }
           end
         end
         path
@@ -133,8 +137,14 @@ RSpec.describe Imports::ZipExtractor do
 
       after { File.delete(zip_path) if File.exist?(zip_path) }
 
-      it 'accepts exports larger than the previous file-count limit' do
+      it 'accepts exports past the previous limit and imports the supported files' do
         expect { described_class.new(import, user.id, zip_path).call }.not_to raise_error
+
+        names = user.imports.where.not(id: import.id).pluck(:name)
+        expect(names).to contain_exactly(
+          'track_0.gpx (from test_archive.zip)',
+          'track_1.gpx (from test_archive.zip)'
+        )
         expect(Import.exists?(import.id)).to be(false)
       end
     end


### PR DESCRIPTION
## Summary

- Raise the ZIP entry ceiling from 1,000 to 25,000 files for large activity exports.
- Preflight the safe entry count before writing extracted payloads.
- Retain the existing expanded-size and path-traversal protections.

## Why

Garmin activity exports in the failed-import set contain between 6,895 and 21,316 files, so all are rejected by the previous fixed 1,000-entry limit despite being only 74–152 MB.

## How to validate

```bash
asdf exec bundle exec rspec spec/services/imports
RUBOCOP_CACHE_ROOT=/private/tmp/dawarich-rubocop-cache asdf exec bundle exec rubocop app/services/imports/zip_extractor.rb spec/services/imports/zip_extractor_spec.rb
```

The relevant suite passes with 192 examples, including a generated archive above the old ceiling and a separate rejection test above the configured ceiling.

## Risk / rollout notes

The 25,000-file ceiling remains hard, and the existing 2 GB expanded-size limit still applies. No migration or feature flag is required.
