### PR TITLE
Add a Poster Studio track width control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Poster Studio has a track width control: a 50–300% slider beside track opacity that scales the route line on the saved poster.
+
 ### Fixed
 
 - Saving a zoomed-out Poster Studio view to the gallery no longer rejects routes that are visibly inside the poster frame (#3204).

--- a/app/controllers/posters_controller.rb
+++ b/app/controllers/posters_controller.rb
@@ -51,6 +51,6 @@ class PostersController < ApplicationController
 
   def poster_params
     params.require(:poster).permit(:name, :title, :lat, :lon, :distance, :theme, :start_at, :end_at, :source,
-                                   :route_fill, :route_opacity)
+                                   :route_fill, :route_opacity, :route_width)
   end
 end

--- a/app/javascript/controllers/poster_studio_editor_controller.js
+++ b/app/javascript/controllers/poster_studio_editor_controller.js
@@ -76,6 +76,8 @@ export default class extends Controller {
     "fontSelect",
     "trackOpacity",
     "trackOpacityLabel",
+    "trackWidth",
+    "trackWidthLabel",
     "summary",
     "format",
     "dpi",
@@ -95,6 +97,7 @@ export default class extends Controller {
     "saveEndAt",
     "saveSource",
     "saveOpacity",
+    "saveWidth",
     "dateStart",
     "dateEnd",
     "loadButton",
@@ -133,6 +136,7 @@ export default class extends Controller {
     this.populateSizePicker()
     this.populateFonts()
     this.trackOpacityLabelTarget.textContent = `${this.trackOpacityTarget.value}%`
+    this.trackWidthLabelTarget.textContent = `${this.trackWidthTarget.value}%`
   }
 
   disconnect() {
@@ -237,6 +241,7 @@ export default class extends Controller {
       extras: true,
       hiddenCategories: [...this.hidden],
       trackOpacity: this.trackOpacityValue(),
+      trackWidth: this.trackWidthValue(),
     })
   }
 
@@ -460,11 +465,16 @@ export default class extends Controller {
       if (!toggle.checked) this.hidden.add(toggle.dataset.layerCategory)
     })
     this.trackOpacityLabelTarget.textContent = `${this.trackOpacityTarget.value}%`
+    this.trackWidthLabelTarget.textContent = `${this.trackWidthTarget.value}%`
     this.scheduleRestyle()
   }
 
   trackOpacityValue() {
     return Number.parseInt(this.trackOpacityTarget.value, 10) / 100
+  }
+
+  trackWidthValue() {
+    return Number.parseInt(this.trackWidthTarget.value, 10) / 100
   }
 
   // ===== Date range =====
@@ -776,6 +786,7 @@ export default class extends Controller {
     this.saveEndAtTarget.value = endAt || ""
     this.saveSourceTarget.value = this.provider.trackSource()
     this.saveOpacityTarget.value = this.trackOpacityTarget.value
+    this.saveWidthTarget.value = this.trackWidthTarget.value
     this.saveFormTarget.requestSubmit()
     this.setStatus("Queued — rendering server-side into Recent posters…")
   }

--- a/app/services/posters/generate.rb
+++ b/app/services/posters/generate.rb
@@ -4,6 +4,8 @@ module Posters
   class Generate
     MAX_DISTANCE = 5_000_000
     MIN_DISTANCE = 500
+    MIN_ROUTE_WIDTH = 0.5
+    MAX_ROUTE_WIDTH = 3.0
     METERS_PER_DEGREE = 111_320.0
 
     def initialize(poster)
@@ -49,6 +51,7 @@ module Posters
         track: track,
         distance: distance,
         route_opacity: route_opacity,
+        route_width: route_width,
         subtitle: subtitle
       ).call
       attach_image(result[:png])
@@ -60,6 +63,13 @@ module Posters
       raw /= 100.0 if raw > 1
       raw = 1.0 if raw <= 0
       raw.clamp(0.05, 1.0)
+    end
+
+    def route_width
+      raw = @poster.settings.fetch('route_width', 100).to_f
+      return 1.0 if raw <= 0
+
+      (raw / 100.0).clamp(MIN_ROUTE_WIDTH, MAX_ROUTE_WIDTH)
     end
 
     def distance

--- a/app/services/posters/native_renderer.rb
+++ b/app/services/posters/native_renderer.rb
@@ -18,11 +18,12 @@ module Posters
     RENDER_TIMEOUT = 180
     TERMINATE_TIMEOUT = 5
 
-    def initialize(poster:, track:, distance:, route_opacity:, subtitle:, command: nil)
+    def initialize(poster:, track:, distance:, route_opacity:, subtitle:, route_width: 1, command: nil)
       @poster = poster
       @track = track
       @distance = distance
       @route_opacity = route_opacity
+      @route_width = route_width
       @subtitle = subtitle
       @command = command || default_command
     end
@@ -47,6 +48,7 @@ module Posters
         tokens: theme_tokens,
         trackGeojson: { type: 'Feature', properties: {}, geometry: @track },
         trackOpacity: @route_opacity,
