### PR TITLE
Support raster XYZ and style.json custom basemaps in Map v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- The Map v2 custom basemap field now accepts raster XYZ tiles (`.png`/`.jpg`/`.jpeg`/`.webp`) and full MapLibre style URLs ending in `.json`, in addition to Protomaps-schema vector tiles. Previously a raster URL rendered as a blank grey map and a style URL was rejected. (#3146)
+
 - Reverse geocoding and place-name provider outages no longer flood error reporting with handled timeouts, dropped TLS connections, or invalid provider responses. A misconfigured or rate-limited provider — a bad API key, for example — is still reported.
 - Reverse geocoding retries point updates that time out while waiting on concurrent writes.
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::SettingsController < ApiController
     unless valid_tiles_url?(settings)
       return render json: {
         message: 'Something went wrong',
-        errors: ['Tile URL must include {z}, {x}, and {y} placeholders']
+        errors: [TILE_URL_ERROR]
       }, status: :unprocessable_content
     end
 
@@ -65,6 +65,8 @@ class Api::V1::SettingsController < ApiController
   MAP_CUSTOMIZATION_KEYS = %i[maps_maplibre_custom_theme maps_maplibre_tiles_url
                               route_color track_color].freeze
   TILE_URL_PLACEHOLDERS = %w[{z} {x} {y}].freeze
+  TILE_URL_ERROR = 'Tile URL must include {z}, {x}, and {y} placeholders, ' \
+                   'or be a MapLibre style URL ending in .json'
 
   def settings_params
     permitted = params.require(:settings).permit(
@@ -119,7 +121,18 @@ class Api::V1::SettingsController < ApiController
     url = settings[:maps_maplibre_tiles_url]
     return true if url.nil?
     return false unless url.is_a?(String)
+    return true if style_json_url?(url)
 
     TILE_URL_PLACEHOLDERS.all? { |placeholder| url.include?(placeholder) }
+  end
+
+  def style_json_url?(url)
+    uri = URI.parse(url)
+    return false unless uri.is_a?(URI::HTTP)
+    return false if uri.host.blank?
+
+    uri.path.to_s.downcase.end_with?('.json')
+  rescue URI::InvalidURIError
+    false
   end
 end

--- a/app/javascript/controllers/maps/maplibre/settings_manager.js
+++ b/app/javascript/controllers/maps/maplibre/settings_manager.js
@@ -1116,25 +1116,64 @@ export class SettingsController {
   async applyMapStyle(styleName) {
     this.syncStyleDependentToggles(styleName)
     const style = await getMapStyle(styleName, {
-      hiddenTileCategories:
-        SettingsManager.getSetting("hiddenTileCategories") || [],
-      disabledPoiGroups: SettingsManager.getSetting("disabledPoiGroups") || [],
-      customTheme: SettingsManager.getSetting("customTheme"),
+      ...this.mapStyleOptions(),
       vectorTilesUrl: SettingsManager.getSetting("vectorTilesUrl"),
     })
 
     // Clear layer references
     this.layerManager.clearLayerReferences()
 
-    this.map.setStyle(style)
+    if (typeof style === "string") {
+      this.applyUserStyleUrl(style, styleName)
+      return
+    }
 
-    // Reload layers after style change. setStyle replaces the whole style
-    // document — including the projection — so globe mode must be restored
-    // or every style/theme change silently drops back to mercator.
-    this.map.once("style.load", () => {
-      this.restoreGlobeProjection()
-      this.controller.loadMapData()
-    })
+    this.map.setStyle(style)
+    this.map.once("style.load", () => this.restoreStyleLayers())
+  }
+
+  mapStyleOptions() {
+    return {
+      hiddenTileCategories:
+        SettingsManager.getSetting("hiddenTileCategories") || [],
+      disabledPoiGroups: SettingsManager.getSetting("disabledPoiGroups") || [],
+      customTheme: SettingsManager.getSetting("customTheme"),
+    }
+  }
+
+  // Reload layers after a style change. setStyle replaces the whole style
+  // document — including the projection — so globe mode must be restored
+  // or every style/theme change silently drops back to mercator.
+  restoreStyleLayers() {
+    this.restoreGlobeProjection()
+    this.controller.loadMapData()
+  }
+
+  applyUserStyleUrl(styleUrl, styleName) {
+    let settled = false
+
+    const onLoad = () => {
+      if (settled) return
+      settled = true
+      this.map.off("error", onError)
+      this.restoreStyleLayers()
+    }
+
+    const onError = async () => {
+      if (settled) return
+      settled = true
+      this.map.off("style.load", onLoad)
+      Toast.error(
+        "Custom map style could not be loaded; reverting to the default style.",
+      )
+      const fallback = await getMapStyle(styleName, this.mapStyleOptions())
+      this.map.setStyle(fallback)
+      this.map.once("style.load", () => this.restoreStyleLayers())
+    }
+
+    this.map.once("style.load", onLoad)
+    this.map.once("error", onError)
+    this.map.setStyle(styleUrl)
   }
 
   restoreGlobeProjection() {
@@ -1354,7 +1393,9 @@ export class SettingsController {
     const raw = event.target.value.trim()
 
     if (!SettingsManager.validVectorTilesUrl(raw)) {
-      Toast.error("Tile URL must include {z}, {x}, and {y} placeholders")
+      Toast.error(
+        "Tile URL must include {z}, {x}, and {y} placeholders, or be a MapLibre style URL ending in .json",
+      )
       return
     }
 

--- a/app/javascript/maps_maplibre/utils/basemap_url.js
+++ b/app/javascript/maps_maplibre/utils/basemap_url.js
@@ -1,0 +1,33 @@
+/**
+ * Classify a custom basemap URL into the kind of MapLibre source it describes.
+ * @param {string} url - Trimmed or untrimmed basemap URL
+ * @returns {'style'|'raster'|'vector'|null} Classification, or null when unusable
+ */
+export function classifyBasemapUrl(url) {
+  if (typeof url !== "string") return null
+
+  const trimmed = url.trim()
+  if (!trimmed) return null
+
+  const path = trimmed.split("?")[0].toLowerCase()
+
+  const hasXyz =
+    trimmed.includes("{z}") &&
+    trimmed.includes("{x}") &&
+    trimmed.includes("{y}")
+
+  if (path.endsWith(".json") && !hasXyz) return "style"
+
+  if (!hasXyz) return null
+
+  if (
+    path.endsWith(".png") ||
+    path.endsWith(".jpg") ||
+    path.endsWith(".jpeg") ||
+    path.endsWith(".webp")
+  ) {
+    return "raster"
+  }
+
+  return "vector"
+}

--- a/app/javascript/maps_maplibre/utils/settings_manager.js
+++ b/app/javascript/maps_maplibre/utils/settings_manager.js
@@ -3,6 +3,8 @@
  * Loads settings from backend API only (no localStorage)
  */
 
+import { classifyBasemapUrl } from "maps_maplibre/utils/basemap_url"
+
 // Route fallback matches Map v1's blue; track color matches the backend
 // Tracks::GeojsonSerializer::DEFAULT_COLOR — keep them in sync.
 export const LAYER_COLOR_DEFAULTS = {
@@ -508,10 +510,7 @@ export class SettingsManager {
   }
 
   static validVectorTilesUrl(url) {
-    return (
-      !url ||
-      ["{z}", "{x}", "{y}"].every((placeholder) => url.includes(placeholder))
-    )
+    return !url || classifyBasemapUrl(url) !== null
   }
 
   /**

--- a/app/javascript/maps_maplibre/utils/style_manager.js
+++ b/app/javascript/maps_maplibre/utils/style_manager.js
@@ -3,10 +3,14 @@
  * Loads and configures local map styles with dynamic tile source
  */
 
+import { classifyBasemapUrl } from "maps_maplibre/utils/basemap_url"
 import { resolveTheme } from "poster_studio/data/theme_loader"
 import { buildBasemapStyle } from "poster_studio/render/style_builder"
 
 const TILE_SOURCE_URL = "https://tyles.dwri.xyz/planet/{z}/{x}/{y}.mvt"
+
+const BASEMAP_ATTRIBUTION =
+  '<a href="https://github.com/protomaps/basemaps">Protomaps</a> © <a href="https://openstreetmap.org">OpenStreetMap</a>'
 
 // Cache for loaded styles
 const styleCache = {}
@@ -42,6 +46,37 @@ async function loadStyleFile(styleName) {
   const style = await response.json()
   styleCache[styleName] = style
   return style
+}
+
+/**
+ * Build a raster basemap style from an XYZ tile URL.
+ * Reuses the light style's glyphs/sprite so re-added app label layers render.
+ * @param {string} url - Raster XYZ tile URL
+ * @returns {Promise<Object>} MapLibre style object
+ */
+async function buildRasterStyle(url) {
+  const base = await loadStyleFile("light")
+  return {
+    version: 8,
+    glyphs: base.glyphs,
+    sprite: base.sprite,
+    sources: {
+      protomaps: {
+        type: "raster",
+        tiles: [url],
+        tileSize: 256,
+        attribution: "",
+      },
+    },
+    layers: [
+      {
+        id: "background",
+        type: "background",
+        paint: { "background-color": "#e0e0e0" },
+      },
+      { id: "basemap-raster", type: "raster", source: "protomaps" },
+    ],
+  }
 }
 
 /**
@@ -324,7 +359,18 @@ function hiddenLayerIds(hiddenCategories) {
  */
 export async function getMapStyle(styleName = "light", options = {}) {
   try {
-    const tilesUrl = options.vectorTilesUrl || TILE_SOURCE_URL
+    const customUrl = options.vectorTilesUrl
+    const basemapType = customUrl ? classifyBasemapUrl(customUrl) : null
+
+    // A full MapLibre style URL replaces the whole document. Hand it to
+    // setStyle/new Map, which fetch it; app layers are re-added on style.load.
+    if (basemapType === "style") return customUrl
+
+    // Raster XYZ tiles need their own source and layer — the vendored vector
+    // layers cannot draw against a raster source.
+    if (basemapType === "raster") return await buildRasterStyle(customUrl)
+
+    const tilesUrl = customUrl || TILE_SOURCE_URL
 
     // Custom themes are built client-side from the user's stored color
     // tokens (poster-minimal basemap) — no vendored JSON to fetch. Base-map
@@ -355,8 +401,7 @@ export async function getMapStyle(styleName = "light", options = {}) {
         minzoom: 0,
         maxzoom: 15,
         attribution:
-          clonedStyle.sources.protomaps.attribution ||
-          '<a href="https://github.com/protomaps/basemaps">Protomaps</a> © <a href="https://openstreetmap.org">OpenStreetMap</a>',
+          clonedStyle.sources.protomaps.attribution || BASEMAP_ATTRIBUTION,
       }
     }
 

--- a/app/views/map/maplibre/_settings_panel.html.erb
+++ b/app/views/map/maplibre/_settings_panel.html.erb
@@ -571,17 +571,17 @@
 
           <div class="divider"></div>
 
-          <!-- Custom Vector Tiles -->
+          <!-- Custom Basemap -->
           <div class="form-control w-full">
             <label class="label">
-              <span class="label-text font-medium">Vector Tiles URL</span>
+              <span class="label-text font-medium">Custom Basemap URL</span>
             </label>
             <input type="url"
                    name="vectorTilesUrl"
                    placeholder="https://tiles.example.com/{z}/{x}/{y}.mvt"
                    class="input input-bordered input-sm w-full"
                    data-action="change->maps--maplibre#updateVectorTilesUrl" />
-            <p class="text-xs text-base-content/60 mt-1">Serve the base map from your own Protomaps-schema vector tile server. Leave empty for the built-in tiles. Must include {z}, {x}, and {y}.</p>
+            <p class="text-xs text-base-content/60 mt-1">Serve the base map from your own source. Accepts Protomaps-schema vector tiles or raster XYZ tiles (both must include {z}, {x}, and {y}), or a full MapLibre style URL ending in .json. Leave empty for the built-in tiles.</p>
           </div>
             </div>
           </details>

--- a/spec/javascript/basemap_url_classify_test.mjs
+++ b/spec/javascript/basemap_url_classify_test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const source = await readFile(
+  new URL(
+    "../../app/javascript/maps_maplibre/utils/basemap_url.js",
+    import.meta.url,
+  ),
+  "utf8",
+)
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+const { classifyBasemapUrl } = await import(moduleUrl)
+
+test("classifies a raster XYZ URL with a jpg extension as raster", () => {
+  assert.equal(
+    classifyBasemapUrl(
+      "https://api.maptiler.com/maps/hybrid/256/{z}/{x}/{y}.jpg?key=abc",
+    ),
+    "raster",
+  )
+})
+
+test("classifies png, jpeg, and webp XYZ URLs as raster", () => {
+  assert.equal(
+    classifyBasemapUrl("https://t.example/{z}/{x}/{y}.png"),
+    "raster",
+  )
+  assert.equal(
+    classifyBasemapUrl("https://t.example/{z}/{x}/{y}.jpeg"),
+    "raster",
+  )
+  assert.equal(
+    classifyBasemapUrl("https://t.example/{z}/{x}/{y}.webp"),
+    "raster",
+  )
+})
+
+test("classifies an XYZ MVT or PBF URL as vector", () => {
+  assert.equal(
+    classifyBasemapUrl("https://tiles.example/{z}/{x}/{y}.mvt"),
+    "vector",
+  )
+  assert.equal(
+    classifyBasemapUrl("https://tiles.example/{z}/{x}/{y}.pbf"),
+    "vector",
+  )
+})
+
+test("classifies an extensionless XYZ URL as vector", () => {
+  assert.equal(
+    classifyBasemapUrl("https://tiles.example/{z}/{x}/{y}"),
+    "vector",
+  )
+})
+
+test("classifies a URL whose path ends in json as a full style", () => {
+  assert.equal(
+    classifyBasemapUrl("https://api.maptiler.com/maps/streets/style.json"),
+    "style",
+  )
+})
+
+test("ignores the query string when detecting a style json path", () => {
+  assert.equal(
+    classifyBasemapUrl(
+      "https://api.maptiler.com/maps/streets/style.json?key=abc",
+    ),
+    "style",
+  )
+})
+
+test("classifies a json XYZ tile template as vector, not a style", () => {
+  assert.equal(
+    classifyBasemapUrl("https://tiles.example/{z}/{x}/{y}.json"),
+    "vector",
+  )
+})
+
+test("does not classify a json XYZ tile template with a query string as a style", () => {
+  assert.equal(
+    classifyBasemapUrl("https://tiles.example/{z}/{x}/{y}.json?key=abc"),
+    "vector",
+  )
+})
+
+test("ignores the query string when detecting a raster extension", () => {
+  assert.equal(
+    classifyBasemapUrl("https://t.example/{z}/{x}/{y}.png?token=xyz&s=256"),
+    "raster",
+  )
+})
+
+test("detects extensions case-insensitively", () => {
+  assert.equal(
+    classifyBasemapUrl("https://t.example/{z}/{x}/{y}.PNG"),
+    "raster",
+  )
+  assert.equal(classifyBasemapUrl("https://t.example/STYLE.JSON"), "style")
+})
+
+test("returns null for a URL with no placeholders and no json extension", () => {
+  assert.equal(classifyBasemapUrl("https://tiles.example.com/basemap"), null)
+})
+
+test("returns null for an XYZ URL missing the x and y placeholders", () => {
+  assert.equal(classifyBasemapUrl("https://tiles.example/{z}.png"), null)
+})
+
+test("returns null for empty, whitespace, or non-string input", () => {
+  assert.equal(classifyBasemapUrl(""), null)
+  assert.equal(classifyBasemapUrl("   "), null)
+  assert.equal(classifyBasemapUrl(null), null)
+  assert.equal(classifyBasemapUrl(undefined), null)
+})
+
+test("trims surrounding whitespace before classifying", () => {
+  assert.equal(
+    classifyBasemapUrl("  https://t.example/{z}/{x}/{y}.png  "),
+    "raster",
+  )
+})

--- a/spec/javascript/settings_manager_test.mjs
+++ b/spec/javascript/settings_manager_test.mjs
@@ -2,6 +2,13 @@ import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 import test from "node:test"
 
+const basemapUrlSource = await readFile(
+  new URL(
+    "../../app/javascript/maps_maplibre/utils/basemap_url.js",
+    import.meta.url,
+  ),
+  "utf8",
+)
 const source = await readFile(
   new URL(
     "../../app/javascript/maps_maplibre/utils/settings_manager.js",
@@ -9,7 +16,9 @@ const source = await readFile(
   ),
   "utf8",
 )
-const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+const withoutImports = source.replace(/^import[\s\S]*?from "[^"]+"\n/gm, "")
+const combinedSource = `${basemapUrlSource}\n${withoutImports}`
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(combinedSource).toString("base64")}`
 const { LAYER_COLOR_DEFAULTS, SettingsManager } = await import(moduleUrl)
 
 async function loadSettingsController(settingsManager) {
@@ -53,6 +62,21 @@ test("vector tile URLs require z, x, and y placeholders", () => {
     false,
   )
   assert.equal(SettingsManager.validVectorTilesUrl(""), true)
+})
+
+test("basemap URLs also accept raster XYZ and full style.json URLs", () => {
+  assert.equal(
+    SettingsManager.validVectorTilesUrl("https://t.example/{z}/{x}/{y}.png"),
+    true,
+  )
+  assert.equal(
+    SettingsManager.validVectorTilesUrl("https://t.example/style.json?key=a"),
+    true,
+  )
+  assert.equal(
+    SettingsManager.validVectorTilesUrl("https://t.example/basemap"),
+    false,
+  )
 })
 
 test("multiple setting updates are persisted in one complete snapshot", async () => {

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -123,7 +123,48 @@ RSpec.describe 'Api::V1::Settings', type: :request do
               params: { settings: { maps_maplibre_tiles_url: 'https://tiles.example.com/{z}.mvt' } }
 
         expect(response).to have_http_status(:unprocessable_content)
-        expect(response.parsed_body['errors']).to include('Tile URL must include {z}, {x}, and {y} placeholders')
+        expect(user.reload.safe_settings.maps_maplibre_tiles_url).to be_nil
+      end
+
+      it 'accepts a raster XYZ maps_maplibre_tiles_url' do
+        patch "/api/v1/settings?api_key=#{api_key}",
+              params: {
+                settings: {
+                  maps_maplibre_tiles_url: 'https://api.maptiler.com/maps/hybrid/256/{z}/{x}/{y}.jpg?key=abc'
+                }
+              }
+
+        expect(response).to have_http_status(:success)
+        expect(user.reload.safe_settings.maps_maplibre_tiles_url)
+          .to eq('https://api.maptiler.com/maps/hybrid/256/{z}/{x}/{y}.jpg?key=abc')
+      end
+
+      it 'accepts a full style URL ending in .json' do
+        patch "/api/v1/settings?api_key=#{api_key}",
+              params: {
+                settings: {
+                  maps_maplibre_tiles_url: 'https://api.maptiler.com/maps/streets/style.json?key=abc'
+                }
+              }
+
+        expect(response).to have_http_status(:success)
+        expect(user.reload.safe_settings.maps_maplibre_tiles_url)
+          .to eq('https://api.maptiler.com/maps/streets/style.json?key=abc')
+      end
+
+      it 'rejects a non-http style.json URL' do
+        patch "/api/v1/settings?api_key=#{api_key}",
+              params: { settings: { maps_maplibre_tiles_url: 'ftp://example.com/style.json' } }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(user.reload.safe_settings.maps_maplibre_tiles_url).to be_nil
+      end
+
+      it 'rejects a maps_maplibre_tiles_url that is neither an XYZ tile URL nor a style.json' do
+        patch "/api/v1/settings?api_key=#{api_key}",
+              params: { settings: { maps_maplibre_tiles_url: 'https://tiles.example.com/basemap' } }
+
+        expect(response).to have_http_status(:unprocessable_content)
         expect(user.reload.safe_settings.maps_maplibre_tiles_url).to be_nil
       end
 


### PR DESCRIPTION
GitHub issue: https://github.com/Freika/dawarich/issues/3146

## Summary
- The Map v2 custom basemap field accepted only Protomaps vector tiles. It now also accepts raster XYZ tile URLs (e.g. a MapTiler `{z}/{x}/{y}.jpg`) and full MapLibre `style.json` URLs.
- URL kind is classified (`style` / `raster` / `vector`) and the right MapLibre source is built; vector behavior is unchanged. Client + server validators relaxed to accept all three.

## Verification
- New JS unit tests for `classifyBasemapUrl` + expanded validator test → full JS suite 33 tests, 0 failures.
- Settings request spec (accept raster XYZ, accept style.json, reject neither) → 42 examples, 0 failures.
- rubocop + biome clean; CHANGELOG updated.

## Caveat
- The MapLibre raster/style-swap wiring is verified against the caller architecture (data layers are re-added on `style.load` via the existing `loadMapData` path) but not browser-rendered — a quick manual check in the running app is worth doing before merge. A user style whose glyphs endpoint lacks the default font may not render labels on re-added data layers (map + data still work).