### PR TITLE
Keep Null Island (0,0) points out of the dataset and visit detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## Unreleased
+
+### Fixed
+
+- Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
+
 ## [1.10.1] - 2026-07-19, Berlin
 
 ### Added

--- a/app/jobs/data_migrations/cleanup_null_island_job.rb
+++ b/app/jobs/data_migrations/cleanup_null_island_job.rb
@@ -8,15 +8,20 @@ class DataMigrations::CleanupNullIslandJob < ApplicationJob
 
     user = find_user_or_skip(user_id) || return
 
-    zero_points = user.points.null_island
-    track_ids = zero_points.where.not(track_id: nil).distinct.pluck(:track_id)
-    affected_months = zero_points.pluck(:timestamp).map do |timestamp|
+    rows = user.points.null_island.pluck(:id, :timestamp, :track_id)
+    track_ids = rows.filter_map(&:last).uniq
+    affected_months = rows.map do |_, timestamp, _|
       time = Time.zone.at(timestamp)
       [time.year, time.month]
     end.uniq
 
-    zero_points.update_all(anomaly: true, updated_at: Time.current)
-    destroy_null_island_visits(user)
+    Point.where(id: rows.map(&:first)).update_all(anomaly: true, updated_at: Time.current) if rows.any?
+    destroyed_visits = destroy_null_island_visits(user)
+
+    Rails.logger.info(
+      "[DataMigrations::CleanupNullIsland] user_id=#{user.id} flagged=#{rows.size} " \
+      "visits_destroyed=#{destroyed_visits} tracks=#{track_ids.size} months=#{affected_months.size}"
+    )
 
     affected_months.each { |year, month| Stats::CalculatingJob.perform_later(user.id, year, month) }
     track_ids.each { |track_id| Tracks::RecalculateJob.perform_later(track_id) }
@@ -35,5 +40,6 @@ class DataMigrations::CleanupNullIslandJob < ApplicationJob
         .joins(:place)
         .where(Points::NullIsland.sql_predicate('places.lonlat'))
         .destroy_all
+        .count
   end
 end

--- a/app/jobs/data_migrations/cleanup_null_island_job.rb
+++ b/app/jobs/data_migrations/cleanup_null_island_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class DataMigrations::CleanupNullIslandJob < ApplicationJob
+  queue_as :data_migrations
+
+  def perform(user_id = nil)
+    return fan_out if user_id.nil?
+
+    user = find_user_or_skip(user_id) || return
+
+    zero_points = user.points.null_island
+    track_ids = zero_points.where.not(track_id: nil).distinct.pluck(:track_id)
+    affected_months = zero_points.pluck(:timestamp).map do |timestamp|
+      time = Time.zone.at(timestamp)
+      [time.year, time.month]
+    end.uniq
+
+    zero_points.update_all(anomaly: true, updated_at: Time.current)
+    destroy_null_island_visits(user)
+
+    affected_months.each { |year, month| Stats::CalculatingJob.perform_later(user.id, year, month) }
+    track_ids.each { |track_id| Tracks::RecalculateJob.perform_later(track_id) }
+  end
+
+  private
+
+  def fan_out
+    User.where(id: Point.null_island.select(:user_id).distinct)
+        .pluck(:id)
+        .each { |user_id| self.class.perform_later(user_id) }
+  end
+
+  def destroy_null_island_visits(user)
+    user.visits
+        .joins(:place)
+        .where(Points::NullIsland.sql_predicate('places.lonlat'))
+        .destroy_all
+  end
+end

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -35,7 +35,7 @@ class Point < ApplicationRecord
   scope :not_visited, -> { where(visit_id: nil) }
   scope :not_anomaly, -> { where(anomaly: [false, nil]) }
   scope :anomaly, -> { where(anomaly: true) }
-  scope :null_island, -> { where(Points::NullIsland.sql_predicate) }
+  scope :null_island, -> { where('lonlat = ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography') }
 
   after_create :async_reverse_geocode, if: -> { DawarichSettings.store_geodata? && !reverse_geocoded? }
   after_create :set_country

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -35,6 +35,7 @@ class Point < ApplicationRecord
   scope :not_visited, -> { where(visit_id: nil) }
   scope :not_anomaly, -> { where(anomaly: [false, nil]) }
   scope :anomaly, -> { where(anomaly: true) }
