### PR TITLE
Clean up Null Island points and backfill legacy Google tracker ids

### DIFF
--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -112,18 +112,8 @@ class Api::V1::PointsController < ApiController
   end
 
   def destroy
-    point = current_api_user.points.find(params[:id])
-    affected_track_id = point.track_id
-    point.destroy
-    User.update_counters(current_api_user.id, points_count: -1)
-
-    if affected_track_id.present?
-      Rails.logger.info(
-        "[PointsController] Point #{point.id} destroyed, " \
-        "enqueuing Tracks::RecalculateJob for track #{affected_track_id}"
-      )
-      Tracks::RecalculateJob.perform_later(affected_track_id)
-    end
+    point = current_api_user.points.without_raw_data.find(params[:id])
+    Points::Destroyer.new(current_api_user, point.id).call
 
     render json: { message: 'Point deleted successfully' }
   end
@@ -141,40 +131,9 @@ class Api::V1::PointsController < ApiController
       }, status: :unprocessable_entity and return
     end
 
-    affected_track_ids = nil
-    destroyed = nil
+    destroyed = Points::Destroyer.new(current_api_user, point_ids).call
 
-    ActiveRecord::Base.transaction do
-      affected_track_ids = current_api_user.points
-                                           .where(id: point_ids)
-                                           .where.not(track_id: nil)
-                                           .distinct
-                                           .pluck(:track_id)
-      destroyed = current_api_user.points.where(id: point_ids).destroy_all
-    end
-
-    deleted_count = destroyed.count
-
-    if deleted_count.positive?
-      User.update_counters(current_api_user.id, points_count: -deleted_count)
-
-      destroyed
-        .map { |p| Time.zone.at(p.timestamp) }
-        .map { |ts| [ts.year, ts.month] }
-        .uniq
-        .each { |year, month| Stats::CalculatingJob.perform_later(current_api_user.id, year, month) }
-    end
-
-    if affected_track_ids.any?
-      Rails.logger.info(
-        "[PointsController] bulk_destroy deleted #{deleted_count} points, " \
-        "enqueuing Tracks::RecalculateJob for #{affected_track_ids.size} tracks: " \
-        "#{affected_track_ids.inspect}"
-      )
-      affected_track_ids.each { |track_id| Tracks::RecalculateJob.perform_later(track_id) }
-    end
-
-    render json: { message: 'Points were successfully destroyed', count: deleted_count }, status: :ok
+    render json: { message: 'Points were successfully destroyed', count: destroyed.count }, status: :ok
   end
 
   def reapply_anomaly_filter

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -33,8 +33,7 @@ class PointsController < ApplicationController
                   status: :see_other and return
     end
 
-    deleted_count = current_user.points.where(id: point_ids).destroy_all.count
-    User.update_counters(current_user.id, points_count: -deleted_count) if deleted_count.positive?
+    Points::Destroyer.new(current_user, point_ids).call
 
     redirect_to points_url(preserved_params),
                 notice: 'Points were successfully destroyed.',

--- a/app/jobs/data_migrations/cleanup_null_island_job.rb
+++ b/app/jobs/data_migrations/cleanup_null_island_job.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class DataMigrations::CleanupNullIslandJob < ApplicationJob
+  queue_as :data_migrations
+
+  def perform(user_id = nil)
+    return fan_out if user_id.nil?
+
+    user = find_user_or_skip(user_id) || return
+
+    rows = user.points.null_island.pluck(:id, :timestamp, :track_id)
+    track_ids = rows.filter_map(&:last).uniq
+    affected_months = rows.map do |_, timestamp, _|
+      time = Time.zone.at(timestamp)
+      [time.year, time.month]
+    end.uniq
+
+    Point.where(id: rows.map(&:first)).update_all(anomaly: true, updated_at: Time.current) if rows.any?
+    destroyed_visits = destroy_null_island_visits(user)
+
+    Rails.logger.info(
+      "[DataMigrations::CleanupNullIsland] user_id=#{user.id} flagged=#{rows.size} " \
+      "visits_destroyed=#{destroyed_visits} tracks=#{track_ids.size} months=#{affected_months.size}"
+    )
+
+    affected_months.each { |year, month| Stats::CalculatingJob.perform_later(user.id, year, month) }
+    track_ids.each { |track_id| Tracks::RecalculateJob.perform_later(track_id) }
+  end
+
+  private
+
+  def fan_out
+    User.where(id: Point.null_island.select(:user_id).distinct)
+        .pluck(:id)
+        .each { |user_id| self.class.perform_later(user_id) }
+  end
+
+  def destroy_null_island_visits(user)
+    user.visits
+        .joins(:place)
+        .where(Points::NullIsland.sql_predicate('places.lonlat'))
+        .destroy_all
+        .count
+  end
+end

--- a/app/jobs/data_migrations/recalculate_per_tracker_tracks_job.rb
+++ b/app/jobs/data_migrations/recalculate_per_tracker_tracks_job.rb
@@ -11,9 +11,9 @@ class DataMigrations::RecalculatePerTrackerTracksJob < ApplicationJob
     user = User.find_by(id: user_id)
     return unless user
 
