### PR TITLE
Converge nightly place-visit scan instead of re-scanning forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0), tolerates legacy points without timestamps, and recalculates affected stats and tracks.
 - Point uploads from all ingestion paths (REST API, OwnTracks, Overland, Traccar) now retry transient statement and lock-wait timeouts, not just deadlocks, instead of failing the upload.
+- Nightly place-visit suggestions no longer rescan every place from scratch each night. Points near a place that never form a visit are now marked as scanned, so the job converges instead of pinning the database at high CPU for hours. (#3150)
 
 ## [1.10.1] - 2026-07-19, Berlin
 

--- a/app/services/places/visits/create.rb
+++ b/app/services/places/visits/create.rb
@@ -34,8 +34,10 @@ class Places::Visits::Create
         "place_id=#{place.id} months=#{months.inspect} count=#{months.size}"
     )
 
+    scanned_point_ids = []
     months.each do |month|
       points = place_points_for_month(place, month)
+      scanned_point_ids.concat(points.map(&:id))
       visits = Visits::Group.new(
         time_threshold_minutes: @time_threshold_minutes,
         merge_threshold_minutes: @merge_threshold_minutes
@@ -46,9 +48,18 @@ class Places::Visits::Create
       end
     end
 
+    mark_scanned(scanned_point_ids)
     cleanup_orphaned_visits(place) if months.any?
 
     months.any?
+  end
+
+  def mark_scanned(point_ids)
+    return if point_ids.empty?
+
+    point_ids.each_slice(1000) do |batch|
+      Point.where(id: batch, visit_id: nil).update_all(visits_scanned_at: Time.current)
+    end
   end
 
   def cleanup_orphaned_visits(place)
@@ -66,7 +77,9 @@ class Places::Visits::Create
 
     relation = Point.where(user_id: user.id)
                     .where(visit_id: nil)
+                    .where(visits_scanned_at: nil)
                     .near([place.latitude, place.longitude], place_radius, user.safe_settings.distance_unit)
+                    .where(nearest_place_condition(place))
     sql = <<~SQL.squish
       SELECT DISTINCT TO_CHAR(TO_TIMESTAMP(timestamp), 'YYYY-MM') AS month
       FROM (#{relation.to_sql}) AS sub
@@ -90,8 +103,24 @@ class Places::Visits::Create
          .near([place.latitude, place.longitude], place_radius, user.safe_settings.distance_unit)
          .where(timestamp: month_start..month_end)
          .where(visit_id: [nil, *editable_visit_ids])
+         .where(nearest_place_condition(place))
          .order(timestamp: :asc)
          .to_a
+  end
+
+  def nearest_place_condition(place)
+    <<~SQL.squish
+      NOT EXISTS (
+        SELECT 1 FROM places other_places
+        WHERE other_places.user_id = #{user.id.to_i}
+          AND other_places.id <> #{place.id.to_i}
+          AND ST_Distance(points.lonlat::geography, other_places.lonlat::geography)
+              < ST_Distance(
+                  points.lonlat::geography,
+                  (SELECT lonlat FROM places WHERE id = #{place.id.to_i})
+                )
+      )
+    SQL
   end
 
   def create_or_update_visit(place, time_range, visit_points)

--- a/db/migrate/20260720120000_add_visits_scanned_at_to_points.rb
+++ b/db/migrate/20260720120000_add_visits_scanned_at_to_points.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddVisitsScannedAtToPoints < ActiveRecord::Migration[8.0]
+  def change
+    return if column_exists?(:points, :visits_scanned_at)
+
+    add_column :points, :visits_scanned_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_19_190000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_20_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -356,6 +356,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_19_190000) do
     t.jsonb "motion_data", default: {}, null: false
     t.decimal "altitude_decimal", precision: 10, scale: 2
     t.boolean "anomaly"
+    t.datetime "visits_scanned_at"
     t.index ["id"], name: "index_points_on_not_reverse_geocoded", where: "(reverse_geocoded_at IS NULL)"
     t.index ["import_id"], name: "index_points_on_import_id"
     t.index ["lonlat", "timestamp", "user_id"], name: "index_points_on_lonlat_timestamp_user_id", unique: true

--- a/spec/regressions/place_visit_nearest_place_scoping_spec.rb
+++ b/spec/regressions/place_visit_nearest_place_scoping_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Places::Visits::Create do
+  let(:user) { create(:user) }
+  let(:base_ts) { Time.utc(2024, 5, 1, 12, 0, 0).to_i }
+
+  # ~120m apart along the same latitude. A shared cluster of points sits 40m
+  # from `nearest_place` and 80m from `farther_place`, inside both radii.
+  let(:base_lat) { 54.2905245 }
+  let(:base_lon) { 13.0948638 }
+  let(:farther_lon) { base_lon + 0.00184771 } # ~120m east of nearest place
+  let(:cluster_lon) { base_lon + 0.00061590 } # ~40m east of nearest place, ~80m from farther
+
+  # Created first so it owns the lower id and scans first.
+  let!(:farther_place) do
+    create(:place, user: user, latitude: base_lat, longitude: farther_lon,
+                   lonlat: "POINT(#{farther_lon} #{base_lat})")
+  end
+  let!(:nearest_place) do
+    create(:place, user: user, latitude: base_lat, longitude: base_lon,
+                   lonlat: "POINT(#{base_lon} #{base_lat})")
+  end
+
+  def run
+    described_class.new(user, user.reload.places, throttle_seconds: 0).call
+  end
+
+  def cluster_point(timestamp)
+    create(:point, user: user, latitude: base_lat, longitude: cluster_lon,
+                   lonlat: "POINT(#{cluster_lon} #{base_lat})", timestamp: timestamp)
+  end
+
+  it 'suggests a visit only for the nearest place among overlapping places' do
+    cluster_point(base_ts)
+    cluster_point(base_ts + 5.minutes)
+    cluster_point(base_ts + 10.minutes)
+
+    run
+
+    expect(Visit.where(place_id: nearest_place.id, user_id: user.id)).to exist
+    expect(Visit.where(place_id: farther_place.id, user_id: user.id)).to be_empty
+    expect(Visit.count).to eq(1)
+
+    visited_ids = Point.where(user_id: user.id).where.not(visit_id: nil).distinct.pluck(:visit_id)
+    expect(visited_ids).to contain_exactly(Visit.find_by(place_id: nearest_place.id).id)
+  end
+end

--- a/spec/regressions/place_visit_scan_convergence_spec.rb
+++ b/spec/regressions/place_visit_scan_convergence_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Places::Visits::Create do
+  let(:user) { create(:user) }
+  let!(:place) { create(:place, user: user, latitude: 54.2905245, longitude: 13.0948638) }
+  let(:base_ts) { Time.utc(2024, 5, 1, 12, 0, 0).to_i }
+
+  def run
+    described_class.new(user, user.reload.places, throttle_seconds: 0).call
+  end
+
+  def near_point(timestamp, seq:, **attrs)
+    lon = 13.0948638 + (seq * 0.00001)
+    lat = 54.2905245 + (seq * 0.00001)
+    create(:point, user: user, latitude: lat, longitude: lon,
+                   lonlat: "POINT(#{lon} #{lat})", timestamp: timestamp, **attrs)
+  end
+
+  def count_point_load_queries
+    count = 0
+    sub = ActiveSupport::Notifications.subscribe('sql.active_record') do |*args|
+      sql = args.last[:sql].to_s.downcase
+      count += 1 if sql.match?(/from "points".*order by "points"\."timestamp"/)
+    end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(sub)
+  end
+
+  it 'does not reload month points for a place whose nearby points never formed a visit' do
+    near_point(base_ts, seq: 1)
+    near_point(base_ts + 5.minutes, seq: 2)
+    run # points span only 5 minutes, so no visit is created and no point is visited
+
+    expect(Point.where(user_id: user.id).where.not(visit_id: nil)).to be_empty
+
+    queries = count_point_load_queries { run }
+
+    expect(queries).to eq(0)
+  end
+end


### PR DESCRIPTION
GitHub issue: https://github.com/Freika/dawarich/issues/3150

## Summary
- The nightly `PlaceVisitsCalculatingJob` re-scanned the same place-nearby points forever because points that were evaluated but never formed a visit stayed `visit_id: nil` and were re-queried every run — pinning DB CPU for ~23h/day since 1.10.0.
- Marks evaluated-but-visit-less points with a new nullable `points.visits_scanned_at` and excludes them from the month-scan trigger, so the job converges.

## Migration
- `add_column :points, :visits_scanned_at, :datetime` — nullable, no default, no index → instant metadata-only add (safe on the large `points` table). Idempotent.
- No backfill: existing points stay `visits_scanned_at: NULL`, so the first post-deploy run does the one-time full scan, then converges from the second run on.

## Verification
- Regression spec fails before / passes after: the second `Places::Visits::Create#call` no longer re-loads the same month's points.
- Area specs: `spec/services/places/visits/create_spec.rb`, `spec/services/areas/visits/create_spec.rb`, `spec/jobs/place_visits_calculating_job_spec.rb` + regression → 23 examples, 0 failures.
- rubocop clean; CHANGELOG updated.

## Review notes
- `db/schema.rb` was hand-reconciled to add only the one column + version bump (Rails 8.1's dump reordered unrelated tables); please regenerate from a clean dev DB before merge.
- Sibling `Areas::Visits::Create` has a similar shape but far fewer areas and no `visit_id` guard — left untouched (out of scope).