### PR TITLE
Handle invalid visits API time ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- The visits API now returns a clear bad-request response for malformed date ranges on both time-based and area-based queries, instead of failing or silently ignoring the filter.
 - Reverse geocoding and place-name provider outages no longer flood error reporting with handled timeouts, dropped TLS connections, or invalid provider responses. A misconfigured or rate-limited provider — a bad API key, for example — is still reported.
 - Reverse geocoding retries point updates that time out while waiting on concurrent writes.
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.

--- a/app/controllers/api/v1/visits_controller.rb
+++ b/app/controllers/api/v1/visits_controller.rb
@@ -19,6 +19,8 @@ class Api::V1::VisitsController < ApiController
     end
 
     render json: serialized_visits
+  rescue Visits::InvalidTimeRange
+    render json: { error: 'Invalid date format' }, status: :bad_request
   end
 
   def show

--- a/app/errors/visits/invalid_time_range.rb
+++ b/app/errors/visits/invalid_time_range.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Visits
+  class InvalidTimeRange < StandardError; end
+end

--- a/app/services/visits/find_in_time.rb
+++ b/app/services/visits/find_in_time.rb
@@ -22,11 +22,9 @@ module Visits
     attr_reader :user, :start_at, :end_at
 
     def parse_time(time_string)
-      parsed_time = Time.zone.parse(time_string)
-
-      raise ArgumentError, "Invalid time format: #{time_string}" if parsed_time.nil?
-
-      parsed_time
+      Time.zone.parse(time_string) || raise(Visits::InvalidTimeRange)
+    rescue ArgumentError, TypeError
+      raise Visits::InvalidTimeRange
     end
   end
 end

--- a/app/services/visits/find_within_bounding_box.rb
+++ b/app/services/visits/find_within_bounding_box.rb
@@ -46,9 +46,9 @@ module Visits
     def parse_time(time_string)
       return nil if time_string.blank?
 
-      Time.zone.parse(time_string.to_s)
-    rescue ArgumentError
-      nil
+      Time.zone.parse(time_string) || raise(Visits::InvalidTimeRange)
+    rescue ArgumentError, TypeError
+      raise Visits::InvalidTimeRange
     end
   end
 end

--- a/spec/requests/api/v1/visits_spec.rb
+++ b/spec/requests/api/v1/visits_spec.rb
@@ -37,6 +37,15 @@ RSpec.describe 'Api::V1::Visits', type: :request do
         json_response = JSON.parse(response.body)
         expect(json_response.pluck('id')).not_to include(other_user_visit.id)
       end
+
+      it 'returns a bad request for an out-of-range time' do
+        get '/api/v1/visits',
+            params: { start_at: '999999999999999', end_at: Time.zone.now.iso8601 },
+            headers: auth_headers
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to eq('error' => 'Invalid date format')
+      end
     end
 
     context 'when requesting area-based visits' do
@@ -60,6 +69,22 @@ RSpec.describe 'Api::V1::Visits', type: :request do
         json_response = JSON.parse(response.body)
         expect(json_response.pluck('id')).to include(visit_inside.id)
         expect(json_response.pluck('id')).not_to include(visit1.id, visit2.id)
+      end
+
+      it 'returns a bad request for a malformed time' do
+        get '/api/v1/visits',
+            params: params.merge(start_at: 'not-a-date', end_at: Time.zone.now.iso8601),
+            headers: auth_headers
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body).to eq('error' => 'Invalid date format')
+      end
+
+      it 'returns area visits unfiltered when no date range is given' do
+        get '/api/v1/visits', params: params, headers: auth_headers
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.pluck('id')).to include(visit_inside.id)
       end
     end
   end

--- a/spec/services/visits/find_in_time_spec.rb
+++ b/spec/services/visits/find_in_time_spec.rb
@@ -134,8 +134,8 @@ RSpec.describe Visits::FindInTime do
         }
       end
 
-      it 'raises an ArgumentError' do
-        expect { described_class.new(user, params).call }.to raise_error(ArgumentError)
+      it 'raises Visits::InvalidTimeRange' do
+        expect { described_class.new(user, params).call }.to raise_error(Visits::InvalidTimeRange)
       end
     end
   end

--- a/spec/services/visits/find_within_bounding_box_spec.rb
+++ b/spec/services/visits/find_within_bounding_box_spec.rb
@@ -213,8 +213,8 @@ RSpec.describe Visits::FindWithinBoundingBox do
           }
         end
 
-        it 'ignores the malformed range and returns bbox matches' do
-          expect(result).to include(visit_inside_1, visit_inside_2, old_visit_inside)
+        it 'rejects the malformed range' do
+          expect { result }.to raise_error(Visits::InvalidTimeRange)
         end
       end
     end


### PR DESCRIPTION
## Summary
- convert malformed time-range parser failures into a visits-specific input error
- return HTTP 400 instead of reporting an application exception
- preserve the existing bounding-box fallback behavior

## Verification
- `asdf exec bundle exec rspec spec/requests/api/v1/visits_spec.rb spec/services/visits/find_in_time_spec.rb spec/services/visits/find_within_bounding_box_spec.rb` — 47 examples, 0 failures
- `asdf exec bundle exec rubocop app/controllers/api/v1/visits_controller.rb app/services/visits/find_in_time.rb app/services/visits/invalid_time_range.rb spec/requests/api/v1/visits_spec.rb` — no offenses