### PR TITLE
fix: quiet handled geocoder provider errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Reverse geocoding and place-name provider outages no longer flood error reporting with handled timeouts, TLS connection failures, or invalid provider responses.
+- Reverse geocoding and place-name provider outages no longer flood error reporting with handled timeouts, dropped TLS connections, or invalid provider responses. A misconfigured or rate-limited provider — a bad API key, for example — is still reported.
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Family location history now actually shows up on Map v2: the history endpoint read coordinates from the legacy `latitude`/`longitude` columns, which are empty on instances that only store the PostGIS `lonlat` value, so nothing was drawn. Coordinates are now derived from `lonlat` (#2977)
+- Reverse geocoding and place-name provider outages no longer flood error reporting with handled timeouts, TLS connection failures, or invalid provider responses.
 - Declining the "Move the visit here?" prompt when picking a distant place for a Map v2 visit no longer renames the visit to that place.
 - Place visit detection no longer leaves an empty duplicate visit behind when a new point bridges two previously separate visits at the same place — they are now merged into one. The nightly re-scan also leaves confirmed visits untouched, so a new nearby point can no longer pull points out of a visit you already confirmed.
 - Re-evaluating anomalous points now refreshes the map immediately instead of occasionally serving a cached copy of the points until the next change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Reverse geocoding and place-name provider outages no longer flood error reporting with handled timeouts, TLS connection failures, or invalid provider responses.
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
 
@@ -78,7 +79,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Family location history now actually shows up on Map v2: the history endpoint read coordinates from the legacy `latitude`/`longitude` columns, which are empty on instances that only store the PostGIS `lonlat` value, so nothing was drawn. Coordinates are now derived from `lonlat` (#2977)
-- Reverse geocoding and place-name provider outages no longer flood error reporting with handled timeouts, TLS connection failures, or invalid provider responses.
 - Declining the "Move the visit here?" prompt when picking a distant place for a Map v2 visit no longer renames the visit to that place.
 - Place visit detection no longer leaves an empty duplicate visit behind when a new point bridges two previously separate visits at the same place — they are now merged into one. The nightly re-scan also leaves confirmed visits untouched, so a new nearby point can no longer pull points out of a visit you already confirmed.
 - Re-evaluating anomalous points now refreshes the map immediately instead of occasionally serving a cached copy of the points until the next change.

--- a/app/services/places/name_fetcher.rb
+++ b/app/services/places/name_fetcher.rb
@@ -41,12 +41,16 @@ module Places
         place.visits.where(name: Place::DEFAULT_NAME).update_all(name: name) if name.present?
         place
       end
-    rescue Geocoder::Error, Geocoder::LookupTimeout => e
+    rescue *ReverseGeocoding::ProviderErrors::TRANSIENT => e
       Rails.logger.warn("Geocoding provider error in NameFetcher for place #{place.id}: #{e.message}")
       nil
     rescue StandardError => e
-      Rails.logger.error("Geocoding error in NameFetcher for place #{place.id}: #{e.message}")
-      ExceptionReporter.call(e)
+      if ReverseGeocoding::ProviderErrors.transient_tls?(e)
+        Rails.logger.warn("Geocoding provider error in NameFetcher for place #{place.id}: #{e.message}")
+      else
+        Rails.logger.error("Geocoding error in NameFetcher for place #{place.id}: #{e.message}")
+        ExceptionReporter.call(e)
+      end
       nil
     end
 

--- a/app/services/places/name_fetcher.rb
+++ b/app/services/places/name_fetcher.rb
@@ -41,6 +41,9 @@ module Places
         place.visits.where(name: Place::DEFAULT_NAME).update_all(name: name) if name.present?
         place
       end
+    rescue Geocoder::Error, Geocoder::LookupTimeout => e
+      Rails.logger.warn("Geocoding provider error in NameFetcher for place #{place.id}: #{e.message}")
+      nil
     rescue StandardError => e
       Rails.logger.error("Geocoding error in NameFetcher for place #{place.id}: #{e.message}")
       ExceptionReporter.call(e)

--- a/app/services/reverse_geocoding/points/fetch_data.rb
+++ b/app/services/reverse_geocoding/points/fetch_data.rb
@@ -45,6 +45,15 @@ class ReverseGeocoding::Points::FetchData
         reverse_geocoded_at: Time.current
       )
     end
+  rescue Geocoder::Error, Geocoder::LookupTimeout => e
+    Rails.logger.warn("Reverse geocoding provider error for point #{point.id}: #{e.message}")
+  rescue OpenSSL::SSL::SSLError => e
+    if e.message.include?('unexpected eof while reading')
+      Rails.logger.warn("Reverse geocoding provider error for point #{point.id}: #{e.message}")
+    else
+      Rails.logger.error("Reverse geocoding error for point #{point.id}: #{e.message}")
+      ExceptionReporter.call(e)
+    end
   rescue StandardError => e
     Rails.logger.error("Reverse geocoding error for point #{point.id}: #{e.message}")
     ExceptionReporter.call(e)

--- a/app/services/reverse_geocoding/points/fetch_data.rb
+++ b/app/services/reverse_geocoding/points/fetch_data.rb
@@ -48,7 +48,7 @@ class ReverseGeocoding::Points::FetchData
   rescue *ReverseGeocoding::ProviderErrors::TRANSIENT => e
     Rails.logger.warn("Reverse geocoding provider error for point #{point.id}: #{e.message}")
   rescue OpenSSL::SSL::SSLError => e
-    if e.message.include?('unexpected eof while reading')
+    if ReverseGeocoding::ProviderErrors.transient_tls?(e)
       Rails.logger.warn("Reverse geocoding provider error for point #{point.id}: #{e.message}")
     else
       Rails.logger.error("Reverse geocoding error for point #{point.id}: #{e.message}")

--- a/app/services/reverse_geocoding/points/fetch_data.rb
+++ b/app/services/reverse_geocoding/points/fetch_data.rb
@@ -45,7 +45,7 @@ class ReverseGeocoding::Points::FetchData
         reverse_geocoded_at: Time.current
       )
     end
