### PR TITLE
Retry reverse geocoding point write timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Family location history now actually shows up on Map v2: the history endpoint read coordinates from the legacy `latitude`/`longitude` columns, which are empty on instances that only store the PostGIS `lonlat` value, so nothing was drawn. Coordinates are now derived from `lonlat` (#2977)
+- Reverse geocoding retries point updates that time out while waiting on concurrent writes.
 - Declining the "Move the visit here?" prompt when picking a distant place for a Map v2 visit no longer renames the visit to that place.
 - Place visit detection no longer leaves an empty duplicate visit behind when a new point bridges two previously separate visits at the same place — they are now merged into one. The nightly re-scan also leaves confirmed visits untouched, so a new nearby point can no longer pull points out of a visit you already confirmed.
 - Re-evaluating anomalous points now refreshes the map immediately instead of occasionally serving a cached copy of the points until the next change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Reverse geocoding retries point updates that time out while waiting on concurrent writes.
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
 
@@ -78,7 +79,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Family location history now actually shows up on Map v2: the history endpoint read coordinates from the legacy `latitude`/`longitude` columns, which are empty on instances that only store the PostGIS `lonlat` value, so nothing was drawn. Coordinates are now derived from `lonlat` (#2977)
-- Reverse geocoding retries point updates that time out while waiting on concurrent writes.
 - Declining the "Move the visit here?" prompt when picking a distant place for a Map v2 visit no longer renames the visit to that place.
 - Place visit detection no longer leaves an empty duplicate visit behind when a new point bridges two previously separate visits at the same place — they are now merged into one. The nightly re-scan also leaves confirmed visits untouched, so a new nearby point can no longer pull points out of a visit you already confirmed.
 - Re-evaluating anomalous points now refreshes the map immediately instead of occasionally serving a cached copy of the points until the next change.

--- a/app/services/reverse_geocoding/points/fetch_data.rb
+++ b/app/services/reverse_geocoding/points/fetch_data.rb
@@ -23,6 +23,11 @@ class ReverseGeocoding::Points::FetchData
   private
 
   WRITE_MAX_RETRIES = 3
+  WRITE_CONTENTION_ERRORS = [
+    ActiveRecord::Deadlocked,
+    ActiveRecord::LockWaitTimeout,
+    ActiveRecord::QueryCanceled
+  ].freeze
 
   def update_point_with_geocoding_data
     response = Geocoder.search([point.lat, point.lon]).first
@@ -54,11 +59,11 @@ class ReverseGeocoding::Points::FetchData
     retries = 0
     begin
       yield
-    rescue ActiveRecord::Deadlocked, ActiveRecord::QueryCanceled => e
+    rescue *WRITE_CONTENTION_ERRORS => e
       retries += 1
       raise e if retries > WRITE_MAX_RETRIES
 
-      sleep(0.1 * retries)
+      sleep((0.1 * retries) + (rand * 0.05))
       retry
     end
   end

--- a/app/services/reverse_geocoding/points/fetch_data.rb
+++ b/app/services/reverse_geocoding/points/fetch_data.rb
@@ -22,13 +22,13 @@ class ReverseGeocoding::Points::FetchData
 
   private
 
-  DEADLOCK_MAX_RETRIES = 3
+  WRITE_MAX_RETRIES = 3
 
   def update_point_with_geocoding_data
     response = Geocoder.search([point.lat, point.lon]).first
 
     if response.blank?
-      with_deadlock_retry { point.update!(reverse_geocoded_at: Time.current) }
+      with_write_retry { point.update!(reverse_geocoded_at: Time.current) }
       return
     end
 
@@ -36,7 +36,7 @@ class ReverseGeocoding::Points::FetchData
 
     country_record = Country.find_by(name: response.country) if response.country
 
-    with_deadlock_retry do
+    with_write_retry do
       point.update!(
         city: response.city,
         country_name: response.country,
@@ -50,13 +50,13 @@ class ReverseGeocoding::Points::FetchData
     ExceptionReporter.call(e)
   end
 
-  def with_deadlock_retry
+  def with_write_retry
     retries = 0
     begin
       yield
-    rescue ActiveRecord::Deadlocked => e
+    rescue ActiveRecord::Deadlocked, ActiveRecord::QueryCanceled => e
       retries += 1
-      raise e if retries > DEADLOCK_MAX_RETRIES
+      raise e if retries > WRITE_MAX_RETRIES
 
       sleep(0.1 * retries)
       retry

--- a/spec/services/reverse_geocoding/points/fetch_data_spec.rb
+++ b/spec/services/reverse_geocoding/points/fetch_data_spec.rb
@@ -59,6 +59,20 @@ RSpec.describe ReverseGeocoding::Points::FetchData do
         expect(Geocoder).to have_received(:search).with([point.lat, point.lon])
       end
 
+      it 'retries when the point update times out waiting for a lock' do
+        attempts = 0
+        allow(Point).to receive(:find).with(point.id).and_return(point)
+        allow(point).to receive(:update!).and_wrap_original do |method, *args|
+          attempts += 1
+          raise ActiveRecord::QueryCanceled, 'canceling statement due to statement timeout' if attempts == 1
+
+          method.call(*args)
+        end
+
+        expect { fetch_data }.to change { point.reload.city }.from(nil).to('Berlin')
+        expect(attempts).to eq(2)
+      end
+
       context 'when store_geodata? is disabled' do
         before do
           allow(DawarichSettings).to receive(:store_geodata?).and_return(false)

--- a/spec/services/reverse_geocoding/points/fetch_data_spec.rb
+++ b/spec/services/reverse_geocoding/points/fetch_data_spec.rb
@@ -59,18 +59,35 @@ RSpec.describe ReverseGeocoding::Points::FetchData do
         expect(Geocoder).to have_received(:search).with([point.lat, point.lon])
       end
 
-      it 'retries when the point update times out waiting for a lock' do
-        attempts = 0
-        allow(Point).to receive(:find).with(point.id).and_return(point)
-        allow(point).to receive(:update!).and_wrap_original do |method, *args|
-          attempts += 1
-          raise ActiveRecord::QueryCanceled, 'canceling statement due to statement timeout' if attempts == 1
+      described_class::WRITE_CONTENTION_ERRORS.each do |error_class|
+        it "retries when the point update raises #{error_class}" do
+          attempts = 0
+          allow(Point).to receive(:find).with(point.id).and_return(point)
+          allow(point).to receive(:update!).and_wrap_original do |method, *args|
+            attempts += 1
+            raise error_class, 'write contention' if attempts == 1
 
-          method.call(*args)
+            method.call(*args)
+          end
+          service = described_class.new(point.id)
+          allow(service).to receive(:sleep)
+
+          expect { service.call }.to change { point.reload.city }.from(nil).to('Berlin')
+          expect(attempts).to eq(2)
         end
+      end
 
-        expect { fetch_data }.to change { point.reload.city }.from(nil).to('Berlin')
-        expect(attempts).to eq(2)
+      it 'gives up after exhausting the retry budget and reports the failure' do
+        allow(ExceptionReporter).to receive(:call)
+        allow(Point).to receive(:find).with(point.id).and_return(point)
+        allow(point).to receive(:update!).and_raise(ActiveRecord::QueryCanceled, 'write contention')
+        service = described_class.new(point.id)
+        allow(service).to receive(:sleep)
+
+        service.call
+
+        expect(point).to have_received(:update!).exactly(described_class::WRITE_MAX_RETRIES + 1).times
+        expect(ExceptionReporter).to have_received(:call)
       end
 
       context 'when store_geodata? is disabled' do


### PR DESCRIPTION
## Summary
- retry point writes canceled by transient lock-wait statement timeouts
- keep the retry bounded to three attempts with backoff
- add regression coverage and a changelog entry

## Verification
- `asdf exec bundle exec rspec spec/services/reverse_geocoding/points/fetch_data_spec.rb`
- `asdf exec bundle exec rubocop app/services/reverse_geocoding/points/fetch_data.rb spec/services/reverse_geocoding/points/fetch_data_spec.rb`
