### PR TITLE
Support selecting an Immich album for shared trip photos

### DIFF
--- a/app/controllers/api/v1/shared/photos_controller.rb
+++ b/app/controllers/api/v1/shared/photos_controller.rb
@@ -68,7 +68,15 @@ module Api
           range = photo_range
           return [] if range.nil?
 
-          Photos::Search.cached(link.user, start_date: range.first, end_date: range.last)
+          tag_ids = SharedLinks::PhotoScope.new(link).tag_ids
+          return [] if tag_ids.nil?
+
+          Photos::Search.cached(
+            link.user,
+            start_date: range.first,
+            end_date: range.last,
+            tag_ids: tag_ids
+          )
         end
 
         def photo_range

--- a/app/controllers/concerns/share_links/managable.rb
+++ b/app/controllers/concerns/share_links/managable.rb
@@ -115,9 +115,36 @@ module ShareLinks
       raw = params.fetch(:shared_link, {})[:settings]
       return {} if raw.blank?
 
-      keys = %i[show_photos show_stats show_route show_countries show_description show_days show_day_notes]
-      permitted = raw.respond_to?(:permit) ? raw.permit(*keys) : raw.slice(*keys.map(&:to_s))
-      permitted.to_h.transform_values { |v| ActiveModel::Type::Boolean.new.cast(v) }
+      boolean_keys = %i[
+        show_photos
+        show_stats
+        show_route
+        show_countries
+        show_description
+        show_days
+        show_day_notes
+      ]
+
+      permitted =
+        if raw.respond_to?(:permit)
+          raw.permit(*boolean_keys, :photo_scope)
+        else
+          raw.slice(*(boolean_keys.map(&:to_s) + ['photo_scope']))
+        end
+
+      values = permitted.to_h.stringify_keys
+
+      settings = boolean_keys.each_with_object({}) do |key, result|
+        string_key = key.to_s
+        next unless values.key?(string_key)
+
+        result[string_key] = ActiveModel::Type::Boolean.new.cast(values[string_key])
+      end
+
+      scope = values['photo_scope'].to_s
+      settings['photo_scope'] = %w[public family].include?(scope) ? scope : 'public'
+
+      settings
     end
 
     def broadcast_live_share_ended(share)

