### PR TITLE
Skip visit geocoding when no provider is configured

### DIFF
--- a/app/services/visits/names/fetcher.rb
+++ b/app/services/visits/names/fetcher.rb
@@ -9,6 +9,7 @@ module Visits
       end
 
       def call
+        return nil unless DawarichSettings.reverse_geocoding_enabled?
         return nil if geocoder_results.blank?
 
         build_place_name

--- a/spec/services/visits/names/fetcher_spec.rb
+++ b/spec/services/visits/names/fetcher_spec.rb
@@ -5,8 +5,35 @@ require 'rails_helper'
 RSpec.describe Visits::Names::Fetcher do
   subject(:fetch_name) { described_class.new([10.0, 10.0]).call }
 
+  context 'when reverse geocoding is disabled' do
+    before do
+      allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(false)
+      allow(Geocoder).to receive(:search)
+    end
+
+    it 'returns no name without querying a geocoder provider' do
+      expect(fetch_name).to be_nil
+      expect(Geocoder).not_to have_received(:search)
+    end
+  end
+
+  context 'when reverse geocoding is enabled' do
+    before do
+      allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+      allow(Geocoder).to receive(:search).and_return([])
+    end
+
+    it 'queries the configured geocoder provider' do
+      expect(fetch_name).to be_nil
+      expect(Geocoder).to have_received(:search).with(
+        [10.0, 10.0], limit: 10, distance_sort: true, radius: 1, units: :km
+      )
+    end
+  end
+
   context 'when the geocoder provider times out' do
     before do
+      allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
       allow(ExceptionReporter).to receive(:call)
       allow(Rails.logger).to receive(:warn)
       allow(Geocoder).to receive(:search).and_raise(Geocoder::LookupTimeout.new('execution expired'))
@@ -23,6 +50,7 @@ RSpec.describe Visits::Names::Fetcher do
     let(:error) { StandardError.new('unexpected failure') }
 
     before do
+      allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
       allow(ExceptionReporter).to receive(:call)
       allow(Geocoder).to receive(:search).and_raise(error)
     end


### PR DESCRIPTION
## Summary

Skip visit-name geocoder requests when no reverse-geocoding provider is configured.

`Geocoder` otherwise falls back to its default Nominatim lookup even though `DawarichSettings.reverse_geocoding_enabled?` is false. During visit detection this adds the full provider timeout to every detected place.

Configured-provider behavior is unchanged.

## Validation

- focused RSpec: 4 examples, 0 failures
- RuboCop: 2 files, 0 offenses
- Ruby syntax checks
- regression check: disabled configuration performs 0 searches; enabled configuration performs 1 search with the original arguments