+  scope :null_island, -> { where(Points::NullIsland.sql_predicate) }
 
   after_create :async_reverse_geocode, if: -> { DawarichSettings.store_geodata? && !reverse_geocoded? }
   after_create :set_country

--- a/app/services/google_maps/semantic_history_importer.rb
+++ b/app/services/google_maps/semantic_history_importer.rb
@@ -26,6 +26,8 @@ class GoogleMaps::SemanticHistoryImporter
 
   def process_batch(batch)
     records = batch.map { |point_data| prepare_point_data(point_data) }
+                   .reject { |record| Points::NullIsland.lonlat?(record[:lonlat]) }
+    return if records.empty?
 
     Point.upsert_all(
       records,

--- a/app/services/imports/bulk_insertable.rb
+++ b/app/services/imports/bulk_insertable.rb
@@ -9,7 +9,10 @@ module Imports
     def bulk_insert_points(batch)
       return 0 if batch.empty?
 
-      unique_batch = batch.compact.uniq { |record| [record[:lonlat], record[:timestamp], record[:user_id]] }
+      unique_batch = batch.compact
+                          .reject { |record| Points::NullIsland.lonlat?(record[:lonlat]) }
+                          .uniq { |record| [record[:lonlat], record[:timestamp], record[:user_id]] }
+      return 0 if unique_batch.empty?
 
       result = Point.upsert_all(
         unique_batch,

--- a/app/services/imports/bulk_insertable.rb
+++ b/app/services/imports/bulk_insertable.rb
@@ -9,9 +9,12 @@ module Imports
     def bulk_insert_points(batch)
       return 0 if batch.empty?
 
-      unique_batch = batch.compact
-                          .reject { |record| Points::NullIsland.lonlat?(record[:lonlat]) }
-                          .uniq { |record| [record[:lonlat], record[:timestamp], record[:user_id]] }
+      compacted = batch.compact
+      unique_batch = compacted
+                     .reject { |record| Points::NullIsland.lonlat?(record[:lonlat]) }
+                     .uniq { |record| [record[:lonlat], record[:timestamp], record[:user_id]] }
+      zero_skipped = compacted.size - compacted.count { |r| !Points::NullIsland.lonlat?(r[:lonlat]) }
+      Rails.logger.info("[#{importer_name}] skipped #{zero_skipped} Null Island (0,0) points") if zero_skipped.positive?
       return 0 if unique_batch.empty?
 
       result = Point.upsert_all(

--- a/app/services/overland/points_creator.rb
+++ b/app/services/overland/points_creator.rb
@@ -16,7 +16,7 @@ class Overland::PointsCreator
 
     payload = data
               .compact
-              .reject { |location| location[:lonlat].nil? || location[:timestamp].nil? }
+              .reject { |location| unusable_location?(location) }
               .map { |location| location.merge(user_id:) }
               .uniq { |location| Point.dedup_key(location) }
 
@@ -36,6 +36,11 @@ class Overland::PointsCreator
   end
 
   private
+
+  def unusable_location?(location)
+    location[:lonlat].nil? || location[:timestamp].nil? ||
+      Points::NullIsland.lonlat?(location[:lonlat])
+  end
 
   def upsert_points(locations)
     created_points = []

--- a/app/services/own_tracks/point_creator.rb
+++ b/app/services/own_tracks/point_creator.rb
@@ -16,6 +16,7 @@ class OwnTracks::PointCreator
 
     payload = parsed_params.merge(user_id:)
     return [] if payload[:timestamp].nil? || payload[:lonlat].nil?
+    return [] if Points::NullIsland.lonlat?(payload[:lonlat])
 
     result = upsert_points([payload])
     if result.any?

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -15,6 +15,7 @@ class Points::AnomalyFilter
     return 0 unless filtering_enabled?
 
     count = 0
+    count += filter_null_island
     count += filter_by_accuracy
     count += filter_by_speed
     count
@@ -32,6 +33,15 @@ class Points::AnomalyFilter
 
   def accuracy_threshold
     @accuracy_threshold ||= user_settings.gps_accuracy_threshold
+  end
+
+  # Pass 0: Null Island — a sustained (0,0) run defeats the speed sandwich
+  # (internal speeds are 0), so exact zeros are flagged unconditionally.
+  def filter_null_island
+    Point.where(user_id: @user_id, timestamp: @start_time..@end_time)
+         .not_anomaly
+         .null_island
+         .update_all(anomaly: true, updated_at: Time.current)
   end
 
   # Pass 1: Mark points with accuracy > threshold

--- a/app/services/points/null_island.rb
+++ b/app/services/points/null_island.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Points::NullIsland
+  LONLAT_REGEX = /\APOINT\s*\(\s*-?0(?:\.0+)?\s+-?0(?:\.0+)?\s*\)\z/i
+
+  def self.sql_predicate(column = 'lonlat')
+    "(ST_X(#{column}::geometry) = 0 AND ST_Y(#{column}::geometry) = 0)"
+  end
+
+  def self.coordinates?(lon, lat)
+    lon.to_f.zero? && lat.to_f.zero?
+  end
+
+  def self.lonlat?(value)
+    value.to_s.match?(LONLAT_REGEX)
+  end
+end

--- a/app/services/points/params.rb
+++ b/app/services/points/params.rb
@@ -57,8 +57,11 @@ class Points::Params
   end
 
   def params_valid?(point)
-    point.dig(:geometry, :coordinates).present? &&
-      point.dig(:properties, :timestamp).present?
+    coordinates = point.dig(:geometry, :coordinates)
+
+    coordinates.present? &&
+      point.dig(:properties, :timestamp).present? &&
+      !Points::NullIsland.coordinates?(coordinates[0], coordinates[1])
   end
 
   def lonlat(point)

--- a/app/services/traccar/point_creator.rb
+++ b/app/services/traccar/point_creator.rb
@@ -16,6 +16,7 @@ class Traccar::PointCreator
 
     payload = parsed.merge(user_id:)
     return [] if payload[:lonlat].nil? || payload[:timestamp].nil?
+    return [] if Points::NullIsland.lonlat?(payload[:lonlat])
 
     result = upsert_points([payload])
     if result.any?

--- a/app/services/visits/stay_point_detector.rb
+++ b/app/services/visits/stay_point_detector.rb
@@ -188,6 +188,7 @@ module Visits
               AND timestamp BETWEEN ? AND ?
               AND lonlat IS NOT NULL
               AND (anomaly IS NULL OR anomaly = FALSE)
+              AND NOT (ST_X(lonlat::geometry) = 0 AND ST_Y(lonlat::geometry) = 0)
             ORDER BY timestamp ASC
           SQL
           user.id, start_at, end_at
@@ -210,6 +211,7 @@ module Visits
            .where(timestamp: start_at..end_at)
            .where('lonlat IS NOT NULL')
            .where('anomaly IS NULL OR anomaly = FALSE')
+           .where("NOT #{Points::NullIsland.sql_predicate}")
            .count
     end
 

--- a/db/migrate/20260719180000_enqueue_null_island_cleanup.rb
+++ b/db/migrate/20260719180000_enqueue_null_island_cleanup.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class EnqueueNullIslandCleanup < ActiveRecord::Migration[8.0]
+  def up
+    DataMigrations::CleanupNullIslandJob.perform_later
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_14_090000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_19_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"

--- a/spec/jobs/data_migrations/cleanup_null_island_job_spec.rb
+++ b/spec/jobs/data_migrations/cleanup_null_island_job_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataMigrations::CleanupNullIslandJob do
+  let(:user) { create(:user) }
+  let(:track) { create(:track, user: user) }
+
+  let!(:zero_point) do
+    create(:point, user: user, latitude: 0.0, longitude: 0.0,
+                   lonlat: 'POINT(0.0 0.0)', track: track,
+                   timestamp: Time.zone.local(2024, 5, 10, 12).to_i)
+  end
+  let!(:normal_point) do
+    create(:point, user: user, latitude: 52.5, longitude: 13.4,
+                   lonlat: 'POINT(13.4 52.5)',
+                   timestamp: Time.zone.local(2024, 5, 10, 13).to_i)
+  end
+
+  let(:zero_place) { create(:place, latitude: 0.0, longitude: 0.0, lonlat: 'POINT(0.0 0.0)') }
+  let(:normal_place) { create(:place) }
+  let!(:zero_visit) { create(:visit, user: user, place: zero_place) }
+  let!(:normal_visit) { create(:visit, user: user, place: normal_place) }
+
+  it 'flags (0,0) points as anomalies' do
+    described_class.perform_now(user.id)
+
+    expect(zero_point.reload.anomaly).to be(true)
+    expect(normal_point.reload.anomaly).not_to be(true)
+  end
+
+  it 'destroys visits placed at (0,0) and keeps the rest' do
+    expect { described_class.perform_now(user.id) }
+      .to change { Visit.exists?(zero_visit.id) }.from(true).to(false)
+
+    expect(Visit.exists?(normal_visit.id)).to be(true)
+  end
+
+  it 'enqueues stats recalculation for affected months and track recalculation' do
+    expect { described_class.perform_now(user.id) }
+      .to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2024, 5)
+      .and have_enqueued_job(Tracks::RecalculateJob).with(track.id)
+  end
+end

--- a/spec/jobs/data_migrations/cleanup_null_island_job_spec.rb
+++ b/spec/jobs/data_migrations/cleanup_null_island_job_spec.rb
@@ -41,4 +41,16 @@ RSpec.describe DataMigrations::CleanupNullIslandJob do
       .to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2024, 5)
       .and have_enqueued_job(Tracks::RecalculateJob).with(track.id)
   end
+
+  describe 'fan out' do
+    it 'enqueues a per-user job for every user with (0,0) points' do
+      other_user = create(:user)
+      create(:point, user: other_user, latitude: 0.0, longitude: 0.0,
+                     lonlat: 'POINT(0.0 0.0)', timestamp: Time.zone.local(2024, 6, 1).to_i)
+
+      expect { described_class.perform_now }
+        .to have_enqueued_job(described_class).with(user.id)
+        .and have_enqueued_job(described_class).with(other_user.id)
+    end
+  end
 end

--- a/spec/services/google_maps/records_importer_spec.rb
+++ b/spec/services/google_maps/records_importer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe GoogleMaps::RecordsImporter do
     end
 
     context 'with regular timestamp' do
-      let(:locations) { super()[0].merge('timestamp' => time.to_s).to_json }
+      let(:locations) { [super()[0].merge('timestamp' => time.to_s)] }
 
       it 'creates a point' do
         expect { parser }.to change(Point, :count).by(1)

--- a/spec/services/imports/bulk_insertable_spec.rb
+++ b/spec/services/imports/bulk_insertable_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Imports::BulkInsertable do
+  let(:harness_class) do
+    Class.new do
+      include Imports::BulkInsertable
+
+      attr_reader :import
+
+      def initialize(import)
+        @import = import
+      end
+
+      def importer_name = 'Test'
+
+      def insert(batch)
+        bulk_insert_points(batch)
+      end
+
+      def on_bulk_insert_error(error)
+        raise error
+      end
+    end
+  end
+
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user) }
+
+  def record(lon, lat, timestamp)
+    {
+      lonlat: "POINT(#{lon} #{lat})",
+      timestamp: timestamp,
+      user_id: user.id,
+      import_id: import.id,
+      created_at: Time.current,
+      updated_at: Time.current
+    }
+  end
+
+  it 'skips records at exactly (0,0) and inserts the rest' do
+    inserted = harness_class.new(import).insert(
+      [record(0.0, 0.0, 1_700_000_000), record(13.5, 52.4, 1_700_000_060)]
+    )
+
+    expect(inserted).to eq(1)
+    expect(user.points.count).to eq(1)
+    expect(user.points.first.lon).to eq(13.5)
+  end
+end