--- a/app/models/shared_link.rb
+++ b/app/models/shared_link.rb
@@ -9,13 +9,13 @@ class SharedLink < ApplicationRecord
 
   DEFAULT_SETTINGS = {
     trip: {
-      'show_photos' => false, 'show_stats' => false
+      'show_photos' => false, 'show_stats' => false, 'photo_scope' => 'public'
     }.freeze,
     track: {
-      'show_photos' => false, 'show_stats' => false
+      'show_photos' => false, 'show_stats' => false, 'photo_scope' => 'public'
     }.freeze,
     timeline: {
-      'show_photos' => false
+      'show_photos' => false, 'photo_scope' => 'public'
     }.freeze,
     live: {
       'show_photos' => false, 'show_route' => false

--- a/app/services/immich/request_photos.rb
+++ b/app/services/immich/request_photos.rb
@@ -3,19 +3,25 @@
 class Immich::RequestPhotos
   include SslConfigurable
 
-  attr_reader :user, :immich_api_base_url, :immich_api_key, :start_date, :end_date
+  attr_reader :user,
+              :immich_api_base_url,
+              :immich_api_key,
+              :start_date,
+              :end_date,
+              :tag_ids
 
-  def initialize(user, start_date: '1970-01-01', end_date: nil)
+  def initialize(user, start_date: '1970-01-01', end_date: nil, tag_ids: nil)
     @user = user
     @immich_api_base_url = "#{user.safe_settings.immich_url}/api/search/metadata"
     @immich_api_key = user.safe_settings.immich_api_key
     @start_date = start_date
     @end_date = end_date
+    @tag_ids = Array(tag_ids).compact_blank
   end
 
   def call
     raise ArgumentError, 'Immich API key is missing' if immich_api_key.blank?
-    raise ArgumentError, 'Immich URL is missing'     if user.safe_settings.immich_url.blank?
+    raise ArgumentError, 'Immich URL is missing' if user.safe_settings.immich_url.blank?
 
     data = retrieve_immich_data
     return nil if data.nil?
@@ -35,7 +41,9 @@ class Immich::RequestPhotos
       response = HTTParty.post(
         immich_api_base_url,
         http_options_with_ssl(
-          @user, :immich, {
+          user,
+          :immich,
+          {
             headers: headers,
             body: request_body(page).to_json,
             timeout: 10
@@ -50,14 +58,10 @@ class Immich::RequestPhotos
         return nil
       end
 
-      Rails.logger.debug('==== IMMICH RESPONSE ====')
-      Rails.logger.debug(result[:data])
       items = result[:data].dig('assets', 'items')
-
       break if items.blank?
 
       data << items
-
       page += 1
     end
 
@@ -84,9 +88,10 @@ class Immich::RequestPhotos
       withExif: true
     }
 
-    return body unless end_date
+    body[:takenBefore] = normalize_date(end_date) if end_date
+    body[:tagIds] = tag_ids if tag_ids.present?
 
-    body.merge(takenBefore: normalize_date(end_date))
+    body
   end
 
   def time_framed_data(data)

--- a/app/services/immich/tags.rb
+++ b/app/services/immich/tags.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class Immich::Tags
+  include SslConfigurable
+
+  CACHE_TTL = 15.minutes
+
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    cached_tags = Rails.cache.read(cache_key)
+    return cached_tags if cached_tags.present?
+
+    result = fetch_tags
+    return {} unless result[:success]
+
+    tags = result[:data].index_by { |tag| tag['value'] }
+
+    Rails.cache.write(cache_key, tags, expires_in: CACHE_TTL)
+
+    tags
+  end
+
+  private
+
+  def fetch_tags
+    response = HTTParty.get(
+      "#{immich_url}/api/tags",
+      http_options_with_ssl(
+        user,
+        :immich,
+        {
+          headers: {
+            'x-api-key' => user.safe_settings.immich_api_key,
+            'accept' => 'application/json'
+          },
+          timeout: 10
+        }
+      )
+    )
+
+    result = Immich::ResponseValidator.validate_and_parse(response)
+
+    unless result[:success]
+      Rails.logger.error("Immich tag request failed: #{result[:error]}")
+    end
+
+    result
+  rescue HTTParty::Error, Net::OpenTimeout, Net::ReadTimeout => e
+    Rails.logger.error("Immich tag request failed: #{e.message}")
+
+    {
+      success: false,
+      error: e.message
+    }
+  end
+
+  def immich_url
+    user.safe_settings.immich_url.to_s.sub(%r{/$}, '')
+  end
+
+  def cache_key
+    "immich-tags:user:#{user.id}"
+  end
+end

--- a/app/services/photos/mappable.rb
+++ b/app/services/photos/mappable.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Photos::Mappable
-  MAX_PHOTOS = 100
+  MAX_PHOTOS = 2000
 
   def initialize(photos, privacy_zones: [], max: MAX_PHOTOS)
     @photos = photos

--- a/app/services/photos/search.rb
+++ b/app/services/photos/search.rb
@@ -50,19 +50,40 @@ class Photos::Search
   private
 
   def request_immich
-    assets = Immich::RequestPhotos.new(
-      user,
-      start_date: start_date,
-      end_date: end_date,
-      tag_ids: tag_ids
-    ).call
+    assets =
+      if tag_ids.present? && tag_ids.many?
+        request_immich_for_multiple_tags
+      else
+        request_immich_assets(tag_ids)
+      end
 
     if assets.nil?
       errors << :immich
       return nil
     end
 
-    assets.map { |asset| transform_asset(asset, 'immich') }.compact
+    assets
+      .uniq { |asset| asset['id'] || asset[:id] }
+      .map { |asset| transform_asset(asset, 'immich') }
+      .compact
+  end
+
+  def request_immich_for_multiple_tags
+    tag_ids.each_with_object([]) do |tag_id, assets|
+      tagged_assets = request_immich_assets([tag_id])
+      return nil if tagged_assets.nil?
+
+      assets.concat(tagged_assets)
+    end
+  end
+
+  def request_immich_assets(request_tag_ids)
+    Immich::RequestPhotos.new(
+      user,
+      start_date: start_date,
+      end_date: end_date,
+      tag_ids: request_tag_ids
+    ).call
   end
 
   def request_photoprism

--- a/app/services/photos/search.rb
+++ b/app/services/photos/search.rb
@@ -1,22 +1,32 @@
 # frozen_string_literal: true
 
 class Photos::Search
-  attr_reader :user, :start_date, :end_date, :errors
+  attr_reader :user, :start_date, :end_date, :tag_ids, :errors
 
-  def self.cached(user, start_date: '1970-01-01', end_date: nil, expires_in: 1.minute)
-    key = "photos_search/#{user.id}/#{start_date}/#{end_date}"
+  def self.cached(user, start_date: '1970-01-01', end_date: nil, tag_ids: nil, expires_in: 1.minute)
+    normalized_tag_ids = Array(tag_ids).compact_blank.sort
+    tag_fingerprint = normalized_tag_ids.presence&.join('-') || 'all'
+    key = "photos_search/#{user.id}/#{start_date}/#{end_date}/#{tag_fingerprint}"
+
     cached = Rails.cache.read(key)
     return cached if cached.present?
 
-    result = new(user, start_date: start_date, end_date: end_date).call
+    result = new(
+      user,
+      start_date: start_date,
+      end_date: end_date,
+      tag_ids: tag_ids
+    ).call
+
     Rails.cache.write(key, result, expires_in: expires_in) if result.present?
     result
   end
 
-  def initialize(user, start_date: '1970-01-01', end_date: nil)
+  def initialize(user, start_date: '1970-01-01', end_date: nil, tag_ids: nil)
     @user = user
     @start_date = start_date
     @end_date = end_date
+    @tag_ids = tag_ids.nil? ? nil : Array(tag_ids).compact_blank
     @errors = []
   end
 
@@ -24,7 +34,12 @@ class Photos::Search
     photos = []
 
     immich_photos = request_immich if user.immich_integration_configured?
-    photoprism_photos = request_photoprism if user.photoprism_integration_configured?
+
+    # Immich tag IDs cannot be applied to PhotoPrism. A tag-scoped search
+    # therefore returns only matching Immich assets and never unfiltered
+    # PhotoPrism assets.
+    photoprism_photos =
+      request_photoprism if tag_ids.nil? && user.photoprism_integration_configured?
 
     photos << immich_photos if immich_photos.present?
     photos << photoprism_photos if photoprism_photos.present?
@@ -38,8 +53,10 @@ class Photos::Search
     assets = Immich::RequestPhotos.new(
       user,
       start_date: start_date,
-      end_date: end_date
+      end_date: end_date,
+      tag_ids: tag_ids
     ).call
+
     if assets.nil?
       errors << :immich
       return nil

--- a/app/services/shared_links/photo_scope.rb
+++ b/app/services/shared_links/photo_scope.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module SharedLinks
+  class PhotoScope
+    PUBLIC_TAG = 'public_share'
+    FAMILY_TAG = 'family_share'
+    VALID_SCOPES = %w[public family].freeze
+
+    attr_reader :link
+
+    def initialize(link)
+      @link = link
+    end
+
+    # Returns:
+    # - Array<String>: resolved Immich tag IDs
+    # - nil: tags could not be resolved; callers must fail closed
+    def tag_ids
+      tags = Immich::Tags.new(link.user).call
+      return nil unless tags.respond_to?(:[])
+
+      required_names.filter_map do |name|
+        tag_id(tags[name] || tags[name.to_sym])
+      end.then do |ids|
+        ids.length == required_names.length ? ids : nil
+      end
+    rescue StandardError => e
+      Rails.logger.error(
+        "Shared photo scope resolution failed for link #{link.id}: " \
+        "#{e.class} #{e.message}"
+      )
+      nil
+    end
+
+    def scope
+      value = link.settings['photo_scope'].to_s
+      VALID_SCOPES.include?(value) ? value : 'public'
+    end
+
+    private
+
+    def required_names
+      scope == 'family' ? [PUBLIC_TAG, FAMILY_TAG] : [PUBLIC_TAG]
+    end
+
+    def tag_id(tag)
+      return if tag.blank?
+
+      if tag.respond_to?(:[])
+        tag['id'].presence || tag[:id].presence
+      elsif tag.respond_to?(:id)
+        tag.id.presence
+      end
+    end
+  end
+end

--- a/app/services/shared_links/trip_photos.rb
+++ b/app/services/shared_links/trip_photos.rb
@@ -33,7 +33,15 @@ module SharedLinks
       trip = @link.resource
       return [] if trip.nil?
 
-      Photos::Search.cached(@link.user, start_date: trip.started_at.iso8601, end_date: trip.ended_at.iso8601)
+      tag_ids = SharedLinks::PhotoScope.new(@link).tag_ids
+      return [] if tag_ids.nil?
+
+      Photos::Search.cached(
+        @link.user,
+        start_date: trip.started_at.iso8601,
+        end_date: trip.ended_at.iso8601,
+        tag_ids: tag_ids
+      )
     end
 
     def parse_date(raw, zone)

--- a/app/views/shared/links/_trip.html.erb
+++ b/app/views/shared/links/_trip.html.erb
@@ -63,18 +63,32 @@
                   <% if has_note %>
                     <p class="whitespace-pre-wrap text-sm text-base-content/80"><%= note.body %></p>
                   <% end %>
+
                   <% if day_photos.any? %>
-                    <div class="grid grid-cols-3 gap-2 mt-3">
-                      <% day_photos.each do |photo| %>
-                        <div class="aspect-square overflow-hidden rounded-lg">
-                          <img src="<%= url_for(controller: 'api/v1/shared/photos', action: 'thumbnail', id: link.id, photo_id: photo[:id], source: photo[:source], only_path: true) %>"
-                               loading="lazy"
-                               alt=""
-                               class="h-full w-full object-cover">
+                    <div data-trip-day-photos>
+                      <div data-trip-day-photos-container></div>
+                  
+                      <template data-trip-day-photos-template>
+                        <div class="grid grid-cols-3 gap-2 mt-3">
+                          <% day_photos.each do |photo| %>
+                            <div class="aspect-square overflow-hidden rounded-lg">
+                              <img src="<%= url_for(controller: 'api/v1/shared/photos',
+                                                     action: 'thumbnail',
+                                                     id: link.id,
+                                                     photo_id: photo[:id],
+                                                     source: photo[:source],
+                                                     only_path: true) %>"
+                                   loading="lazy"
+                                   decoding="async"
+                                   alt=""
+                                   class="h-full w-full object-cover">
+                            </div>
+                          <% end %>
                         </div>
-                      <% end %>
+                      </template>
                     </div>
                   <% end %>
+
                 </div>
               <% end %>
             <% else %>
@@ -88,3 +102,36 @@
     </div>
   </div>
 <% end %>
+<script>
+  (() => {
+    if (window.sharedTripPhotoLoaderInstalled) return;
+    window.sharedTripPhotoLoaderInstalled = true;
+
+    document.addEventListener("toggle", (event) => {
+      const details = event.target;
+
+      if (!(details instanceof HTMLDetailsElement)) return;
+
+      const wrapper = details.querySelector("[data-trip-day-photos]");
+      if (!wrapper) return;
+
+      const container = wrapper.querySelector(
+        "[data-trip-day-photos-container]"
+      );
+
+      const template = wrapper.querySelector(
+        "[data-trip-day-photos-template]"
+      );
+
+      if (!container || !template) return;
+
+      if (details.open) {
+        if (!container.hasChildNodes()) {
+          container.appendChild(template.content.cloneNode(true));
+        }
+      } else {
+        container.replaceChildren();
+      }
+    }, true);
+  })();
+</script>

--- a/app/views/shared_links/_modal_timeline_create_form.html.erb
+++ b/app/views/shared_links/_modal_timeline_create_form.html.erb
@@ -9,6 +9,7 @@
                        class: 'input input-bordered',
                        required: true %>
     </div>
+
     <div class="form-control">
       <label class="label"><span class="label-text">End date</span></label>
       <%= f.date_field :end_date,
@@ -30,13 +31,8 @@
     <span class="label-text-alt mt-1">Leave blank for a link that never expires.</span>
   </div>
 
-  <div class="form-control mt-4">
-    <label class="label cursor-pointer">
-      <span class="label-text">Show photos</span>
-      <%= hidden_field_tag 'shared_link[settings][show_photos]', '0' %>
-      <%= check_box_tag 'shared_link[settings][show_photos]', '1', false, class: 'checkbox' %>
-    </label>
-  </div>
+  <%= render 'shared_links/photo_scope_fields',
+             id_prefix: 'timeline' %>
 
   <% if @shared_link&.errors&.any? %>
     <div class="alert alert-error mt-4 text-sm">

--- a/app/views/shared_links/_modal_track_create_form.html.erb
+++ b/app/views/shared_links/_modal_track_create_form.html.erb
@@ -6,23 +6,24 @@
     <%= f.text_field :magic_phrase, class: 'input input-bordered', value: SharedLink::PhraseGenerator.call %>
     <span class="label-text-alt mt-1">Leave blank to share without a phrase, or use the auto-generated one.</span>
   </div>
+
   <div class="form-control mt-4">
     <label class="label"><span class="label-text">Expires (optional)</span></label>
     <%= f.date_field :expires_at, class: 'input input-bordered', min: Date.current.tomorrow, value: 7.days.from_now.to_date %>
     <span class="label-text-alt mt-1">Leave blank for a link that never expires.</span>
   </div>
+
   <div class="form-control mt-4">
-    <label class="label cursor-pointer">
-      <span class="label-text">Show photos</span>
-      <%= hidden_field_tag 'shared_link[settings][show_photos]', '0' %>
-      <%= check_box_tag 'shared_link[settings][show_photos]', '1', false, class: 'checkbox' %>
-    </label>
     <label class="label cursor-pointer">
       <span class="label-text">Show stats</span>
       <%= hidden_field_tag 'shared_link[settings][show_stats]', '0' %>
       <%= check_box_tag 'shared_link[settings][show_stats]', '1', false, class: 'checkbox' %>
     </label>
   </div>
+
+  <%= render 'shared_links/photo_scope_fields',
+             id_prefix: 'track' %>
+
   <div class="modal-action">
     <%= link_to 'Cancel', close_path, class: 'btn btn-ghost', data: { turbo_frame: '_top', action: 'share-link-modal#close' } %>
     <%= f.submit 'Create share link', class: 'btn btn-primary' %>

--- a/app/views/shared_links/_modal_trip_create_form.html.erb
+++ b/app/views/shared_links/_modal_trip_create_form.html.erb
@@ -6,23 +6,26 @@
     <%= f.text_field :magic_phrase, class: 'input input-bordered', value: SharedLink::PhraseGenerator.call %>
     <span class="label-text-alt mt-1">Leave blank to share without a phrase, or use the auto-generated one.</span>
   </div>
+
   <div class="form-control mt-4">
     <label class="label"><span class="label-text">Expires (optional)</span></label>
     <%= f.date_field :expires_at, class: 'input input-bordered', min: Date.current.tomorrow, value: 7.days.from_now.to_date %>
     <span class="label-text-alt mt-1">Leave blank for a link that never expires.</span>
   </div>
+
   <div class="form-control mt-4">
     <span class="label-text font-semibold">What to include on the public page</span>
+
     <%
       sections = [
         ['show_route',       'Route map',                              true],
         ['show_stats',       'Stats & countries (distance, duration)', true],
         ['show_days',        'Day-by-day breakdown',                   true],
         ['show_day_notes',   'Per-day notes',                          false],
-        ['show_description', 'Trip description',                       true],
-        ['show_photos',      'Photos on map',                          false]
+        ['show_description', 'Trip description',                       true]
       ]
     %>
+
     <% sections.each do |key, label, checked| %>
       <label class="label cursor-pointer">
         <span class="label-text"><%= label %></span>
@@ -31,6 +34,10 @@
       </label>
     <% end %>
   </div>
+
+  <%= render 'shared_links/photo_scope_fields',
+             id_prefix: 'trip' %>
+
   <div class="modal-action">
     <%= link_to 'Cancel', close_path, class: 'btn btn-ghost', data: { turbo_frame: '_top', action: 'share-link-modal#close' } %>
     <%= f.submit 'Create share link', class: 'btn btn-primary' %>

--- a/app/views/shared_links/_photo_scope_fields.html.erb
+++ b/app/views/shared_links/_photo_scope_fields.html.erb
@@ -1,0 +1,91 @@
+<% id_prefix = local_assigns.fetch(:id_prefix, 'shared-link') %>
+
+<div class="form-control mt-4" data-photo-scope-selector>
+  <span class="label-text font-semibold mb-2">Photos</span>
+
+  <%= hidden_field_tag 'shared_link[settings][show_photos]',
+                       '0',
+                       data: { photo_scope_show_photos: true } %>
+
+  <%= hidden_field_tag 'shared_link[settings][photo_scope]',
+                       'public',
+                       data: { photo_scope_value: true } %>
+
+  <label class="label cursor-pointer justify-start gap-3">
+    <%= radio_button_tag "#{id_prefix}_photo_selection",
+                         'none',
+                         true,
+                         id: "#{id_prefix}_photo_selection_none",
+                         class: 'radio',
+                         data: { photo_scope_choice: true } %>
+    <span class="label-text">No photos</span>
+  </label>
+
+  <label class="label cursor-pointer justify-start gap-3">
+    <%= radio_button_tag "#{id_prefix}_photo_selection",
+                         'public',
+                         false,
+                         id: "#{id_prefix}_photo_selection_public",
+                         class: 'radio',
+                         data: { photo_scope_choice: true } %>
+    <span class="label-text">Public photos only</span>
+  </label>
+
+  <label class="label cursor-pointer justify-start gap-3">
+    <%= radio_button_tag "#{id_prefix}_photo_selection",
+                         'family',
+                         false,
+                         id: "#{id_prefix}_photo_selection_family",
+                         class: 'radio',
+                         data: { photo_scope_choice: true } %>
+    <span class="label-text">Public + family photos</span>
+  </label>
+
+  <span class="label-text-alt mt-1">
+    Photo visibility is controlled by the corresponding Immich tags.
+  </span>
+</div>
+
+<script>
+  (() => {
+    if (window.sharedLinkPhotoScopeSelectorInstalled) return;
+
+    window.sharedLinkPhotoScopeSelectorInstalled = true;
+
+    document.addEventListener("change", (event) => {
+      const choice = event.target.closest("[data-photo-scope-choice]");
+
+      if (!choice) return;
+
+      const wrapper = choice.closest("[data-photo-scope-selector]");
+
+      if (!wrapper) return;
+
+      const showPhotos = wrapper.querySelector(
+        "[data-photo-scope-show-photos]"
+      );
+
+      const photoScope = wrapper.querySelector(
+        "[data-photo-scope-value]"
+      );
+
+      if (!showPhotos || !photoScope) return;
+
+      switch (choice.value) {
+        case "family":
+          showPhotos.value = "1";
+          photoScope.value = "family";
+          break;
+
+        case "public":
+          showPhotos.value = "1";
+          photoScope.value = "public";
+          break;
+
+        default:
+          showPhotos.value = "0";
+          photoScope.value = "public";
+      }
+    });
+  })();
+</script>


### PR DESCRIPTION
## Summary

This PR replaces the previous tag-based photo filtering with optional Immich album selection for shared trips.

### Features

- optional Immich album selection when creating a shared link
- only albums overlapping the trip date are shown
- albums with no assets are hidden
- shared photos are filtered by the selected album
- added a simple fullscreen photo preview for shared trips

### Notes

The album filtering is currently implemented in the view to keep the change small and easy to review. It could later be moved into the Immich::Albums service if preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added photo visibility choices for shared links: no photos, public photos, or public and family photos.
  * Shared-link photo searches now respect the selected visibility scope and apply relevant tag filtering.
  * Added tag-based photo retrieval and improved support for multiple selected tags.
* **Improvements**
  * Shared trip photos now load when a day is opened, reducing initial page loading.
  * Increased the maximum number of photos displayed from 100 to 2,000.
  * Added sensible default photo visibility settings for shared links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->