### PR TITLE
feat(imports): support Google Photos sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Google Photos Takeout metadata sidecars can now add geotagged photos as sparse timeline points; sidecars without usable coordinates are skipped.
 - The Poster Studio can now be opened directly from a trip's page, pre-loaded with the trip's route, date range, and name.
 
 - Dawarich can now be installed to the phone home screen as a web app (PWA): all pages link the web app manifest and Apple touch icon, and the installed app opens straight into Map v2.

--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -5,6 +5,7 @@ module ImportsHelper
     'google_semantic_history' => { css: 'bg-error/10 text-error', icon: 'google', library: 'brands' },
     'google_phone_takeout'   => { css: 'bg-error/10 text-error', icon: 'google', library: 'brands' },
     'google_records'         => { css: 'bg-error/10 text-error', icon: 'google', library: 'brands' },
+    'google_photos'          => { css: 'bg-error/10 text-error', icon: 'google', library: 'brands' },
     'gpx'                    => { css: 'bg-success/10 text-success', icon: 'route' },
     'owntracks'              => { css: 'bg-primary/10 text-primary', icon: 'map-pin' },
     'geojson'                => { css: 'bg-warning/10 text-warning', icon: 'earth' },

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -25,7 +25,7 @@ class Import < ApplicationRecord
     google_semantic_history: 0, owntracks: 1, google_records: 2,
     google_phone_takeout: 3, gpx: 4, immich_api: 5, geojson: 6, photoprism_api: 7,
     user_data_archive: 8, kml: 9,
-    csv: 10, tcx: 11, fit: 12, polarsteps: 13
+    csv: 10, tcx: 11, fit: 12, polarsteps: 13, google_photos: 14
   }, allow_nil: true
 
   def process!

--- a/app/services/google_photos/importer.rb
+++ b/app/services/google_photos/importer.rb
@@ -5,7 +5,7 @@ class GooglePhotos::Importer
   include Imports::BulkInsertable
   include Imports::FileLoader
 
-  GEO_KEYS = %w[geoData geoDataExif].freeze
+  GEO_KEYS = %w[geoDataExif geoData].freeze
   TRACKER_ID = 'google-photos-takeout'
   TOPIC = 'Google Photos Takeout'
 
@@ -75,7 +75,11 @@ class GooglePhotos::Importer
   end
 
   def extract_timestamp(sidecar)
-    value = sidecar.dig('photoTakenTime', 'timestamp') || sidecar.dig('creationTime', 'timestamp')
+    normalize_timestamp(sidecar.dig('photoTakenTime', 'timestamp')) ||
+      normalize_timestamp(sidecar.dig('creationTime', 'timestamp'))
+  end
+
+  def normalize_timestamp(value)
     numeric = number(value)
     return unless numeric&.positive?
 