+        trackWidth: @route_width,
         view: {
           lat: @poster.settings['lat'].to_f,
           lon: @poster.settings['lon'].to_f,

--- a/app/views/posters/_studio.html.erb
+++ b/app/views/posters/_studio.html.erb
@@ -226,6 +226,17 @@
                        data-poster-studio-editor-target="trackOpacity"
                        data-action="input->poster-studio-editor#layersChanged">
               </div>
+              <div class="pt-2">
+                <div class="flex items-center justify-between py-1">
+                  <span class="label-text text-xs">Track width</span>
+                  <span class="text-xs font-medium tabular-nums opacity-80"
+                        data-poster-studio-editor-target="trackWidthLabel"></span>
+                </div>
+                <input type="range" min="50" max="300" step="10" value="100"
+                       class="range range-primary range-xs"
+                       data-poster-studio-editor-target="trackWidth"
+                       data-action="input->poster-studio-editor#layersChanged">
+              </div>
             </div>
           </details>
 
@@ -391,6 +402,7 @@
             <%= f.hidden_field :end_at, data: { poster_studio_editor_target: 'saveEndAt' } %>
             <%= f.hidden_field :source, data: { poster_studio_editor_target: 'saveSource' } %>
             <%= f.hidden_field :route_opacity, data: { poster_studio_editor_target: 'saveOpacity' } %>
+            <%= f.hidden_field :route_width, data: { poster_studio_editor_target: 'saveWidth' } %>
           <% end %>
         </div>
       </aside>

--- a/spec/services/posters/generate_spec.rb
+++ b/spec/services/posters/generate_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Posters::Generate do
 
     it 'renders with the poster distance, opacity, subtitle and track' do
       expect(Posters::NativeRenderer).to receive(:new).with(
-        poster: poster, track: track, distance: 6000, route_opacity: 1.0,
+        poster: poster, track: track, distance: 6000, route_opacity: 1.0, route_width: 1.0,
         subtitle: '1 Apr 2026 – 30 Apr 2026'
       ).and_return(renderer)
 
@@ -62,6 +62,44 @@ RSpec.describe Posters::Generate do
     end
   end
 
+  context 'when settings request a percentage track width' do
+    let(:poster) do
+      create(:poster, settings: attributes_for(:poster)[:settings].merge('route_width' => '250'))
+    end
+
+    before { allow_any_instance_of(Posters::TrackBuilder).to receive(:call).and_return(track) }
+
+    it 'passes the width as a multiplier' do
+      expect(Posters::NativeRenderer).to receive(:new).with(hash_including(route_width: 2.5)).and_return(renderer)
+
+      run_generate
+    end
+  end
+
+  context 'when settings omit the track width' do
+    before { allow_any_instance_of(Posters::TrackBuilder).to receive(:call).and_return(track) }
+
+    it 'falls back to the unscaled width' do
+      expect(Posters::NativeRenderer).to receive(:new).with(hash_including(route_width: 1.0)).and_return(renderer)
+
+      run_generate
+    end
+  end
+
+  context 'when settings request a track width beyond the slider range' do
+    let(:poster) do
+      create(:poster, settings: attributes_for(:poster)[:settings].merge('route_width' => '900'))
+    end
+
+    before { allow_any_instance_of(Posters::TrackBuilder).to receive(:call).and_return(track) }
+
+    it 'clamps the width to the maximum multiplier' do
+      expect(Posters::NativeRenderer).to receive(:new).with(hash_including(route_width: 3.0)).and_return(renderer)
+
+      run_generate
+    end
+  end
+
   context 'when the requested distance fits within the poster studio range' do
     let(:poster) { create(:poster, settings: attributes_for(:poster)[:settings].merge('distance' => 2_924_948)) }
 
@@ -83,6 +121,24 @@ RSpec.describe Posters::Generate do
       expect(Posters::NativeRenderer).to receive(:new).with(hash_including(distance: 5_000_000)).and_return(renderer)
 
       run_generate
+    end
+  end
+
+  context 'when a continent-wide frame is saved to the gallery' do
+    let(:poster) do
+      create(:poster, settings: attributes_for(:poster)[:settings].merge(
+        'lat' => '40.019826138511576', 'lon' => '17.87175149999996', 'distance' => '2924948'
+      ))
+    end
+    let(:track_through_rome) { { 'type' => 'MultiLineString', 'coordinates' => [[[12.49, 41.90], [12.50, 41.91]]] } }
+
+    before { allow_any_instance_of(Posters::TrackBuilder).to receive(:call).and_return(track_through_rome) }
+
+    it 'completes instead of reporting the track as outside the map area' do
+      run_generate
+
+      expect(poster.reload).to be_completed
+      expect(poster.settings['error']).to be_nil
     end
   end
 

--- a/spec/services/posters/generate_spec.rb
+++ b/spec/services/posters/generate_spec.rb
@@ -100,6 +100,34 @@ RSpec.describe Posters::Generate do
     end
   end
 
+  context 'when settings request a track width below the slider range' do
+    let(:poster) do
+      create(:poster, settings: attributes_for(:poster)[:settings].merge('route_width' => '10'))
+    end
+
+    before { allow_any_instance_of(Posters::TrackBuilder).to receive(:call).and_return(track) }
+
+    it 'clamps the width to the minimum multiplier' do
+      expect(Posters::NativeRenderer).to receive(:new).with(hash_including(route_width: 0.5)).and_return(renderer)
+
+      run_generate
+    end
+  end
+
+  context 'when settings request a negative track width' do
+    let(:poster) do
+      create(:poster, settings: attributes_for(:poster)[:settings].merge('route_width' => '-50'))
+    end
+
+    before { allow_any_instance_of(Posters::TrackBuilder).to receive(:call).and_return(track) }
+
+    it 'falls back to the unscaled width' do
+      expect(Posters::NativeRenderer).to receive(:new).with(hash_including(route_width: 1.0)).and_return(renderer)
+
+      run_generate
+    end
+  end
+
   context 'when the requested distance fits within the poster studio range' do
     let(:poster) { create(:poster, settings: attributes_for(:poster)[:settings].merge('distance' => 2_924_948)) }
 

--- a/spec/services/posters/native_renderer_spec.rb
+++ b/spec/services/posters/native_renderer_spec.rb
@@ -41,6 +41,23 @@ RSpec.describe Posters::NativeRenderer do
       expect(result[:pdf]).to eq('PDF:Berlin')
     end
 
+    it 'carries the track width multiplier into the job' do
+      job = JSON.parse(
+        described_class.new(
+          poster: poster, track: track, distance: 15_000, route_opacity: 0.6,
+          route_width: 2.5, subtitle: '1 Oct 2025 – 31 Oct 2025', command: fake_command
+        ).call[:png]
+      )
+
+      expect(job['trackWidth']).to eq(2.5)
+    end
+
+    it 'defaults the track width multiplier to 1' do
+      job = JSON.parse(build_renderer.call[:png])
+
+      expect(job['trackWidth']).to eq(1)
+    end
+
     it 'renders the explicit settings title when present' do
       poster.settings['title'] = 'My Trip'
 

--- a/vendor/poster_renderer/render.mjs
+++ b/vendor/poster_renderer/render.mjs
@@ -81,6 +81,7 @@ async function main() {
     theme,
     trackGeojson: job.trackGeojson ?? { type: "FeatureCollection", features: [] },
     trackOpacity: job.trackOpacity ?? 1,
+    trackWidth: job.trackWidth ?? 1,
     ...(job.tilesUrl ? { tileUrl: job.tilesUrl } : {}),
   })
 