-    Points::TrackerIdBackfiller.new(user).call
+    backfilled = Points::TrackerIdBackfiller.new(user).call
 
-    return unless user.tracks.where(tracker_id: nil).exists?
+    return unless backfilled.positive? || user.tracks.where(tracker_id: nil).exists?
 
     Users::RecalculateDataJob.perform_now(user.id, notify: false)
   end
@@ -22,7 +22,11 @@ class DataMigrations::RecalculatePerTrackerTracksJob < ApplicationJob
 
   def enqueue_pending_users
     user_ids = User
-               .where('EXISTS (SELECT 1 FROM tracks WHERE tracks.user_id = users.id AND tracks.tracker_id IS NULL)')
+               .where(
+                 'EXISTS (SELECT 1 FROM tracks WHERE tracks.user_id = users.id AND tracks.tracker_id IS NULL) ' \
+                 'OR EXISTS (SELECT 1 FROM points WHERE points.user_id = users.id AND points.tracker_id IN (?))',
+                 Points::TrackerIdBackfiller::LEGACY_CONSTANTS
+               )
                .pluck(:id)
     return if user_ids.empty?
 

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -35,6 +35,7 @@ class Point < ApplicationRecord
   scope :not_visited, -> { where(visit_id: nil) }
   scope :not_anomaly, -> { where(anomaly: [false, nil]) }
   scope :anomaly, -> { where(anomaly: true) }
+  scope :null_island, -> { where('lonlat = ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography') }
 
   after_create :async_reverse_geocode, if: -> { DawarichSettings.store_geodata? && !reverse_geocoded? }
   after_create :set_country