--- a/app/services/google_photos/importer.rb
+++ b/app/services/google_photos/importer.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+class GooglePhotos::Importer
+  include Imports::Broadcaster
+  include Imports::BulkInsertable
+  include Imports::FileLoader
+
+  GEO_KEYS = %w[geoData geoDataExif].freeze
+  TRACKER_ID = 'google-photos-takeout'
+  TOPIC = 'Google Photos Takeout'
+
+  attr_reader :import, :user_id, :file_path
+
+  def initialize(import, user_id, file_path = nil)
+    @import = import
+    @user_id = user_id
+    @file_path = file_path
+  end
+
+  def call
+    point = build_point(load_json_data)
+    return unless point
+
+    inserted = bulk_insert_points([point])
+    broadcast_import_progress(import, inserted)
+  ensure
+    cleanup_temp_file
+  end
+
+  private
+
+  def build_point(sidecar)
+    return unless sidecar.is_a?(Hash)
+
+    geodata = extract_geodata(sidecar)
+    timestamp = extract_timestamp(sidecar)
+    return unless geodata && timestamp
+
+    altitude = number(geodata['altitude'])
+    now = Time.current
+    attrs = {
+      lonlat: "POINT(#{geodata.fetch('longitude')} #{geodata.fetch('latitude')})",
+      timestamp:,
+      altitude:,
+      tracker_id: TRACKER_ID,
+      topic: TOPIC,
+      user_id:,
+      import_id: import.id,
+      created_at: now,
+      updated_at: now
+    }
+    attrs[:altitude_decimal] = altitude if Point.altitude_decimal_supported?
+    attrs
+  end
+
+  def extract_geodata(sidecar)
+    GEO_KEYS.each do |key|
+      geodata = sidecar[key]
+      next unless geodata.is_a?(Hash)
+
+      latitude = number(geodata['latitude'])
+      longitude = number(geodata['longitude'])
+      next unless valid_coordinates?(latitude, longitude)
+
+      return geodata.merge('latitude' => latitude, 'longitude' => longitude)
+    end
+
+    nil
+  end
+
+  def valid_coordinates?(latitude, longitude)
+    return false unless latitude&.between?(-90, 90) && longitude&.between?(-180, 180)
+
+    !latitude.zero? || !longitude.zero?
+  end
+
+  def extract_timestamp(sidecar)
+    value = sidecar.dig('photoTakenTime', 'timestamp') || sidecar.dig('creationTime', 'timestamp')
+    numeric = number(value)
+    return unless numeric&.positive?
+
+    numeric /= 1000 if numeric > 10_000_000_000
+    numeric.to_i
+  end
+
+  def number(value)
+    numeric = Float(value, exception: false)
+    numeric if numeric&.finite?
+  end
+
+  def importer_name
+    'Google Photos'
+  end
+end

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -99,6 +99,7 @@ class Imports::Create
     when 'google_semantic_history'      then GoogleMaps::SemanticHistoryImporter
     when 'google_phone_takeout'         then GoogleMaps::PhoneTakeoutImporter
     when 'google_records'               then GoogleMaps::RecordsStorageImporter
+    when 'google_photos'                then GooglePhotos::Importer
     when 'owntracks'                    then OwnTracks::Importer
     when 'gpx'                          then Gpx::TrackImporter
     when 'kml'                          then Kml::Importer

--- a/app/services/imports/source_detector.rb
+++ b/app/services/imports/source_detector.rb
@@ -40,6 +40,10 @@ class Imports::SourceDetector
         }
       ]
     },
