### PR TITLE
Make visit suggestion consistent and predictable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
+- Place names you set yourself are no longer overwritten by nightly reverse geocoding. Renaming a place, creating one by hand, or picking one on the timeline locks its name; renaming it back to "Suggested place" hands it back to auto-naming.
+- Real-time visit detection no longer stops after the first run for users who track continuously — the debounce key is now released when the job runs.
+- The nightly visit suggestion job no longer scans forward to the end of the calendar year; it processes only the day it was asked for.
+- Merged visits now report the correct duration, centre, radius and suggested name instead of keeping the values of the first cluster in the merge.
+- Visit suggestion failures no longer show a raw stack trace in your notifications, and repeated failures within an hour no longer create a notification each time.
 
 ## [1.10.1] - 2026-07-19, Berlin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Google Semantic History and phone Timeline imports now tag points with a per-import tracker id instead of one shared constant, so tracks from different devices are no longer braided together. A one-time backfill rewrites existing points and regenerates affected tracks per user.
 - Points at exactly (0,0) — a common GPS glitch — are no longer accepted from any ingestion path (API, OwnTracks, Overland, Traccar, file imports) and no longer produce suggested visits at "Null Island". Existing (0,0) points are flagged as anomalies by a one-time cleanup that also removes visits placed at (0,0) and recalculates affected stats and tracks.
