### PR TITLE
Stop the legacy lat/lon column drop from crash-looping startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Upgrading to 1.10.1 no longer crash-loops on instances with heavy write traffic. Dropping the legacy `points.latitude`/`points.longitude` columns needs an exclusive lock that busy instances could not win in one attempt, which aborted the migration and restarted the container in a loop. The drop is now retried, and if it still cannot get the lock it is handed to a background job so startup completes (#3176)
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Upgrading to 1.10.1 no longer crash-loops on instances with heavy write traffic. Dropping the legacy `points.latitude`/`points.longitude` columns needs an exclusive lock that busy instances could not win in one attempt, which aborted the migration and restarted the container in a loop. The drop is now retried, and if it still cannot get the lock it is handed to a background job so startup completes (#3176)
+- Instances with heavy write traffic no longer crash-loop on the 1.10.1 upgrade. Dropping the legacy `points.latitude`/`points.longitude` columns needs an exclusive lock that busy instances could not win in one attempt, which aborted the migration and restarted the container in a loop. The drop is now retried, and if it still cannot get the lock it is handed to a background job so startup completes (#3176)
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Instances with heavy write traffic no longer crash-loop on the 1.10.1 upgrade. Dropping the legacy `points.latitude`/`points.longitude` columns needs an exclusive lock that busy instances could not win in one attempt, which aborted the migration and restarted the container in a loop. The drop is now retried, and if it still cannot get the lock it is handed to a background job so startup completes (#3176)
+- Instances with heavy write traffic no longer crash-loop on the 1.10.1 upgrade. Dropping the legacy `points.latitude`/`points.longitude` columns needs an exclusive lock that busy instances could not win in one attempt, which aborted the migration and restarted the container in a loop. The drop is now retried, and if it still cannot get the lock it is handed to a background job so startup completes. If that job cannot get the lock either, the columns stay and the log prints the statement to run by hand — they are unused, so nothing breaks in the meantime (#3176)
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
 

--- a/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
+++ b/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class DataMigrations::DropLegacyLatLonJob < ApplicationJob
+  queue_as :data_migrations
+
+  LOCK_TIMEOUT = '5s'
+
+  # Losing the lock race is the expected case on a busy instance, so back off
+  # and try again over the next few hours rather than reporting a failure.
+  retry_on ActiveRecord::LockWaitTimeout, wait: :polynomially_longer, attempts: 25
+  retry_on ActiveRecord::StatementTimeout, wait: :polynomially_longer, attempts: 25
+
+  def perform
+    connection = ActiveRecord::Base.connection
+    return unless legacy_columns?(connection)
+
+    connection.execute("SET lock_timeout = '#{LOCK_TIMEOUT}'")
+    connection.execute('ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude')
+
+    Rails.logger.info('[DataMigrations::DropLegacyLatLon] dropped legacy points.latitude / points.longitude')
+  ensure
+    connection&.execute('RESET lock_timeout')
+  end
+
+  private
+
+  def legacy_columns?(connection)
+    connection.column_exists?(:points, :latitude) || connection.column_exists?(:points, :longitude)
+  end
+end

--- a/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
+++ b/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
@@ -3,10 +3,13 @@
 class DataMigrations::DropLegacyLatLonJob < ApplicationJob
   queue_as :data_migrations
 
-  # Each attempt queues an ACCESS EXCLUSIVE request that holds up every points
-  # reader and writer behind it, so keep the wait short: the lock is either free
-  # almost immediately or held by a long transaction a longer wait cannot outlast.
-  LOCK_TIMEOUT = '1s'
+  # Long enough to catch the gap between two batched writes. The same release
+  # backfills tracker ids and clears raw_data in 5k/10k-row batches that each
+  # hold RowExclusive on points for seconds at a time, so a one-second wait
+  # would expire inside a batch and lose every attempt. Each try does stall
+  # points behind an ACCESS EXCLUSIVE request, but at one try per five minutes
+  # that is a fraction of a percent of the time.
+  LOCK_TIMEOUT = '5s'
 
   MAX_ATTEMPTS = 288
 
@@ -28,7 +31,8 @@ class DataMigrations::DropLegacyLatLonJob < ApplicationJob
     Rails.logger.error(
       "[DataMigrations::DropLegacyLatLon] gave up after #{MAX_ATTEMPTS} attempts (#{error.class}: #{error.message}); " \
       'points.latitude / points.longitude are still present. Drop them once traffic is quiet with: ' \
-      'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude;'
+      "BEGIN; SET LOCAL lock_timeout = '#{LOCK_TIMEOUT}'; " \
+      'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude; COMMIT;'
     )
   end
 

--- a/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
+++ b/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
@@ -7,8 +7,10 @@ class DataMigrations::DropLegacyLatLonJob < ApplicationJob
 
   # Losing the lock race is the expected case on a busy instance, so back off
   # and try again over the next few hours rather than reporting a failure.
-  retry_on ActiveRecord::LockWaitTimeout, wait: :polynomially_longer, attempts: 25
-  retry_on ActiveRecord::StatementTimeout, wait: :polynomially_longer, attempts: 25
+  # QueryAborted covers both LockWaitTimeout's sibling StatementTimeout and the
+  # QueryCanceled that PostgreSQL raises when statement_timeout fires.
+  retry_on ActiveRecord::LockWaitTimeout, wait: 5.minutes, attempts: 25
+  retry_on ActiveRecord::QueryAborted, wait: 5.minutes, attempts: 25
 
   def perform
     connection = ActiveRecord::Base.connection

--- a/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
+++ b/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
@@ -6,22 +6,28 @@ class DataMigrations::DropLegacyLatLonJob < ApplicationJob
   LOCK_TIMEOUT = '5s'
 
   # Losing the lock race is the expected case on a busy instance, so back off
-  # and try again over the next few hours rather than reporting a failure.
+  # and keep trying rather than reporting a failure. Attempts are unlimited
+  # because exhausting them re-raises into Sidekiq's own retries, turning a
+  # quiet wait into weeks of reported failures ending in the dead set.
   # QueryAborted covers both LockWaitTimeout's sibling StatementTimeout and the
   # QueryCanceled that PostgreSQL raises when statement_timeout fires.
-  retry_on ActiveRecord::LockWaitTimeout, wait: 5.minutes, attempts: 25
-  retry_on ActiveRecord::QueryAborted, wait: 5.minutes, attempts: 25
+  retry_on ActiveRecord::LockWaitTimeout, wait: 5.minutes, attempts: :unlimited
+  retry_on ActiveRecord::QueryAborted, wait: 5.minutes, attempts: :unlimited
 
   def perform
     connection = ActiveRecord::Base.connection
     return unless legacy_columns?(connection)
 
+    # A pooled connection can carry a statement_timeout set by another job; the
+    # drop must be bounded by lock_timeout alone or every retry is cancelled.
+    connection.execute('SET statement_timeout = 0')
     connection.execute("SET lock_timeout = '#{LOCK_TIMEOUT}'")
     connection.execute('ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude')
 
     Rails.logger.info('[DataMigrations::DropLegacyLatLon] dropped legacy points.latitude / points.longitude')
   ensure
     connection&.execute('RESET lock_timeout')
+    connection&.execute('RESET statement_timeout')
   end
 
   private

--- a/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
+++ b/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
@@ -5,29 +5,46 @@ class DataMigrations::DropLegacyLatLonJob < ApplicationJob
 
   LOCK_TIMEOUT = '5s'
 
-  # Losing the lock race is the expected case on a busy instance, so back off
-  # and keep trying rather than reporting a failure. Attempts are unlimited
-  # because exhausting them re-raises into Sidekiq's own retries, turning a
-  # quiet wait into weeks of reported failures ending in the dead set.
+  MAX_ATTEMPTS = 288
+
+  # Losing the lock race is the expected case on a busy instance, so back off and
+  # try again over the next day rather than reporting a failure. Attempts are
+  # capped: each one stalls points writes for LOCK_TIMEOUT, so a drop that can
+  # never win must stop and say so instead of retrying invisibly forever.
   # QueryAborted covers both LockWaitTimeout's sibling StatementTimeout and the
   # QueryCanceled that PostgreSQL raises when statement_timeout fires.
-  retry_on ActiveRecord::LockWaitTimeout, wait: 5.minutes, attempts: :unlimited
-  retry_on ActiveRecord::QueryAborted, wait: 5.minutes, attempts: :unlimited
+  retry_on ActiveRecord::LockWaitTimeout, wait: 5.minutes, attempts: MAX_ATTEMPTS do |_job, error|
+    log_exhaustion(error)
+  end
+
+  retry_on ActiveRecord::QueryAborted, wait: 5.minutes, attempts: MAX_ATTEMPTS do |_job, error|
+    log_exhaustion(error)
+  end
+
+  def self.log_exhaustion(error)
+    Rails.logger.error(
+      "[DataMigrations::DropLegacyLatLon] gave up after #{MAX_ATTEMPTS} attempts (#{error.class}: #{error.message}); " \
+      'points.latitude / points.longitude are still present and must be dropped manually'
+    )
+  end
 
   def perform
     connection = ActiveRecord::Base.connection
     return unless legacy_columns?(connection)
 
-    # A pooled connection can carry a statement_timeout set by another job; the
-    # drop must be bounded by lock_timeout alone or every retry is cancelled.
-    connection.execute('SET statement_timeout = 0')
-    connection.execute("SET lock_timeout = '#{LOCK_TIMEOUT}'")
-    connection.execute('ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude')
+    # SET LOCAL binds both timeouts to this transaction's backend so they survive
+    # PgBouncer transaction pooling — a bare SET + ALTER can otherwise land on
+    # different servers, leaving the drop with no timeout at all and an unbounded
+    # ACCESS EXCLUSIVE request queued ahead of every points read and write.
+    # statement_timeout is pinned off so only lock_timeout bounds the wait; the
+    # drop itself is metadata-only once the lock is held.
+    connection.transaction do
+      connection.execute('SET LOCAL statement_timeout = 0')
+      connection.execute("SET LOCAL lock_timeout = '#{LOCK_TIMEOUT}'")
+      connection.execute('ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude')
+    end
 
     Rails.logger.info('[DataMigrations::DropLegacyLatLon] dropped legacy points.latitude / points.longitude')
-  ensure
-    connection&.execute('RESET lock_timeout')
-    connection&.execute('RESET statement_timeout')
   end
 
   private

--- a/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
+++ b/app/jobs/data_migrations/drop_legacy_lat_lon_job.rb
@@ -3,7 +3,10 @@
 class DataMigrations::DropLegacyLatLonJob < ApplicationJob
   queue_as :data_migrations
 
-  LOCK_TIMEOUT = '5s'
+  # Each attempt queues an ACCESS EXCLUSIVE request that holds up every points
+  # reader and writer behind it, so keep the wait short: the lock is either free
+  # almost immediately or held by a long transaction a longer wait cannot outlast.
+  LOCK_TIMEOUT = '1s'
 
   MAX_ATTEMPTS = 288
 
@@ -24,7 +27,8 @@ class DataMigrations::DropLegacyLatLonJob < ApplicationJob
   def self.log_exhaustion(error)
     Rails.logger.error(
       "[DataMigrations::DropLegacyLatLon] gave up after #{MAX_ATTEMPTS} attempts (#{error.class}: #{error.message}); " \
-      'points.latitude / points.longitude are still present and must be dropped manually'
+      'points.latitude / points.longitude are still present. Drop them once traffic is quiet with: ' \
+      'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude;'
     )
   end
 

--- a/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
+++ b/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
@@ -4,6 +4,9 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
   BATCH_SIZE = 50_000
+  DROP_LOCK_TIMEOUT = '5s'
+  DROP_MAX_ATTEMPTS = 10
+  DROP_BACKOFF_SECONDS = 3
 
   def up
     return unless column_exists?(:points, :latitude) || column_exists?(:points, :longitude)
@@ -32,12 +35,44 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
       Rails.logger.info "[DropLegacyLatLonFromPoints] backfilled lonlat for #{backfilled} points"
     end
 
-    execute "SET lock_timeout = '5s'"
-    # Single statement so both columns drop atomically and a rerun never sees
-    # only one of them missing.
-    execute 'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude'
-    execute 'RESET lock_timeout'
-    Rails.logger.info '[DropLegacyLatLonFromPoints] done'
+    drop_legacy_columns
+  end
+
+  # The drop needs ACCESS EXCLUSIVE on points. On a live instance the ingestion
+  # workers write constantly, so a single short attempt loses the race and
+  # aborted the whole migration, which crash-looped the container: the next boot
+  # replayed the migration from scratch and lost the race again.
+  #
+  # The lock timeout stays short so a waiting drop never queues ahead of writers
+  # and stalls the app. If every attempt loses, the drop is handed to a
+  # background job that keeps retrying, so boot completes instead of looping.
+  def drop_legacy_columns
+    attempts = 0
+
+    begin
+      attempts += 1
+      execute "SET lock_timeout = '#{DROP_LOCK_TIMEOUT}'"
+      # Single statement so both columns drop atomically and a rerun never sees
+      # only one of them missing.
+      execute 'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude'
+      Rails.logger.info '[DropLegacyLatLonFromPoints] done'
+    rescue ActiveRecord::LockWaitTimeout, ActiveRecord::StatementTimeout => e
+      if attempts < DROP_MAX_ATTEMPTS
+        Rails.logger.warn(
+          "[DropLegacyLatLonFromPoints] could not acquire lock (attempt #{attempts}/#{DROP_MAX_ATTEMPTS}): #{e.message}"
+        )
+        sleep(DROP_BACKOFF_SECONDS * attempts)
+        retry
+      end
+
+      Rails.logger.warn(
+        "[DropLegacyLatLonFromPoints] could not acquire lock in #{DROP_MAX_ATTEMPTS} attempts; " \
+        'handing the drop to DataMigrations::DropLegacyLatLonJob'
+      )
+      DataMigrations::DropLegacyLatLonJob.perform_later
+    ensure
+      execute 'RESET lock_timeout'
+    end
   end
 
   def down

--- a/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
+++ b/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
@@ -52,10 +52,15 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
 
     begin
       attempts += 1
-      execute "SET lock_timeout = '#{DROP_LOCK_TIMEOUT}'"
-      # Single statement so both columns drop atomically and a rerun never sees
-      # only one of them missing.
-      execute 'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude'
+      # SET LOCAL keeps both timeouts on the same backend as the ALTER under
+      # PgBouncer transaction pooling; a bare SET can land elsewhere and leave
+      # the drop unbounded. Single ALTER statement so both columns drop
+      # atomically and a rerun never sees only one of them missing.
+      transaction do
+        execute 'SET LOCAL statement_timeout = 0'
+        execute "SET LOCAL lock_timeout = '#{DROP_LOCK_TIMEOUT}'"
+        execute 'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude'
+      end
       Rails.logger.info '[DropLegacyLatLonFromPoints] done'
     rescue ActiveRecord::LockWaitTimeout, ActiveRecord::QueryAborted => e
       if attempts < DROP_MAX_ATTEMPTS
@@ -71,21 +76,20 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
         'handing the drop to DataMigrations::DropLegacyLatLonJob'
       )
       enqueue_drop_job
-    ensure
-      execute 'RESET lock_timeout'
     end
   end
 
-  # Redis may not be reachable yet when migrations run, and an unreachable queue
-  # must not abort the migration — that is the crash loop this change removes.
-  # The columns are unused, so leaving them in place is safe. Only connection
-  # failures are swallowed; anything else is a bug worth surfacing.
+  # Redis may not be reachable yet when migrations run, and no enqueue failure
+  # may abort the migration — that is the crash loop this change removes. The
+  # rescue is deliberately broad: a malformed REDIS_URL, an exhausted pool and a
+  # refused connection all reach here, and none of them are worth a restart loop.
+  # The columns are unused, so leaving them in place is safe.
   def enqueue_drop_job
     DataMigrations::DropLegacyLatLonJob.perform_later
-  rescue RedisClient::Error, SocketError, IOError, SystemCallError => e
-    Rails.logger.warn(
-      "[DropLegacyLatLonFromPoints] could not enqueue DataMigrations::DropLegacyLatLonJob: #{e.message}; " \
-      'the legacy columns remain and will be dropped on a later boot'
+  rescue StandardError => e
+    Rails.logger.error(
+      '[DropLegacyLatLonFromPoints] could not enqueue DataMigrations::DropLegacyLatLonJob ' \
+      "(#{e.class}: #{e.message}); the legacy columns remain and will be dropped on a later boot"
     )
   end
 

--- a/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
+++ b/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
@@ -56,7 +56,7 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
       # only one of them missing.
       execute 'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude'
       Rails.logger.info '[DropLegacyLatLonFromPoints] done'
-    rescue ActiveRecord::LockWaitTimeout, ActiveRecord::StatementTimeout => e
+    rescue ActiveRecord::LockWaitTimeout, ActiveRecord::QueryAborted => e
       if attempts < DROP_MAX_ATTEMPTS
         Rails.logger.warn(
           "[DropLegacyLatLonFromPoints] could not acquire lock (attempt #{attempts}/#{DROP_MAX_ATTEMPTS}): #{e.message}"
@@ -69,10 +69,22 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
         "[DropLegacyLatLonFromPoints] could not acquire lock in #{DROP_MAX_ATTEMPTS} attempts; " \
         'handing the drop to DataMigrations::DropLegacyLatLonJob'
       )
-      DataMigrations::DropLegacyLatLonJob.perform_later
+      enqueue_drop_job
     ensure
       execute 'RESET lock_timeout'
     end
+  end
+
+  # Redis may not be reachable yet when migrations run, and an unreachable queue
+  # must not abort the migration — that is the crash loop this change removes.
+  # The columns are unused, so leaving them in place is safe.
+  def enqueue_drop_job
+    DataMigrations::DropLegacyLatLonJob.perform_later
+  rescue StandardError => e
+    Rails.logger.warn(
+      "[DropLegacyLatLonFromPoints] could not enqueue DataMigrations::DropLegacyLatLonJob: #{e.message}; " \
+      'the legacy columns remain and will be dropped on a later boot'
+    )
   end
 
   def down

--- a/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
+++ b/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
@@ -99,7 +99,8 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
       '[DropLegacyLatLonFromPoints] could not enqueue DataMigrations::DropLegacyLatLonJob ' \
       "(#{e.class}: #{e.message}); points.latitude / points.longitude are still present. " \
       'Drop them once traffic is quiet with: ' \
-      'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude;'
+      "BEGIN; SET LOCAL lock_timeout = '#{DROP_LOCK_TIMEOUT}'; " \
+      'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude; COMMIT;'
     )
   end
 

--- a/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
+++ b/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
@@ -4,8 +4,12 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
   BATCH_SIZE = 50_000
-  DROP_LOCK_TIMEOUT = '5s'
-  DROP_MAX_ATTEMPTS = 10
+  # Every attempt queues an ACCESS EXCLUSIVE request that holds up each points
+  # reader and writer behind it, so keep the wait short: the lock is either free
+  # almost immediately or held by a long transaction that a longer wait will not
+  # outlast. Boot only needs a couple of tries — the job is the real fallback.
+  DROP_LOCK_TIMEOUT = '1s'
+  DROP_MAX_ATTEMPTS = 3
   DROP_BACKOFF_SECONDS = 3
 
   def up
@@ -84,12 +88,18 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
   # rescue is deliberately broad: a malformed REDIS_URL, an exhausted pool and a
   # refused connection all reach here, and none of them are worth a restart loop.
   # The columns are unused, so leaving them in place is safe.
+  #
+  # Nothing retries this. The migration is recorded as applied either way and
+  # this is the only place that enqueues the job, so the log has to carry the
+  # manual remedy rather than promise a later boot will pick it up.
   def enqueue_drop_job
     DataMigrations::DropLegacyLatLonJob.perform_later
   rescue StandardError => e
     Rails.logger.error(
       '[DropLegacyLatLonFromPoints] could not enqueue DataMigrations::DropLegacyLatLonJob ' \
-      "(#{e.class}: #{e.message}); the legacy columns remain and will be dropped on a later boot"
+      "(#{e.class}: #{e.message}); points.latitude / points.longitude are still present. " \
+      'Drop them once traffic is quiet with: ' \
+      'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude;'
     )
   end
 

--- a/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
+++ b/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
@@ -43,9 +43,10 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
   # aborted the whole migration, which crash-looped the container: the next boot
   # replayed the migration from scratch and lost the race again.
   #
-  # The lock timeout stays short so a waiting drop never queues ahead of writers
-  # and stalls the app. If every attempt loses, the drop is handed to a
-  # background job that keeps retrying, so boot completes instead of looping.
+  # A queued ACCESS EXCLUSIVE request does block the writers behind it, so the
+  # lock timeout stays short to bound each stall to DROP_LOCK_TIMEOUT. If every
+  # attempt loses, the drop is handed to a background job that keeps retrying,
+  # so boot completes instead of looping.
   def drop_legacy_columns
     attempts = 0
 
@@ -77,10 +78,11 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
 
   # Redis may not be reachable yet when migrations run, and an unreachable queue
   # must not abort the migration — that is the crash loop this change removes.
-  # The columns are unused, so leaving them in place is safe.
+  # The columns are unused, so leaving them in place is safe. Only connection
+  # failures are swallowed; anything else is a bug worth surfacing.
   def enqueue_drop_job
     DataMigrations::DropLegacyLatLonJob.perform_later
-  rescue StandardError => e
+  rescue RedisClient::Error, SocketError, IOError, SystemCallError => e
     Rails.logger.warn(
       "[DropLegacyLatLonFromPoints] could not enqueue DataMigrations::DropLegacyLatLonJob: #{e.message}; " \
       'the legacy columns remain and will be dropped on a later boot'

--- a/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
+++ b/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataMigrations::DropLegacyLatLonJob do
+  let(:connection) { ActiveRecord::Base.connection }
+
+  before { allow(ActiveRecord::Base).to receive(:connection).and_return(connection) }
+
+  it 'does nothing when the legacy columns are already gone' do
+    allow(connection).to receive(:column_exists?).and_return(false)
+    allow(connection).to receive(:execute)
+
+    described_class.perform_now
+
+    expect(connection).not_to have_received(:execute).with(/DROP COLUMN/)
+  end
+
+  it 'drops both legacy columns in a single statement' do
+    allow(connection).to receive(:column_exists?).and_return(true)
+    allow(connection).to receive(:execute)
+
+    described_class.perform_now
+
+    expect(connection).to have_received(:execute).with(
+      'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude'
+    )
+  end
+
+  it 'resets the lock timeout even when the drop loses the lock race' do
+    allow(connection).to receive(:column_exists?).and_return(true)
+    allow(connection).to receive(:execute) do |sql|
+      raise ActiveRecord::LockWaitTimeout, 'lock timeout' if sql.include?('DROP COLUMN')
+    end
+
+    described_class.perform_now
+
+    expect(connection).to have_received(:execute).with('RESET lock_timeout')
+  end
+
+  it 'retries rather than failing when the lock is unavailable' do
+    expect(described_class.rescue_handlers.map(&:first)).to include('ActiveRecord::LockWaitTimeout')
+  end
+end

--- a/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
+++ b/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe DataMigrations::DropLegacyLatLonJob do
   end
 
   it 'retries rather than failing when the lock is unavailable' do
-    expect(described_class.rescue_handlers.map(&:first)).to include('ActiveRecord::LockWaitTimeout')
+    allow(connection).to receive(:column_exists?).and_return(true)
+    allow(connection).to receive(:execute) do |sql|
+      raise ActiveRecord::LockWaitTimeout, 'lock timeout' if sql.include?('DROP COLUMN')
+    end
+
+    expect { described_class.perform_now }.to have_enqueued_job(described_class)
+  end
+
+  it 'retries when a statement_timeout cancels the drop' do
+    allow(connection).to receive(:column_exists?).and_return(true)
+    allow(connection).to receive(:execute) do |sql|
+      raise ActiveRecord::QueryCanceled, 'statement timeout' if sql.include?('DROP COLUMN')
+    end
+
+    expect { described_class.perform_now }.to have_enqueued_job(described_class)
   end
 end

--- a/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
+++ b/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe DataMigrations::DropLegacyLatLonJob do
     )
   end
 
+  it 'clears any statement timeout inherited from the pooled connection' do
+    allow(connection).to receive(:column_exists?).and_return(true)
+    allow(connection).to receive(:execute)
+
+    described_class.perform_now
+
+    expect(connection).to have_received(:execute).with('SET statement_timeout = 0')
+    expect(connection).to have_received(:execute).with('RESET statement_timeout')
+  end
+
   it 'resets the lock timeout even when the drop loses the lock race' do
     allow(connection).to receive(:column_exists?).and_return(true)
     allow(connection).to receive(:execute) do |sql|

--- a/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
+++ b/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
@@ -27,25 +27,24 @@ RSpec.describe DataMigrations::DropLegacyLatLonJob do
     )
   end
 
-  it 'clears any statement timeout inherited from the pooled connection' do
+  it 'scopes both timeouts to the transaction so pooling cannot separate them' do
     allow(connection).to receive(:column_exists?).and_return(true)
     allow(connection).to receive(:execute)
 
     described_class.perform_now
 
-    expect(connection).to have_received(:execute).with('SET statement_timeout = 0')
-    expect(connection).to have_received(:execute).with('RESET statement_timeout')
+    expect(connection).to have_received(:execute).with('SET LOCAL statement_timeout = 0')
+    expect(connection).to have_received(:execute).with("SET LOCAL lock_timeout = '5s'")
   end
 
-  it 'resets the lock timeout even when the drop loses the lock race' do
+  it 'runs the drop inside a transaction' do
     allow(connection).to receive(:column_exists?).and_return(true)
-    allow(connection).to receive(:execute) do |sql|
-      raise ActiveRecord::LockWaitTimeout, 'lock timeout' if sql.include?('DROP COLUMN')
-    end
+    allow(connection).to receive(:execute)
+    allow(connection).to receive(:transaction).and_call_original
 
     described_class.perform_now
 
-    expect(connection).to have_received(:execute).with('RESET lock_timeout')
+    expect(connection).to have_received(:transaction)
   end
 
   it 'retries rather than failing when the lock is unavailable' do

--- a/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
+++ b/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe DataMigrations::DropLegacyLatLonJob do
     )
   end
 
+  it 'waits long enough to catch the gap between batched writes' do
+    expect(described_class::LOCK_TIMEOUT).to eq('5s')
+  end
+
   it 'scopes both timeouts to the transaction so pooling cannot separate them' do
     allow(connection).to receive(:column_exists?).and_return(true)
     allow(connection).to receive(:execute)

--- a/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
+++ b/spec/jobs/data_migrations/drop_legacy_lat_lon_job_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe DataMigrations::DropLegacyLatLonJob do
     described_class.perform_now
 
     expect(connection).to have_received(:execute).with('SET LOCAL statement_timeout = 0')
-    expect(connection).to have_received(:execute).with("SET LOCAL lock_timeout = '5s'")
+    expect(connection).to have_received(:execute).with(
+      "SET LOCAL lock_timeout = '#{described_class::LOCK_TIMEOUT}'"
+    )
   end
 
   it 'runs the drop inside a transaction' do

--- a/spec/migrations/drop_legacy_lat_lon_from_points_spec.rb
+++ b/spec/migrations/drop_legacy_lat_lon_from_points_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb')
+
+RSpec.describe DropLegacyLatLonFromPoints, :non_transactional do
+  subject(:migration) { described_class.new }
+
+  before do
+    allow(migration).to receive(:sleep)
+    allow(migration).to receive(:column_exists?).and_return(true)
+    allow(migration).to receive(:execute).and_call_original
+  end
+
+  def stub_drop_raising(error_class, times: described_class::DROP_MAX_ATTEMPTS)
+    attempts = 0
+
+    allow(migration).to receive(:execute) do |sql|
+      next nil unless sql.include?('DROP COLUMN')
+
+      attempts += 1
+      raise error_class, 'canceling statement due to lock timeout' if attempts <= times
+
+      nil
+    end
+
+    -> { attempts }
+  end
+
+  it 'does not abort the migration when the drop never wins the lock race' do
+    stub_drop_raising(ActiveRecord::LockWaitTimeout)
+    allow(DataMigrations::DropLegacyLatLonJob).to receive(:perform_later)
+
+    expect { migration.send(:drop_legacy_columns) }.not_to raise_error
+  end
+
+  it 'hands the drop to a background job once attempts are exhausted' do
+    stub_drop_raising(ActiveRecord::LockWaitTimeout)
+    allow(DataMigrations::DropLegacyLatLonJob).to receive(:perform_later)
+
+    migration.send(:drop_legacy_columns)
+
+    expect(DataMigrations::DropLegacyLatLonJob).to have_received(:perform_later)
+  end
+
+  it 'retries until the lock is acquired instead of failing on the first loss' do
+    attempts = stub_drop_raising(ActiveRecord::LockWaitTimeout, times: 2)
+    allow(DataMigrations::DropLegacyLatLonJob).to receive(:perform_later)
+
+    migration.send(:drop_legacy_columns)
+
+    expect(attempts.call).to eq(3)
+    expect(DataMigrations::DropLegacyLatLonJob).not_to have_received(:perform_later)
+  end
+
+  it 'always resets the lock timeout it set' do
+    stub_drop_raising(ActiveRecord::LockWaitTimeout)
+    allow(DataMigrations::DropLegacyLatLonJob).to receive(:perform_later)
+
+    migration.send(:drop_legacy_columns)
+
+    expect(migration).to have_received(:execute).with('RESET lock_timeout')
+  end
+end

--- a/spec/migrations/drop_legacy_lat_lon_from_points_spec.rb
+++ b/spec/migrations/drop_legacy_lat_lon_from_points_spec.rb
@@ -53,13 +53,13 @@ RSpec.describe DropLegacyLatLonFromPoints, :non_transactional do
     expect(DataMigrations::DropLegacyLatLonJob).not_to have_received(:perform_later)
   end
 
-  it 'always resets the lock timeout it set' do
-    stub_drop_raising(ActiveRecord::LockWaitTimeout)
-    allow(DataMigrations::DropLegacyLatLonJob).to receive(:perform_later)
+  it 'scopes both timeouts to the transaction so pooling cannot separate them' do
+    stub_drop_raising(ActiveRecord::LockWaitTimeout, times: 0)
 
     migration.send(:drop_legacy_columns)
 
-    expect(migration).to have_received(:execute).with('RESET lock_timeout')
+    expect(migration).to have_received(:execute).with('SET LOCAL statement_timeout = 0')
+    expect(migration).to have_received(:execute).with("SET LOCAL lock_timeout = '5s'")
   end
 
   it 'hands off rather than aborting when a statement_timeout cancels the drop' do

--- a/spec/migrations/drop_legacy_lat_lon_from_points_spec.rb
+++ b/spec/migrations/drop_legacy_lat_lon_from_points_spec.rb
@@ -53,6 +53,11 @@ RSpec.describe DropLegacyLatLonFromPoints, :non_transactional do
     expect(DataMigrations::DropLegacyLatLonJob).not_to have_received(:perform_later)
   end
 
+  it 'keeps the boot-time lock wait and attempt budget short' do
+    expect(described_class::DROP_LOCK_TIMEOUT).to eq('1s')
+    expect(described_class::DROP_MAX_ATTEMPTS).to eq(3)
+  end
+
   it 'scopes both timeouts to the transaction so pooling cannot separate them' do
     stub_drop_raising(ActiveRecord::LockWaitTimeout, times: 0)
 

--- a/spec/migrations/drop_legacy_lat_lon_from_points_spec.rb
+++ b/spec/migrations/drop_legacy_lat_lon_from_points_spec.rb
@@ -61,4 +61,19 @@ RSpec.describe DropLegacyLatLonFromPoints, :non_transactional do
 
     expect(migration).to have_received(:execute).with('RESET lock_timeout')
   end
+
+  it 'hands off rather than aborting when a statement_timeout cancels the drop' do
+    stub_drop_raising(ActiveRecord::QueryCanceled)
+
+    expect { migration.send(:drop_legacy_columns) }.to have_enqueued_job(DataMigrations::DropLegacyLatLonJob)
+  end
+
+  it 'does not abort the migration when the job cannot be enqueued' do
+    stub_drop_raising(ActiveRecord::LockWaitTimeout)
+    allow(DataMigrations::DropLegacyLatLonJob).to receive(:perform_later).and_raise(
+      RedisClient::CannotConnectError, 'connection refused'
+    )
+
+    expect { migration.send(:drop_legacy_columns) }.not_to raise_error
+  end
 end

--- a/spec/migrations/drop_legacy_lat_lon_from_points_spec.rb
+++ b/spec/migrations/drop_legacy_lat_lon_from_points_spec.rb
@@ -59,7 +59,9 @@ RSpec.describe DropLegacyLatLonFromPoints, :non_transactional do
     migration.send(:drop_legacy_columns)
 
     expect(migration).to have_received(:execute).with('SET LOCAL statement_timeout = 0')
-    expect(migration).to have_received(:execute).with("SET LOCAL lock_timeout = '5s'")
+    expect(migration).to have_received(:execute).with(
+      "SET LOCAL lock_timeout = '#{described_class::DROP_LOCK_TIMEOUT}'"
+    )
   end
 
   it 'hands off rather than aborting when a statement_timeout cancels the drop' do


### PR DESCRIPTION
Fixes #3176.

## Problem

`DropLegacyLatLonFromPoints` shipped in 1.10.1 ending with:

```ruby
execute "SET lock_timeout = '5s'"
execute 'ALTER TABLE points DROP COLUMN IF EXISTS latitude, DROP COLUMN IF EXISTS longitude'
```

`DROP COLUMN` needs an `ACCESS EXCLUSIVE` lock on `points`. On an instance that is actively ingesting, that lock is not available within 5s, so the statement raises `ActiveRecord::LockWaitTimeout`, the migration aborts, and the container exits. The orchestrator restarts it, the migration replays from the top, and loses the race again — a crash loop with no way out.

The reporter's log shows the shape: the pre-drop backfill scanned for 33.9s to update 0 rows, then the `ALTER TABLE` died immediately after.

## Change

**Boot stops being the only chance to win the lock.** The migration retries a few times, then hands the drop to `DataMigrations::DropLegacyLatLonJob` and lets startup finish. The columns are unused (`Point.ignored_columns` already excludes them), so running with them briefly present is harmless.

**Both timeouts are bound to the transaction that runs the `ALTER`.** A bare `SET` and the following statement can land on different backends under PgBouncer transaction pooling, leaving the drop with no timeout at all. `SET LOCAL` inside an explicit `transaction` keeps them together, matching `Visits::StayPointDetector`.

**A waiting drop does queue ahead of writers** — a pending `ACCESS EXCLUSIVE` request holds up every later `points` reader and writer. Boot therefore waits only 1s and tries 3 times (~12s worst case) so a deploy is never held up. The job waits 5s, because this same release backfills tracker ids and clears `raw_data` in 5k/10k-row batches that each hold RowExclusive on `points` for seconds — a 1s wait would expire inside a batch and lose every attempt, and at one try per five minutes a 5s stall is a fraction of a percent of the time.

**Nothing that can fail here aborts the migration.** An unreachable Redis, a malformed `REDIS_URL` and an exhausted pool are all caught at the enqueue site — none is worth restarting the container for.

**Timeouts are rescued by the classes PostgreSQL actually raises.** `LockWaitTimeout` (55P03) and `QueryAborted` (57014 → `QueryCanceled`). `ActiveRecord::StatementTimeout` is never raised by the PG adapter — it is MySQL/SQLite-only.

**The job retries every 5 minutes for 24h, then stops and says so.** Retrying invisibly forever would stall `points` writes indefinitely with nothing in the retry set, dead set, or logs. On exhaustion it logs the manual `ALTER TABLE` to run.

## Verification

- `rspec spec/migrations/ spec/jobs/data_migrations/` — 10 and 66 examples, 0 failures (14 of those are in the two files this PR adds)
- RuboCop on changed files — no offenses
- Reproduced the original failure first: the pre-fix statement sequence raises `ActiveRecord::LockWaitTimeout` and aborts, which is what the new specs assert no longer happens
- Both regression specs mutation-checked: narrowing the enqueue rescue, and removing the `QueryAborted` handler, each turn a passing spec red

## Known limitations

- The specs stub `execute`; no test holds a real `ACCESS EXCLUSIVE` lock from a second connection, so real contention is not exercised.
- If the enqueue fails, or the job exhausts its 288 attempts, the columns stay. The migration is recorded as applied either way and this is the only place that enqueues the job, so both paths log the manual statement (wrapped in `BEGIN; SET LOCAL lock_timeout …` so pasting it cannot queue an unbounded `ACCESS EXCLUSIVE`) rather than promising a later boot will pick it up. Only `Rails.logger` carries this — `ExceptionReporter` is a no-op on self-hosted.
- Instances that already ran this migration are unaffected: `up` returns before the backfill and the lock retry. Verified on production, where `points.latitude` no longer exists.
- Restarts also repeat the 33.9s backfill scan, because `index_points_on_lonlat` is GiST and cannot serve `lonlat IS NULL`. That is now bounded — the migration completes on the first boot instead of replaying forever — but the scan itself is left alone here to keep the change focused.