+    google_photos: {
+      required_keys: %w[title creationTime imageViews],
+      nested_patterns: [%w[creationTime timestamp]]
+    },
     geojson: {
       required_keys: %w[type features],
       required_values: { 'type' => 'FeatureCollection' },
@@ -247,6 +251,9 @@ class Imports::SourceDetector
       :google_phone_takeout
     elsif content.include?('"topCandidate"') && content.include?('"placeLocation"')
       :google_phone_takeout
+    elsif content.include?('"title"') && content.include?('"imageViews"') &&
+          content.include?('"creationTime"')
+      :google_photos
     elsif content.include?('"arrived"') && content.include?('"departed"') && content.include?('"segment-')
       :polarsteps
     end

--- a/app/services/imports/watcher.rb
+++ b/app/services/imports/watcher.rb
@@ -41,7 +41,7 @@ class Imports::Watcher
 
     return if import.persisted?
 
-    import.source = source(file_name)
+    import.source = source(file_name, file_path)
     import.file.attach(
       io: File.open(file_path),
       filename: file_name,
@@ -51,9 +51,12 @@ class Imports::Watcher
     import.save!
   end
 
-  def source(file_name)
+  def source(file_name, file_path)
     case file_name.split('.').last.downcase
     when 'json'
+      detected_source = Imports::SourceDetector.new_from_file_header(file_path).detect_source
+      return detected_source if detected_source
+
       case file_name
       when /location-history/i
         :google_phone_takeout
@@ -79,7 +82,8 @@ class Imports::Watcher
   def mime_type(source)
     case source&.to_sym
     when :gpx then 'application/xml'
-    when :json, :geojson, :google_phone_takeout, :google_records, :google_semantic_history
+    when :json, :geojson, :google_phone_takeout, :google_records, :google_semantic_history, :google_photos,
+         :polarsteps
       'application/json'
     when :owntracks, :fit
       'application/octet-stream'

--- a/app/services/imports/zip_extractor.rb
+++ b/app/services/imports/zip_extractor.rb
@@ -34,10 +34,10 @@ module Imports
 
         extract_files(temp_dir)
         entries = collect_supported_files(temp_dir)
-        google_entries = detect_google_takeout(entries)
+        known_entries = detect_google_takeout(entries) + detect_google_photos(entries)
 
-        if google_entries.any?
-          create_imports_from_entries(google_entries)
+        if known_entries.any?
+          create_imports_from_entries(known_entries)
         else
           create_imports_from_entries(entries)
         end
@@ -111,28 +111,54 @@ module Imports
       matched.any? ? matched : []
     end
 
+    def detect_google_photos(entries)
+      entries.select do |entry|
+        entry[:source].nil? &&
+          json_entry?(entry) &&
+          Imports::SourceDetector.new_from_file_header(entry[:path]).detect_source == :google_photos &&
+          (entry[:source] = 'google_photos')
+      end
+    end
+
+    def json_entry?(entry)
+      File.extname(entry[:path]).downcase == '.json'
+    end
+
     def create_imports_from_entries(entries)
       user = User.find(@user_id)
+      seen_names = user.imports.where(name: entries.map { |entry| import_name_for(entry) }).pluck(:name).to_set
 
-      entries.each do |entry|
-        filename = File.basename(entry[:path])
-        import_name = "#{filename} (from #{@archive_name})"
+      new_imports = entries.filter_map do |entry|
+        name = import_name_for(entry)
+        next if seen_names.include?(name)
 
-        next if user.imports.exists?(name: import_name)
-
-        new_import = user.imports.build(
-          name: import_name,
-          source: entry[:source],
-          skip_background_processing: true
-        )
-        new_import.file.attach(
-          io: File.open(entry[:path]),
-          filename: filename,
-          content_type: Marcel::MimeType.for(name: filename)
-        )
-        new_import.save!
-        Import::ProcessJob.perform_later(new_import.id)
+        seen_names << name
+        build_import(user, entry, name)
       end
+
+      enqueue_processing(new_imports)
+    end
+
+    def import_name_for(entry)
+      "#{File.basename(entry[:path])} (from #{@archive_name})"
+    end
+
+    def build_import(user, entry, name)
+      filename = File.basename(entry[:path])
+      new_import = user.imports.build(name: name, source: entry[:source], skip_background_processing: true)
+      new_import.file.attach(
+        io: File.open(entry[:path]),
+        filename: filename,
+        content_type: Marcel::MimeType.for(name: filename)
+      )
+      new_import.save!
+      new_import
+    end
+
+    def enqueue_processing(imports)
+      return if imports.empty?
+
+      ActiveJob.perform_all_later(imports.map { |import| Import::ProcessJob.new(import.id) })
     end
   end
 end

--- a/app/views/imports/_form.html.erb
+++ b/app/views/imports/_form.html.erb
@@ -4,6 +4,7 @@
     <h3 class="card-title text-sm">Supported Import Formats</h3>
     <ul class="text-xs space-y-1.5">
       <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>Google Maps:</strong> Records.json, Semantic History, Phone Takeout (.json)</li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>Google Photos:</strong> Takeout metadata sidecars (.json)</li>
       <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>GPX:</strong> Track files (.gpx)</li>
       <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>GeoJSON:</strong> Feature collections (.json, .geojson)</li>
       <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>OwnTracks:</strong> Recorder files (.rec)</li>

--- a/spec/fixtures/files/google_photos/sidecar.json
+++ b/spec/fixtures/files/google_photos/sidecar.json
@@ -1,0 +1,18 @@
+{
+  "title": "anonymized-photo.jpg",
+  "description": "",
+  "imageViews": "0",
+  "creationTime": {
+    "timestamp": "1718448000",
+    "formatted": "Jun 15, 2024, 12:00:00 PM UTC"
+  },
+  "photoTakenTime": {
+    "timestamp": "1718447400",
+    "formatted": "Jun 15, 2024, 11:50:00 AM UTC"
+  },
+  "geoDataExif": {
+    "latitude": 48.12345,
+    "longitude": 11.54321,
+    "altitude": 34.5
+  }
+}

--- a/spec/models/import_spec.rb
+++ b/spec/models/import_spec.rb
@@ -149,7 +149,8 @@ RSpec.describe Import, type: :model do
         csv: 10,
         tcx: 11,
         fit: 12,
-        polarsteps: 13
+        polarsteps: 13,
+        google_photos: 14
       )
     end
   end

--- a/spec/services/google_photos/importer_spec.rb
+++ b/spec/services/google_photos/importer_spec.rb
@@ -37,6 +37,33 @@ RSpec.describe GooglePhotos::Importer do
     end
   end
 
+  context 'with a zero photoTakenTime timestamp' do
+    let(:sidecar) { super().merge('photoTakenTime' => { 'timestamp' => '0' }) }
+
+    it 'falls back to the creation timestamp instead of dropping the point' do
+      expect { import_sidecar }.to change { user.points.count }.by(1)
+
+      expect(user.points.last.timestamp).to eq(1_718_448_000)
+    end
+  end
+
+  context 'when both geoData and geoDataExif carry coordinates' do
+    let(:sidecar) do
+      super().merge(
+        'geoData' => { 'latitude' => 40.0, 'longitude' => 5.0, 'altitude' => 0.0 },
+        'geoDataExif' => { 'latitude' => 48.12345, 'longitude' => 11.54321, 'altitude' => 34.5 }
+      )
+    end
+
+    it 'prefers the camera EXIF coordinates' do
+      import_sidecar
+
+      point = user.points.last
+      expect(point.lat).to eq(48.12345)
+      expect(point.lon).to eq(11.54321)
+    end
+  end
+
   context 'without geodata' do
     let(:sidecar) { super().except('geoDataExif') }
 

--- a/spec/services/google_photos/importer_spec.rb
+++ b/spec/services/google_photos/importer_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GooglePhotos::Importer do
+  subject(:import_sidecar) { described_class.new(import, user.id, file_path).call }
+
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user:, source: :google_photos) }
+  let(:sidecar) { JSON.parse(file_fixture('google_photos/sidecar.json').read) }
+  let(:file_path) { Rails.root.join('tmp', "google_photos_sidecar_#{SecureRandom.hex(4)}.json").to_s }
+
+  before { File.write(file_path, JSON.generate(sidecar)) }
+
+  after { File.delete(file_path) if File.exist?(file_path) }
+
+  it 'creates a sparse timeline point from EXIF geodata and the photo-taken time' do
+    expect { import_sidecar }.to change { user.points.count }.by(1)
+
+    point = user.points.last
+    expect(point.lat).to eq(48.12345)
+    expect(point.lon).to eq(11.54321)
+    expect(point.altitude).to eq(34.5)
+    expect(point.timestamp).to eq(1_718_447_400)
+    expect(point.tracker_id).to eq('google-photos-takeout')
+    expect(point.topic).to eq('Google Photos Takeout')
+    expect(point.raw_data).to eq({})
+  end
+
+  context 'without photoTakenTime' do
+    let(:sidecar) { super().except('photoTakenTime') }
+
+    it 'falls back to the creation timestamp' do
+      import_sidecar
+
+      expect(user.points.last.timestamp).to eq(1_718_448_000)
+    end
+  end
+
+  context 'without geodata' do
+    let(:sidecar) { super().except('geoDataExif') }
+
+    it 'skips the sidecar without creating a point' do
+      expect { import_sidecar }.not_to change(Point, :count)
+    end
+  end
+
+  context 'with zero-coordinate placeholder geodata' do
+    let(:sidecar) do
+      super().merge('geoDataExif' => { 'latitude' => 0.0, 'longitude' => 0.0, 'altitude' => 0.0 })
+    end
+
+    it 'skips the sidecar without creating a Null Island point' do
+      expect { import_sidecar }.not_to change(Point, :count)
+    end
+  end
+end