-- Place names you set yourself are no longer overwritten by nightly reverse geocoding. Renaming a place, creating one by hand, or picking one on the timeline locks its name; renaming it back to "Suggested place" hands it back to auto-naming.
+- Place names you set yourself are no longer overwritten by nightly reverse geocoding. Renaming a place, creating one by hand, or picking one on the timeline locks its name; renaming it back to "Suggested place" hands it back to auto-naming. Map v2 and the place drawer show when a name is locked (#3086, #3175)
 - Real-time visit detection no longer stops after the first run for users who track continuously — the debounce key is now released when the job runs.
 - The nightly visit suggestion job no longer scans forward to the end of the calendar year; it processes only the day it was asked for.
 - Merged visits now report the correct duration, centre, radius and suggested name instead of keeping the values of the first cluster in the merge.
-- Visit suggestion failures no longer show a raw stack trace in your notifications, and repeated failures within an hour no longer create a notification each time.
+- Visit suggestion failures no longer show a raw stack trace in your notifications, and repeated failures within an hour no longer create a notification each time (#3091)
 
 ## [1.10.1] - 2026-07-19, Berlin
 

--- a/app/controllers/api/v1/places_controller.rb
+++ b/app/controllers/api/v1/places_controller.rb
@@ -69,6 +69,7 @@ module Api
 
       def create
         @place = current_api_user.places.build(place_params.except(:tag_ids))
+        @place.user_named = true
 
         if @place.save
           add_tags if tag_ids.present?
@@ -180,6 +181,7 @@ module Api
           icon: place.tags.first&.icon,
           color: place.tags.first&.color,
           visits_count: place.visits.size,
+          name_locked: place.name_locked?,
           created_at: place.created_at,
           tags: place.tags.map do |tag|
             {

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -19,6 +19,7 @@ class PlacesController < ApplicationController
 
   def create
     @place = current_user.places.build(place_params.except(:tag_ids))
+    @place.user_named = true
 
     if @place.save
       add_tags if tag_ids.present?

--- a/app/javascript/controllers/maps/maplibre/data_loader.js
+++ b/app/javascript/controllers/maps/maplibre/data_loader.js
@@ -505,6 +505,7 @@ export class DataLoader {
           latitude: place.latitude,
           longitude: place.longitude,
           note: place.note,
+          nameLocked: Boolean(place.name_locked),
           // Stringify tags for MapLibre GL JS compatibility
           tags: JSON.stringify(place.tags || []),
           // Use first tag's color if available

--- a/app/javascript/controllers/maps/maplibre/event_handlers.js
+++ b/app/javascript/controllers/maps/maplibre/event_handlers.js
@@ -191,6 +191,11 @@ export class EventHandlers {
       <div class="space-y-2">
         ${properties.tag ? `<div class="badge badge-sm badge-primary">${escapeHtml(properties.tag)}</div>` : ""}
         ${properties.description ? `<div>${escapeHtml(properties.description)}</div>` : ""}
+        ${
+          properties.nameLocked
+            ? `<div class="text-xs opacity-70" data-testid="place-name-lock">🔒 You named this place, so automatic naming won't change it. Rename it to "Suggested place" to hand it back.</div>`
+            : ""
+        }
       </div>
     `
 

--- a/app/jobs/visit_suggesting_job.rb
+++ b/app/jobs/visit_suggesting_job.rb
@@ -8,6 +8,8 @@ class VisitSuggestingJob < ApplicationJob
 
   # Passing timespan of more than 3 years somehow results in duplicated Places
   def perform(user_id:, start_at:, end_at:)
+    release_debounce_key(user_id)
+
     user = find_user_or_skip(user_id) || return
 
     return unless user.safe_settings.visits_suggestions_enabled?
@@ -27,6 +29,13 @@ class VisitSuggestingJob < ApplicationJob
   end
 
   private
+
+  # retry: false means a transient Redis blip here would otherwise drop the whole run.
+  def release_debounce_key(user_id)
+    Visits::RealtimeDebouncer.new(user_id).clear
+  rescue StandardError => e
+    Rails.logger.warn("[VisitSuggestingJob] debounce key release failed user_id=#{user_id}: #{e.class}: #{e.message}")
+  end
 
   def parse_date(date)
     date.is_a?(String) ? Time.zone.parse(date) : date.to_datetime

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -14,7 +14,10 @@ class Place < ApplicationRecord
   has_many :place_visits, dependent: :destroy
   has_many :suggested_visits, -> { distinct }, through: :place_visits, source: :visit
 
+  attr_accessor :machine_named, :user_named
+
   before_validation :build_lonlat, if: -> { latitude.present? && longitude.present? }
+  before_save :lock_name_on_user_edit
 
   validates :name, presence: true, length: { maximum: 255 }
   validates :lonlat, presence: true
@@ -39,6 +42,10 @@ class Place < ApplicationRecord
     lonlat.y
   end
 
+  def name_locked?
+    name_locked_at.present?
+  end
+
   def osm_id
     geodata.dig('properties', 'osm_id')
   end
@@ -59,5 +66,15 @@ class Place < ApplicationRecord
 
   def build_lonlat
     self.lonlat = "POINT(#{longitude} #{latitude})"
+  end
+
+  def lock_name_on_user_edit
+    return if machine_named
+    return unless will_save_change_to_name?
+
+    return self.name_locked_at = nil if name == DEFAULT_NAME
+    return if new_record? && !user_named
+
+    self.name_locked_at = Time.current
   end
 end

--- a/app/serializers/api/place_serializer.rb
+++ b/app/serializers/api/place_serializer.rb
@@ -17,7 +17,8 @@ class Api::PlaceSerializer
       geodata:    place.geodata,
       created_at: place.created_at,
       updated_at: place.updated_at,
-      reverse_geocoded_at: place.reverse_geocoded_at
+      reverse_geocoded_at: place.reverse_geocoded_at,
+      name_locked: place.name_locked?
     }
   end
 

--- a/app/services/places/name_fetcher.rb
+++ b/app/services/places/name_fetcher.rb
@@ -33,12 +33,16 @@ module Places
       name = ::Visits::Names::Builder.build_from_properties(properties)
 
       ActiveRecord::Base.transaction do
-        place.name = name if name.present?
+        place.machine_named = true
+        place.name = name if name.present? && !place.name_locked?
         place.city = properties['city'] if properties['city'].present?
         place.country = properties['country'] if properties['country'].present?
         place.geodata = result.data if DawarichSettings.store_geodata?
         place.save!
-        place.visits.where(name: Place::DEFAULT_NAME).update_all(name: name) if name.present?
+
+        propagated_name = place.name
+        place.visits.where(name: Place::DEFAULT_NAME).update_all(name: propagated_name) if propagated_name.present?
+
         place
       end
     rescue StandardError => e

--- a/app/services/reverse_geocoding/places/fetch_data.rb
+++ b/app/services/reverse_geocoding/places/fetch_data.rb
@@ -36,15 +36,18 @@ class ReverseGeocoding::Places::FetchData
 
     data = normalize_geocoder_data(reverse_geocoded_place.data)
 
-    place.update!(
-      name:       place_name(data),
+    attributes = {
       lonlat:     build_point_coordinates(data['geometry']['coordinates']),
       city:       data['properties']['city'],
       country:    data['properties']['country'],
       geodata:    data,
       source:     Place.sources[:photon],
       reverse_geocoded_at: Time.current
-    )
+    }
+    attributes[:name] = place_name(data) unless place.name_locked?
+
+    place.machine_named = true
+    place.update!(attributes)
   end
 
   def find_place(place_data, existing_places)
@@ -107,7 +110,7 @@ class ReverseGeocoding::Places::FetchData
   end
 
   def populate_place_attributes(place, data)
-    place.name = place_name(data)
+    place.name = place_name(data) unless place.name_locked?
     place.city = data['properties']['city']
     place.country = data['properties']['country']
     place.geodata = data

--- a/app/services/visits/create.rb
+++ b/app/services/visits/create.rb
@@ -64,7 +64,8 @@ module Visits
         latitude: lat_f,
         longitude: lon_f,
         lonlat: "POINT(#{lon_f} #{lat_f})",
-        source: :manual
+        source: :manual,
+        user_named: true
       )
     rescue ActiveRecord::RecordInvalid => e
       ExceptionReporter.call(e, "Failed to create place: #{e.message}")

--- a/app/services/visits/merger.rb
+++ b/app/services/visits/merger.rb
@@ -3,6 +3,8 @@
 module Visits
   # Merges consecutive visits that are likely part of the same stay
   class Merger
+    include Visits::DetectionHelpers
+
     MAXIMUM_VISIT_GAP = 30.minutes
     SIGNIFICANT_MOVEMENT_THRESHOLD = 50 # meters
 
@@ -17,23 +19,47 @@ module Visits
 
       merged = []
       current_merged = visits.first
+      absorbed = false
 
       visits[1..].each do |visit|
         if can_merge_visits?(current_merged, visit)
-          # Merge the visits
           current_merged[:end_time] = visit[:end_time]
           current_merged[:points].concat(visit[:points])
+          recalculate_center(current_merged)
+          absorbed = true
         else
+          finalize(current_merged) if absorbed
           merged << current_merged
           current_merged = visit
+          absorbed = false
         end
       end
 
+      finalize(current_merged) if absorbed
       merged << current_merged
       merged
     end
 
     private
+
+    # Runs on every absorption because can_merge_visits? compares against the running centre.
+    def recalculate_center(visit)
+      center = calculate_weighted_center(visit[:points])
+
+      visit[:center_lat] = center[0]
+      visit[:center_lon] = center[1]
+    end
+
+    # Runs once when a merge chain closes: radius and the name lookup are expensive
+    # and only the final values are ever consumed.
+    def finalize(visit)
+      center = [visit[:center_lat], visit[:center_lon]]
+
+      visit[:duration] = visit[:end_time] - visit[:start_time]
+      visit[:radius] = calculate_visit_radius(visit[:points], center)
+      visit[:suggested_name] =
+        suggest_place_name(visit[:points]) || fetch_place_name(center) || visit[:suggested_name]
+    end
 
     def can_merge_visits?(first_visit, second_visit)
       return false unless same_location?(first_visit, second_visit)

--- a/app/services/visits/realtime_debouncer.rb
+++ b/app/services/visits/realtime_debouncer.rb
@@ -3,7 +3,10 @@
 class Visits::RealtimeDebouncer
   DEBOUNCE_DELAY = 5.minutes
   REDIS_KEY_TTL = 10.minutes
-  LOOKBACK_WINDOW = 25.hours
+  # Clusters that match an existing visit never claim their points, so every run
+  # re-detects and re-names them. Now that the key is released each run, keep the
+  # window tight — BulkVisitsSuggestingJob still re-scans the whole previous day.
+  LOOKBACK_WINDOW = 6.hours
 
   def initialize(user_id)
     @user_id = user_id

--- a/app/services/visits/select_place.rb
+++ b/app/services/visits/select_place.rb
@@ -15,6 +15,7 @@ module Visits
     def call
       with_dedup_lock do
         place = find_by_name_and_proximity || create_place
+        place.update!(name_locked_at: Time.current) unless place.name_locked?
         @visit.update!(place_id: place.id, name: place.name)
         place
       end
@@ -56,7 +57,8 @@ module Visits
         city: @photon[:city],
         country: @photon[:country],
         geodata: DawarichSettings.store_geodata? ? (@photon[:geodata] || {}) : {},
-        source: :photon
+        source: :photon,
+        user_named: true
       )
     end
   end

--- a/app/services/visits/suggest.rb
+++ b/app/services/visits/suggest.rb
@@ -22,17 +22,44 @@ class Visits::Suggest
 
     visits
   rescue StandardError => e
-    # create a notification with stacktrace and what arguments were used
-    user.notifications.create!(
-      kind: :error,
-      title: 'Error suggesting visits',
-      content: "Error suggesting visits: #{e.message}\n#{e.backtrace.join("\n")}"
+    Rails.logger.error(
+      "[Visits::Suggest] user_id=#{user.id} range=#{start_at}..#{end_at} " \
+      "#{e.class}: #{e.message}\n#{e.backtrace&.join("\n")}"
     )
 
+    notify_failure(e)
     ExceptionReporter.call(e)
+
+    []
   end
 
   private
+
+  ERROR_TITLE = 'Error suggesting visits'
+  ERROR_DEDUP_WINDOW = 1.hour
+
+  # The debouncer can schedule a run every five minutes; without this an outage
+  # would bury the notification list under hundreds of identical rows. The claim
+  # is a Redis SET NX so two concurrent runs can't both pass the check, and it
+  # fails open — a Redis problem must never swallow the error notification.
+  def notify_failure(error)
+    return unless claim_error_window?
+
+    user.notifications.create!(
+      kind: :error,
+      title: ERROR_TITLE,
+      content: "Error suggesting visits: #{error.message}"
+    )
+  end
+
+  def claim_error_window?
+    Sidekiq.redis do |redis|
+      redis.set("visit_suggest_error:user:#{user.id}", 1, nx: true, ex: ERROR_DEDUP_WINDOW.to_i)
+    end
+  rescue StandardError => e
+    Rails.logger.warn("[Visits::Suggest] error-notification dedupe unavailable: #{e.class}: #{e.message}")
+    true
+  end
 
   def create_visits_notification(user)
     content = <<~CONTENT

--- a/app/services/visits/time_chunks.rb
+++ b/app/services/visits/time_chunks.rb
@@ -9,10 +9,7 @@ module Visits
     end
 
     def call
-      # If the start date is in the future or equal to the end date,
-      # handle as a special case extending to the end of the start's year
-      # or if the start and end are in the same year, return the year chunk
-      return [start_at..start_at.end_of_year] if start_in_future? || same_year?
+      return [start_at..end_at] if start_in_future? || same_year?
 
       # First chunk: from start_at to end of that year
       first_end = start_at.end_of_year

--- a/app/views/places/_drawer.html.erb
+++ b/app/views/places/_drawer.html.erb
@@ -11,7 +11,14 @@
       <% end %>
     </div>
     <div class="place-drawer__titles">
-      <h2 class="place-drawer__name"><%= place.name %></h2>
+      <h2 class="place-drawer__name">
+        <%= place.name %>
+        <% if place.name_locked? %>
+          <span class="place-drawer__name-lock"
+                title="You named this place, so automatic naming will not change it. Rename it to &quot;<%= Place::DEFAULT_NAME %>&quot; to hand it back to automatic naming."
+                data-testid="place-name-lock"><%= icon 'lock', class: 'w-4 h-4 inline' %></span>
+        <% end %>
+      </h2>
       <% if stats[:location_line].present? %>
         <p class="place-drawer__location"><%= stats[:location_line] %></p>
       <% end %>

--- a/db/migrate/20260727120000_add_name_locked_at_to_places.rb
+++ b/db/migrate/20260727120000_add_name_locked_at_to_places.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddNameLockedAtToPlaces < ActiveRecord::Migration[8.0]
+  def change
+    return if column_exists?(:places, :name_locked_at)
+
+    add_column :places, :name_locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_19_190000) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_27_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -310,6 +310,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_19_190000) do
     t.bigint "user_id"
     t.text "note"
     t.boolean "demo", default: false, null: false
+    t.datetime "name_locked_at"
     t.index "(((geodata -> 'properties'::text) ->> 'osm_id'::text))", name: "index_places_on_geodata_osm_id"
     t.index ["demo"], name: "index_places_on_demo_true", where: "(demo = true)"
     t.index ["lonlat"], name: "index_places_on_lonlat", using: :gist

--- a/spec/jobs/visit_suggesting_job_spec.rb
+++ b/spec/jobs/visit_suggesting_job_spec.rb
@@ -117,6 +117,35 @@ RSpec.describe VisitSuggestingJob, type: :job do
     end
   end
 
+  describe 'realtime debounce key' do
+    let(:redis_key) { "visit_realtime:user:#{user.id}" }
+
+    before do
+      Sidekiq.redis { |redis| redis.del(redis_key) }
+      allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+    end
+
+    after { Sidekiq.redis { |redis| redis.del(redis_key) } }
+
+    it 'still runs when Redis is unavailable' do
+      allow_any_instance_of(Visits::RealtimeDebouncer)
+        .to receive(:clear).and_raise(RedisClient::CannotConnectError, 'redis down')
+
+      expect(Visits::Suggest).to receive(:new).at_least(:once).and_call_original
+
+      described_class.perform_now(user_id: user.id, start_at: start_at, end_at: end_at)
+    end
+
+    it 'releases the key so the debouncer can schedule the next run' do
+      Visits::RealtimeDebouncer.new(user.id).trigger
+
+      described_class.perform_now(user_id: user.id, start_at: start_at, end_at: end_at)
+
+      expect { Visits::RealtimeDebouncer.new(user.id).trigger }
+        .to have_enqueued_job(VisitSuggestingJob).with(hash_including(user_id: user.id))
+    end
+  end
+
   describe 'queue name' do
     it 'uses the visit_suggesting queue' do
       expect(described_class.queue_name).to eq('visit_suggesting')

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -165,4 +165,60 @@ RSpec.describe Place, type: :model do
       end
     end
   end
+
+  describe 'name locking' do
+    let(:place) { create(:place, name: Place::DEFAULT_NAME) }
+
+    it 'is unlocked when created' do
+      expect(place.name_locked?).to be(false)
+    end
+
+    it 'locks the name when it is renamed' do
+      expect { place.update!(name: "Mum's house") }
+        .to change { place.reload.name_locked? }.from(false).to(true)
+    end
+
+    it 'does not lock when another attribute changes' do
+      place.update!(city: 'Leipzig')
+
+      expect(place.reload.name_locked?).to be(false)
+    end
+
+    it 'does not lock a machine-named place' do
+      machine_place = build(:place, name: 'Photon Suggestion')
+      machine_place.machine_named = true
+      machine_place.save!
+
+      expect(machine_place.reload.name_locked?).to be(false)
+    end
+
+    it 'does not lock a place minted by detection' do
+      expect(create(:place, name: 'Photon Suggestion').name_locked?).to be(false)
+    end
+
+    it 'locks a place created with a user-supplied name' do
+      user_place = build(:place, name: "Mum's house")
+      user_place.user_named = true
+      user_place.save!
+
+      expect(user_place.reload.name_locked?).to be(true)
+    end
+
+    it 'clears the lock when the name is reset to the default' do
+      place.update!(name: "Mum's house")
+
+      expect { place.update!(name: Place::DEFAULT_NAME) }
+        .to change { place.reload.name_locked? }.from(true).to(false)
+    end
+
+    it 'keeps an existing lock when a machine write touches other attributes' do
+      place.update!(name: "Mum's house")
+      locked_at = place.reload.name_locked_at
+
+      place.machine_named = true
+      place.update!(city: 'Leipzig')
+
+      expect(place.reload.name_locked_at).to be_within(1.second).of(locked_at)
+    end
+  end
 end

--- a/spec/requests/api/v1/places_spec.rb
+++ b/spec/requests/api/v1/places_spec.rb
@@ -297,4 +297,23 @@ RSpec.describe 'Api::V1::Places', type: :request do
       expect(response).to have_http_status(:unauthorized)
     end
   end
+
+  describe 'name lock exposure' do
+    let(:user) { create(:user) }
+    let(:place) { create(:place, user: user, name: Place::DEFAULT_NAME) }
+
+    it 'reports the lock state so Map v2 can surface it' do
+      place.update!(name: "Mum's house")
+
+      get api_v1_place_path(place), headers: { 'Authorization' => "Bearer #{user.api_key}" }
+
+      expect(response.parsed_body['name_locked']).to be(true)
+    end
+
+    it 'reports an auto-named place as unlocked' do
+      get api_v1_place_path(place), headers: { 'Authorization' => "Bearer #{user.api_key}" }
+
+      expect(response.parsed_body['name_locked']).to be(false)
+    end
+  end
 end

--- a/spec/requests/places_spec.rb
+++ b/spec/requests/places_spec.rb
@@ -344,4 +344,54 @@ RSpec.describe '/places', type: :request do
       expect_turbo_stream_action('replace', 'place-drawer')
     end
   end
+
+  describe 'name locking' do
+    let(:user) { create(:user) }
+
+    before { sign_in user }
+
+    it 'locks the name of a place the user creates by hand' do
+      post places_path, params: { place: { name: "Mum's house", latitude: 51.3402, longitude: 12.3712 } },
+                        as: :turbo_stream
+
+      expect(user.places.last).to be_name_locked
+    end
+
+    it 'shows a lock indicator on the drawer for a locked place' do
+      place = create(:place, user: user, name: Place::DEFAULT_NAME)
+      place.update!(name: "Mum's house")
+
+      get place_path(place)
+
+      expect(response.body).to include('place-name-lock')
+    end
+
+    it 'shows the lock in the drawer response right after a rename' do
+      place = create(:place, user: user, name: Place::DEFAULT_NAME)
+
+      patch place_path(place), params: { place: { name: "Mum's house" } },
+                               headers: { 'Turbo-Frame' => 'place-drawer' }, as: :turbo_stream
+
+      expect(response.body).to include('place-name-lock')
+    end
+
+    it 'drops the lock from the drawer when the name is reset to the default' do
+      place = create(:place, user: user, name: Place::DEFAULT_NAME)
+      place.update!(name: "Mum's house")
+
+      patch place_path(place), params: { place: { name: Place::DEFAULT_NAME } },
+                               headers: { 'Turbo-Frame' => 'place-drawer' }, as: :turbo_stream
+
+      expect(place.reload).not_to be_name_locked
+      expect(response.body).not_to include('place-name-lock')
+    end
+
+    it 'shows no lock indicator for an auto-named place' do
+      place = create(:place, user: user, name: Place::DEFAULT_NAME)
+
+      get place_path(place)
+
+      expect(response.body).not_to include('place-name-lock')
+    end
+  end
 end

--- a/spec/services/places/name_fetcher_spec.rb
+++ b/spec/services/places/name_fetcher_spec.rb
@@ -68,6 +68,36 @@ RSpec.describe Places::NameFetcher do
         service.call
       end
 
+      context 'when the name is locked by the user' do
+        let(:place) do
+          create(
+            :place,
+            name: "Mum's house",
+            name_locked_at: 1.day.ago,
+            city: nil,
+            country: nil,
+            geodata: {},
+            lonlat: 'POINT(10.0 10.0)'
+          )
+        end
+
+        it 'keeps the user-supplied name' do
+          expect { service.call }.not_to change(place, :name)
+        end
+
+        it 'still refreshes city and country' do
+          expect { service.call }.to change(place, :city).from(nil).to('New York')
+        end
+
+        it 'propagates the locked name to visits still using the default name' do
+          visit = create(:visit, place: place, user: place.user, name: Place::DEFAULT_NAME)
+
+          service.call
+
+          expect(visit.reload.name).to eq("Mum's house")
+        end
+      end
+
       context 'when DawarichSettings.store_geodata? is enabled' do
         before do
           allow(DawarichSettings).to receive(:store_geodata?).and_return(true)

--- a/spec/services/reverse_geocoding/places/fetch_data_spec.rb
+++ b/spec/services/reverse_geocoding/places/fetch_data_spec.rb
@@ -51,6 +51,50 @@ RSpec.describe ReverseGeocoding::Places::FetchData do
           .and change { place.reload.country }.to('Germany')
       end
 
+      context 'when the place name is locked by the user' do
+        let(:place) { create(:place, name: "Mum's house", name_locked_at: 1.day.ago) }
+
+        it 'keeps the user-supplied name' do
+          expect { service.call }.not_to change { place.reload.name }
+        end
+
+        it 'still refreshes city and country' do
+          expect { service.call }.to change { place.reload.city }.to('Berlin')
+        end
+      end
+
+      context 'when a sibling place has a locked name' do
+        let(:sibling) do
+          create(:place, user: place.user, name: 'Sibling I named', name_locked_at: 1.day.ago,
+                         geodata: { 'properties' => { 'osm_id' => 99_999 } })
+        end
+
+        let(:sibling_geocoded_place) do
+          double(
+            data: {
+              'geometry' => { 'coordinates' => [13.0948638, 54.2905245] },
+              'properties' => {
+                'osm_id' => 99_999, 'name' => 'Photon Override', 'osm_value' => 'cafe',
+                'city' => 'Hamburg', 'country' => 'Germany'
+              }
+            }
+          )
+        end
+
+        before do
+          sibling
+          allow(Geocoder).to receive(:search).and_return([mock_geocoded_place, sibling_geocoded_place])
+        end
+
+        it 'keeps the locked sibling name through the bulk upsert' do
+          expect { service.call }.not_to change { sibling.reload.name }
+        end
+
+        it 'still refreshes the locked sibling city' do
+          expect { service.call }.to change { sibling.reload.city }.to('Hamburg')
+        end
+      end
+
       it 'sets reverse_geocoded_at timestamp' do
         expect { service.call }.to change { place.reload.reverse_geocoded_at }
           .from(nil)

--- a/spec/services/visits/merger_spec.rb
+++ b/spec/services/visits/merger_spec.rb
@@ -105,6 +105,121 @@ RSpec.describe Visits::Merger do
       end
     end
 
+    context 'when consecutive visits are merged' do
+      let(:base_time) { Time.zone.local(2024, 5, 1, 10, 0, 0).to_i }
+      let(:points) { user.points.order(timestamp: :asc) }
+
+      let(:geodata) do
+        { 'type' => 'Feature', 'properties' => { 'type' => 'street', 'name' => 'Nikolaistrasse' } }
+      end
+
+      let!(:point_a) do
+        create(:point, user: user, timestamp: base_time, geodata: geodata,
+                       latitude: 51.3402, longitude: 12.3712, accuracy: 10)
+      end
+
+      let!(:point_b) do
+        create(:point, user: user, timestamp: base_time + 1200, geodata: geodata,
+                       latitude: 51.3404, longitude: 12.3712, accuracy: 10)
+      end
+
+      let(:visit_a) do
+        {
+          start_time: base_time,
+          end_time: base_time + 600,
+          duration: 600,
+          center_lat: 51.3402,
+          center_lon: 12.3712,
+          radius: 500,
+          suggested_name: 'Stale first-cluster name',
+          points: [point_a]
+        }
+      end
+
+      let(:visit_b) do
+        {
+          start_time: base_time + 1200,
+          end_time: base_time + 1800,
+          duration: 600,
+          center_lat: 51.3404,
+          center_lon: 12.3712,
+          radius: 500,
+          suggested_name: 'Second cluster name',
+          points: [point_b]
+        }
+      end
+
+      subject(:merger) { described_class.new(points) }
+
+      it 'merges the pair into one visit' do
+        expect(merger.merge_visits([visit_a, visit_b]).size).to eq(1)
+      end
+
+      it 'recomputes duration to span the merged range' do
+        merged = merger.merge_visits([visit_a, visit_b]).first
+
+        expect(merged[:duration]).to eq(merged[:end_time] - merged[:start_time])
+        expect(merged[:duration]).to eq(1800)
+      end
+
+      it 'recomputes the centre from every merged point' do
+        merged = merger.merge_visits([visit_a, visit_b]).first
+
+        expect(merged[:center_lat]).to be_within(0.00001).of(51.3403)
+        expect(merged[:center_lon]).to be_within(0.00001).of(12.3712)
+      end
+
+      it 'recomputes the radius against the new centre' do
+        merged = merger.merge_visits([visit_a, visit_b]).first
+
+        expect(merged[:radius]).to eq(15)
+      end
+
+      it 'recomputes the suggested name from every merged point' do
+        merged = merger.merge_visits([visit_a, visit_b]).first
+
+        expect(merged[:suggested_name]).to be_present
+        expect(merged[:suggested_name]).not_to eq('Stale first-cluster name')
+      end
+
+      it 'keeps the pre-merge name when the geocoder lookup fails' do
+        point_a.update!(geodata: {})
+        point_b.update!(geodata: {})
+        allow(Geocoder).to receive(:search).and_return([])
+
+        merged = merger.merge_visits([visit_a, visit_b]).first
+
+        expect(merged[:suggested_name]).to eq('Stale first-cluster name')
+      end
+
+      it 'finalizes once across a three-visit chain' do
+        point_c = create(:point, user: user, timestamp: base_time + 2400, geodata: geodata,
+                                 latitude: 51.3406, longitude: 12.3712, accuracy: 10)
+        visit_c = {
+          start_time: base_time + 2400, end_time: base_time + 3000, duration: 600,
+          center_lat: 51.3406, center_lon: 12.3712, radius: 500,
+          suggested_name: 'Third cluster name', points: [point_c]
+        }
+
+        result = merger.merge_visits([visit_a, visit_b, visit_c])
+
+        expect(result.size).to eq(1)
+        expect(result.first[:points].size).to eq(3)
+        expect(result.first[:duration]).to eq(3000)
+        expect(result.first[:center_lat]).to be_within(0.00001).of(51.3404)
+      end
+
+      it 'leaves an unmerged visit untouched' do
+        far_visit = visit_b.merge(center_lat: 51.9, start_time: base_time + 99_999,
+                                  end_time: base_time + 100_599)
+
+        result = merger.merge_visits([visit_a, far_visit])
+
+        expect(result.last[:suggested_name]).to eq('Second cluster name')
+        expect(result.last[:radius]).to eq(500)
+      end
+    end
+
     context 'with empty visits array' do
       let(:points) { user.points.order(timestamp: :asc) }
 

--- a/spec/services/visits/select_place_spec.rb
+++ b/spec/services/visits/select_place_spec.rb
@@ -37,6 +37,21 @@ RSpec.describe Visits::SelectPlace do
       expect(visit.name).to eq('Café Bravo')
     end
 
+    it 'locks the name of a place the user picked so reverse geocoding cannot rewrite it' do
+      place = described_class.new(user: user, visit: visit, photon: photon_payload).call
+
+      expect(place.reload).to be_name_locked
+    end
+
+    it 'locks the name of an existing place the user picked' do
+      existing = create(:place, user: user, name: photon_payload[:name],
+                                latitude: photon_payload[:latitude], longitude: photon_payload[:longitude])
+
+      described_class.new(user: user, visit: visit, photon: photon_payload.except(:osm_id, :geodata)).call
+
+      expect(existing.reload).to be_name_locked
+    end
+
     it 'does not match another user\'s place at the same name and coords (isolation)' do
       other = create(:user)
       create(:place, user: other, name: 'Café Bravo', latitude: 52.5126, longitude: 13.4012)

--- a/spec/services/visits/suggest_spec.rb
+++ b/spec/services/visits/suggest_spec.rb
@@ -110,6 +110,72 @@ RSpec.describe Visits::Suggest do
       end
     end
 
+    context 'when detection raises' do
+      before do
+        allow(Visits::SmartDetect).to receive(:new).and_raise(StandardError, 'detector exploded')
+        Sidekiq.redis { |redis| redis.del("visit_suggest_error:user:#{user.id}") }
+      end
+
+      after do
+        Sidekiq.redis { |redis| redis.del("visit_suggest_error:user:#{user.id}") }
+      rescue StandardError
+        nil
+      end
+
+      it 'returns an empty collection' do
+        expect(described_class.new(user, start_at:, end_at:).call).to eq([])
+      end
+
+      it 'logs the failure with a backtrace for self-hosted operators' do
+        allow(Rails.logger).to receive(:error)
+
+        described_class.new(user, start_at:, end_at:).call
+
+        expect(Rails.logger).to have_received(:error).with(/detector exploded/)
+      end
+
+      it 'does not repeat the notification while an unread one is recent' do
+        3.times { described_class.new(user, start_at:, end_at:).call }
+
+        expect(user.notifications.where(title: 'Error suggesting visits').count).to eq(1)
+      end
+
+      it 'notifies again once the dedup window has passed' do
+        described_class.new(user, start_at:, end_at:).call
+        Sidekiq.redis { |redis| redis.del("visit_suggest_error:user:#{user.id}") }
+
+        described_class.new(user, start_at:, end_at:).call
+
+        expect(user.notifications.where(title: 'Error suggesting visits').count).to eq(2)
+      end
+
+      it 'suppresses the notification when another run already claimed the window' do
+        Sidekiq.redis { |redis| redis.set("visit_suggest_error:user:#{user.id}", 1, ex: 3600) }
+
+        described_class.new(user, start_at:, end_at:).call
+
+        expect(user.notifications.where(title: 'Error suggesting visits')).to be_empty
+      end
+
+      it 'still notifies when Redis is unavailable' do
+        allow(Sidekiq).to receive(:redis).and_raise(RedisClient::CannotConnectError, 'redis down')
+
+        described_class.new(user, start_at:, end_at:).call
+
+        expect(user.notifications.where(title: 'Error suggesting visits').count).to eq(1)
+      end
+
+      it 'notifies the user without leaking a backtrace' do
+        described_class.new(user, start_at:, end_at:).call
+
+        notification = user.notifications.order(:id).last
+
+        expect(notification.kind).to eq('error')
+        expect(notification.content).to include('detector exploded')
+        expect(notification.content).not_to match(/\.rb:\d+/)
+      end
+    end
+
     # The Lite plan window is enforced inside `Visits::SmartDetect` (which is
     # what `Visits::Suggest#call` delegates to). The corresponding regression
     # test lives in spec/services/visits/smart_detect_spec.rb.

--- a/spec/services/visits/time_chunks_spec.rb
+++ b/spec/services/visits/time_chunks_spec.rb
@@ -38,8 +38,21 @@ RSpec.describe Visits::TimeChunks do
       end
     end
 
+    context 'with the nightly single-day range' do
+      it 'ends the chunk at end_at rather than the end of the calendar year' do
+        start_at = DateTime.new(2026, 1, 2).beginning_of_day
+        end_at = DateTime.new(2026, 1, 2).end_of_day
+
+        chunks = described_class.new(start_at: start_at, end_at: end_at).call
+
+        expect(chunks.size).to eq(1)
+        expect(chunks[0].first).to eq(start_at)
+        expect(chunks[0].last).to eq(end_at)
+      end
+    end
+
     context 'with a span within a single year' do
-      it 'creates a single chunk ending at year end' do
+      it 'creates a single chunk ending at end_at' do
         start_at = DateTime.new(2020, 3, 15)
         end_at = DateTime.new(2020, 10, 20)
 
@@ -48,8 +61,7 @@ RSpec.describe Visits::TimeChunks do
 
         expect(chunks.size).to eq(1)
         expect(chunks[0].begin).to eq(start_at)
-        # The implementation appears to extend to the end of the year
-        expect(chunks[0].end).to eq(DateTime.new(2020, 12, 31).end_of_day)
+        expect(chunks[0].end).to eq(end_at)
       end
     end
 
@@ -76,7 +88,7 @@ RSpec.describe Visits::TimeChunks do
     end
 
     context 'with start and end dates in the same day' do
-      it 'returns a single chunk ending at the end of the year' do
+      it 'returns a single chunk covering only that day' do
         date = DateTime.new(2020, 5, 15)
         start_at = date.beginning_of_day
         end_at = date.end_of_day
@@ -86,8 +98,7 @@ RSpec.describe Visits::TimeChunks do
 
         expect(chunks.size).to eq(1)
         expect(chunks[0].begin).to eq(start_at)
-        # Implementation extends to end of year
-        expect(chunks[0].end).to eq(DateTime.new(2020, 12, 31).end_of_day)
+        expect(chunks[0].end).to eq(end_at)
       end
     end
 
@@ -130,22 +141,21 @@ RSpec.describe Visits::TimeChunks do
     end
 
     context 'with start date after end date' do
-      it 'still creates a chunk for start date year' do
+      it 'returns a single chunk bounded by the given dates' do
         start_at = DateTime.new(2023, 1, 1)
         end_at = DateTime.new(2020, 1, 1)
 
         service = described_class.new(start_at: start_at, end_at: end_at)
         chunks = service.call
 
-        # The implementation creates one chunk for the start date year
         expect(chunks.size).to eq(1)
         expect(chunks[0].begin).to eq(start_at)
-        expect(chunks[0].end).to eq(DateTime.new(2023, 12, 31).end_of_day)
+        expect(chunks[0].end).to eq(end_at)
       end
     end
 
     context 'when start date equals end date' do
-      it 'returns a single chunk extending to year end' do
+      it 'returns a single zero-length chunk' do
         date = DateTime.new(2022, 6, 15, 12, 30)
 
         service = described_class.new(start_at: date, end_at: date)
@@ -153,8 +163,7 @@ RSpec.describe Visits::TimeChunks do
 
         expect(chunks.size).to eq(1)
         expect(chunks[0].begin).to eq(date)
-        # Implementation extends to end of year
-        expect(chunks[0].end).to eq(DateTime.new(2022, 12, 31).end_of_day)
+        expect(chunks[0].end).to eq(date)
       end
     end
   end


### PR DESCRIPTION
Five bugs in the visit-suggestion subsystem, found while auditing it end to end. Each fix is independent; the batch is grouped because they all feed the same nightly path.

## What was wrong

**Realtime detection died after one run.** `Visits::RealtimeDebouncer#clear` was defined but never called anywhere — the sibling `Tracks::RealtimeDebouncer` *is* cleared, by `Tracks::RealtimeGenerationJob`. Since every incoming point slides the Redis TTL, the `nx: true` guard never released for a continuously-tracking user: realtime visit detection fired exactly once, then never again until tracking paused for 10 consecutive minutes. Closes #2875, #2705.

**The nightly job scanned to the end of the calendar year.** `Visits::TimeChunks` discarded `end_at` whenever start and end fell in the same year, so `BulkVisitsSuggestingJob`'s "yesterday" range became "yesterday .. 31 December" and `VisitSuggestingJob` looped day-by-day across the remainder of the year, every night, per user.

**Error notifications carried a stack trace.** `Visits::Suggest` interpolated `e.backtrace` into a user-facing `Notification` and returned `ExceptionReporter.call`'s value rather than an array — `FullHistoryRedetectJob` does `.call.size` on it. Closes #3091.

**Merged visits reported the wrong duration.** `Visits::Merger` updated `end_time` and concatenated points but never recomputed `duration`, `center_lat/lon`, `radius` or `suggested_name`. `Visits::Creator` then wrote the *pre-merge* duration, and the stale `suggested_name` made `PlaceFinder` resolve the merged visit to the first sub-cluster's place. Possible cause of #2775.

**Reverse geocoding overwrote user-chosen place names, nightly.** `Visits::Suggest` enqueues `ReverseGeocodingJob('place', id)` for every place touched by a new visit — existing ones included — and three services then overwrote the name unconditionally: `FetchData#update_place`, `FetchData#populate_place_attributes` (written via `Place.upsert_all`, so model callbacks cannot guard it), and `Places::NameFetcher`. Meanwhile every place is stamped `source: :photon`, including ones the user personally picked, so `place.manual?` was never a usable "the user named this" signal. Closes #3086, #3175, #2347.

## How

- `VisitSuggestingJob` releases the debounce key, wrapped so a transient Redis error can't drop the whole run under `retry: false`. The realtime lookback drops from 25h to 6h — clusters that match an existing visit never claim their points, so a long window re-detected and re-geocoded the same clusters on every run. `BulkVisitsSuggestingJob` still re-scans the full previous day.
- `TimeChunks` honours `end_at`. Three specs asserted the old behaviour in their own titles ("The implementation appears to extend to the end of the year") — characterization tests documenting the bug, rewritten to specify the correct one.
- `Visits::Suggest` returns `[]`, logs class/message/backtrace to `Rails.logger` unconditionally (`ExceptionReporter` returns early when self-hosted, so self-hosters had no trace anywhere), and gates repeat notifications behind a Redis `SET NX` claim with a 1h TTL. The claim **fails open** — a Redis problem must never swallow an error notification.
- `Visits::Merger` recomputes the centre on every absorption, because `can_merge_visits?` compares the next candidate against the running centre. Duration, radius and `suggested_name` are recomputed once when a chain closes — radius is O(n) haversines and the name lookup can hit the network, and only the final values are consumed. A visit that never merged is left untouched, so no geocoder call is made for it, and a failed lookup keeps the pre-merge name rather than blanking it.
- New `places.name_locked_at`. `Place` gains two transient accessors: `user_named` (opt in on creation) and `machine_named` (opt out on update). The callback locks on rename of a persisted record, or on creation when `user_named` is set — so factory- and `PlaceFinder`-minted places stay unlocked. Locking is wired into both place controllers' `create`, `Visits::Create`, and `Visits::SelectPlace` (including the branch that reuses an existing nearby place). The lock is not one-way: renaming a place back to `Place::DEFAULT_NAME` clears it. State is exposed through both place serializers and surfaced in the Map v2 info panel and the place drawer.

## Notes for review

- `db/schema.rb` is a two-line diff on purpose. `rails db:migrate` regenerated the whole file with Rails 8.1's alphabetical column dumper (466 lines, schema version bumped to `[8.1]`); that was reverted and the single column added by hand. The repo still declares `ActiveRecord::Schema[8.0]`.
- **Concurrency was deliberately left alone.** `Visits::SmartDetect#with_user_lock` degrades to a bare `yield` when `advisory_locks: false` (Cloud/PgBouncer), so restoring the realtime cadence widens an already-unlocked window. Not addressed here: it is pre-existing architecture, `Tracks::PerUserLock` is already an over-contended source of `AcquisitionTimeout` noise, and there are four writers to `visits` across three lock namespaces plus two unlocked ones. Unifying them is a design change, not a line to slip into a fix batch.
- `CHANGELOG.md` will conflict with `dev` — both sides added entries under `## Unreleased`. Everything else auto-merges, including the reverse-geocoding files.

## Verification

```
spec/services + spec/models + spec/jobs + spec/requests + spec/serializers
  → 5939 examples, 0 failures

rubocop on the changed Ruby → no offenses
biome on the changed JS  → 6 warnings, byte-identical to the dev baseline
```

Every fix was written test-first; the specs fail on `dev` for the stated reason. 28 files, +579/-34.
