### PR TITLE
Handle duplicate legacy point backfills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Upgrading from pre-1.10.1 releases no longer fails when legacy coordinate rows duplicate already-backfilled points (#3200)
 - Reverse geocoding and place-name provider outages no longer flood error reporting with handled timeouts, dropped TLS connections, or invalid provider responses. A misconfigured or rate-limited provider — a bad API key, for example — is still reported.
 - Reverse geocoding retries point updates that time out while waiting on concurrent writes.
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - The per-email API login brute-force throttle now counts `application/json` request bodies, so password grinding against `POST /api/v1/auth/login` is bounded per account even when an attacker rotates source IPs.
+- Upgrading from a release older than 1.10.1 no longer crash-loops when the legacy coordinate columns hold points that collide once they are copied into `lonlat`. The migration that drops `points.latitude` / `points.longitude` now removes a legacy row whose coordinates are already recorded for that user and timestamp — whether the coordinate is held by a point that carries a `lonlat` already, or by an earlier legacy row backfilled in the same batch — and corrects the affected user and import point counters. (#3200)
 
 ## [1.14.4] - 2026-09-06, Berlin
 

--- a/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
+++ b/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
@@ -16,20 +16,19 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
     # to the drop instead of referencing a missing column.
     if column_exists?(:points, :latitude) && column_exists?(:points, :longitude)
       backfilled = 0
-      loop do
-        updated = execute(<<~SQL.squish).cmd_tuples
-          UPDATE points
-          SET lonlat = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
-          WHERE id IN (
-            SELECT id FROM points
-            WHERE lonlat IS NULL AND longitude IS NOT NULL AND latitude IS NOT NULL
-            LIMIT #{BATCH_SIZE}
-          )
-        SQL
-        backfilled += updated
-        break if updated.zero?
+      deduplicated = 0
+      cursor = 0
+
+      while (batch_end = next_batch_end(cursor))
+        deduplicated += remove_duplicate_legacy_points(cursor, batch_end)
+        backfilled += backfill_legacy_points(cursor, batch_end)
+        cursor = batch_end
       end
-      Rails.logger.info "[DropLegacyLatLonFromPoints] backfilled lonlat for #{backfilled} points"
+
+      Rails.logger.info(
+        "[DropLegacyLatLonFromPoints] backfilled lonlat for #{backfilled} points; " \
+        "removed #{deduplicated} duplicates"
+      )
     end
 
     execute "SET lock_timeout = '5s'"
@@ -43,5 +42,84 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
   def down
     execute 'ALTER TABLE points ADD COLUMN IF NOT EXISTS latitude numeric(10,6), ' \
             'ADD COLUMN IF NOT EXISTS longitude numeric(10,6)'
+  end
+
+  private
+
+  def next_batch_end(cursor)
+    select_value(<<~SQL.squish)&.to_i
+      SELECT MAX(id)
+      FROM (
+        SELECT id
+        FROM points
+        WHERE id > #{cursor}
+          AND lonlat IS NULL
+          AND longitude IS NOT NULL
+          AND latitude IS NOT NULL
+        ORDER BY id
+        LIMIT #{BATCH_SIZE}
+      ) candidates
+    SQL
+  end
+
+  def backfill_legacy_points(cursor, batch_end)
+    execute(<<~SQL.squish).cmd_tuples
+      UPDATE points
+      SET lonlat = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
+      WHERE id > #{cursor}
+        AND id <= #{batch_end}
+        AND lonlat IS NULL
+        AND longitude IS NOT NULL
+        AND latitude IS NOT NULL
+    SQL
+  end
+
+  def remove_duplicate_legacy_points(cursor, batch_end)
+    result = execute(<<~SQL.squish)
+      WITH duplicate_points AS (
+        SELECT legacy.id
+        FROM points legacy
+        WHERE legacy.id > #{cursor}
+          AND legacy.id <= #{batch_end}
+          AND legacy.lonlat IS NULL
+          AND legacy.longitude IS NOT NULL
+          AND legacy.latitude IS NOT NULL
+          AND EXISTS (
+            SELECT 1
+            FROM points existing
+            WHERE existing.id != legacy.id
+              AND existing.user_id = legacy.user_id
+              AND existing.timestamp = legacy.timestamp
+              AND existing.lonlat = ST_SetSRID(ST_MakePoint(legacy.longitude, legacy.latitude), 4326)
+          )
+      ), deleted AS (
+        DELETE FROM points
+        USING duplicate_points
+        WHERE points.id = duplicate_points.id
+        RETURNING points.user_id, points.import_id
+      ), deleted_user_counts AS (
+        SELECT user_id, COUNT(*) AS count
+        FROM deleted
+        GROUP BY user_id
+      ), updated_users AS (
+        UPDATE users
+        SET points_count = GREATEST(users.points_count - deleted_user_counts.count, 0)
+        FROM deleted_user_counts
+        WHERE users.id = deleted_user_counts.user_id
+      ), deleted_import_counts AS (
+        SELECT import_id, COUNT(*) AS count
+        FROM deleted
+        WHERE import_id IS NOT NULL
+        GROUP BY import_id
+      ), updated_imports AS (
+        UPDATE imports
+        SET points_count = GREATEST(imports.points_count - deleted_import_counts.count, 0)
+        FROM deleted_import_counts
+        WHERE imports.id = deleted_import_counts.import_id
+      )
+      SELECT COUNT(*) AS count FROM deleted
+    SQL
+
+    result.first['count'].to_i
   end
 end

--- a/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
+++ b/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
@@ -23,20 +23,19 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
     # to the drop instead of referencing a missing column.
     if column_exists?(:points, :latitude) && column_exists?(:points, :longitude)
       backfilled = 0
-      loop do
-        updated = execute(<<~SQL.squish).cmd_tuples
-          UPDATE points
-          SET lonlat = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
-          WHERE id IN (
-            SELECT id FROM points
-            WHERE lonlat IS NULL AND longitude IS NOT NULL AND latitude IS NOT NULL
-            LIMIT #{BATCH_SIZE}
-          )
-        SQL
-        backfilled += updated
-        break if updated.zero?
+      deduplicated = 0
+      cursor = 0
+
+      while (batch_end = next_batch_end(cursor))
+        deduplicated += remove_duplicate_legacy_points(cursor, batch_end)
+        backfilled += backfill_legacy_points(cursor, batch_end)
+        cursor = batch_end
       end
-      Rails.logger.info "[DropLegacyLatLonFromPoints] backfilled lonlat for #{backfilled} points"
+
+      Rails.logger.info(
+        "[DropLegacyLatLonFromPoints] backfilled lonlat for #{backfilled} points; " \
+        "removed #{deduplicated} duplicates"
+      )
     end
 
     drop_legacy_columns
@@ -107,5 +106,105 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
   def down
     execute 'ALTER TABLE points ADD COLUMN IF NOT EXISTS latitude numeric(10,6), ' \
             'ADD COLUMN IF NOT EXISTS longitude numeric(10,6)'
+  end
+
+  private
+
+  def next_batch_end(cursor)
+    select_value(<<~SQL.squish)&.to_i
+      SELECT MAX(id)
+      FROM (
+        SELECT id
+        FROM points
+        WHERE id > #{cursor}
+          AND lonlat IS NULL
+          AND longitude IS NOT NULL
+          AND latitude IS NOT NULL
+        ORDER BY id
+        LIMIT #{BATCH_SIZE}
+      ) candidates
+    SQL
+  end
+
+  def backfill_legacy_points(cursor, batch_end)
+    execute(<<~SQL.squish).cmd_tuples
+      UPDATE points
+      SET lonlat = ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
+      WHERE id > #{cursor}
+        AND id <= #{batch_end}
+        AND lonlat IS NULL
+        AND longitude IS NOT NULL
+        AND latitude IS NOT NULL
+    SQL
+  end
+
+  # A legacy row is dropped when the coordinate it would be backfilled to is
+  # already taken for that (user_id, timestamp) — either by a row that carries a
+  # lonlat already, or by an earlier legacy row in the same batch that will be
+  # backfilled to the identical point. The second case has to be handled here
+  # too: a unique btree index is checked per row inside a statement, so a single
+  # UPDATE that gives two rows the same key raises the violation on its own.
+  #
+  # DISTINCT ON picks the survivor through a sort, which uses the same btree
+  # opclass the unique index is built on. Grouping the geography by hash instead
+  # reports duplicates the index would not, and this statement deletes rows.
+  def remove_duplicate_legacy_points(cursor, batch_end)
+    result = execute(<<~SQL.squish)
+      WITH candidates AS (
+        SELECT legacy.id,
+               legacy.user_id,
+               legacy.timestamp,
+               ST_SetSRID(ST_MakePoint(legacy.longitude, legacy.latitude), 4326)::geography AS target_lonlat
+        FROM points legacy
+        WHERE legacy.id > #{cursor}
+          AND legacy.id <= #{batch_end}
+          AND legacy.lonlat IS NULL
+          AND legacy.longitude IS NOT NULL
+          AND legacy.latitude IS NOT NULL
+      ), keepers AS (
+        SELECT DISTINCT ON (user_id, timestamp, target_lonlat) id
+        FROM candidates
+        ORDER BY user_id, timestamp, target_lonlat, id
+      ), duplicate_points AS (
+        SELECT candidates.id
+        FROM candidates
+        WHERE candidates.id NOT IN (SELECT keepers.id FROM keepers)
+           OR EXISTS (
+             SELECT 1
+             FROM points existing
+             WHERE existing.id != candidates.id
+               AND existing.user_id = candidates.user_id
+               AND existing.timestamp = candidates.timestamp
+               AND existing.lonlat = candidates.target_lonlat
+           )
+      ), deleted AS (
+        DELETE FROM points
+        USING duplicate_points
+        WHERE points.id = duplicate_points.id
+        RETURNING points.user_id, points.import_id
+      ), deleted_user_counts AS (
+        SELECT user_id, COUNT(*) AS count
+        FROM deleted
+        GROUP BY user_id
+      ), updated_users AS (
+        UPDATE users
+        SET points_count = GREATEST(users.points_count - deleted_user_counts.count, 0)
+        FROM deleted_user_counts
+        WHERE users.id = deleted_user_counts.user_id
+      ), deleted_import_counts AS (
+        SELECT import_id, COUNT(*) AS count
+        FROM deleted
+        WHERE import_id IS NOT NULL
+        GROUP BY import_id
+      ), updated_imports AS (
+        UPDATE imports
+        SET points_count = GREATEST(imports.points_count - deleted_import_counts.count, 0)
+        FROM deleted_import_counts
+        WHERE imports.id = deleted_import_counts.import_id
+      )
+      SELECT COUNT(*) AS count FROM deleted
+    SQL
+
+    result.first['count'].to_i
   end
 end

--- a/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
+++ b/db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb
@@ -138,16 +138,6 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
     SQL
   end
 
-  # A legacy row is dropped when the coordinate it would be backfilled to is
-  # already taken for that (user_id, timestamp) — either by a row that carries a
-  # lonlat already, or by an earlier legacy row in the same batch that will be
-  # backfilled to the identical point. The second case has to be handled here
-  # too: a unique btree index is checked per row inside a statement, so a single
-  # UPDATE that gives two rows the same key raises the violation on its own.
-  #
-  # DISTINCT ON picks the survivor through a sort, which uses the same btree
-  # opclass the unique index is built on. Grouping the geography by hash instead
-  # reports duplicates the index would not, and this statement deletes rows.
   def remove_duplicate_legacy_points(cursor, batch_end)
     result = execute(<<~SQL.squish)
       WITH candidates AS (
@@ -161,6 +151,8 @@ class DropLegacyLatLonFromPoints < ActiveRecord::Migration[8.0]
           AND legacy.lonlat IS NULL
           AND legacy.longitude IS NOT NULL
           AND legacy.latitude IS NOT NULL
+          AND legacy.user_id IS NOT NULL
+          AND legacy.timestamp IS NOT NULL
       ), keepers AS (
         SELECT DISTINCT ON (user_id, timestamp, target_lonlat) id
         FROM candidates

--- a/spec/regressions/legacy_point_coordinate_backfill_spec.rb
+++ b/spec/regressions/legacy_point_coordinate_backfill_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb')
+
+RSpec.describe 'Legacy point coordinate backfill', :non_transactional do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user:) }
+  let(:timestamp) { Time.utc(2026, 1, 15, 12).to_i }
+  let(:longitude) { 13.405 }
+  let(:latitude) { 52.52 }
+
+  before do
+    connection.add_column(:points, :latitude, :decimal, precision: 10, scale: 6)
+    connection.add_column(:points, :longitude, :decimal, precision: 10, scale: 6)
+  end
+
+  after do
+    connection.remove_column(:points, :latitude) if connection.column_exists?(:points, :latitude)
+    connection.remove_column(:points, :longitude) if connection.column_exists?(:points, :longitude)
+  end
+
+  it 'finishes when a legacy-only row duplicates an already-backfilled point' do
+    stub_const('DropLegacyLatLonFromPoints::BATCH_SIZE', 1)
+    existing = create(:point, user:, import:, timestamp:, lonlat: "POINT(#{longitude} #{latitude})")
+    backfill_id = connection.select_value(<<~SQL.squish)
+      INSERT INTO points (user_id, import_id, timestamp, latitude, longitude, lonlat, created_at, updated_at)
+      VALUES (#{user.id}, #{import.id}, #{timestamp + 1}, 48.8566, 2.3522, NULL, NOW(), NOW())
+      RETURNING id
+    SQL
+    legacy_id = connection.select_value(<<~SQL.squish)
+      INSERT INTO points (user_id, import_id, timestamp, latitude, longitude, lonlat, created_at, updated_at)
+      VALUES (#{user.id}, #{import.id}, #{timestamp}, #{latitude}, #{longitude}, NULL, NOW(), NOW())
+      RETURNING id
+    SQL
+
+    user.update_column(:points_count, 3)
+    import.update_column(:points_count, 3)
+
+    expect { DropLegacyLatLonFromPoints.new.up }.not_to raise_error
+    expect(Point.where(id: [existing.id, backfill_id, legacy_id]).count).to eq(2)
+    expect(Point.find(backfill_id).lonlat.x).to eq(2.3522)
+    expect(Point.find(backfill_id).lonlat.y).to eq(48.8566)
+    expect(Point.find_by(id: [existing.id, legacy_id]).lonlat).to eq(existing.lonlat)
+    expect(user.reload.points_count).to eq(2)
+    expect(import.reload.points_count).to eq(2)
+  end
+end

--- a/spec/regressions/legacy_point_coordinate_backfill_spec.rb
+++ b/spec/regressions/legacy_point_coordinate_backfill_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Legacy point coordinate backfill', :non_transactional do
     expect(Point.where(id: [existing.id, backfill_id, legacy_id]).count).to eq(2)
     expect(Point.find(backfill_id).lonlat.x).to eq(2.3522)
     expect(Point.find(backfill_id).lonlat.y).to eq(48.8566)
-    expect(Point.find_by(id: [existing.id, legacy_id]).lonlat).to eq(existing.lonlat)
+    expect(Point.where(id: [existing.id, legacy_id]).pluck(:id)).to eq([existing.id])
     expect(user.reload.points_count).to eq(2)
     expect(import.reload.points_count).to eq(2)
   end
@@ -68,5 +68,21 @@ RSpec.describe 'Legacy point coordinate backfill', :non_transactional do
     expect(Point.find(first_id).lonlat.y).to eq(latitude)
     expect(user.reload.points_count).to eq(1)
     expect(import.reload.points_count).to eq(1)
+  end
+
+  it 'keeps legacy rows with a missing user or timestamp that the unique index would accept' do
+    ids = [
+      [user.id, 'NULL'], [user.id, 'NULL'],
+      ['NULL', timestamp], ['NULL', timestamp]
+    ].map do |user_id, ts|
+      connection.select_value(<<~SQL.squish)
+        INSERT INTO points (user_id, timestamp, latitude, longitude, lonlat, created_at, updated_at)
+        VALUES (#{user_id}, #{ts}, #{latitude}, #{longitude}, NULL, NOW(), NOW())
+        RETURNING id
+      SQL
+    end
+
+    expect { DropLegacyLatLonFromPoints.new.up }.not_to raise_error
+    expect(Point.where(id: ids).where.not(lonlat: nil).pluck(:id)).to match_array(ids)
   end
 end

--- a/spec/regressions/legacy_point_coordinate_backfill_spec.rb
+++ b/spec/regressions/legacy_point_coordinate_backfill_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260714090000_drop_legacy_lat_lon_from_points.rb')
+
+RSpec.describe 'Legacy point coordinate backfill', :non_transactional do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user:) }
+  let(:timestamp) { Time.utc(2026, 1, 15, 12).to_i }
+  let(:longitude) { 13.405 }
+  let(:latitude) { 52.52 }
+
+  before do
+    connection.add_column(:points, :latitude, :decimal, precision: 10, scale: 6)
+    connection.add_column(:points, :longitude, :decimal, precision: 10, scale: 6)
+  end
+
+  after do
+    connection.remove_column(:points, :latitude) if connection.column_exists?(:points, :latitude)
+    connection.remove_column(:points, :longitude) if connection.column_exists?(:points, :longitude)
+  end
+
+  it 'finishes when a legacy-only row duplicates an already-backfilled point' do
+    stub_const('DropLegacyLatLonFromPoints::BATCH_SIZE', 1)
+    existing = create(:point, user:, import:, timestamp:, lonlat: "POINT(#{longitude} #{latitude})")
+    backfill_id = connection.select_value(<<~SQL.squish)
+      INSERT INTO points (user_id, import_id, timestamp, latitude, longitude, lonlat, created_at, updated_at)
+      VALUES (#{user.id}, #{import.id}, #{timestamp + 1}, 48.8566, 2.3522, NULL, NOW(), NOW())
+      RETURNING id
+    SQL
+    legacy_id = connection.select_value(<<~SQL.squish)
+      INSERT INTO points (user_id, import_id, timestamp, latitude, longitude, lonlat, created_at, updated_at)
+      VALUES (#{user.id}, #{import.id}, #{timestamp}, #{latitude}, #{longitude}, NULL, NOW(), NOW())
+      RETURNING id
+    SQL
+
+    user.update_column(:points_count, 3)
+    import.update_column(:points_count, 3)
+
+    expect { DropLegacyLatLonFromPoints.new.up }.not_to raise_error
+    expect(Point.where(id: [existing.id, backfill_id, legacy_id]).count).to eq(2)
+    expect(Point.find(backfill_id).lonlat.x).to eq(2.3522)
+    expect(Point.find(backfill_id).lonlat.y).to eq(48.8566)
+    expect(Point.find_by(id: [existing.id, legacy_id]).lonlat).to eq(existing.lonlat)
+    expect(user.reload.points_count).to eq(2)
+    expect(import.reload.points_count).to eq(2)
+  end
+
+  it 'finishes when two legacy-only rows backfill onto the same point in one batch' do
+    first_id = connection.select_value(<<~SQL.squish)
+      INSERT INTO points (user_id, import_id, timestamp, latitude, longitude, lonlat, created_at, updated_at)
+      VALUES (#{user.id}, #{import.id}, #{timestamp}, #{latitude}, #{longitude}, NULL, NOW(), NOW())
+      RETURNING id
+    SQL
+    second_id = connection.select_value(<<~SQL.squish)
+      INSERT INTO points (user_id, import_id, timestamp, latitude, longitude, lonlat, created_at, updated_at)
+      VALUES (#{user.id}, #{import.id}, #{timestamp}, #{latitude}, #{longitude}, NULL, NOW(), NOW())
+      RETURNING id
+    SQL
+
+    user.update_column(:points_count, 2)
+    import.update_column(:points_count, 2)
+
+    expect { DropLegacyLatLonFromPoints.new.up }.not_to raise_error
+    expect(Point.where(id: [first_id, second_id]).pluck(:id)).to eq([first_id])
+    expect(Point.find(first_id).lonlat.x).to eq(longitude)
+    expect(Point.find(first_id).lonlat.y).to eq(latitude)
+    expect(user.reload.points_count).to eq(1)
+    expect(import.reload.points_count).to eq(1)
+  end
+end


### PR DESCRIPTION
GitHub issue: https://github.com/Freika/dawarich/issues/3200

## Summary
- removes exact legacy-only point duplicates before backfilling `lonlat`
- walks the large points table once in ID-ordered batches
- keeps affected user and import point counters accurate
- covers duplicate and normal backfill paths across batch boundaries

## Verification
- focused regression: 1 example, 0 failures
- RuboCop: 2 files, no offenses
- full RSpec: 7,016 examples, 1 pre-existing failure in `google_phone_takeout_invalid_utf8_spec.rb`
- the same unrelated failure reproduces on OneDev `dev` at `1ec08149d20a83f10d0c1936f6028f48d36182e3`

## Review
- cycle 1 findings fixed: large-table cursor batching, import counter maintenance, release-note scope

## Coordination
GitHub PR https://github.com/Freika/dawarich/pull/3198 changes the same migration for an adjacent lock-timeout crash and will require merge-order coordination; it does not handle this duplicate-key failure.