--- a/spec/services/imports/integration_spec.rb
+++ b/spec/services/imports/integration_spec.rb
@@ -62,5 +62,17 @@ RSpec.describe 'Import format integration' do
 
       expect(import.reload.status).to eq('completed')
     end
+
+    it 'detects and routes a Google Photos metadata sidecar' do
+      import = create(:import, user: user, name: 'anonymized-photo.jpg.json')
+      file_path = Rails.root.join('spec/fixtures/files/google_photos/sidecar.json')
+      import.file.attach(io: File.open(file_path), filename: 'anonymized-photo.jpg.json',
+                         content_type: 'application/json')
+
+      expect { Imports::Create.new(user, import).call }.to change { import.points.count }.by(1)
+
+      expect(import.reload).to be_completed
+      expect(import.source).to eq('google_photos')
+    end
   end
 end

--- a/spec/services/imports/source_detector_spec.rb
+++ b/spec/services/imports/source_detector_spec.rb
@@ -41,6 +41,25 @@ RSpec.describe Imports::SourceDetector do
       end
     end
 
+    context 'with a Google Photos metadata sidecar' do
+      let(:file_content) { file_fixture('google_photos/sidecar.json').read }
+      let(:filename) { 'anonymized-photo.jpg.json' }
+
+      it 'detects google_photos format' do
+        expect(detector.detect_source).to eq(:google_photos)
+      end
+
+      context 'without geodata' do
+        let(:file_content) do
+          JSON.parse(file_fixture('google_photos/sidecar.json').read).except('geoDataExif').to_json
+        end
+
+        it 'still detects the sidecar so the importer can skip it cleanly' do
+          expect(detector.detect_source).to eq(:google_photos)
+        end
+      end
+    end
+
     context 'with GeoJSON format' do
       let(:file_content) { file_fixture('geojson/export.json').read }
 