--- a/app/services/google_maps/phone_takeout_importer.rb
+++ b/app/services/google_maps/phone_takeout_importer.rb
@@ -21,7 +21,7 @@ class GoogleMaps::PhoneTakeoutImporter
       point_data.merge(
         import_id: import.id,
         topic: 'Google Maps Phone Timeline Export',
-        tracker_id: 'google-maps-phone-timeline-export',
+        tracker_id: "google-phone-#{import.id}",
         user_id: user_id,
         created_at: Time.current,
         updated_at: Time.current

--- a/app/services/google_maps/records_importer.rb
+++ b/app/services/google_maps/records_importer.rb
@@ -52,7 +52,7 @@ class GoogleMaps::RecordsImporter
 
   def tracker_id_for(location)
     device_tag = location['deviceTag']
-    return 'google-maps-timeline-export' if device_tag.nil? || device_tag.to_s.strip.empty?
+    return "google-records-#{import.id}" if device_tag.nil? || device_tag.to_s.strip.empty?
 
     "google-records-device-#{device_tag}"
   end

--- a/app/services/google_maps/semantic_history_importer.rb
+++ b/app/services/google_maps/semantic_history_importer.rb
@@ -26,6 +26,8 @@ class GoogleMaps::SemanticHistoryImporter
 
   def process_batch(batch)
     records = batch.map { |point_data| prepare_point_data(point_data) }
+                   .reject { |record| Points::NullIsland.lonlat?(record[:lonlat]) }
+    return if records.empty?
 
     Point.upsert_all(
       records,
@@ -45,7 +47,7 @@ class GoogleMaps::SemanticHistoryImporter
       accuracy: point_data[:accuracy],
       motion_data: point_data[:motion_data],
       topic: 'Google Maps Timeline Export',
-      tracker_id: 'google-maps-timeline-export',
+      tracker_id: "google-semantic-#{import.id}",
       import_id: import.id,
       user_id: user_id,
       created_at: Time.current,

--- a/app/services/imports/bulk_insertable.rb
+++ b/app/services/imports/bulk_insertable.rb
@@ -9,7 +9,13 @@ module Imports
     def bulk_insert_points(batch)
       return 0 if batch.empty?
 
-      unique_batch = batch.compact.uniq { |record| [record[:lonlat], record[:timestamp], record[:user_id]] }
+      compacted = batch.compact
+      unique_batch = compacted
+                     .reject { |record| Points::NullIsland.lonlat?(record[:lonlat]) }
+                     .uniq { |record| [record[:lonlat], record[:timestamp], record[:user_id]] }
+      zero_skipped = compacted.size - compacted.count { |r| !Points::NullIsland.lonlat?(r[:lonlat]) }
+      Rails.logger.info("[#{importer_name}] skipped #{zero_skipped} Null Island (0,0) points") if zero_skipped.positive?
+      return 0 if unique_batch.empty?
 
       result = Point.upsert_all(
         unique_batch,

--- a/app/services/overland/points_creator.rb
+++ b/app/services/overland/points_creator.rb
@@ -16,7 +16,7 @@ class Overland::PointsCreator
 
     payload = data
               .compact
-              .reject { |location| location[:lonlat].nil? || location[:timestamp].nil? }
+              .reject { |location| unusable_location?(location) }
               .map { |location| location.merge(user_id:) }
               .uniq { |location| Point.dedup_key(location) }
 
@@ -36,6 +36,11 @@ class Overland::PointsCreator
   end
 
   private
+
+  def unusable_location?(location)
+    location[:lonlat].nil? || location[:timestamp].nil? ||
+      Points::NullIsland.lonlat?(location[:lonlat])
+  end
 
   def upsert_points(locations)
     created_points = []

--- a/app/services/own_tracks/point_creator.rb
+++ b/app/services/own_tracks/point_creator.rb
@@ -16,6 +16,7 @@ class OwnTracks::PointCreator
 
     payload = parsed_params.merge(user_id:)
     return [] if payload[:timestamp].nil? || payload[:lonlat].nil?
+    return [] if Points::NullIsland.lonlat?(payload[:lonlat])
 
     result = upsert_points([payload])
     if result.any?

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -15,6 +15,7 @@ class Points::AnomalyFilter
     return 0 unless filtering_enabled?
 
     count = 0
+    count += filter_null_island
     count += filter_by_accuracy
     count += filter_by_speed
     count
@@ -32,6 +33,15 @@ class Points::AnomalyFilter
 
   def accuracy_threshold
     @accuracy_threshold ||= user_settings.gps_accuracy_threshold
+  end
+
+  # Pass 0: Null Island — a sustained (0,0) run defeats the speed sandwich
+  # (internal speeds are 0), so exact zeros are flagged unconditionally.
+  def filter_null_island
+    Point.where(user_id: @user_id, timestamp: @start_time..@end_time)
+         .not_anomaly
+         .null_island
+         .update_all(anomaly: true, updated_at: Time.current)
   end
 
   # Pass 1: Mark points with accuracy > threshold

--- a/app/services/points/destroyer.rb
+++ b/app/services/points/destroyer.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class Points::Destroyer
+  def initialize(user, point_ids)
+    @user = user
+    @point_ids = Array(point_ids)
+  end
+
+  def call
+    destroyed = nil
+
+    ActiveRecord::Base.transaction do
+      destroyed = user.points.where(id: point_ids).without_raw_data.destroy_all
+    end
+
+    return destroyed if destroyed.empty?
+
+    User.update_counters(user.id, points_count: -destroyed.count)
+
+    enqueue_stats_recalculation(destroyed)
+    enqueue_track_recalculation(destroyed)
+
+    destroyed
+  end
+
+  private
+
+  attr_reader :user, :point_ids
+
+  def enqueue_stats_recalculation(destroyed)
+    destroyed
+      .map { |point| Time.zone.at(point.timestamp) }
+      .map { |time| [time.year, time.month] }
+      .uniq
+      .each do |year, month|
+        Rails.logger.info("[Points::Destroyer] enqueuing Stats::CalculatingJob for #{year}-#{month}")
+        Stats::CalculatingJob.perform_later(user.id, year, month)
+      end
+  end
+
+  def enqueue_track_recalculation(destroyed)
+    track_ids = destroyed.filter_map(&:track_id).uniq
+    return if track_ids.empty?
+
+    Rails.logger.info(
+      "[Points::Destroyer] deleted #{destroyed.count} points, " \
+      "enqueuing Tracks::RecalculateJob for #{track_ids.size} tracks: #{track_ids.inspect}"
+    )
+    track_ids.each { |track_id| Tracks::RecalculateJob.perform_later(track_id) }
+  end
+end

--- a/app/services/points/null_island.rb
+++ b/app/services/points/null_island.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Points::NullIsland
+  LONLAT_REGEX = /\APOINT\s*\(\s*-?0(?:\.0+)?\s+-?0(?:\.0+)?\s*\)\z/i
+
+  def self.sql_predicate(column = 'lonlat')
+    "(ST_X(#{column}::geometry) = 0 AND ST_Y(#{column}::geometry) = 0)"
+  end
+
+  def self.coordinates?(lon, lat)
+    lon.to_f.zero? && lat.to_f.zero?
+  end
+
+  def self.lonlat?(value)
+    value.to_s.match?(LONLAT_REGEX)
+  end
+end

--- a/app/services/points/params.rb
+++ b/app/services/points/params.rb
@@ -57,8 +57,11 @@ class Points::Params
   end
 
   def params_valid?(point)
-    point.dig(:geometry, :coordinates).present? &&
-      point.dig(:properties, :timestamp).present?
+    coordinates = point.dig(:geometry, :coordinates)
+
+    coordinates.present? &&
+      point.dig(:properties, :timestamp).present? &&
+      !Points::NullIsland.coordinates?(coordinates[0], coordinates[1])
   end
 
   def lonlat(point)

--- a/app/services/points/tracker_id_backfiller.rb
+++ b/app/services/points/tracker_id_backfiller.rb
@@ -2,6 +2,7 @@
 
 class Points::TrackerIdBackfiller
   BATCH_SIZE = 5_000
+  LEGACY_CONSTANTS = %w[google-maps-timeline-export google-maps-phone-timeline-export].freeze
 
   attr_reader :user
 
@@ -34,7 +35,10 @@ class Points::TrackerIdBackfiller
         SELECT id FROM points
         WHERE user_id = #{user.id.to_i}
           AND id > #{cursor.to_i}
-          AND tracker_id IS NULL
+          AND (
+            tracker_id IS NULL
+            OR tracker_id IN (#{LEGACY_CONSTANTS.map { |c| "'#{c}'" }.join(', ')})
+          )
           AND (
             length(btrim(raw_data->>'deviceTag')) > 0
             OR length(btrim(raw_data->>'tid')) > 0

--- a/app/services/traccar/point_creator.rb
+++ b/app/services/traccar/point_creator.rb
@@ -16,6 +16,7 @@ class Traccar::PointCreator
 
     payload = parsed.merge(user_id:)
     return [] if payload[:lonlat].nil? || payload[:timestamp].nil?
+    return [] if Points::NullIsland.lonlat?(payload[:lonlat])
 
     result = upsert_points([payload])
     if result.any?

--- a/app/services/visits/stay_point_detector.rb
+++ b/app/services/visits/stay_point_detector.rb
@@ -188,6 +188,7 @@ module Visits
               AND timestamp BETWEEN ? AND ?
               AND lonlat IS NOT NULL
               AND (anomaly IS NULL OR anomaly = FALSE)
+              AND NOT (ST_X(lonlat::geometry) = 0 AND ST_Y(lonlat::geometry) = 0)
             ORDER BY timestamp ASC
           SQL
           user.id, start_at, end_at
@@ -210,6 +211,7 @@ module Visits
            .where(timestamp: start_at..end_at)
            .where('lonlat IS NOT NULL')
            .where('anomaly IS NULL OR anomaly = FALSE')
+           .where("NOT #{Points::NullIsland.sql_predicate}")
            .count
     end
 

--- a/db/migrate/20260719180000_enqueue_null_island_cleanup.rb
+++ b/db/migrate/20260719180000_enqueue_null_island_cleanup.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class EnqueueNullIslandCleanup < ActiveRecord::Migration[8.0]
+  def up
+    DataMigrations::CleanupNullIslandJob.perform_later
+  end
+
+  def down; end
+end

--- a/db/migrate/20260719185000_add_legacy_tracker_points_index.rb
+++ b/db/migrate/20260719185000_add_legacy_tracker_points_index.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddLegacyTrackerPointsIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :points, :user_id,
+              where: "tracker_id IN ('google-maps-timeline-export', 'google-maps-phone-timeline-export')",
+              name: 'idx_points_user_id_legacy_tracker',
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/migrate/20260719190000_enqueue_legacy_tracker_id_backfill.rb
+++ b/db/migrate/20260719190000_enqueue_legacy_tracker_id_backfill.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class EnqueueLegacyTrackerIdBackfill < ActiveRecord::Migration[8.0]
+  def up
+    DataMigrations::RecalculatePerTrackerTracksJob.perform_later
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_14_090000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_19_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -368,6 +368,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_14_090000) do
     t.index ["user_id", "id"], name: "index_points_on_unarchived", where: "((raw_data_archived = false) AND (raw_data <> '{}'::jsonb))"
     t.index ["user_id", "timestamp"], name: "idx_points_user_visit_null_timestamp", where: "(visit_id IS NULL)"
     t.index ["user_id", "timestamp"], name: "index_points_on_user_id_and_timestamp", order: { timestamp: :desc }
+    t.index ["user_id"], name: "idx_points_user_id_legacy_tracker", where: "((tracker_id)::text = ANY ((ARRAY['google-maps-timeline-export'::character varying, 'google-maps-phone-timeline-export'::character varying])::text[]))"
     t.index ["user_id"], name: "index_points_on_user_id"
     t.index ["visit_id"], name: "index_points_on_visit_id"
   end

--- a/spec/jobs/data_migrations/cleanup_null_island_job_spec.rb
+++ b/spec/jobs/data_migrations/cleanup_null_island_job_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataMigrations::CleanupNullIslandJob do
+  let(:user) { create(:user) }
+  let(:track) { create(:track, user: user) }
+
+  let!(:zero_point) do
+    create(:point, user: user, latitude: 0.0, longitude: 0.0,
+                   lonlat: 'POINT(0.0 0.0)', track: track,
+                   timestamp: Time.zone.local(2024, 5, 10, 12).to_i)
+  end
+  let!(:normal_point) do
+    create(:point, user: user, latitude: 52.5, longitude: 13.4,
+                   lonlat: 'POINT(13.4 52.5)',
+                   timestamp: Time.zone.local(2024, 5, 10, 13).to_i)
+  end
+
+  let(:zero_place) { create(:place, latitude: 0.0, longitude: 0.0, lonlat: 'POINT(0.0 0.0)') }
+  let(:normal_place) { create(:place) }
+  let!(:zero_visit) { create(:visit, user: user, place: zero_place) }
+  let!(:normal_visit) { create(:visit, user: user, place: normal_place) }
+
+  it 'flags (0,0) points as anomalies' do
+    described_class.perform_now(user.id)
+
+    expect(zero_point.reload.anomaly).to be(true)
+    expect(normal_point.reload.anomaly).not_to be(true)
+  end
+
+  it 'destroys visits placed at (0,0) and keeps the rest' do
+    expect { described_class.perform_now(user.id) }
+      .to change { Visit.exists?(zero_visit.id) }.from(true).to(false)
+
+    expect(Visit.exists?(normal_visit.id)).to be(true)
+  end
+
+  it 'enqueues stats recalculation for affected months and track recalculation' do
+    expect { described_class.perform_now(user.id) }
+      .to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2024, 5)
+      .and have_enqueued_job(Tracks::RecalculateJob).with(track.id)
+  end
+
+  describe 'fan out' do
+    it 'enqueues a per-user job for every user with (0,0) points' do
+      other_user = create(:user)
+      create(:point, user: other_user, latitude: 0.0, longitude: 0.0,
+                     lonlat: 'POINT(0.0 0.0)', timestamp: Time.zone.local(2024, 6, 1).to_i)
+
+      expect { described_class.perform_now }
+        .to have_enqueued_job(described_class).with(user.id)
+        .and have_enqueued_job(described_class).with(other_user.id)
+    end
+  end
+end

--- a/spec/jobs/data_migrations/recalculate_per_tracker_tracks_job_spec.rb
+++ b/spec/jobs/data_migrations/recalculate_per_tracker_tracks_job_spec.rb
@@ -54,6 +54,16 @@ RSpec.describe DataMigrations::RecalculatePerTrackerTracksJob do
         described_class.perform_now
       end.not_to have_enqueued_job(described_class)
     end
+
+    it 'enqueues users whose points still carry a legacy importer constant' do
+      Track.where(tracker_id: nil).update_all(tracker_id: 'backfilled')
+      user_with_legacy_points = create(:user)
+      create(:point, user: user_with_legacy_points, tracker_id: 'google-maps-timeline-export')
+
+      expect do
+        described_class.perform_now
+      end.to have_enqueued_job(described_class).with(user_with_legacy_points.id).exactly(:once)
+    end
   end
 
   describe 'with user_id: processing one user' do

--- a/spec/regressions/google_records_import_per_device_tracker_id_spec.rb
+++ b/spec/regressions/google_records_import_per_device_tracker_id_spec.rb
@@ -25,15 +25,15 @@ RSpec.describe 'Google records.json import scopes tracker_id by device_tag' do
     expect(tracker_ids).to contain_exactly(
       'google-records-device-1111111111',
       'google-records-device-2222222222',
-      'google-maps-timeline-export'
+      "google-records-#{import.id}"
     )
   end
 
-  it 'falls back to the legacy tracker_id when device_tag is missing' do
+  it 'falls back to the per-import tracker_id when device_tag is missing' do
     run_import
 
-    legacy_count = Point.where(import_id: import.id, tracker_id: 'google-maps-timeline-export').count
-    expect(legacy_count).to eq(1)
+    fallback_count = Point.where(import_id: import.id, tracker_id: "google-records-#{import.id}").count
+    expect(fallback_count).to eq(1)
   end
 
   def build_location(_label, device_tag:, lat:, lon:, offset:)

--- a/spec/requests/api/v1/points_spec.rb
+++ b/spec/requests/api/v1/points_spec.rb
@@ -381,6 +381,26 @@ RSpec.describe 'Api::V1::Points', type: :request do
           delete "/api/v1/points/#{trackless_point.id}?api_key=#{user.api_key}"
         end.not_to have_enqueued_job(Tracks::RecalculateJob)
       end
+
+      it 'enqueues a stats recalculation for the point month' do
+        expect do
+          delete "/api/v1/points/#{trackless_point.id}?api_key=#{user.api_key}"
+        end.to have_enqueued_job(Stats::CalculatingJob)
+          .with(user.id, Time.zone.at(trackless_point.timestamp).year, Time.zone.at(trackless_point.timestamp).month)
+      end
+    end
+
+    context 'when recalculating stats' do
+      let(:track) { create(:track, user: user) }
+      let!(:tracked_point) do
+        create(:point, user: user, track: track, timestamp: Time.zone.local(2024, 5, 10, 12).to_i)
+      end
+
+      it 'enqueues a stats recalculation for the point month' do
+        expect do
+          delete "/api/v1/points/#{tracked_point.id}?api_key=#{user.api_key}"
+        end.to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2024, 5)
+      end
     end
 
     context 'when user is inactive' do

--- a/spec/requests/points_spec.rb
+++ b/spec/requests/points_spec.rb
@@ -125,6 +125,16 @@ RSpec.describe '/points', type: :request do
       expect(Point.find_by(id: point2.id)).to be_nil
     end
 
+    it 'enqueues stats and track recalculation' do
+      track = create(:track, user:)
+      tracked = create(:point, user:, track:, timestamp: Time.zone.local(2024, 5, 10, 12).to_i)
+
+      expect do
+        delete bulk_destroy_points_url, params: { point_ids: [tracked.id] }
+      end.to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2024, 5)
+                                                     .and have_enqueued_job(Tracks::RecalculateJob).with(track.id)
+    end
+
     it 'returns a 303 status code' do
       delete bulk_destroy_points_url, params: { point_ids: [point1.id, point2.id] }
 

--- a/spec/services/google_maps/phone_takeout_importer_spec.rb
+++ b/spec/services/google_maps/phone_takeout_importer_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe GoogleMaps::PhoneTakeoutImporter do
           # 2 frequentPlaces from userLocationProfile
           expect { parser }.to change { Point.count }.by(6)
         end
+
+        it 'stamps the per-import tracker id on every point' do
+          parser
+
+          expect(Point.distinct.pluck(:tracker_id)).to eq(["google-phone-#{import.id}"])
+        end
       end
     end
 

--- a/spec/services/google_maps/records_importer_spec.rb
+++ b/spec/services/google_maps/records_importer_spec.rb
@@ -39,10 +39,28 @@ RSpec.describe GoogleMaps::RecordsImporter do
     end
 
     context 'with regular timestamp' do
-      let(:locations) { super()[0].merge('timestamp' => time.to_s).to_json }
+      let(:locations) { [super()[0].merge('timestamp' => time.to_s)] }
 
       it 'creates a point' do
         expect { parser }.to change(Point, :count).by(1)
+      end
+
+      it 'derives the tracker id from the deviceTag' do
+        parser
+
+        expect(Point.last.tracker_id).to eq('google-records-device-1234567890')
+      end
+    end
+
+    context 'without a deviceTag' do
+      let(:locations) do
+        [super()[0].except('deviceTag').merge('timestamp' => time.to_s)]
+      end
+
+      it 'falls back to the per-import tracker id' do
+        parser
+
+        expect(Point.last.tracker_id).to eq("google-records-#{import.id}")
       end
     end
 

--- a/spec/services/google_maps/semantic_history_importer_spec.rb
+++ b/spec/services/google_maps/semantic_history_importer_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe GoogleMaps::SemanticHistoryImporter do
           expect(Point.last.lonlat.to_s).to eq('POINT (12.3411111 12.3411111)')
         end
 
+        it 'stamps the per-import tracker id' do
+          parser
+
+          expect(Point.last.tracker_id).to eq("google-semantic-#{import.id}")
+        end
+
         context 'when waypointPath is blank' do
           let(:file_name) { 'with_activitySegment_without_startLocation_without_waypointPath' }
 

--- a/spec/services/imports/bulk_insertable_spec.rb
+++ b/spec/services/imports/bulk_insertable_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Imports::BulkInsertable do
+  let(:harness_class) do
+    Class.new do
+      include Imports::BulkInsertable
+
+      attr_reader :import
+
+      def initialize(import)
+        @import = import
+      end
+
+      def importer_name = 'Test'
+
+      def insert(batch)
+        bulk_insert_points(batch)
+      end
+
+      def on_bulk_insert_error(error)
+        raise error
+      end
+    end
+  end
+
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user) }
+
+  def record(lon, lat, timestamp)
+    {
+      lonlat: "POINT(#{lon} #{lat})",
+      timestamp: timestamp,
+      user_id: user.id,
+      import_id: import.id,
+      created_at: Time.current,
+      updated_at: Time.current
+    }
+  end
+
+  it 'skips records at exactly (0,0) and inserts the rest' do
+    inserted = harness_class.new(import).insert(
+      [record(0.0, 0.0, 1_700_000_000), record(13.5, 52.4, 1_700_000_060)]
+    )
+
+    expect(inserted).to eq(1)
+    expect(user.points.count).to eq(1)
+    expect(user.points.first.lon).to eq(13.5)
+  end
+end