--- a/spec/services/own_tracks/point_creator_spec.rb
+++ b/spec/services/own_tracks/point_creator_spec.rb
@@ -64,4 +64,19 @@ RSpec.describe OwnTracks::PointCreator do
       expect(call_service).to eq([])
     end
   end
+
+  context 'when the payload is at Null Island (0,0)' do
+    let(:point_params) do
+      parsed = OwnTracks::RecParser.new(File.read(file_path)).call.first
+      parsed.merge('lat' => 0.0, 'lon' => 0.0, lat: 0.0, lon: 0.0)
+    end
+
+    it 'drops the point' do
+      expect { call_service }.not_to(change { Point.where(user:).count })
+    end
+
+    it 'returns an empty array' do
+      expect(call_service).to eq([])
+    end
+  end
 end

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -220,5 +220,37 @@ RSpec.describe Points::AnomalyFilter do
         expect(early_spike.reload.anomaly).not_to be true
       end
     end
+
+    context 'Pass 3: Null Island (0,0)' do
+      let(:start_time) { 2.hours.ago.to_i }
+      let(:end_time) { Time.current.to_i }
+
+      let!(:before_zero) do
+        create(:point, user: user, latitude: 52.5, longitude: 13.4,
+                       lonlat: 'POINT(13.4 52.5)', accuracy: 10, timestamp: 90.minutes.ago.to_i)
+      end
+      let!(:zero_run) do
+        3.times.map do |i|
+          create(:point, user: user, latitude: 0.0, longitude: 0.0,
+                         lonlat: 'POINT(0.0 0.0)', accuracy: 10,
+                         timestamp: (80 - (i * 10)).minutes.ago.to_i)
+        end
+      end
+      let!(:after_zero) do
+        create(:point, user: user, latitude: 52.5001, longitude: 13.4001,
+                       lonlat: 'POINT(13.4001 52.5001)', accuracy: 10, timestamp: 40.minutes.ago.to_i)
+      end
+
+      before { described_class.new(user.id, start_time, end_time).call }
+
+      it 'flags every point of a sustained (0,0) run' do
+        expect(zero_run.map { |p| p.reload.anomaly }).to all(be(true))
+      end
+
+      it 'does not flag the surrounding real points' do
+        expect(before_zero.reload.anomaly).not_to be true
+        expect(after_zero.reload.anomaly).not_to be true
+      end
+    end
   end
 end