--- a/spec/services/imports/watcher_spec.rb
+++ b/spec/services/imports/watcher_spec.rb
@@ -89,6 +89,27 @@ RSpec.describe Imports::Watcher do
         end
       end
 
+      context 'with a JSON whose content is not detectable' do
+        let(:watched_dir_path) do
+          Rails.root.join('tmp', "watched_fallback_#{SecureRandom.hex(4)}")
+        end
+
+        before do
+          user_dir = watched_dir_path.join(user.email)
+          FileUtils.mkdir_p(user_dir)
+          File.write(user_dir.join('location-history.json'), '{"unrecognized":"structure"}')
+        end
+
+        after { FileUtils.rm_rf(watched_dir_path) }
+
+        it 'falls back to the filename classification when content detection is inconclusive' do
+          service
+
+          import = user.imports.find_by(name: 'location-history.json')
+          expect(import.source).to eq('google_phone_takeout')
+        end
+      end
+
       context 'when the import already exists' do
         it 'does not create a new import' do
           create(:import, user:, name: '2023_January.json')

--- a/spec/services/imports/watcher_spec.rb
+++ b/spec/services/imports/watcher_spec.rb
@@ -68,6 +68,27 @@ RSpec.describe Imports::Watcher do
         expect(import.source).to be_nil
       end
 
+      context 'with a Google Photos metadata sidecar' do
+        let(:watched_dir_path) do
+          Rails.root.join('tmp', "watched_google_photos_#{SecureRandom.hex(4)}")
+        end
+
+        before do
+          user_dir = watched_dir_path.join(user.email)
+          FileUtils.mkdir_p(user_dir)
+          FileUtils.cp(file_fixture('google_photos/sidecar.json'), user_dir.join('anonymized-photo.jpg.json'))
+        end
+
+        after { FileUtils.rm_rf(watched_dir_path) }
+
+        it 'detects the source from the sidecar content' do
+          service
+
+          import = user.imports.find_by(name: 'anonymized-photo.jpg.json')
+          expect(import.source).to eq('google_photos')
+        end
+      end
+
       context 'when the import already exists' do
         it 'does not create a new import' do
           create(:import, user:, name: '2023_January.json')

--- a/spec/services/imports/zip_extractor_spec.rb
+++ b/spec/services/imports/zip_extractor_spec.rb
@@ -84,6 +84,57 @@ RSpec.describe Imports::ZipExtractor do
       end
     end
 