--- a/spec/services/own_tracks/point_creator_spec.rb
+++ b/spec/services/own_tracks/point_creator_spec.rb
@@ -64,4 +64,19 @@ RSpec.describe OwnTracks::PointCreator do
       expect(call_service).to eq([])
     end
   end
+
+  context 'when the payload is at Null Island (0,0)' do
+    let(:point_params) do
+      parsed = OwnTracks::RecParser.new(File.read(file_path)).call.first
+      parsed.merge('lat' => 0.0, 'lon' => 0.0, lat: 0.0, lon: 0.0)
+    end
+
+    it 'drops the point' do
+      expect { call_service }.not_to(change { Point.where(user:).count })
+    end
+
+    it 'returns an empty array' do
+      expect(call_service).to eq([])
+    end
+  end
 end

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -220,5 +220,37 @@ RSpec.describe Points::AnomalyFilter do
         expect(early_spike.reload.anomaly).not_to be true
       end
     end
+
+    context 'Pass 3: Null Island (0,0)' do
+      let(:start_time) { 2.hours.ago.to_i }
+      let(:end_time) { Time.current.to_i }
+
+      let!(:before_zero) do
+        create(:point, user: user, latitude: 52.5, longitude: 13.4,
+                       lonlat: 'POINT(13.4 52.5)', accuracy: 10, timestamp: 90.minutes.ago.to_i)
+      end
+      let!(:zero_run) do
+        3.times.map do |i|
+          create(:point, user: user, latitude: 0.0, longitude: 0.0,
+                         lonlat: 'POINT(0.0 0.0)', accuracy: 10,
+                         timestamp: (80 - (i * 10)).minutes.ago.to_i)
+        end
+      end
+      let!(:after_zero) do
+        create(:point, user: user, latitude: 52.5001, longitude: 13.4001,
+                       lonlat: 'POINT(13.4001 52.5001)', accuracy: 10, timestamp: 40.minutes.ago.to_i)
+      end
+
+      before { described_class.new(user.id, start_time, end_time).call }
+
+      it 'flags every point of a sustained (0,0) run' do
+        expect(zero_run.map { |p| p.reload.anomaly }).to all(be(true))
+      end
+
+      it 'does not flag the surrounding real points' do
+        expect(before_zero.reload.anomaly).not_to be true
+        expect(after_zero.reload.anomaly).not_to be true
+      end
+    end
   end
 end