--- a/spec/services/points/params_spec.rb
+++ b/spec/services/points/params_spec.rb
@@ -105,4 +105,31 @@ RSpec.describe Points::Params do
       expect(result.first[:course_accuracy]).to eq(12.5)
     end
   end
+
+  describe 'Null Island filtering' do
+    let(:user) { create(:user) }
+    let(:params) do
+      {
+        locations: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [0.0, 0.0] },
+            properties: { timestamp: '2025-01-17T21:03:01Z' }
+          },
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [13.5, 52.4] },
+            properties: { timestamp: '2025-01-17T21:04:01Z' }
+          }
+        ]
+      }
+    end
+
+    it 'drops locations at exactly (0,0) and keeps the rest' do
+      result = described_class.new(params, user.id).call
+
+      expect(result.size).to eq(1)
+      expect(result.first[:lonlat]).to eq('POINT(13.5 52.4)')
+    end
+  end
 end

--- a/spec/services/traccar/point_creator_spec.rb
+++ b/spec/services/traccar/point_creator_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe Traccar::PointCreator do
     }
   end
 
+  context 'when the payload is at Null Island (0,0)' do
+    let(:point_params) do
+      super().tap { |params| params[:location] = params[:location].merge(latitude: 0.0, longitude: 0.0) }
+    end
+
+    it 'drops the point and returns an empty array' do
+      expect { expect(call_service).to eq([]) }.not_to(change { Point.where(user:).count })
+    end
+  end
+
   it 'creates a point' do
     expect { call_service }.to change { Point.where(user:).count }.by(1)
   end