-  rescue Geocoder::Error, Geocoder::LookupTimeout => e
+  rescue *ReverseGeocoding::ProviderErrors::TRANSIENT => e
     Rails.logger.warn("Reverse geocoding provider error for point #{point.id}: #{e.message}")
   rescue OpenSSL::SSL::SSLError => e
     if e.message.include?('unexpected eof while reading')

--- a/app/services/reverse_geocoding/provider_errors.rb
+++ b/app/services/reverse_geocoding/provider_errors.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module ReverseGeocoding
+  module ProviderErrors
+    TRANSIENT = [
+      Geocoder::LookupTimeout,
+      Geocoder::NetworkError,
+      Geocoder::ServiceUnavailable,
+      Geocoder::ResponseParseError
+    ].freeze
+
+    TRANSIENT_TLS_MESSAGE = 'unexpected eof while reading'
+
+    def self.transient_tls?(error)
+      error.is_a?(OpenSSL::SSL::SSLError) && error.message.include?(TRANSIENT_TLS_MESSAGE)
+    end
+  end
+end

--- a/app/services/visits/names/fetcher.rb
+++ b/app/services/visits/names/fetcher.rb
@@ -22,6 +22,10 @@ module Visits
         @geocoder_results ||= Geocoder.search(
           center, limit: 10, distance_sort: true, radius: 1, units: :km
         )
+      rescue Geocoder::Error, Geocoder::LookupTimeout => e
+        Rails.logger.warn("Geocoding provider error while fetching a visit name: #{e.message}")
+
+        []
       rescue StandardError => e
         ExceptionReporter.call(e)
 

