### PR TITLE
Persist manually named places across re-visits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Manually named places now persist across re-visits: a suggested visit reuses your curated place instead of falling back to the reverse-geocoded address or minting a duplicate when the cluster center drifts. (#3086)
 - Reverse geocoding and place-name provider outages no longer flood error reporting with handled timeouts, dropped TLS connections, or invalid provider responses. A misconfigured or rate-limited provider — a bad API key, for example — is still reported.
 - Reverse geocoding retries point updates that time out while waiting on concurrent writes.
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.

--- a/app/services/visits/place_finder.rb
+++ b/app/services/visits/place_finder.rb
@@ -3,6 +3,7 @@
 module Visits
   class PlaceFinder
     SIMILARITY_RADIUS = 50
+    MANUAL_MATCH_RADIUS = 100
 
     attr_reader :user
 
@@ -22,16 +23,21 @@ module Visits
 
     private
 
-    # Rank candidates within the radius by exact-name, then manual-over-photon, then distance.
-    # Avoids minting duplicate "Suggested place" rows and prefers user-curated places.
+    # Prefer a user-named place over a reverse-geocoded one, then exact-name, then distance.
+    # Manual places are matched within a wider radius so a re-visit whose cluster center
+    # drifted still reuses the curated place instead of minting a new "Suggested place".
     def find_existing_place(lat, lon, name)
-      candidates = user.places.near([lat, lon], SIMILARITY_RADIUS, :m).to_a
-      return nil if candidates.empty?
+      candidates = user.places.near([lat, lon], MANUAL_MATCH_RADIUS, :m).to_a
+      manual = candidates.select(&:manual?)
+      pool = manual.presence || candidates.select do |place|
+        distance_meters(lat, lon, place.lat, place.lon) <= SIMILARITY_RADIUS
+      end
+      return nil if pool.empty?
 
-      candidates.min_by do |place|
+      pool.min_by do |place|
         [
-          name.present? && place.name == name ? 0 : 1,
           place.manual? ? 0 : 1,
+          name.present? && place.name == name ? 0 : 1,
           distance_meters(lat, lon, place.lat, place.lon)
         ]
       end

--- a/spec/regressions/manual_place_name_persistence_spec.rb
+++ b/spec/regressions/manual_place_name_persistence_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Visits::PlaceFinder do
+  let(:user) { create(:user) }
+  let(:center_lat) { 52.5126 }
+  let(:center_lon) { 13.4012 }
+  let(:visit_data) do
+    {
+      center_lat: center_lat,
+      center_lon: center_lon,
+      suggested_name: '123 Fourth Street',
+      points: [],
+      start_time: Time.zone.now.to_i,
+      end_time: (Time.zone.now + 1.hour).to_i,
+      duration: 3600
+    }
+  end
+
+  before do
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+    allow(DawarichSettings).to receive(:store_geodata?).and_return(false)
+  end
+
+  def place_at(lat, lon, name:, source:)
+    create(:place, user: user, name: name, source: source,
+                   latitude: lat, longitude: lon, lonlat: "POINT(#{lon} #{lat})", geodata: {})
+  end
+
+  it 'returns the manual place even when a photon place matches the reverse-geocoded name' do
+    photon = place_at(center_lat, center_lon, name: '123 Fourth Street', source: :photon)
+    manual = place_at(center_lat, center_lon, name: 'My Favorite Address', source: :manual)
+
+    result = described_class.new(user).find_or_create_place(visit_data)
+
+    expect(result).to eq(manual)
+    expect(result).not_to eq(photon)
+  end
+
+  it 'reuses a manual place near the cluster instead of minting a new photon place' do
+    # ~70 m north of the center — outside the 50 m photon similarity radius.
+    manual = place_at(center_lat + 0.00063, center_lon, name: 'My Favorite Address', source: :manual)
+
+    result = nil
+    expect { result = described_class.new(user).find_or_create_place(visit_data) }
+      .not_to(change { Place.count })
+    expect(result).to eq(manual)
+  end
+end


### PR DESCRIPTION
GitHub issue: https://github.com/Freika/dawarich/issues/3086

## Summary
- A suggested visit now reuses your curated place instead of the reverse-geocoded address or a duplicate when the cluster center drifts.

## Verification
- New regression spec fails before the fix and passes after.
- Affected-area specs run green.
- rubocop clean; CHANGELOG updated.