--- a/spec/services/visits/stay_point_detector_spec.rb
+++ b/spec/services/visits/stay_point_detector_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Visits::StayPointDetector do
   # Defaults: radius 100 m, min_dwell 300 s, min_points 3, max_gap 3600 s, merge_gap 900 s, drift_cap 1.5.
 
   describe '#call' do
+    it 'ignores points at exactly (0,0)' do
+      6.times do |i|
+        create(:point, user: user, latitude: 0.0, longitude: 0.0,
+                       lonlat: 'POINT(0.0 0.0)', timestamp: base_ts + (i * 120),
+                       accuracy: 10, visit_id: nil)
+      end
+
+      expect(detect).to be_empty
+    end
+
     it '(a) groups a tight stationary cluster into one visit' do
       6.times { |i| make_point(at: base_ts + i * 120, dnorth: (i.even? ? 5 : -5)) }
 


### PR DESCRIPTION
## Problem

A device that glitches and reports exact **(0,0)** repeatedly (a real-world Android failure mode) corrupts three surfaces at once:

- The speed-based anomaly sandwich test (`Points::AnomalyFilter`) requires **both** incoming and outgoing speeds above the threshold, so inside a run of (0,0) points the internal speed is 0 and **no point of the run is ever flagged** — only single-point spikes are caught.
- The stay-point detector has no plausibility guard, so the tight (0,0) cluster becomes a **high-confidence suggested visit in the Gulf of Guinea** (confidence 95 in the reproduction), and the real home timeline shows a giant fake gap.
- The Berlin↔(0,0) round trip leaks ~11,890 km into monthly distance stats.

