### PR TITLE
Tolerate null timestamps in the Null Island cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
-- Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0), tolerates legacy points without timestamps, and recalculates affected stats and tracks.
 
 ## [1.10.1] - 2026-07-19, Berlin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
+- Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0), tolerates legacy points without timestamps, and recalculates affected stats and tracks.
 
 ## [1.10.1] - 2026-07-19, Berlin
 

--- a/app/jobs/data_migrations/cleanup_null_island_job.rb
+++ b/app/jobs/data_migrations/cleanup_null_island_job.rb
@@ -10,7 +10,9 @@ class DataMigrations::CleanupNullIslandJob < ApplicationJob
 
     rows = user.points.null_island.pluck(:id, :timestamp, :track_id)
     track_ids = rows.filter_map(&:last).uniq
-    affected_months = rows.map do |_, timestamp, _|
+    affected_months = rows.filter_map do |_, timestamp, _|
+      next if timestamp.nil?
+
       time = Time.zone.at(timestamp)
       [time.year, time.month]
     end.uniq

--- a/spec/jobs/data_migrations/cleanup_null_island_job_spec.rb
+++ b/spec/jobs/data_migrations/cleanup_null_island_job_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe DataMigrations::CleanupNullIslandJob do
       .and have_enqueued_job(Tracks::RecalculateJob).with(track.id)
   end
 
+  it 'flags legacy points without timestamps and recalculates their tracks' do
+    zero_point.update_column(:timestamp, nil)
+
+    expect { described_class.perform_now(user.id) }.not_to raise_error
+
+    expect(Tracks::RecalculateJob).to have_been_enqueued.with(track.id)
+    expect(Stats::CalculatingJob).not_to have_been_enqueued
+    expect(zero_point.reload.anomaly).to be(true)
+  end
+
   describe 'fan out' do
     it 'enqueues a per-user job for every user with (0,0) points' do
       other_user = create(:user)


### PR DESCRIPTION
## Summary
- tolerate legacy Null Island points whose `timestamp` is null so the one-time cleanup job stops crashing part-way through

## Context
The ingestion guards and the cleanup job itself already shipped. This change is only the follow-up fix for legacy rows with a null timestamp, which aborted the cleanup before it finished flagging a user's points.

## Verification
- `rspec spec/jobs/data_migrations/cleanup_null_island_job_spec.rb`
- RuboCop on changed files — no offenses

## Known follow-up (not in this PR)
`Calculateable#path_coordinates` does not filter `anomaly IS NOT TRUE`, so a recalculated track can still include a flagged (0,0) point. That gap predates this change and affects the already-merged cleanup path too; tracked separately.