--- a/app/services/visits/names/fetcher.rb
+++ b/app/services/visits/names/fetcher.rb
@@ -22,12 +22,16 @@ module Visits
         @geocoder_results ||= Geocoder.search(
           center, limit: 10, distance_sort: true, radius: 1, units: :km
         )
-      rescue Geocoder::Error, Geocoder::LookupTimeout => e
+      rescue *ReverseGeocoding::ProviderErrors::TRANSIENT => e
         Rails.logger.warn("Geocoding provider error while fetching a visit name: #{e.message}")
 
         []
       rescue StandardError => e
-        ExceptionReporter.call(e)
+        if ReverseGeocoding::ProviderErrors.transient_tls?(e)
+          Rails.logger.warn("Geocoding provider error while fetching a visit name: #{e.message}")
+        else
+          ExceptionReporter.call(e)
+        end
 
         []
       end

--- a/spec/services/places/name_fetcher_spec.rb
+++ b/spec/services/places/name_fetcher_spec.rb
@@ -141,6 +141,34 @@ RSpec.describe Places::NameFetcher do
       end
     end
 
+    context 'when the geocoder provider times out' do
+      before do
+        allow(ExceptionReporter).to receive(:call)
+        allow(Rails.logger).to receive(:warn)
+        allow(Geocoder).to receive(:search).and_raise(Geocoder::LookupTimeout.new('execution expired'))
+      end
+
+      it 'returns nil without reporting an application exception' do
+        expect(service.call).to be_nil
+        expect(ExceptionReporter).not_to have_received(:call)
+        expect(Rails.logger).to have_received(:warn).with(/Geocoding provider error in NameFetcher/)
+      end
+    end
+
+    context 'when geocoding fails unexpectedly' do
+      let(:error) { StandardError.new('unexpected failure') }
+
+      before do
+        allow(ExceptionReporter).to receive(:call)
+        allow(Geocoder).to receive(:search).and_raise(error)
+      end
+
+      it 'reports the application exception' do
+        expect(service.call).to be_nil
+        expect(ExceptionReporter).to have_received(:call).with(error)
+      end
+    end
+
     context 'when geocoding returns no results' do
       before do
         allow(Geocoder).to receive(:search).and_return([])

--- a/spec/services/reverse_geocoding/points/fetch_data_spec.rb
+++ b/spec/services/reverse_geocoding/points/fetch_data_spec.rb
@@ -169,4 +169,60 @@ RSpec.describe ReverseGeocoding::Points::FetchData do
       expect { fetch_data }.not_to(change { point.reload.city })
     end
   end
