### PR TITLE
Dedup visit suggestions against tracked points after an address change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0), tolerates legacy points without timestamps, and recalculates affected stats and tracks.
 - Point uploads from all ingestion paths (REST API, OwnTracks, Overland, Traccar) now retry transient statement and lock-wait timeouts, not just deadlocks, instead of failing the upload.
+- Re-running visit detection after you correct the address of a confirmed visit no longer produces a near-duplicate suggestion: duplicate detection now compares against the confirmed visit's tracked points instead of its moved place marker. (#2952)
 
 ## [1.10.1] - 2026-07-19, Berlin
 

--- a/app/services/visits/creator.rb
+++ b/app/services/visits/creator.rb
@@ -86,7 +86,7 @@ module Visits
             start: start_time, end: end_time
           )
           .find_each do |visit|
-        visit_lat, visit_lon = visit.center
+        visit_lat, visit_lon = dedup_center(visit)
         next unless visit_lat && visit_lon
 
         # Calculate distance between centers
@@ -101,6 +101,16 @@ module Visits
       end
 
       nil
+    end
+
+    def dedup_center(visit)
+      return visit.center unless visit.place_id
+
+      lat, lon = visit.points.pick(
+        Arel.sql('ST_Y(ST_Centroid(ST_Collect(lonlat::geometry)))'),
+        Arel.sql('ST_X(ST_Centroid(ST_Collect(lonlat::geometry)))')
+      )
+      lat && lon ? [lat, lon] : visit.center
     end
 
     def confirmed_visit_owning_points(visit_data)

--- a/spec/regressions/visit_dedup_uses_confirmed_visit_points_after_place_move_spec.rb
+++ b/spec/regressions/visit_dedup_uses_confirmed_visit_points_after_place_move_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Visit re-detection dedup after a confirmed visit place is moved' do
+  let(:user) { create(:user) }
+
+  # Coordinates the confirmed visit's points actually cluster around (Leipzig).
+  let(:home_lat) { 51.3402 }
+  let(:home_lon) { 12.3712 }
+
+  # Place marker dragged far from the points during an address correction (~4 km away).
+  let(:moved_place) do
+    create(
+      :place,
+      name: 'Home', user_id: nil,
+      latitude: 51.3600, longitude: 12.4200, lonlat: 'POINT(12.4200 51.3600)'
+    )
+  end
+
+  let!(:confirmed_visit) do
+    create(
+      :visit,
+      user: user, place: moved_place, area: nil, status: :confirmed,
+      started_at: 1.5.hours.ago, ended_at: 45.minutes.ago, duration: 45
+    )
+  end
+
+  before do
+    create(:point, user: user, visit: confirmed_visit, lonlat: "POINT(#{home_lon} #{home_lat})")
+    create(:point, user: user, visit: confirmed_visit,
+                   lonlat: "POINT(#{home_lon + 0.0002} #{home_lat + 0.0002})")
+
+    place_finder = instance_double(Visits::PlaceFinder, find_or_create_place: nil)
+    allow(Visits::PlaceFinder).to receive(:new).with(user).and_return(place_finder)
+  end
+
+  it 'does not re-suggest a visit for a cluster sitting on the confirmed visit points' do
+    candidate = {
+      start_time: 1.hour.ago.to_i,
+      end_time: 30.minutes.ago.to_i,
+      duration: 30.minutes.to_i,
+      center_lat: home_lat,
+      center_lon: home_lon,
+      radius: 50,
+      suggested_name: 'Home',
+      points: [create(:point, user: user), create(:point, user: user)]
+    }
+
+    visits = Visits::Creator.new(user).create_visits([candidate])
+
+    expect(visits).to be_empty
+    expect(user.visits.reload.count).to eq(1)
+  end
+end

--- a/spec/services/visits/creator_spec.rb
+++ b/spec/services/visits/creator_spec.rb
@@ -283,6 +283,41 @@ longitude: -73.9000)
       end
     end
 
+    context 'when a confirmed area visit has points sitting off the area centre' do
+      let!(:area) { create(:area, user: user, latitude: 51.3402, longitude: 12.3712, radius: 100) }
+      let!(:existing_visit) do
+        create(
+          :visit,
+          user: user, place: nil, area: area, status: :confirmed,
+          started_at: 1.5.hours.ago, ended_at: 45.minutes.ago, duration: 45
+        )
+      end
+      let(:visit_data) do
+        {
+          start_time: 1.hour.ago.to_i,
+          end_time: 30.minutes.ago.to_i,
+          duration: 30.minutes.to_i,
+          center_lat: 51.3402,
+          center_lon: 12.3712,
+          radius: 50,
+          suggested_name: 'Home',
+          points: [point1, point2]
+        }
+      end
+
+      before do
+        create(:point, user: user, visit: existing_visit, lonlat: 'POINT(12.3812 51.3502)')
+        create(:point, user: user, visit: existing_visit, lonlat: 'POINT(12.3822 51.3512)')
+      end
+
+      it 'dedups against the area centre despite off-centre points' do
+        visits = subject.create_visits([visit_data])
+
+        expect(visits).to be_empty
+        expect(user.visits.reload.count).to eq(1)
+      end
+    end
+
     context 'when matching an area' do
       let!(:area) { create(:area, user: user, latitude: 40.7128, longitude: -74.0060, radius: 100) }
 


### PR DESCRIPTION
After a confirmed visit's place marker is moved by an address correction, re-detection deduped against the moved marker and produced a near-duplicate suggestion. Dedup against the confirmed visit's tracked-points centroid, falling back to the place centre when it has no points.

Fixes Freika/dawarich#2952