### PR TITLE
Keep live points within the selected map date range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0), tolerates legacy points without timestamps, and recalculates affected stats and tracks.
 - Point uploads from all ingestion paths (REST API, OwnTracks, Overland, Traccar) now retry transient statement and lock-wait timeouts, not just deadlocks, instead of failing the upload.
+- Live Map no longer adds or zooms to newly-recorded points that fall outside the currently selected Map v2 date range. Points recorded after local midnight still appear when the map is left on the default "today" view (#3098).
 
 ## [1.10.1] - 2026-07-19, Berlin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Live map updates respect a selected historical date range (#3098).
+
 - Upgrades rebuild invalid statistics indexes left by interrupted migrations and restore duplicate protection (#2700)
 - Browser and API password sign-in now respect OIDC-only configuration (#2961)
 

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -7,6 +7,7 @@ import { featureToPhoto } from "maps_maplibre/utils/feature_to_photo"
 import { cancelAllPreviews } from "maps_maplibre/utils/layer_gate"
 import { loadLastView, saveView } from "maps_maplibre/utils/map_view_store"
 import { performanceMonitor } from "maps_maplibre/utils/performance_monitor"
+import { parseTimestamp } from "maps_maplibre/utils/realtime_date_filter"
 import { SearchManager } from "maps_maplibre/utils/search_manager"
 import { SettingsManager } from "maps_maplibre/utils/settings_manager"
 import { AreaSelectionManager } from "./maplibre/area_selection_manager"
@@ -363,6 +364,16 @@ export default class extends Controller {
       new Date(this.endDateValue),
     )
 
+    // Snapshot the load-time window so realtime filtering can tell the default
+    // "today" view (whose frozen end goes stale across local midnight) apart
+    // from an explicitly selected past range.
+    const loadEnd = parseTimestamp(this.endDateValue)
+    this.defaultDateRange = {
+      startValue: this.startDateValue,
+      endValue: this.endDateValue,
+      reachesNow: loadEnd !== null && loadEnd >= Date.now(),
+    }
+
     this.loadMapData().then(() => {
       if (this.settings?.familyEnabled) {
         this.loadFamilyMembers()
@@ -522,6 +533,26 @@ export default class extends Controller {
     })
     this.refreshTimelineFeedIfActive?.()
     this.debouncedLoadFamilyHistory?.()
+  }
+
+  /**
+   * The active window realtime points are filtered against. When the range is
+   * still the untouched load-time window that reached the present, the end is
+   * left open so live points recorded after local midnight keep showing.
+   */
+  realtimeDateRange() {
+    const startValue = this.startDateValue
+    const endValue = this.endDateValue
+    const unchanged =
+      this.defaultDateRange &&
+      startValue === this.defaultDateRange.startValue &&
+      endValue === this.defaultDateRange.endValue
+
+    return {
+      startValue,
+      endValue,
+      treatEndAsOpen: Boolean(unchanged && this.defaultDateRange.reachesNow),
+    }
   }
 
   debouncedLoadFamilyHistory() {

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -9,6 +9,7 @@ import { featureToPhoto } from "maps_maplibre/utils/feature_to_photo"
 import { cancelAllPreviews } from "maps_maplibre/utils/layer_gate"
 import { loadLastView, saveView } from "maps_maplibre/utils/map_view_store"
 import { performanceMonitor } from "maps_maplibre/utils/performance_monitor"
+import { parseTimestamp } from "maps_maplibre/utils/realtime_date_filter"
 import { SearchManager } from "maps_maplibre/utils/search_manager"
 import { SettingsManager } from "maps_maplibre/utils/settings_manager"
 import { AreaSelectionManager } from "./maplibre/area_selection_manager"
@@ -340,6 +341,16 @@ export default class extends Controller {
       new Date(this.endDateValue),
     )
 
+    // Snapshot the load-time window so realtime filtering can tell the default
+    // "today" view (whose frozen end goes stale across local midnight) apart
+    // from an explicitly selected past range.
+    const loadEnd = parseTimestamp(this.endDateValue)
+    this.defaultDateRange = {
+      startValue: this.startDateValue,
+      endValue: this.endDateValue,
+      reachesNow: loadEnd !== null && loadEnd >= Date.now(),
+    }
+
     this.loadMapData().then(() => {
       if (this.settings?.familyEnabled) {
         this.loadFamilyMembers()
@@ -505,6 +516,26 @@ export default class extends Controller {
     })
     this.refreshTimelineFeedIfActive?.()
     this.debouncedLoadFamilyHistory?.()
+  }
+
+  /**
+   * The active window realtime points are filtered against. When the range is
+   * still the untouched load-time window that reached the present, the end is
+   * left open so live points recorded after local midnight keep showing.
+   */
+  realtimeDateRange() {
+    const startValue = this.startDateValue
+    const endValue = this.endDateValue
+    const unchanged =
+      this.defaultDateRange &&
+      startValue === this.defaultDateRange.startValue &&
+      endValue === this.defaultDateRange.endValue
+
+    return {
+      startValue,
+      endValue,
+      treatEndAsOpen: Boolean(unchanged && this.defaultDateRange.reachesNow),
+    }
   }
 
   debouncedLoadFamilyHistory() {

--- a/app/javascript/controllers/maps/maplibre_realtime_controller.js
+++ b/app/javascript/controllers/maps/maplibre_realtime_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 import { createMapChannel } from "maps_maplibre/channels/map_channel"
 import { Toast } from "maps_maplibre/components/toast"
+import { pointMatchesActiveDateRange } from "maps_maplibre/utils/realtime_date_filter"
 import { SettingsManager } from "maps_maplibre/utils/settings_manager"
 
 /**
@@ -175,6 +176,15 @@ export default class extends Controller {
 
     const [lat, lon, battery, altitude, timestamp, velocity, id, countryName] =
       pointData
+
+    if (
+      !pointMatchesActiveDateRange(
+        timestamp,
+        mapsController.realtimeDateRange(),
+      )
+    ) {
+      return
+    }
 
     const pointsLayer = mapsController.layerManager?.getLayer("points")
     if (!pointsLayer) {

--- a/app/javascript/controllers/maps/maplibre_realtime_controller.js
+++ b/app/javascript/controllers/maps/maplibre_realtime_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { translate } from "i18n"
 import { createMapChannel } from "maps_maplibre/channels/map_channel"
 import { Toast } from "maps_maplibre/components/toast"
+import { pointMatchesActiveDateRange } from "maps_maplibre/utils/realtime_date_filter"
 import { SettingsManager } from "maps_maplibre/utils/settings_manager"
 
 /**
@@ -176,6 +177,15 @@ export default class extends Controller {
 
     const [lat, lon, battery, altitude, timestamp, velocity, id, countryName] =
       pointData
+
+    if (
+      !pointMatchesActiveDateRange(
+        timestamp,
+        mapsController.realtimeDateRange(),
+      )
+    ) {
+      return
+    }
 
     const pointsLayer = mapsController.layerManager?.getLayer("points")
     if (!pointsLayer) {

--- a/app/javascript/maps_maplibre/utils/realtime_date_filter.js
+++ b/app/javascript/maps_maplibre/utils/realtime_date_filter.js
@@ -1,0 +1,47 @@
+const EPOCH_SECONDS_LIMIT = 1e10
+
+/**
+ * Normalize a broadcast timestamp (epoch seconds, epoch milliseconds, or an
+ * ISO string) into epoch milliseconds. Returns null for empty/unparseable input.
+ */
+export function parseTimestamp(value) {
+  if (value === null || value === undefined || value === "") {
+    return null
+  }
+
+  const numeric = Number(value)
+  if (Number.isFinite(numeric)) {
+    return numeric < EPOCH_SECONDS_LIMIT ? numeric * 1000 : numeric
+  }
+
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+/**
+ * Decide whether a realtime point falls inside the map's active date range.
+ * `range.treatEndAsOpen` skips the upper bound so the default "today" window
+ * keeps showing points recorded after local midnight.
+ */
+export function pointMatchesActiveDateRange(timestamp, range = {}) {
+  const pointTime = parseTimestamp(timestamp)
+  if (pointTime === null) {
+    return false
+  }
+
+  const startTime = parseTimestamp(range.startValue)
+  if (startTime !== null && pointTime < startTime) {
+    return false
+  }
+
+  if (range.treatEndAsOpen) {
+    return true
+  }
+
+  const endTime = parseTimestamp(range.endValue)
+  if (endTime !== null && pointTime > endTime) {
+    return false
+  }
+
+  return true
+}

--- a/spec/javascript/maplibre_realtime_filter_test.mjs
+++ b/spec/javascript/maplibre_realtime_filter_test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const source = await readFile(
+  new URL(
+    "../../app/javascript/maps_maplibre/utils/realtime_date_filter.js",
+    import.meta.url,
+  ),
+  "utf8",
+)
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+const { parseTimestamp, pointMatchesActiveDateRange } = await import(moduleUrl)
+
+const secondsAt = (iso) => String(Math.floor(Date.parse(iso) / 1000))
+const msAt = (iso) => Date.parse(iso)
+
+const range = {
+  startValue: "2026-07-21T00:00:00+00:00",
+  endValue: "2026-07-21T23:59:00+00:00",
+}
+
+test("parseTimestamp scales epoch seconds to milliseconds", () => {
+  assert.equal(parseTimestamp("1721520300"), 1721520300000)
+  assert.equal(parseTimestamp(1721520300), 1721520300000)
+})
+
+test("parseTimestamp passes epoch milliseconds through unchanged", () => {
+  assert.equal(parseTimestamp("1721520300000"), 1721520300000)
+  assert.equal(parseTimestamp(1721520300000), 1721520300000)
+})
+
+test("parseTimestamp parses ISO strings with an offset", () => {
+  assert.equal(
+    parseTimestamp("2026-07-21T12:00:00+00:00"),
+    Date.parse("2026-07-21T12:00:00+00:00"),
+  )
+})
+
+test("parseTimestamp returns null for null, undefined, and empty input", () => {
+  assert.equal(parseTimestamp(null), null)
+  assert.equal(parseTimestamp(undefined), null)
+  assert.equal(parseTimestamp(""), null)
+  assert.equal(parseTimestamp("not-a-date"), null)
+})
+
+test("point inside the active range is kept", () => {
+  assert.equal(
+    pointMatchesActiveDateRange(secondsAt("2026-07-21T12:00:00Z"), range),
+    true,
+  )
+})
+
+test("point inside the active range is kept for millisecond timestamps", () => {
+  assert.equal(
+    pointMatchesActiveDateRange(msAt("2026-07-21T12:00:00Z"), range),
+    true,
+  )
+})
+
+test("point before the start of the range is dropped", () => {
+  assert.equal(
+    pointMatchesActiveDateRange(secondsAt("2026-07-20T23:00:00Z"), range),
+    false,
+  )
+})
+
+test("point after the end of the range is dropped", () => {
+  assert.equal(
+    pointMatchesActiveDateRange(secondsAt("2026-07-22T01:00:00Z"), range),
+    false,
+  )
+})
+
+test("point exactly on the start boundary is kept", () => {
+  assert.equal(
+    pointMatchesActiveDateRange(secondsAt("2026-07-21T00:00:00Z"), range),
+    true,
+  )
+})
+
+test("point exactly on the end boundary is kept", () => {
+  assert.equal(
+    pointMatchesActiveDateRange(secondsAt("2026-07-21T23:59:00Z"), range),
+    true,
+  )
+})
+
+test("point with an unparseable timestamp is dropped", () => {
+  assert.equal(pointMatchesActiveDateRange("", range), false)
+  assert.equal(pointMatchesActiveDateRange(null, range), false)
+})
+
+test("default today range keeps points recorded after local midnight", () => {
+  const openEndedToday = { ...range, treatEndAsOpen: true }
+
+  assert.equal(
+    pointMatchesActiveDateRange(
+      secondsAt("2026-07-22T00:05:00Z"),
+      openEndedToday,
+    ),
+    true,
+  )
+})
+
+test("an open-ended range would drop the after-midnight point when the end is enforced", () => {
+  assert.equal(
+    pointMatchesActiveDateRange(secondsAt("2026-07-22T00:05:00Z"), {
+      ...range,
+      treatEndAsOpen: false,
+    }),
+    false,
+  )
+})
+
+test("open-ended range still drops points before the start", () => {
+  assert.equal(
+    pointMatchesActiveDateRange(secondsAt("2026-07-20T12:00:00Z"), {
+      ...range,
+      treatEndAsOpen: true,
+    }),
+    false,
+  )
+})


### PR DESCRIPTION
Incoming live points are filtered against the active map date range, preventing current points from leaking into historical views. Accepted points update both the rendered layer and cached data. The default live view continues accepting points after midnight.

Validation: 277 JavaScript tests passed; Playwright exercised the actual realtime handler: an out-of-range point was ignored and a matching point added. The combined application passed 9721 RSpec examples.

Fixes #3098.

Final combined verification on dev 5eb0e15c: 9721 RSpec examples, 0 failures, using a freshly prepared disposable test database; 284 JavaScript tests passed. Current CI status is shown in the PR checks.