### PR DESCRIPTION
Stacked on #3230 — base is `fix/poster-large-area-save` so this diff shows only the track width work. GitHub will retarget it to `dev` once #3230 merges.

## Why

`buildPosterStyle` has accepted a `trackWidth` multiplier since the studio landed (`style_builder.js:171`), applied to both the casing and route line layers. Nothing ever set it: the studio controller, `render.mjs`, and `Posters::NativeRenderer` all left it at the default of 1. Track opacity got a slider, persistence and server plumbing; width got the parameter and nothing else.

At continent-scale framing (now reachable via #3230) a fixed line weight is the wrong default in both directions — a dense multi-year track reads as a blob, a sparse one as a hairline.

## Change

A 50-300% slider beside Track opacity, persisted as `route_width`, converted server-side to a 0.5-3.0 multiplier.

| Layer | Change |
| --- | --- |
| `_studio.html.erb` | range input 50-300 step 10, plus hidden `route_width` field |
| `poster_studio_editor_controller.js` | targets, `trackWidthValue()`, live restyle, save wiring |
| `posters_controller.rb` | permit `:route_width` |
| `Posters::Generate` | `route_width`, `MIN_ROUTE_WIDTH` 0.5 / `MAX_ROUTE_WIDTH` 3.0 |
| `Posters::NativeRenderer` | `route_width:` kwarg (default 1) into the job as `trackWidth` |
| `vendor/poster_renderer/render.mjs` | `trackWidth: job.trackWidth ?? 1` |

Values outside the range clamp to the nearest bound (`900` becomes 3.0); missing, zero, and negative values fall back to 1.0. Existing posters carry no `route_width`, so they hit the fallback and render unchanged.

## Verification

- `rspec spec/services/posters/ spec/requests/posters_spec.rb` — 48 examples, 0 failures
- Full suite — 7022 examples, 1 failure: `spec/regressions/google_phone_takeout_invalid_utf8_spec.rb:40`, a stale `Imports::SecureFileDownloader` double, pre-existing and unrelated to this diff
- `rubocop` on all changed Ruby — no offenses
- `biome check` on the studio controller — clean; `node --check render.mjs` — OK
- End-to-end through Rails (real Points → `TrackBuilder` → `Generate` → `render.sh` → attached PNG) at `route_width` 50 and 300: both `completed`, distinct output

Not covered: the slider itself is unexercised in a browser; the Ruby conversion and the renderer's use of the multiplier are both under test, but the widget is not.

Also includes a regression test for #3204 — a continent-wide frame completes rather than failing the area check. It fails on the old 20 km clamp with the exact user-facing string from the issue.