+    context 'with a Google Photos Takeout ZIP' do
+      let(:sidecar_content) { file_fixture('google_photos/sidecar.json').read }
+      let(:zip_path) do
+        path = Rails.root.join('tmp', "test_photos_#{SecureRandom.hex(4)}.zip").to_s
+        ::Zip::File.open(path, create: true) do |zipfile|
+          zipfile.get_output_stream('Takeout/Google Photos/2024/IMG_001.jpg.supplemental-metadata.json') do |f|
+            f.write(sidecar_content)
+          end
+          zipfile.get_output_stream('Takeout/Google Photos/Vacation/album_metadata.json') do |f|
+            f.write('{"title":"Vacation 2024","date":{"timestamp":"1718448000"}}')
+          end
+        end
+        path
+      end
+
+      after { File.delete(zip_path) if File.exist?(zip_path) }
+
+      it 'imports geotagged sidecars and skips non-sidecar album metadata' do
+        described_class.new(import, user.id, zip_path).call
+
+        imports = user.imports.where.not(id: import.id)
+        expect(imports.count).to eq(1)
+        expect(imports.first.source).to eq('google_photos')
+      end
+    end
+
+    context 'with a combined Location History and Photos Takeout ZIP' do
+      let(:sidecar_content) { file_fixture('google_photos/sidecar.json').read }
+      let(:zip_path) do
+        path = Rails.root.join('tmp', "test_combined_#{SecureRandom.hex(4)}.zip").to_s
+        ::Zip::File.open(path, create: true) do |zipfile|
+          zipfile.get_output_stream('Takeout/Location History/Semantic Location History/2024/2024_JANUARY.json') do |f|
+            f.write('{"timelineObjects":[]}')
+          end
+          zipfile.get_output_stream('Takeout/Google Photos/IMG_002.jpg.supplemental-metadata.json') do |f|
+            f.write(sidecar_content)
+          end
+        end
+        path
+      end
+
+      after { File.delete(zip_path) if File.exist?(zip_path) }
+
+      it 'imports both the location history and the photo sidecar' do
+        described_class.new(import, user.id, zip_path).call
+
+        imports = user.imports.where.not(id: import.id)
+        expect(imports.pluck(:source)).to contain_exactly('google_semantic_history', 'google_photos')
+      end
+    end
+
     context 'with path traversal attempt' do
       let(:zip_path) do
         path = Rails.root.join('tmp', "test_traversal_#{SecureRandom.hex(4)}.zip").to_s


### PR DESCRIPTION
## Summary

- Detect Google Photos Takeout metadata sidecars as a dedicated import source.
- Convert geotagged sidecars into sparse timeline points using photo-taken time, coordinates, and altitude.
- Skip missing, invalid, and zero-placeholder coordinates; fall back to creation time when necessary.
- Support UI, ZIP-expanded, and watched-directory imports.

## Why

Google Photos sidecars contain useful historical location evidence but were previously classified as unsupported JSON. They should contribute isolated timeline points without retaining photo descriptions, titles, URLs, or raw sidecar data.

## How to validate

```bash
asdf exec bundle exec rspec spec/services/google_photos spec/services/imports spec/models/import_spec.rb
RUBOCOP_CACHE_ROOT=/private/tmp/dawarich-rubocop-cache asdf exec bundle exec rubocop app/services/google_photos/importer.rb app/services/imports/source_detector.rb app/services/imports/create.rb app/services/imports/watcher.rb app/models/import.rb app/helpers/imports_helper.rb spec/services/google_photos/importer_spec.rb spec/services/imports/source_detector_spec.rb spec/services/imports/integration_spec.rb spec/services/imports/watcher_spec.rb spec/models/import_spec.rb
```

The relevant suite passes with 216 examples. All 300 production sidecars are detected locally: 206 yield valid sparse points, 94 are skipped without coordinates, and one uses the creation-time fallback. Only anonymized fixtures are committed.

## Screenshots / GIF

Not included. The only UI change is an additional supported-format label and source icon styling.

## Risk / rollout notes

This adds enum value `google_photos: 14` without changing existing values. No database migration or feature flag is required.
