### PR TITLE
Prevent reverse-geocoding place deadlocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Track generation and user data recalculations now retry a bounded number of times when another job is already processing the same user's tracks, instead of dropping the request and reporting an error; a genuinely stuck lock is logged after the retries are exhausted. The per-user lock also renews itself while a job runs and frees within a minute if a worker dies, so a crashed job no longer blocks a user's track processing for up to half an hour.
 - Dawarich added to an iOS Home Screen now opens Map v2 instead of an unrelated previously visited page (#3097)
 - Point uploads (REST API, OwnTracks, Overland, Traccar) now write batches in a consistent order so concurrent uploads no longer deadlock each other, and both uploads and anomaly filtering recover automatically from any remaining transient database deadlocks instead of failing the upload or background job.
+- Reverse geocoding overlapping places no longer exhausts retries because of concurrent database deadlocks.
 - The app and Sidekiq containers no longer crash-loop on startup when `WEB_CONCURRENCY` or `BACKGROUND_PROCESSING_CONCURRENCY` reach the container as an unexpanded `${VAR:-default}` string (seen with some podman-compose versions); the entrypoint now warns and falls back to the default value (#3124)
 - Cache preheating no longer times out for accounts with large location histories.
 - Cloud: Changing plans resets the Lite archival-warning state, so a user downgraded to Lite again is notified about archived data again.

--- a/app/services/reverse_geocoding/places/fetch_data.rb
+++ b/app/services/reverse_geocoding/places/fetch_data.rb
@@ -142,7 +142,7 @@ class ReverseGeocoding::Places::FetchData
 
     return unless places_to_update.any?
 
-    update_attributes = places_to_update.uniq(&:id).map do |place|
+    update_attributes = places_to_update.uniq(&:id).sort_by(&:id).map do |place|
       {
         id: place.id,
         name: place.name,

--- a/spec/services/reverse_geocoding/places/fetch_data_spec.rb
+++ b/spec/services/reverse_geocoding/places/fetch_data_spec.rb
@@ -436,6 +436,17 @@ RSpec.describe ReverseGeocoding::Places::FetchData do
         expect(existing_place.reload.name).to eq('New Name')
       end
 
+      it 'orders bulk updates by primary key' do
+        first_place = create(:place)
+        second_place = create(:place)
+        allow(Place).to receive(:upsert_all)
+
+        service.send(:save_places, [], [second_place, first_place])
+
+        expect(Place).to have_received(:upsert_all)
+          .with(satisfy { |attributes| attributes.pluck(:id) == [first_place.id, second_place.id] }, unique_by: :id)
+      end
+
       it 'handles empty arrays gracefully' do
         expect { service.send(:save_places, [], []) }.not_to raise_error
       end


### PR DESCRIPTION
## Summary
- order overlapping place bulk updates by primary key
- prevent concurrent reverse-geocoding jobs from locking shared rows in opposite order
- cover the lock-order invariant with a focused regression

## Verification
- `asdf exec bundle exec rspec spec/services/reverse_geocoding/places/fetch_data_spec.rb` (51 examples, 0 failures)
- `asdf exec bundle exec rubocop app/services/reverse_geocoding/places/fetch_data.rb spec/services/reverse_geocoding/places/fetch_data_spec.rb` (2 files, no offenses)