Reproduced deterministically: seed an evening at home, an overnight run of 16 points at exact (0,0), a morning at home → `AnomalyFilter` flags 0 of 16, and a 7-hour visit at `0.0,0.0` ("Suggested place") is created.

## Change

- **`Points::NullIsland`** — shared predicate ((0,0) in SQL and coordinate/lonlat forms) + `Point.null_island` scope.
- **Ingestion drops exact (0,0)** in every live path: batch points API (`Points::Params`), OwnTracks (`PointCreator` accept-and-drop, so a glitching tracker never enters a retry loop), Overland, and all file importers via `Imports::BulkInsertable`.
- **`Points::AnomalyFilter`** — new unconditional pass flags exact (0,0) before the accuracy/speed passes (safety net for pre-existing rows and any path that bypasses the guard).
- **`Visits::StayPointDetector`** — excludes (0,0) candidates (defense in depth).
- **Repair**: `DataMigrations::CleanupNullIslandJob`, enqueued by a data migration — flags existing (0,0) points, destroys visits placed at (0,0), then schedules `Stats::CalculatingJob` per affected month and `Tracks::RecalculateJob` per affected track.
- Drive-by spec fix: `records_importer_spec` "regular timestamp" passed a raw JSON **string**; `String#[]` lookups silently produced (0,0) coordinates, so the spec was asserting that garbage input creates a Null Island point. It now passes the parsed array the importer actually receives.

## Tests

9 new examples across `params_spec`, `anomaly_filter_spec` (sustained-run case), `stay_point_detector_spec`, `own_tracks/point_creator_spec`, new `imports/bulk_insertable_spec` and `data_migrations/cleanup_null_island_job_spec`. Full regression over points/own_tracks/overland/google_maps/imports/visits/data_migrations: **803 examples, 0 failures**.

Verified end-to-end against a running instance: the same seed that produced the 0/16-flagged, 7-hour Null Island visit now yields **16/16 flagged and no (0,0) visit**.

## Before / after

| Before | After |
|---|---|
| ![before timeline](https://raw.githubusercontent.com/Freika/dawarich/null-island-assets/1-before-timeline.png) | ![after timeline](https://raw.githubusercontent.com/Freika/dawarich/null-island-assets/3-after-timeline.png) |
| Timeline shows a "Suggested place" pinned in the Gulf of Guinea; the home day is truncated by the fake overnight gap | Only the real home visits remain; the phantom suggestion is gone |
| ![before map](https://raw.githubusercontent.com/Freika/dawarich/null-island-assets/2-before-map.png) | ![after map](https://raw.githubusercontent.com/Freika/dawarich/null-island-assets/4-after-map.png) |
| The date range renders as a globe stretched from Berlin to Null Island | The same date range fits the actual neighborhood |

Screenshots are served from the throwaway `null-island-assets` branch; it can be deleted once this PR is closed.