--- a/spec/services/points/destroyer_spec.rb
+++ b/spec/services/points/destroyer_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Points::Destroyer do
+  let(:user) { create(:user) }
+
+  describe '#call' do
+    context 'with tracked and untracked points across months' do
+      let(:track1) { create(:track, user: user) }
+      let(:track2) { create(:track, user: user) }
+      let!(:may_point) do
+        create(:point, user: user, track: track1, timestamp: Time.zone.local(2024, 5, 10, 12).to_i)
+      end
+      let!(:may_point_same_track) do
+        create(:point, user: user, track: track1, timestamp: Time.zone.local(2024, 5, 10, 13).to_i)
+      end
+      let!(:june_point) do
+        create(:point, user: user, track: track2, timestamp: Time.zone.local(2024, 6, 2, 9).to_i)
+      end
+      let!(:untracked_point) do
+        create(:point, user: user, track: nil, timestamp: Time.zone.local(2024, 7, 1, 8).to_i)
+      end
+      let(:point_ids) { [may_point.id, may_point_same_track.id, june_point.id, untracked_point.id] }
+
+      it 'destroys the points' do
+        expect { described_class.new(user, point_ids).call }.to change { user.points.count }.by(-4)
+      end
+
+      it 'decrements the points counter' do
+        user.update_column(:points_count, 10)
+
+        expect { described_class.new(user, point_ids).call }
+          .to change { user.reload.points_count }.by(-4)
+      end
+
+      it 'enqueues one track recalculation per distinct affected track' do
+        expect { described_class.new(user, point_ids).call }
+          .to have_enqueued_job(Tracks::RecalculateJob).with(track1.id).exactly(:once)
+          .and have_enqueued_job(Tracks::RecalculateJob).with(track2.id).exactly(:once)
+      end
+
+      it 'enqueues one stats recalculation per distinct affected month' do
+        expect { described_class.new(user, point_ids).call }
+          .to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2024, 5).exactly(:once)
+          .and have_enqueued_job(Stats::CalculatingJob).with(user.id, 2024, 6).exactly(:once)
+          .and have_enqueued_job(Stats::CalculatingJob).with(user.id, 2024, 7).exactly(:once)
+      end
+
+      it 'returns the destroyed points' do
+        expect(described_class.new(user, point_ids).call.map(&:id)).to match_array(point_ids)
+      end
+    end
+
+    context 'with points belonging to another user' do
+      let(:other_user) { create(:user) }
+      let!(:own_point) { create(:point, user: user, track: nil) }
+      let!(:foreign_point) { create(:point, user: other_user, track: nil) }
+
+      it 'only destroys points of the given user' do
+        expect { described_class.new(user, [own_point.id, foreign_point.id]).call }
+          .to change { user.points.count }.by(-1)
+          .and change { other_user.points.count }.by(0)
+      end
+    end
+
+    context 'with no matching points' do
+      it 'does not change the points counter' do
+        expect { described_class.new(user, [-1]).call }.not_to(change { user.reload.points_count })
+      end
+
+      it 'enqueues no jobs' do
+        expect { described_class.new(user, [-1]).call }.not_to have_enqueued_job
+      end
+    end
+  end
+end

