### PR TITLE
Fix legacy trial email retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Trial lifecycle email jobs left over from older releases are now discarded instead of retrying forever in the background queue. Mail addressed to a record that has since been deleted is also discarded rather than retried.
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
 

--- a/app/jobs/users/mailer_sending_job.rb
+++ b/app/jobs/users/mailer_sending_job.rb
@@ -13,8 +13,22 @@ class Users::MailerSendingJob < ApplicationJob
     'account_destroy_confirmation' => ['UsersMailer', :account_destroy_confirmation]
   }.freeze
 
+  LEGACY_MANAGER_EMAIL_TYPES = %w[
+    trial_expired
+    trial_expires_soon
+    post_trial_reminder_early
+    post_trial_reminder_late
+  ].freeze
+
   def perform(user_id, email_type, **options)
     user = find_user_or_skip(user_id) || return
+
+    if LEGACY_MANAGER_EMAIL_TYPES.include?(email_type.to_s)
+      Rails.logger.info(
+        "[Users::MailerSendingJob] skipping legacy Manager-owned email_type=#{email_type} user_id=#{user.id}"
+      )
+      return
+    end
 
     mailer_class_name, action = MAILER_REGISTRY.fetch(email_type.to_s) do
       raise UnknownEmailType, "Unknown email_type=#{email_type.inspect} user_id=#{user.id}"

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,4 +3,8 @@
 class ApplicationMailer < ActionMailer::Base
   default from: ENV['SMTP_FROM']
   layout 'mailer'
+
+  rescue_from ActiveJob::DeserializationError do |exception|
+    Rails.logger.info("[ApplicationMailer] discarding delivery for a missing record: #{exception.message}")
+  end
 end

--- a/app/mailers/users_mailer.rb
+++ b/app/mailers/users_mailer.rb
@@ -47,4 +47,12 @@ class UsersMailer < ApplicationMailer
 
     mail(to: @user.email, subject: 'Dawarich account temporarily locked')
   end
+
+  def trial_expired; end
+
+  def trial_expires_soon; end
+
+  def post_trial_reminder_early; end
+
+  def post_trial_reminder_late; end
 end

--- a/spec/jobs/users/mailer_sending_job_spec.rb
+++ b/spec/jobs/users/mailer_sending_job_spec.rb
@@ -95,6 +95,30 @@ RSpec.describe Users::MailerSendingJob, type: :job do
       end
     end
 
+    context 'when email_type is a legacy trial lifecycle email' do
+      %w[trial_expired trial_expires_soon post_trial_reminder_early post_trial_reminder_late].each do |email_type|
+        it "skips #{email_type}" do
+          expect do
+            described_class.perform_now(user.id, email_type)
+          end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+        end
+
+        it "logs that #{email_type} was skipped" do
+          allow(Rails.logger).to receive(:info)
+
+          described_class.perform_now(user.id, email_type)
+
+          expect(Rails.logger).to have_received(:info).with(/skipping legacy Manager-owned email_type=#{email_type}/)
+        end
+
+        it "delivers nothing for #{email_type} when a stale ActionMailer job bypasses this wrapper" do
+          expect do
+            UsersMailer.with(user: user).public_send(email_type).deliver_now
+          end.not_to(change { ActionMailer::Base.deliveries.size })
+        end
+      end
+    end
+
     context 'registry coverage' do
       # Prove every entry in MAILER_REGISTRY actually resolves to a real mailer
       # action. A typo in the registry would otherwise silently break production.

--- a/spec/mailers/users_mailer_spec.rb
+++ b/spec/mailers/users_mailer_spec.rb
@@ -51,4 +51,30 @@ RSpec.describe UsersMailer, type: :mailer do
       expect(mail.text_part.body.encoded).to include('password')
     end
   end
+
+  describe 'legacy trial lifecycle emails' do
+    %i[trial_expired trial_expires_soon post_trial_reminder_early post_trial_reminder_late].each do |action|
+      it "delivers nothing for a stale #{action} job" do
+        mail = UsersMailer.with(user: user).public_send(action)
+
+        expect { mail.deliver_now }.not_to(change { ActionMailer::Base.deliveries.size })
+      end
+    end
+
+    it 'delivers nothing for a stale job without user params' do
+      mail = UsersMailer.with({}).trial_expired
+
+      expect { mail.deliver_now }.not_to(change { ActionMailer::Base.deliveries.size })
+    end
+
+    it 'discards a stale delivery job whose user record is gone' do
+      job = ActionMailer::MailDeliveryJob.new(
+        'UsersMailer', 'trial_expired', 'deliver_now', args: [], params: { user: user }
+      )
+      serialized = job.serialize
+      User.unscoped.where(id: user.id).delete_all
+
+      expect { ActiveJob::Base.execute(serialized) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Skip stale Users::MailerSendingJob legacy trial lifecycle email types now owned by Manager
- Restore compatibility UsersMailer actions for older queued ActionMailer jobs while disabling delivery
- Add focused regressions and changelog entry

## GlitchTip
- Cluster includes DAWARICH-8I/AE/BH/C1/BE/C0/AS/8G/8H/A6/8T/AK/BB/B0/AL/97/A8/AU and DAWARICH-C2/C3/C4/C5

## Verification
- `bundle exec rspec spec/jobs/users/mailer_sending_job_spec.rb spec/mailers/users_mailer_spec.rb`
- `bundle exec rubocop app/jobs/users/mailer_sending_job.rb app/mailers/users_mailer.rb spec/jobs/users/mailer_sending_job_spec.rb spec/mailers/users_mailer_spec.rb`
