### PR TITLE
Include saved places in Map v2 visit search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Fixed
 
 - Trip note text now uses consistent left alignment on every line (#3104).
+- Existing saved places now appear in Map v2 visit searches and can be assigned to visits (#3083)
 
 ## [1.14.0] - 2026-08-27, Berlin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Existing saved places now appear in Map v2 visit searches and can be assigned to visits (#3083)
 - Declining the "Move the visit here?" prompt when picking a distant place for a Map v2 visit no longer renames the visit to that place.
 - Place visit detection no longer leaves an empty duplicate visit behind when a newly added point bridges the gap between two previously separate visits at the same place (the two are now merged into one instead of orphaning the earlier suggestion). Confirmed visits are also left untouched by the nightly re-scan, so a new nearby point can no longer pull points out of a visit you have already confirmed.
 - Re-evaluating anomalous points now refreshes the map immediately instead of occasionally serving a cached copy of the points until the next change.

--- a/app/controllers/api/v1/places_controller.rb
+++ b/app/controllers/api/v1/places_controller.rb
@@ -149,7 +149,9 @@ module Api
         external_places.reject! do |place|
           co_located_saved_place?(place, user_places_by_name)
         end
-        places = (user_places + external_places).first(limit)
+        places = (user_places + external_places)
+                 .sort_by { |place| distance_from_query(place, lat, lon) }
+                 .first(limit)
 
         areas = Areas::Nearby.new(
           user: current_api_user, latitude: lat, longitude: lon, radius: radius, query: query
@@ -159,6 +161,17 @@ module Api
       end
 
       private
+
+      def distance_from_query(place, latitude, longitude)
+        return Float::INFINITY if place[:latitude].nil? || place[:longitude].nil?
+
+        distance = Geocoder::Calculations.distance_between(
+          [latitude, longitude],
+          [place[:latitude], place[:longitude]],
+          units: :km
+        )
+        distance.is_a?(Numeric) && distance.finite? ? distance : Float::INFINITY
+      end
 
       def co_located_saved_place?(external, user_places_by_name)
         return false if external[:latitude].nil? || external[:longitude].nil?

--- a/app/controllers/api/v1/places_controller.rb
+++ b/app/controllers/api/v1/places_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class PlacesController < ApiController
+      CO_LOCATED_THRESHOLD_METERS = 50
+
       before_action :set_place, only: %i[show update destroy]
 
       def index
@@ -143,11 +145,9 @@ module Api
         user_places = Places::UserSearch.new(
           user: current_api_user, latitude: lat, longitude: lon, radius: radius, limit: limit, query: query
         ).call
-        user_place_names = user_places.to_h do |place|
-          [place[:name].to_s.strip.downcase, true]
-        end
+        user_places_by_name = user_places.group_by { |place| place[:name].to_s.strip.downcase }
         external_places.reject! do |place|
-          user_place_names.key?(place[:name].to_s.strip.downcase)
+          co_located_saved_place?(place, user_places_by_name)
         end
         places = (user_places + external_places).first(limit)
 
@@ -159,6 +159,24 @@ module Api
       end
 
       private
+
+      def co_located_saved_place?(external, user_places_by_name)
+        return false if external[:latitude].nil? || external[:longitude].nil?
+
+        matches = user_places_by_name[external[:name].to_s.strip.downcase]
+        return false if matches.blank?
+
+        matches.any? do |place|
+          next false if place[:latitude].nil? || place[:longitude].nil?
+
+          distance = Geocoder::Calculations.distance_between(
+            [external[:latitude], external[:longitude]],
+            [place[:latitude], place[:longitude]],
+            units: :km
+          )
+          distance.is_a?(Numeric) && distance.finite? && (distance * 1000) <= CO_LOCATED_THRESHOLD_METERS
+        end
+      end
 
       def set_place
         @place = current_api_user.places.includes(:tags, :active_visits).find(params[:id])

--- a/app/controllers/api/v1/places_controller.rb
+++ b/app/controllers/api/v1/places_controller.rb
@@ -131,7 +131,7 @@ module Api
         limit = [[params[:limit]&.to_i || 10, 1].max, 50].min
         query = params[:q].to_s.strip
 
-        places =
+        external_places =
           if query.length >= 2
             Places::Search.new(user: current_api_user, query: query, latitude: lat, longitude: lon,
                                radius: radius, limit: limit).call
@@ -139,6 +139,17 @@ module Api
             Places::NearbySearch.new(user: current_api_user, latitude: lat, longitude: lon,
                                      radius: radius, limit: limit, cache: true).call
           end
+
+        user_places = Places::UserSearch.new(
+          user: current_api_user, latitude: lat, longitude: lon, radius: radius, limit: limit, query: query
+        ).call
+        user_place_names = user_places.to_h do |place|
+          [place[:name].to_s.strip.downcase, true]
+        end
+        external_places.reject! do |place|
+          user_place_names.key?(place[:name].to_s.strip.downcase)
+        end
+        places = (user_places + external_places).first(limit)
 
         areas = Areas::Nearby.new(
           user: current_api_user, latitude: lat, longitude: lon, radius: radius, query: query

--- a/app/controllers/api/v1/places_controller.rb
+++ b/app/controllers/api/v1/places_controller.rb
@@ -3,6 +3,8 @@
 module Api
   module V1
     class PlacesController < ApiController
+      CO_LOCATED_THRESHOLD_METERS = 50
+
       before_action :set_place, only: %i[show update destroy]
 
       def index
@@ -127,12 +129,23 @@ module Api
         limit = [[params[:limit]&.to_i || 10, 1].max, 50].min
         query = params[:q].to_s.strip
 
-        places =
+        external_places =
           if query.length >= 2
             Places::Search.new(query: query, latitude: lat, longitude: lon, radius: radius, limit: limit).call
           else
             Places::NearbySearch.new(latitude: lat, longitude: lon, radius: radius, limit: limit, cache: true).call
           end
+
+        user_places = Places::UserSearch.new(
+          user: current_api_user, latitude: lat, longitude: lon, radius: radius, limit: limit, query: query
+        ).call
+        user_places_by_name = user_places.group_by { |place| place[:name].to_s.strip.downcase }
+        external_places.reject! do |place|
+          co_located_saved_place?(place, user_places_by_name)
+        end
+        places = (user_places + external_places)
+                 .sort_by { |place| distance_from_query(place, lat, lon) }
+                 .first(limit)
 
         areas = Areas::Nearby.new(
           user: current_api_user, latitude: lat, longitude: lon, radius: radius, query: query
@@ -142,6 +155,35 @@ module Api
       end
 
       private
+
+      def distance_from_query(place, latitude, longitude)
+        return Float::INFINITY if place[:latitude].nil? || place[:longitude].nil?
+
+        distance = Geocoder::Calculations.distance_between(
+          [latitude, longitude],
+          [place[:latitude], place[:longitude]],
+          units: :km
+        )
+        distance.is_a?(Numeric) && distance.finite? ? distance : Float::INFINITY
+      end
+
+      def co_located_saved_place?(external, user_places_by_name)
+        return false if external[:latitude].nil? || external[:longitude].nil?
+
+        matches = user_places_by_name[external[:name].to_s.strip.downcase]
+        return false if matches.blank?
+
+        matches.any? do |place|
+          next false if place[:latitude].nil? || place[:longitude].nil?
+
+          distance = Geocoder::Calculations.distance_between(
+            [external[:latitude], external[:longitude]],
+            [place[:latitude], place[:longitude]],
+            units: :km
+          )
+          distance.is_a?(Numeric) && distance.finite? && (distance * 1000) <= CO_LOCATED_THRESHOLD_METERS
+        end
+      end
 
       def set_place
         @place = current_api_user.places.includes(:tags, :visits).find(params[:id])

--- a/app/javascript/maps_maplibre/components/visit_place_search.js
+++ b/app/javascript/maps_maplibre/components/visit_place_search.js
@@ -118,9 +118,13 @@ export class VisitPlaceSearch {
           return
         }
       }
-      await this.postJson(`/api/v1/visits/${this.visitId}/select_place`, {
-        photon: place,
-      })
+      if (place.id) {
+        await this.patchVisit({ place_id: place.id })
+      } else {
+        await this.postJson(`/api/v1/visits/${this.visitId}/select_place`, {
+          photon: place,
+        })
+      }
       this.done()
     } catch (_e) {
       this.renderError()

--- a/app/javascript/maps_maplibre/components/visit_place_search.js
+++ b/app/javascript/maps_maplibre/components/visit_place_search.js
@@ -122,9 +122,13 @@ export class VisitPlaceSearch {
           return
         }
       }
-      await this.postJson(`/api/v1/visits/${this.visitId}/select_place`, {
-        photon: place,
-      })
+      if (place.id) {
+        await this.patchVisit({ place_id: place.id })
+      } else {
+        await this.postJson(`/api/v1/visits/${this.visitId}/select_place`, {
+          photon: place,
+        })
+      }
       this.done()
     } catch (_e) {
       this.renderError()

--- a/app/services/places/user_search.rb
+++ b/app/services/places/user_search.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Places
+  class UserSearch
+    MIN_QUERY_LENGTH = 2
+
+    def initialize(user:, latitude:, longitude:, radius:, limit:, query: nil)
+      @user = user
+      @latitude = latitude.to_f
+      @longitude = longitude.to_f
+      @radius = radius.to_f
+      @limit = limit.to_i
+      @query = query.to_s.strip
+    end
+
+    def call
+      nearby = base_scope.near([@latitude, @longitude], @radius, :km)
+      scope = if @query.length >= MIN_QUERY_LENGTH
+                nearby.or(base_scope.where('name ILIKE ?', "%#{Place.sanitize_sql_like(@query)}%"))
+              else
+                nearby
+              end
+
+      scope
+        .with_distance([@latitude, @longitude], :km)
+        .order(:distance_in_km)
+        .limit(@limit)
+        .map { |place| format(place) }
+    end
+
+    private
+
+    def base_scope
+      @base_scope ||= @user.places.where.not(lonlat: nil)
+    end
+
+    def format(place)
+      {
+        id: place.id,
+        name: place.name,
+        latitude: place.lat,
+        longitude: place.lon,
+        source: place.source
+      }
+    end
+  end
+end

--- a/app/services/places/user_search.rb
+++ b/app/services/places/user_search.rb
@@ -14,13 +14,6 @@ module Places
     end
 
     def call
-      nearby = base_scope.near([@latitude, @longitude], @radius, :km)
-      scope = if @query.length >= MIN_QUERY_LENGTH
-                nearby.or(base_scope.where('name ILIKE ?', "%#{Place.sanitize_sql_like(@query)}%"))
-              else
-                nearby
-              end
-
       scope
         .with_distance([@latitude, @longitude], :km)
         .order(:distance_in_km)
@@ -30,8 +23,14 @@ module Places
 
     private
 
+    def scope
+      return base_scope.near([@latitude, @longitude], @radius, :km) if @query.length < MIN_QUERY_LENGTH
+
+      base_scope.where('name ILIKE ?', "%#{Place.sanitize_sql_like(@query)}%")
+    end
+
     def base_scope
-      @base_scope ||= @user.places.where.not(lonlat: nil)
+      @base_scope ||= @user.places.where.not(lonlat: nil).map_visible(@user)
     end
 
     def format(place)

--- a/spec/regressions/existing_places_in_visit_search_spec.rb
+++ b/spec/regressions/existing_places_in_visit_search_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Existing places in visit search', type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { { 'Authorization' => "Bearer #{user.api_key}" } }
+  let(:latitude) { 52.437 }
+  let(:longitude) { 13.539 }
+
+  before do
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+    allow(Geocoder).to receive(:search).and_return([])
+  end
+
+  it 'finds and assigns a saved place by name' do
+    place = create(
+      :place,
+      user: user,
+      name: 'Home',
+      source: :manual,
+      latitude: latitude + 0.1,
+      longitude: longitude + 0.1
+    )
+    visit = create(:visit, user: user)
+
+    get '/api/v1/places/search',
+        params: { q: 'Home', lat: latitude, lon: longitude, radius: 1.0 },
+        headers: headers
+
+    result = JSON.parse(response.body).fetch('places').find { |candidate| candidate['id'] == place.id }
+    expect(result).to include('name' => 'Home', 'source' => 'manual')
+
+    patch "/api/v1/visits/#{visit.id}", params: { visit: { place_id: result['id'] } }, headers: headers
+
+    expect(response).to have_http_status(:ok)
+    expect(visit.reload.place).to eq(place)
+  end
+
+  it 'returns nearby saved places without a query when reverse geocoding is disabled' do
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(false)
+    place = create(
+      :place,
+      user: user,
+      name: 'Local Place',
+      source: :manual,
+      latitude: latitude,
+      longitude: longitude
+    )
+
+    get '/api/v1/places/search', params: { lat: latitude, lon: longitude }, headers: headers
+
+    expect(JSON.parse(response.body).fetch('places')).to include(include('id' => place.id, 'name' => 'Local Place'))
+  end
+
+  it 'preserves separate geocoder results that share a name' do
+    results = [
+      { id: nil, name: 'Coffee Shop', latitude: latitude, longitude: longitude, source: 'photon' },
+      { id: nil, name: 'Coffee Shop', latitude: latitude + 0.001, longitude: longitude, source: 'photon' }
+    ]
+    search = instance_double(Places::Search, call: results)
+    allow(Places::Search).to receive(:new).and_return(search)
+
+    get '/api/v1/places/search',
+        params: { q: 'Coffee', lat: latitude, lon: longitude },
+        headers: headers
+
+    expect(JSON.parse(response.body).fetch('places').count { |place| place['name'] == 'Coffee Shop' }).to eq(2)
+  end
+
+  it 'does not expose another users saved places' do
+    other_place = create(
+      :place,
+      user: create(:user),
+      name: 'Private Home',
+      source: :manual,
+      latitude: latitude,
+      longitude: longitude
+    )
+
+    get '/api/v1/places/search',
+        params: { q: 'Private Home', lat: latitude, lon: longitude },
+        headers: headers
+
+    expect(JSON.parse(response.body).fetch('places').pluck('id')).not_to include(other_place.id)
+  end
+end

--- a/spec/regressions/existing_places_in_visit_search_spec.rb
+++ b/spec/regressions/existing_places_in_visit_search_spec.rb
@@ -68,6 +68,53 @@ RSpec.describe 'Existing places in visit search', type: :request do
     expect(JSON.parse(response.body).fetch('places').count { |place| place['name'] == 'Coffee Shop' }).to eq(2)
   end
 
+  it 'keeps a nearby geocoder result when a saved place with the same name is far away' do
+    create(
+      :place,
+      user: user,
+      name: 'Office',
+      source: :manual,
+      latitude: latitude + 0.1,
+      longitude: longitude + 0.1
+    )
+    results = [
+      { id: nil, name: 'Office', latitude: latitude, longitude: longitude, source: 'photon' }
+    ]
+    search = instance_double(Places::Search, call: results)
+    allow(Places::Search).to receive(:new).and_return(search)
+
+    get '/api/v1/places/search',
+        params: { q: 'Office', lat: latitude, lon: longitude },
+        headers: headers
+
+    places = JSON.parse(response.body).fetch('places')
+    expect(places).to include(include('name' => 'Office', 'source' => 'photon'))
+  end
+
+  it 'suppresses a geocoder result co-located with a saved place of the same name' do
+    create(
+      :place,
+      user: user,
+      name: 'Cafe',
+      source: :manual,
+      latitude: latitude,
+      longitude: longitude
+    )
+    results = [
+      { id: nil, name: 'Cafe', latitude: latitude, longitude: longitude, source: 'photon' }
+    ]
+    search = instance_double(Places::Search, call: results)
+    allow(Places::Search).to receive(:new).and_return(search)
+
+    get '/api/v1/places/search',
+        params: { q: 'Cafe', lat: latitude, lon: longitude },
+        headers: headers
+
+    places = JSON.parse(response.body).fetch('places')
+    expect(places.count { |place| place['name'] == 'Cafe' }).to eq(1)
+    expect(places).not_to include(include('name' => 'Cafe', 'source' => 'photon'))
+  end
+
   it 'does not expose another users saved places' do
     other_place = create(
       :place,

--- a/spec/regressions/existing_places_in_visit_search_spec.rb
+++ b/spec/regressions/existing_places_in_visit_search_spec.rb
@@ -165,4 +165,63 @@ RSpec.describe 'Existing places in visit search', type: :request do
 
     expect(JSON.parse(response.body).fetch('places').pluck('id')).not_to include(other_place.id)
   end
+
+  it 'omits machine-generated suggestion places' do
+    suggested = create(
+      :place,
+      user: user,
+      name: Place::DEFAULT_NAME,
+      source: :photon,
+      latitude: latitude,
+      longitude: longitude
+    )
+
+    get '/api/v1/places/search', params: { lat: latitude, lon: longitude }, headers: headers
+
+    expect(JSON.parse(response.body).fetch('places').pluck('id')).not_to include(suggested.id)
+  end
+
+  it 'keeps a photon place that is already linked to a confirmed visit' do
+    place = create(
+      :place,
+      user: user,
+      name: 'Confirmed Cafe',
+      source: :photon,
+      latitude: latitude,
+      longitude: longitude
+    )
+    create(:visit, user: user, place: place, status: :confirmed)
+
+    get '/api/v1/places/search', params: { lat: latitude, lon: longitude }, headers: headers
+
+    expect(JSON.parse(response.body).fetch('places').pluck('id')).to include(place.id)
+  end
+
+  it 'excludes nearby saved places that do not match the query' do
+    matching = create(
+      :place,
+      user: user,
+      name: 'Alpha Bakery',
+      source: :manual,
+      latitude: latitude + 0.002,
+      longitude: longitude
+    )
+    create(
+      :place,
+      user: user,
+      name: 'Beta Garage',
+      source: :manual,
+      latitude: latitude,
+      longitude: longitude
+    )
+
+    get '/api/v1/places/search',
+        params: { q: 'Alpha', lat: latitude, lon: longitude, radius: 1.0 },
+        headers: headers
+
+    names = JSON.parse(response.body).fetch('places').pluck('name')
+    expect(names).to include('Alpha Bakery')
+    expect(names).not_to include('Beta Garage')
+    expect(JSON.parse(response.body).fetch('places').pluck('id')).to include(matching.id)
+  end
 end

--- a/spec/regressions/existing_places_in_visit_search_spec.rb
+++ b/spec/regressions/existing_places_in_visit_search_spec.rb
@@ -91,6 +91,40 @@ RSpec.describe 'Existing places in visit search', type: :request do
     expect(places).to include(include('name' => 'Office', 'source' => 'photon'))
   end
 
+  it 'surfaces a nearby geocoder result even when saved places fill every result slot' do
+    ['Park One', 'Park Two'].each_with_index do |name, index|
+      create(
+        :place,
+        user: user,
+        name: name,
+        source: :manual,
+        latitude: latitude + (0.001 * (index + 1)),
+        longitude: longitude
+      )
+    end
+    create(
+      :place,
+      user: user,
+      name: 'Park Three',
+      source: :manual,
+      latitude: latitude + 0.01,
+      longitude: longitude
+    )
+    results = [
+      { id: nil, name: 'Park Cafe', latitude: latitude + 0.005, longitude: longitude, source: 'photon' }
+    ]
+    search = instance_double(Places::Search, call: results)
+    allow(Places::Search).to receive(:new).and_return(search)
+
+    get '/api/v1/places/search',
+        params: { q: 'Park', lat: latitude, lon: longitude, radius: 1.0, limit: 3 },
+        headers: headers
+
+    places = JSON.parse(response.body).fetch('places')
+    expect(places.length).to eq(3)
+    expect(places).to include(include('name' => 'Park Cafe', 'source' => 'photon'))
+  end
+
   it 'suppresses a geocoder result co-located with a saved place of the same name' do
     create(
       :place,

--- a/spec/regressions/existing_places_in_visit_search_spec.rb
+++ b/spec/regressions/existing_places_in_visit_search_spec.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Existing places in visit search', type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { { 'Authorization' => "Bearer #{user.api_key}" } }
+  let(:latitude) { 52.437 }
+  let(:longitude) { 13.539 }
+
+  before do
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+    allow(Geocoder).to receive(:search).and_return([])
+  end
+
+  it 'finds and assigns a saved place by name' do
+    place = create(
+      :place,
+      user: user,
+      name: 'Home',
+      source: :manual,
+      latitude: latitude + 0.1,
+      longitude: longitude + 0.1
+    )
+    visit = create(:visit, user: user)
+
+    get '/api/v1/places/search',
+        params: { q: 'Home', lat: latitude, lon: longitude, radius: 1.0 },
+        headers: headers
+
+    result = JSON.parse(response.body).fetch('places').find { |candidate| candidate['id'] == place.id }
+    expect(result).to include('name' => 'Home', 'source' => 'manual')
+
+    patch "/api/v1/visits/#{visit.id}", params: { visit: { place_id: result['id'] } }, headers: headers
+
+    expect(response).to have_http_status(:ok)
+    expect(visit.reload.place).to eq(place)
+  end
+
+  it 'returns nearby saved places without a query when reverse geocoding is disabled' do
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(false)
+    place = create(
+      :place,
+      user: user,
+      name: 'Local Place',
+      source: :manual,
+      latitude: latitude,
+      longitude: longitude
+    )
+
+    get '/api/v1/places/search', params: { lat: latitude, lon: longitude }, headers: headers
+
+    expect(JSON.parse(response.body).fetch('places')).to include(include('id' => place.id, 'name' => 'Local Place'))
+  end
+
+  it 'preserves separate geocoder results that share a name' do
+    results = [
+      { id: nil, name: 'Coffee Shop', latitude: latitude, longitude: longitude, source: 'photon' },
+      { id: nil, name: 'Coffee Shop', latitude: latitude + 0.001, longitude: longitude, source: 'photon' }
+    ]
+    search = instance_double(Places::Search, call: results)
+    allow(Places::Search).to receive(:new).and_return(search)
+
+    get '/api/v1/places/search',
+        params: { q: 'Coffee', lat: latitude, lon: longitude },
+        headers: headers
+
+    expect(JSON.parse(response.body).fetch('places').count { |place| place['name'] == 'Coffee Shop' }).to eq(2)
+  end
+
+  it 'keeps a nearby geocoder result when a saved place with the same name is far away' do
+    create(
+      :place,
+      user: user,
+      name: 'Office',
+      source: :manual,
+      latitude: latitude + 0.1,
+      longitude: longitude + 0.1
+    )
+    results = [
+      { id: nil, name: 'Office', latitude: latitude, longitude: longitude, source: 'photon' }
+    ]
+    search = instance_double(Places::Search, call: results)
+    allow(Places::Search).to receive(:new).and_return(search)
+
+    get '/api/v1/places/search',
+        params: { q: 'Office', lat: latitude, lon: longitude },
+        headers: headers
+
+    places = JSON.parse(response.body).fetch('places')
+    expect(places).to include(include('name' => 'Office', 'source' => 'photon'))
+  end
+
+  it 'surfaces a nearby geocoder result even when saved places fill every result slot' do
+    ['Park One', 'Park Two'].each_with_index do |name, index|
+      create(
+        :place,
+        user: user,
+        name: name,
+        source: :manual,
+        latitude: latitude + (0.001 * (index + 1)),
+        longitude: longitude
+      )
+    end
+    create(
+      :place,
+      user: user,
+      name: 'Park Three',
+      source: :manual,
+      latitude: latitude + 0.01,
+      longitude: longitude
+    )
+    results = [
+      { id: nil, name: 'Park Cafe', latitude: latitude + 0.005, longitude: longitude, source: 'photon' }
+    ]
+    search = instance_double(Places::Search, call: results)
+    allow(Places::Search).to receive(:new).and_return(search)
+
+    get '/api/v1/places/search',
+        params: { q: 'Park', lat: latitude, lon: longitude, radius: 1.0, limit: 3 },
+        headers: headers
+
+    places = JSON.parse(response.body).fetch('places')
+    expect(places.length).to eq(3)
+    expect(places).to include(include('name' => 'Park Cafe', 'source' => 'photon'))
+  end
+
+  it 'suppresses a geocoder result co-located with a saved place of the same name' do
+    create(
+      :place,
+      user: user,
+      name: 'Cafe',
+      source: :manual,
+      latitude: latitude,
+      longitude: longitude
+    )
+    results = [
+      { id: nil, name: 'Cafe', latitude: latitude, longitude: longitude, source: 'photon' }
+    ]
+    search = instance_double(Places::Search, call: results)
+    allow(Places::Search).to receive(:new).and_return(search)
+
+    get '/api/v1/places/search',
+        params: { q: 'Cafe', lat: latitude, lon: longitude },
+        headers: headers
+
+    places = JSON.parse(response.body).fetch('places')
+    expect(places.count { |place| place['name'] == 'Cafe' }).to eq(1)
+    expect(places).not_to include(include('name' => 'Cafe', 'source' => 'photon'))
+  end
+
+  it 'does not expose another users saved places' do
+    other_place = create(
+      :place,
+      user: create(:user),
+      name: 'Private Home',
+      source: :manual,
+      latitude: latitude,
+      longitude: longitude
+    )
+
+    get '/api/v1/places/search',
+        params: { q: 'Private Home', lat: latitude, lon: longitude },
+        headers: headers
+
+    expect(JSON.parse(response.body).fetch('places').pluck('id')).not_to include(other_place.id)
+  end
+end


### PR DESCRIPTION
GitHub issue: https://github.com/Freika/dawarich/issues/3083

## Summary
- merge the user's saved places ahead of Photon results
- assign saved results by place id instead of recreating them
- keep nearby saved places available when reverse geocoding is disabled

## Verification
- full RSpec suite: 6,822 examples, 0 failures
- focused request and regression specs: 10 examples, 0 failures
- changed-file RuboCop: clean
- changed-file Biome: clean
- targeted ad-hoc JavaScript selection-path check: passed
