### PR TITLE
fix: safely remove empty tracks during recalculation

### DIFF
--- a/app/jobs/tracks/recalculate_job.rb
+++ b/app/jobs/tracks/recalculate_job.rb
@@ -10,6 +10,12 @@ class Tracks::RecalculateJob < ApplicationJob
       return
     end
 
+    unless track.points.exists?
+      return if Track.delete_orphaned([track.id]).positive?
+
+      track.reload
+    end
+
     track.recalculate_path_and_distance!
 
     track.broadcast_geojson_updated

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -62,13 +62,23 @@ class Track < ApplicationRecord
     ids = Array(ids).uniq
     return 0 if ids.empty?
 
-    owners = where(id: ids).pluck(:id, :user_id)
-    return 0 if owners.empty?
+    deleted_owners = []
+    transaction do
+      owners = where(id: ids).where.missing(:points).lock('FOR UPDATE OF tracks').pluck(:id, :user_id)
+      return 0 if owners.empty?
 
-    TrackSegment.where(track_id: ids).delete_all
-    deleted = where(id: ids).delete_all
-    broadcast_destroyed(owners)
-    deleted
+      orphan_ids = owners.map(&:first)
+      TrackSegment.where(track_id: orphan_ids).delete_all
+      where(id: orphan_ids).delete_all
+      deleted_owners = owners
+    end
+
+    broadcast_destroyed(deleted_owners)
+    deleted_owners.size
+  rescue ActiveRecord::InvalidForeignKey
+    # A point was assigned after the orphan check. The transaction is rolled
+    # back, leaving both the track and its segments intact for recalculation.
+    0
   end
 
   def self.broadcast_destroyed(track_owner_pairs)

--- a/db/migrate/20260724164000_add_points_track_foreign_key.rb
+++ b/db/migrate/20260724164000_add_points_track_foreign_key.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddPointsTrackForeignKey < ActiveRecord::Migration[8.0]
+  # Adds protection for new writes/deletes without scanning historic points.
+  # A later migration can validate after dangling legacy track references are remediated.
+  def up
+    add_foreign_key :points, :tracks, column: :track_id, on_delete: :restrict, validate: false
+  end
+
+  def down
+    remove_foreign_key :points, :tracks, column: :track_id, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_19_190000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_24_164000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -626,6 +626,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_19_190000) do
   add_foreign_key "place_visits", "places"
   add_foreign_key "place_visits", "visits"
   add_foreign_key "points", "points_raw_data_archives", column: "raw_data_archive_id", on_delete: :restrict
+  add_foreign_key "points", "tracks", column: "track_id", on_delete: :restrict
   add_foreign_key "points", "users"
   add_foreign_key "points", "visits"
   add_foreign_key "points_raw_data_archives", "users"

--- a/spec/jobs/tracks/recalculate_job_spec.rb
+++ b/spec/jobs/tracks/recalculate_job_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Tracks::RecalculateJob, type: :job do
 
     before do
       allow(ExceptionReporter).to receive(:call)
+      create_list(:point, 2, user: user, track: track)
     end
 
     it 'recalculates path and distance for the track' do
@@ -34,6 +35,38 @@ RSpec.describe Tracks::RecalculateJob, type: :job do
       it 'does not attempt to recalculate' do
         expect_any_instance_of(Track).not_to receive(:recalculate_path_and_distance!)
         described_class.perform_now(-1)
+      end
+    end
+
+    context 'when track has no points' do
+      before { track.points.delete_all }
+
+      it 'deletes the orphaned track instead of reporting an invalid path' do
+        track
+
+        expect do
+          described_class.perform_now(track.id)
+        end.to change(Track, :count).by(-1)
+
+        expect(ExceptionReporter).not_to have_received(:call)
+        expect(Track.exists?(track.id)).to be false
+      end
+    end
+
+    context 'when a point is reattached after the orphan check' do
+      before { track.points.delete_all }
+
+      it 'keeps and recalculates the track' do
+        allow(track.points).to receive(:exists?).and_return(false)
+        allow(Track).to receive(:delete_orphaned).with([track.id]) do
+          create(:point, user: user, track: track)
+          0
+        end
+
+        expect_any_instance_of(Track).to receive(:recalculate_path_and_distance!)
+        described_class.perform_now(track.id)
+
+        expect(Track.exists?(track.id)).to be true
       end
     end
 

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Track, type: :model do
       expect(TrackSegment.where(track_id: orphan.id)).to be_empty
     end
 
+    it 'does not delete tracks that still have points' do
+      track = create(:track, user: user)
+      segment = create(:track_segment, track: track)
+      create(:point, user: user, track: track)
+
+      expect(Track.delete_orphaned([track.id])).to eq(0)
+      expect(Track.exists?(track.id)).to be true
+      expect(TrackSegment.exists?(segment.id)).to be true
+    end
+
     it 'broadcasts a destroyed event to the owner for each deleted track' do
       orphan = create(:track, user: user)
 


### PR DESCRIPTION
fix: safely remove empty tracks during recalculation