### PR TITLE
Fix live map date-range filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Photoprism photo imports no longer fail with an HTTP 400: the `after` and `before` filters are now sent as plain `YYYY-MM-DD` dates, which Photoprism's search API requires (recent Photoprism rejects full timestamps, including the `before` value shipped in 1.9.2). Since a bare `before` date is coarser than the requested range, results are additionally bounded in-app by the exact end timestamp, and a blank start date no longer breaks the import (#3034).
 - Live Map no longer adds or zooms to newly-recorded points that fall outside the currently selected Map v2 date range (#3098).
-- Cloud: for Lite users viewing a single import on the map, the points counter no longer includes unrelated points from the same date range (the `X-Total-Points-In-Range` header is now scoped to the import).
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
 
@@ -96,7 +94,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Opening "View on map" for an import on Map v2 now shows only that import's points, instead of every point within the import's date range (#2734)
 - Place and area visit detection no longer silently finds zero visits for users whose distance unit is kilometers (the search radius was being truncated to 0 by integer division) (#3031).
 - Points added retroactively through the API or trackers (with timestamps in the past) now get their routes generated, instead of only connecting after a manual data recalculation (#3036).
-- Photoprism photo imports no longer fail with an HTTP 400: the `after`/`before` filters are now sent as plain `YYYY-MM-DD` dates, as recent Photoprism requires (it rejects the full timestamps shipped in 1.9.2). Results are still bounded in-app by the exact end timestamp, and a blank start date no longer breaks the import (#3034).
 
 
 ## [1.9.2] - 2026-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Photoprism photo imports no longer fail with an HTTP 400: the `after` and `before` filters are now sent as plain `YYYY-MM-DD` dates, which Photoprism's search API requires (recent Photoprism rejects full timestamps, including the `before` value shipped in 1.9.2). Since a bare `before` date is coarser than the requested range, results are additionally bounded in-app by the exact end timestamp, and a blank start date no longer breaks the import (#3034).
+- Live Map no longer adds or zooms to newly-recorded points that fall outside the currently selected Map v2 date range (#3098).
+- Cloud: for Lite users viewing a single import on the map, the points counter no longer includes unrelated points from the same date range (the `X-Total-Points-In-Range` header is now scoped to the import).
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
 
@@ -94,9 +97,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Place and area visit detection no longer silently finds zero visits for users whose distance unit is kilometers (the search radius was being truncated to 0 by integer division) (#3031).
 - Points added retroactively through the API or trackers (with timestamps in the past) now get their routes generated, instead of only connecting after a manual data recalculation (#3036).
 - Photoprism photo imports no longer fail with an HTTP 400: the `after`/`before` filters are now sent as plain `YYYY-MM-DD` dates, as recent Photoprism requires (it rejects the full timestamps shipped in 1.9.2). Results are still bounded in-app by the exact end timestamp, and a blank start date no longer breaks the import (#3034).
-- Photoprism photo imports no longer fail with an HTTP 400: the `after` and `before` filters are now sent as plain `YYYY-MM-DD` dates, which Photoprism's search API requires (recent Photoprism rejects full timestamps, including the `before` value shipped in 1.9.2). Since a bare `before` date is coarser than the requested range, results are additionally bounded in-app by the exact end timestamp, and a blank start date no longer breaks the import (#3034).
-- Live Map no longer adds or zooms to newly-recorded points that fall outside the currently selected Map v2 date range (#3098).
-- Cloud: for Lite users viewing a single import on the map, the points counter no longer includes unrelated points from the same date range (the `X-Total-Points-In-Range` header is now scoped to the import).
 
 
 ## [1.9.2] - 2026-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Opening "View on map" for an import on Map v2 now shows only that import's points, instead of every point within the import's date range (#2734)
 - Place and area visit detection no longer silently finds zero visits for users whose distance unit is kilometers (the search radius was being truncated to 0 by integer division) (#3031).
 - Points added retroactively through the API or trackers (with timestamps in the past) now get their routes generated, instead of only connecting after a manual data recalculation (#3036).
+- Photoprism photo imports no longer fail with an HTTP 400: the `after`/`before` filters are now sent as plain `YYYY-MM-DD` dates, as recent Photoprism requires (it rejects the full timestamps shipped in 1.9.2). Results are still bounded in-app by the exact end timestamp, and a blank start date no longer breaks the import (#3034).
 
 
 ## [1.9.2] - 2026-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Place and area visit detection no longer silently finds zero visits for users whose distance unit is kilometers (the search radius was being truncated to 0 by integer division) (#3031).
 - Points added retroactively through the API or trackers (with timestamps in the past) now get their routes generated, instead of only connecting after a manual data recalculation (#3036).
 - Photoprism photo imports no longer fail with an HTTP 400: the `after`/`before` filters are now sent as plain `YYYY-MM-DD` dates, as recent Photoprism requires (it rejects the full timestamps shipped in 1.9.2). Results are still bounded in-app by the exact end timestamp, and a blank start date no longer breaks the import (#3034).
+- Photoprism photo imports no longer fail with an HTTP 400: the `after` and `before` filters are now sent as plain `YYYY-MM-DD` dates, which Photoprism's search API requires (recent Photoprism rejects full timestamps, including the `before` value shipped in 1.9.2). Since a bare `before` date is coarser than the requested range, results are additionally bounded in-app by the exact end timestamp, and a blank start date no longer breaks the import (#3034).
+- Live Map no longer adds or zooms to newly-recorded points that fall outside the currently selected Map v2 date range (#3098).
+- Cloud: for Lite users viewing a single import on the map, the points counter no longer includes unrelated points from the same date range (the `X-Total-Points-In-Range` header is now scoped to the import).
 
 
 ## [1.9.2] - 2026-06-25

--- a/app/javascript/controllers/maps/maplibre_realtime_controller.js
+++ b/app/javascript/controllers/maps/maplibre_realtime_controller.js
@@ -176,6 +176,10 @@ export default class extends Controller {
     const [lat, lon, battery, altitude, timestamp, velocity, id, countryName] =
       pointData
 
+    if (!this.pointMatchesActiveDateRange(timestamp, mapsController)) {
+      return
+    }
+
     const pointsLayer = mapsController.layerManager?.getLayer("points")
     if (!pointsLayer) {
       console.warn("[Realtime Controller] Points layer not found")
@@ -254,7 +258,43 @@ export default class extends Controller {
     }
   }
 
-  // Note: Notifications are handled by notifications_controller.js in the navbar
+  pointMatchesActiveDateRange(timestamp, mapsController) {
+    const pointTime = this.parseTimestamp(timestamp)
+    const startTime = this.parseTimestamp(mapsController.startDateValue)
+    const endTime = this.parseTimestamp(mapsController.endDateValue)
+
+    if (pointTime === null) {
+      return false
+    }
+
+    if (startTime !== null && pointTime < startTime) {
+      return false
+    }
+
+    if (endTime !== null && pointTime > endTime) {
+      return false
+    }
+
+    return true
+  }
+
+  parseTimestamp(timestamp) {
+    if (timestamp === null || timestamp === undefined || timestamp === "") {
+      return null
+    }
+
+    const numericTimestamp = Number(timestamp)
+
+    if (Number.isFinite(numericTimestamp)) {
+      return numericTimestamp < 10000000000
+        ? numericTimestamp * 1000
+        : numericTimestamp
+    }
+
+    const parsedTimestamp = Date.parse(timestamp)
+
+    return Number.isNaN(parsedTimestamp) ? null : parsedTimestamp
+  }
 
   /**
    * Update the recent point marker
@@ -285,7 +325,7 @@ export default class extends Controller {
    */
   zoomToPoint(longitude, latitude) {
     const mapsController = this.mapsV2Controller
-    if (!mapsController || !mapsController.map) {
+    if (!mapsController?.map) {
       console.warn("[Realtime Controller] Map not available for zooming")
       return
     }


### PR DESCRIPTION
## Summary
- Ignore live point broadcasts outside the active Map v2 date range before updating layers or zooming
- Preserve live updates for points that fall inside the selected range
- Add changelog entry

## Verification
- `node` ad-hoc verification for in-range/out-of-range live payloads
- `npx @biomejs/biome check app/javascript/controllers/maps/maplibre_realtime_controller.js`

GitHub issue: https://github.com/Freika/dawarich/issues/3098
