### PR TITLE
feat: remember the Map v2 "Edit points" choice across sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- The Map v2 "Edit points" toggle is now remembered between sessions instead of resetting to off on every page load; it still defaults to off, so points stay protected from accidental drags until you opt in. On the Lite plan it stays session-only, since editing points requires Pro. (#3085)
+
 ### Fixed
 
+- Turning "Edit points" off on Map v2 now reliably disables point dragging. Changing the map style while editing was on left a stale drag handler attached, so points stayed draggable no matter what the toggle said.
 - The Dawarich app and Sidekiq containers now restart automatically after a graceful (exit 0) shutdown instead of staying down, so a stray SIGHUP no longer takes an instance offline until manual intervention (#3099).
 - Nightly place- and area-visit calculation no longer fails when an instance contains legacy points without timestamps.
 - Import rows on the Imports page now update their status live as an import processes, instead of staying on "Processing" until the page is manually reloaded. (#3174)

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -82,6 +82,7 @@ class Api::V1::SettingsController < ApiController
       :min_minutes_spent_in_city, :max_gap_minutes_in_city,
       :stay_max_gap_minutes,
       :gps_filtering_enabled, :gps_accuracy_threshold,
+      :point_dragging_enabled,
       enabled_map_layers: [],
       enabled_transportation_modes: [],
       maps_maplibre_custom_theme: [

--- a/app/javascript/controllers/maps/maplibre/layer_manager.js
+++ b/app/javascript/controllers/maps/maplibre/layer_manager.js
@@ -13,8 +13,10 @@ import { ReplayMarkerLayer } from "maps_maplibre/layers/replay_marker_layer"
 import { RoutesLayer } from "maps_maplibre/layers/routes_layer"
 import { TracksLayer } from "maps_maplibre/layers/tracks_layer"
 import { VisitsLayer } from "maps_maplibre/layers/visits_layer"
+import { isGatedPlan } from "maps_maplibre/utils/layer_gate"
 import { lazyLoader } from "maps_maplibre/utils/lazy_loader"
 import { performanceMonitor } from "maps_maplibre/utils/performance_monitor"
+import { SettingsManager } from "maps_maplibre/utils/settings_manager"
 
 /**
  * Manages all map layers lifecycle and visibility
@@ -224,6 +226,10 @@ export class LayerManager {
     if (this.layers.tracksLayer?._stopFlowAnimation) {
       this.layers.tracksLayer._stopFlowAnimation()
     }
+    // Drag handlers live on the map, not the style, so an orphaned points
+    // layer keeps moving points. setEditMode, not disableDragging: add() arms
+    // enableDragging on a timer that re-checks editModeEnabled.
+    this.layers.pointsLayer?.setEditMode(false)
     this.layers = {}
     this.eventHandlersSetup = false
   }
@@ -411,6 +417,11 @@ export class LayerManager {
         apiClient: this.api,
         layerManager: this,
         styleName: this.settings.mapStyle,
+        // Live cache, not this.settings: that snapshot is replaced wholesale
+        // when advanced settings are saved. Lite can't write points.
+        editModeEnabled:
+          SettingsManager.getSetting("pointDraggingEnabled") === true &&
+          !isGatedPlan(this.controller?.userPlanValue),
       })
       this.layers.pointsLayer.add(pointsGeoJSON)
     } else {

--- a/app/javascript/controllers/maps/maplibre/settings_manager.js
+++ b/app/javascript/controllers/maps/maplibre/settings_manager.js
@@ -60,6 +60,7 @@ export class SettingsController {
     // Sync layer toggles
     const toggleMap = {
       pointsToggle: "pointsVisible",
+      pointsEditToggle: "pointDraggingEnabled",
       routesToggle: "routesVisible",
       heatmapToggle: "heatmapEnabled",
       hexagonsToggle: "hexagonsEnabled",
@@ -82,6 +83,7 @@ export class SettingsController {
       "hexagonsToggle",
       "fogToggle",
       "scratchToggle",
+      "pointsEditToggle",
     ])
 
     Object.entries(toggleMap).forEach(([targetName, settingKey]) => {
@@ -1264,6 +1266,14 @@ export class SettingsController {
     }
 
     await SettingsManager.updateSetting("fogOfWarMode", mode)
+  }
+
+  togglePointsEditing(event) {
+    const enabled = event.target.checked
+
+    this.layerManager.getLayer("points")?.setEditMode(enabled)
+
+    SettingsManager.updateSetting("pointDraggingEnabled", enabled)
   }
 
   updateRouteOpacity(event) {

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -62,6 +62,7 @@ export default class extends Controller {
     "searchResults",
     // Layer toggles
     "pointsToggle",
+    "pointsEditToggle",
     "routesToggle",
     "heatmapToggle",
     "hexagonsToggle",
@@ -1403,8 +1404,7 @@ export default class extends Controller {
   }
 
   togglePointsEditing(event) {
-    const pointsLayer = this.layerManager.getLayer("points")
-    pointsLayer?.setEditMode(event.currentTarget.checked)
+    return this.settingsController.togglePointsEditing(event)
   }
   toggleRoutes(event) {
     return this.routesManager.toggleRoutes(event)

--- a/app/javascript/maps_maplibre/layers/points_layer.js
+++ b/app/javascript/maps_maplibre/layers/points_layer.js
@@ -17,7 +17,7 @@ export class PointsLayer extends BaseLayer {
     this.justDragged = false
     this.draggedFeature = null
     this.canvas = null
-    this.editModeEnabled = false
+    this.editModeEnabled = options.editModeEnabled === true
 
     // Bind event handlers once and store references for proper cleanup
     this._onMouseEnter = this.onMouseEnter.bind(this)

--- a/app/javascript/maps_maplibre/utils/settings_manager.js
+++ b/app/javascript/maps_maplibre/utils/settings_manager.js
@@ -52,6 +52,7 @@ const DEFAULT_SETTINGS = {
   stayMaxGapMinutes: 60,
   gpsFilteringEnabled: true,
   gpsAccuracyThreshold: 100,
+  pointDraggingEnabled: false,
   transportationExpertMode: false,
   enabledTransportationModes: [
     "unknown",
@@ -122,6 +123,7 @@ const BACKEND_SETTINGS_MAP = {
   stayMaxGapMinutes: "stay_max_gap_minutes",
   gpsFilteringEnabled: "gps_filtering_enabled",
   gpsAccuracyThreshold: "gps_accuracy_threshold",
+  pointDraggingEnabled: "point_dragging_enabled",
   transportationExpertMode: "transportation_expert_mode",
   enabledTransportationModes: "enabled_transportation_modes",
   transportationThresholds: "transportation_thresholds",
@@ -329,6 +331,8 @@ export class SettingsManager {
               )
             } else if (frontendKey === "gpsFilteringEnabled") {
               value = value === true || value === "true"
+            } else if (frontendKey === "pointDraggingEnabled") {
+              value = value === true || value === "true"
             } else if (frontendKey === "speedColoredRoutes") {
               value = value === true || value === "true"
             } else if (frontendKey === "globeProjection") {
@@ -436,6 +440,8 @@ export class SettingsManager {
             } else if (frontendKey === "transportationExpertMode") {
               value = Boolean(value)
             } else if (frontendKey === "liveMapEnabled") {
+              value = Boolean(value)
+            } else if (frontendKey === "pointDraggingEnabled") {
               value = Boolean(value)
             } else if (frontendKey === "transportationThresholds" && value) {
               value = SettingsManager._convertTransportationThresholds(

--- a/app/services/users/safe_settings.rb
+++ b/app/services/users/safe_settings.rb
@@ -81,7 +81,8 @@ class Users::SafeSettings
     'visit_min_points' => 3,
     'visit_min_duration_minutes' => 5,
     'visit_density_fill_enabled' => true,
-    'stay_max_gap_minutes' => 60
+    'stay_max_gap_minutes' => 60,
+    'point_dragging_enabled' => false
   }.freeze
 
   GPS_ACCURACY_THRESHOLD_MIN = 50
@@ -136,7 +137,8 @@ class Users::SafeSettings
       visit_min_points: visit_min_points,
       visit_min_duration_minutes: visit_min_duration_minutes,
       visit_density_fill_enabled: visit_density_fill_enabled?,
-      stay_max_gap_minutes: stay_max_gap_minutes
+      stay_max_gap_minutes: stay_max_gap_minutes,
+      point_dragging_enabled: point_dragging_enabled?
     }
   end
 
@@ -353,6 +355,10 @@ class Users::SafeSettings
   def gps_accuracy_threshold
     raw = settings['gps_accuracy_threshold'] || DEFAULT_VALUES['gps_accuracy_threshold']
     raw.to_i.clamp(GPS_ACCURACY_THRESHOLD_MIN, GPS_ACCURACY_THRESHOLD_MAX)
+  end
+
+  def point_dragging_enabled?
+    ActiveModel::Type::Boolean.new.cast(settings['point_dragging_enabled']) || false
   end
 
   def visit_radius_meters

--- a/app/views/map/maplibre/_settings_panel.html.erb
+++ b/app/views/map/maplibre/_settings_panel.html.erb
@@ -73,10 +73,16 @@
             <label class="label cursor-pointer justify-start gap-3 ml-14 mt-1">
               <input type="checkbox"
                      class="toggle toggle-primary toggle-sm"
+                     data-maps--maplibre-target="pointsEditToggle"
                      data-action="change->maps--maplibre#togglePointsEditing" />
               <span class="label-text">Edit points</span>
             </label>
-            <p class="text-sm text-base-content/60 ml-24">Allow dragging points to correct their position</p>
+            <% if current_user.plan_restricted? %>
+              <p class="text-sm text-base-content/60 ml-24">Allow dragging points to correct their position.</p>
+              <p class="text-xs text-warning ml-24 mt-1">Editing points is a Pro feature — this stays on for the current session only, and moves aren't saved on the Lite plan.</p>
+            <% else %>
+              <p class="text-sm text-base-content/60 ml-24">Allow dragging points to correct their position. Remembered across sessions.</p>
+            <% end %>
           </div>
 
           <div class="divider"></div>

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -64,6 +64,28 @@ RSpec.describe 'Api::V1::Settings', type: :request do
         expect(user.reload.timezone).to eq('UTC')
       end
 
+      it 'updates point_dragging_enabled' do
+        patch "/api/v1/settings?api_key=#{api_key}", params: { settings: { point_dragging_enabled: true } }
+
+        expect(response).to have_http_status(:success)
+        expect(user.reload.safe_settings.point_dragging_enabled?).to be true
+      end
+
+      it 'returns point_dragging_enabled in the response' do
+        patch "/api/v1/settings?api_key=#{api_key}", params: { settings: { point_dragging_enabled: true } }
+
+        expect(response.parsed_body['settings']['point_dragging_enabled']).to be true
+      end
+
+      it 'turns point_dragging_enabled back off' do
+        user.update!(settings: user.settings.merge('point_dragging_enabled' => true))
+
+        patch "/api/v1/settings?api_key=#{api_key}", params: { settings: { point_dragging_enabled: false } }
+
+        expect(response).to have_http_status(:success)
+        expect(user.reload.safe_settings.point_dragging_enabled?).to be false
+      end
+
       it 'updates fog_of_war_mode' do
         patch "/api/v1/settings?api_key=#{api_key}", params: { settings: { fog_of_war_mode: 'hexagons' } }
 
@@ -267,6 +289,14 @@ RSpec.describe 'Api::V1::Settings', type: :request do
 
           expect(response).to have_http_status(:success)
           expect(lite_user.reload.safe_settings.maps_maplibre_style).to eq('dark')
+        end
+
+        it 'still persists point_dragging_enabled so it applies after an upgrade' do
+          patch "/api/v1/settings?api_key=#{lite_api_key}",
+                params: { settings: { point_dragging_enabled: true } }
+
+          expect(response).to have_http_status(:success)
+          expect(lite_user.reload.safe_settings.point_dragging_enabled?).to be true
         end
       end
 

--- a/spec/services/users/safe_settings_spec.rb
+++ b/spec/services/users/safe_settings_spec.rb
@@ -75,7 +75,8 @@ RSpec.describe Users::SafeSettings do
             visit_min_points: 3,
             visit_min_duration_minutes: 5,
             visit_density_fill_enabled: true,
-            stay_max_gap_minutes: 60
+            stay_max_gap_minutes: 60,
+            point_dragging_enabled: false
           }
         )
       end
@@ -177,7 +178,8 @@ RSpec.describe Users::SafeSettings do
             'visit_min_points' => 3,
             'visit_min_duration_minutes' => 5,
             'visit_density_fill_enabled' => true,
-            'stay_max_gap_minutes' => 60
+            'stay_max_gap_minutes' => 60,
+            'point_dragging_enabled' => false
           }
         )
       end
@@ -249,7 +251,8 @@ RSpec.describe Users::SafeSettings do
             visit_min_points: 3,
             visit_min_duration_minutes: 5,
             visit_density_fill_enabled: true,
-            stay_max_gap_minutes: 60
+            stay_max_gap_minutes: 60,
+            point_dragging_enabled: false
           }
         )
       end
@@ -846,6 +849,36 @@ RSpec.describe Users::SafeSettings do
 
     it 'is included in #config' do
       expect(described_class.new({}).config).to include(stay_max_gap_minutes: 60)
+    end
+  end
+
+  describe '#point_dragging_enabled?' do
+    it 'returns false when missing' do
+      expect(described_class.new({}).point_dragging_enabled?).to be false
+    end
+
+    it 'returns false when explicitly nil' do
+      expect(described_class.new({ 'point_dragging_enabled' => nil }).point_dragging_enabled?).to be false
+    end
+
+    it 'returns true for true' do
+      expect(described_class.new({ 'point_dragging_enabled' => true }).point_dragging_enabled?).to be true
+    end
+
+    it 'returns true for "1"' do
+      expect(described_class.new({ 'point_dragging_enabled' => '1' }).point_dragging_enabled?).to be true
+    end
+
+    it 'returns false for "0"' do
+      expect(described_class.new({ 'point_dragging_enabled' => '0' }).point_dragging_enabled?).to be false
+    end
+
+    it 'returns false for "false"' do
+      expect(described_class.new({ 'point_dragging_enabled' => 'false' }).point_dragging_enabled?).to be false
+    end
+
+    it 'is included in #config' do
+      expect(described_class.new({}).config).to include(point_dragging_enabled: false)
     end
   end
 


### PR DESCRIPTION
The toggle reset to off on every page load, so anyone correcting a batch of points had to re-enable it after every reload. It is now stored as the point_dragging_enabled user setting and restored on load. The default stays false, so a fresh account behaves exactly as before and points remain protected from accidental drags until the user opts in.

Supersedes #3085, which predates the Edit points toggle and proposed a second control defaulting dragging back on.

Also fixes a pre-existing leak: clearLayerReferences orphaned the points layer without detaching its map-level drag handlers. MapLibre delegated listeners live on the Map rather than the style, so changing the map style while editing was on left dragging permanently enabled, with the toggle only ever reaching the replacement layer instance.

Lite users are excluded from the restore because the write API rejects point updates on that plan; the preference is still persisted so it applies after an upgrade.