+
+  context 'when the geocoder provider is temporarily unavailable' do
+    before do
+      allow(ExceptionReporter).to receive(:call)
+      allow(Rails.logger).to receive(:warn)
+      allow(Geocoder).to receive(:search).and_raise(Geocoder::LookupTimeout.new('execution expired'))
+    end
+
+    it 'does not report a handled provider outage as an application exception' do
+      expect { fetch_data }.not_to raise_error
+      expect(ExceptionReporter).not_to have_received(:call)
+      expect(Rails.logger).to have_received(:warn).with(/Reverse geocoding provider error for point #{point.id}/)
+    end
+  end
+
+  context 'when the geocoder provider returns an invalid response' do
+    before do
+      allow(ExceptionReporter).to receive(:call)
+      allow(Rails.logger).to receive(:warn)
+      allow(Geocoder).to receive(:search).and_raise(Geocoder::ResponseParseError.new('bad gateway'))
+    end
+
+    it 'does not report a handled provider response as an application exception' do
+      expect { fetch_data }.not_to raise_error
+      expect(ExceptionReporter).not_to have_received(:call)
+      expect(Rails.logger).to have_received(:warn).with(/Reverse geocoding provider error for point #{point.id}/)
+    end
+  end
+
+  context 'when the geocoder provider closes the TLS connection unexpectedly' do
+    before do
+      allow(ExceptionReporter).to receive(:call)
+      allow(Rails.logger).to receive(:warn)
+      allow(Geocoder).to receive(:search).and_raise(OpenSSL::SSL::SSLError.new('unexpected eof while reading'))
+    end
+
+    it 'does not report a handled provider connection failure as an application exception' do
+      expect { fetch_data }.not_to raise_error
+      expect(ExceptionReporter).not_to have_received(:call)
+      expect(Rails.logger).to have_received(:warn).with(/Reverse geocoding provider error for point #{point.id}/)
+    end
+  end
+
+  context 'when the geocoder TLS failure is not transient' do
+    let(:error) { OpenSSL::SSL::SSLError.new('certificate verify failed') }
+
+    before do
+      allow(ExceptionReporter).to receive(:call)
+      allow(Geocoder).to receive(:search).and_raise(error)
+    end
+
+    it 'reports the application exception' do
+      expect { fetch_data }.not_to raise_error
+      expect(ExceptionReporter).to have_received(:call).with(error)
+    end
+  end
 end

--- a/spec/services/reverse_geocoding/points/fetch_data_spec.rb
+++ b/spec/services/reverse_geocoding/points/fetch_data_spec.rb
@@ -198,6 +198,18 @@ RSpec.describe ReverseGeocoding::Points::FetchData do
     end
   end
 
+  context 'when the geocoder is misconfigured rather than briefly unavailable' do
+    [Geocoder::InvalidApiKey, Geocoder::ConfigurationError, Geocoder::OverQueryLimitError].each do |error_class|
+      it "still reports #{error_class} so the outage is not silent" do
+        allow(ExceptionReporter).to receive(:call)
+        allow(Geocoder).to receive(:search).and_raise(error_class.new('misconfigured'))
+
+        expect { fetch_data }.not_to raise_error
+        expect(ExceptionReporter).to have_received(:call)
+      end
+    end
+  end
+
   context 'when the geocoder provider closes the TLS connection unexpectedly' do
     before do
       allow(ExceptionReporter).to receive(:call)

--- a/spec/services/visits/names/fetcher_spec.rb
+++ b/spec/services/visits/names/fetcher_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Visits::Names::Fetcher do
+  subject(:fetch_name) { described_class.new([10.0, 10.0]).call }
+
+  context 'when the geocoder provider times out' do
+    before do
+      allow(ExceptionReporter).to receive(:call)
+      allow(Rails.logger).to receive(:warn)
+      allow(Geocoder).to receive(:search).and_raise(Geocoder::LookupTimeout.new('execution expired'))
+    end
+
+    it 'returns no name without reporting an application exception' do
+      expect(fetch_name).to be_nil
+      expect(ExceptionReporter).not_to have_received(:call)
+      expect(Rails.logger).to have_received(:warn).with(/Geocoding provider error while fetching a visit name/)
+    end
+  end
+
+  context 'when name building fails unexpectedly' do
+    let(:error) { StandardError.new('unexpected failure') }
+
+    before do
+      allow(ExceptionReporter).to receive(:call)
+      allow(Geocoder).to receive(:search).and_raise(error)
+    end
+
+    it 'reports the application exception' do
+      expect(fetch_name).to be_nil
+      expect(ExceptionReporter).to have_received(:call).with(error)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Treat reverse-geocoding provider timeouts, transient TLS EOF failures, and invalid responses as handled provider failures
- Treat provider timeouts during visit/place name fetching as handled degraded results
- Preserve reporting for unexpected application errors and persistent TLS failures
- Add focused regressions for handled and unexpected provider-failure families

## Verification
- `asdf exec bundle exec rspec spec/services/reverse_geocoding/points/fetch_data_spec.rb spec/services/visits/names/fetcher_spec.rb spec/services/places/name_fetcher_spec.rb` — 44 examples, 0 failures
- `asdf exec bundle exec rubocop app/services/visits/names/fetcher.rb app/services/places/name_fetcher.rb spec/services/visits/names/fetcher_spec.rb spec/services/places/name_fetcher_spec.rb` — 4 files, no offenses