--- a/spec/services/points/params_spec.rb
+++ b/spec/services/points/params_spec.rb
@@ -105,4 +105,31 @@ RSpec.describe Points::Params do
       expect(result.first[:course_accuracy]).to eq(12.5)
     end
   end
+
+  describe 'Null Island filtering' do
+    let(:user) { create(:user) }
+    let(:params) do
+      {
+        locations: [
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [0.0, 0.0] },
+            properties: { timestamp: '2025-01-17T21:03:01Z' }
+          },
+          {
+            type: 'Feature',
+            geometry: { type: 'Point', coordinates: [13.5, 52.4] },
+            properties: { timestamp: '2025-01-17T21:04:01Z' }
+          }
+        ]
+      }
+    end
+
+    it 'drops locations at exactly (0,0) and keeps the rest' do
+      result = described_class.new(params, user.id).call
+
+      expect(result.size).to eq(1)
+      expect(result.first[:lonlat]).to eq('POINT(13.5 52.4)')
+    end
+  end
 end

--- a/spec/services/points/tracker_id_backfiller_spec.rb
+++ b/spec/services/points/tracker_id_backfiller_spec.rb
@@ -60,6 +60,42 @@ RSpec.describe Points::TrackerIdBackfiller do
     expect(point.reload.tracker_id).to eq('iphone')
   end
 
