### PR TITLE
Fix NoMethodError from the DNS cache when the resolver gets a nil name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0), tolerates legacy points without timestamps, and recalculates affected stats and tracks.
 - Point uploads from all ingestion paths (REST API, OwnTracks, Overland, Traccar) now retry transient statement and lock-wait timeouts, not just deadlocks, instead of failing the upload.
+- The DNS caching layer no longer crashes with a misleading `NoMethodError` when the SMTP server is not configured in the background worker, so email delivery surfaces the real configuration error instead. (#3038)
 
 ## [1.10.1] - 2026-07-19, Berlin
 

--- a/config/initializers/dns_cache.rb
+++ b/config/initializers/dns_cache.rb
@@ -11,6 +11,10 @@ Rails.application.config.after_initialize do
       alias_method :getaddress_without_cache, :getaddress
 
       def getaddress(name)
+        # Let the original resolver raise its usual error for non-string
+        # names (e.g. nil when SMTP settings are missing)
+        return getaddress_without_cache(name) unless name.is_a?(String)
+
         # Skip caching for IP addresses (no DNS lookup needed)
         return getaddress_without_cache(name) if ip_address?(name)
 

--- a/spec/initializers/dns_cache_spec.rb
+++ b/spec/initializers/dns_cache_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'DNS cache initializer' do
+  it 'lets the original resolver raise for nil names' do
+    expect { Resolv.getaddress(nil) }.to raise_error(ArgumentError, /cannot interpret as DNS name/)
+  end
+
+  it 'still short-circuits IP address literals' do
+    expect(Resolv.getaddress('127.0.0.1')).to eq('127.0.0.1')
+  end
+end

--- a/spec/initializers/dns_cache_spec.rb
+++ b/spec/initializers/dns_cache_spec.rb
@@ -3,11 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe 'DNS cache initializer' do
-  it 'lets the original resolver raise for nil names' do
-    expect { Resolv.getaddress(nil) }.to raise_error(ArgumentError, /cannot interpret as DNS name/)
+  describe 'non-String hosts' do
+    it 'lets the original resolver raise for nil names' do
+      expect { Resolv.getaddress(nil) }.to raise_error(ArgumentError, /cannot interpret as DNS name/)
+    end
+
+    it 'lets the original resolver raise for names that are not string-like' do
+      expect { Resolv.getaddress(42) }.to raise_error(TypeError, /no implicit conversion/)
+    end
   end
 
-  it 'still short-circuits IP address literals' do
-    expect(Resolv.getaddress('127.0.0.1')).to eq('127.0.0.1')
+  describe 'IP address literals' do
+    it 'returns them without a DNS lookup' do
+      expect(Resolv.getaddress('127.0.0.1')).to eq('127.0.0.1')
+    end
+  end
+
+  describe 'hostnames' do
+    it 'resolves once and serves later calls from the cache' do
+      allow(Resolv).to receive(:getaddress_without_cache).and_return('203.0.113.10')
+
+      expect(Resolv.getaddress('cache-me.invalid')).to eq('203.0.113.10')
+      expect(Resolv.getaddress('cache-me.invalid')).to eq('203.0.113.10')
+
+      expect(Resolv).to have_received(:getaddress_without_cache).once
+    end
   end
 end


### PR DESCRIPTION
Fixes #3038. The dns_cache initializer's ip_address? helper calls name.match?, and since resolv-replace routes SMTP connections through Resolv.getaddress, a missing SMTP address in the Sidekiq container ends up here as nil and dies with NoMethodError instead of the real configuration error. Non-string names now fall through to the original resolver, which raises its usual ArgumentError, and there's a small spec covering both paths.