+  it 'rewrites the legacy semantic-import constant to the per-import value' do
+    import = create(:import, user: user)
+    point = create(:point, user: user, tracker_id: 'google-maps-timeline-export', raw_data: {}, import: import)
+
+    described_class.new(user).call
+
+    expect(point.reload.tracker_id).to eq("legacy-import-#{import.id}")
+  end
+
+  it 'upgrades a legacy-constant point to its deviceTag when raw_data still has one' do
+    import = create(:import, user: user)
+    point = create(:point, user: user, tracker_id: 'google-maps-timeline-export',
+                           raw_data: { 'deviceTag' => 3_333_333_333 }, import: import)
+
+    described_class.new(user).call
+
+    expect(point.reload.tracker_id).to eq('google-records-device-3333333333')
+  end
+
+  it 'rewrites the legacy phone-takeout constant to the per-import value' do
+    import = create(:import, user: user)
+    point = create(:point, user: user, tracker_id: 'google-maps-phone-timeline-export', raw_data: {}, import: import)
+
+    described_class.new(user).call
+
+    expect(point.reload.tracker_id).to eq("legacy-import-#{import.id}")
+  end
+
+  it 'leaves per-device records tracker ids untouched' do
+    point = create(:point, user: user, tracker_id: 'google-records-device-123', raw_data: {})
+
+    described_class.new(user).call
+
+    expect(point.reload.tracker_id).to eq('google-records-device-123')
+  end
+
   it 'only updates points belonging to the passed user' do
     other_user = create(:user)
     other_point = create(:point, user: other_user, tracker_id: nil, raw_data: { 'tid' => 'wt' })

--- a/spec/services/traccar/point_creator_spec.rb
+++ b/spec/services/traccar/point_creator_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe Traccar::PointCreator do
     }
   end
 
+  context 'when the payload is at Null Island (0,0)' do
+    let(:point_params) do
+      super().tap { |params| params[:location] = params[:location].merge(latitude: 0.0, longitude: 0.0) }
+    end
+
+    it 'drops the point and returns an empty array' do
+      expect { expect(call_service).to eq([]) }.not_to(change { Point.where(user:).count })
+    end
+  end
+
   it 'creates a point' do
     expect { call_service }.to change { Point.where(user:).count }.by(1)
   end

--- a/spec/services/visits/stay_point_detector_spec.rb
+++ b/spec/services/visits/stay_point_detector_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Visits::StayPointDetector do
   # Defaults: radius 100 m, min_dwell 300 s, min_points 3, max_gap 3600 s, merge_gap 900 s, drift_cap 1.5.
 
   describe '#call' do
+    it 'ignores points at exactly (0,0)' do
+      6.times do |i|
+        create(:point, user: user, latitude: 0.0, longitude: 0.0,
+                       lonlat: 'POINT(0.0 0.0)', timestamp: base_ts + (i * 120),
+                       accuracy: 10, visit_id: nil)
+      end
+
+      expect(detect).to be_empty
+    end
+
     it '(a) groups a tight stationary cluster into one visit' do
       6.times { |i| make_point(at: base_ts + i * 120, dnorth: (i.even? ? 5 : -5)) }
 


### PR DESCRIPTION
## Null Island (0,0) cleanup
- Reject `(0,0)` points at ingest across the REST, OwnTracks, Overland, Traccar creators and the Google importers, via a new `Points::NullIsland` helper.
- Extract `Points::Destroyer` (destroy + points counter + stats/track recalculation) and use it from the point-delete endpoints.
- `CleanupNullIslandJob` + its migration purge any existing `(0,0)` points.

## Legacy Google Timeline tracker ids
- Google timeline / semantic / phone-takeout imports now write a **per-import** `tracker_id` instead of a shared constant.
- `Points::TrackerIdBackfiller` + a data migration recalculate per-tracker tracks for legacy exports, backed by a partial index on `points(user_id)` scoped to the legacy tracker values.

## Verification
- **232 examples, 0 failures** across the affected specs.
- RuboCop clean (37 files).
- `schema.rb` shows only the version bump + the new `idx_points_user_id_legacy_tracker` index — no unrelated dump churn.
