### PR TITLE
Ship poster print ordering on by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Changed
+
+- Ordering a printed poster from the Poster Studio is now available to everyone, instead of sitting behind a feature flag that was off by default. An instance that would rather not offer it can switch the `poster_ordering` flag off at `/admin/flipper`, or leave `PRINT_ORDER_URL` blank.
+
 ### Fixed
 
 - Self-hosted mode is now recognised from common `SELF_HOSTED` values (quoted `"true"`, `TRUE`, whitespace-padded, `1`, `yes`, `on`), not only the exact string `true`, so a non-canonical value no longer silently flips a self-hosted instance into cloud mode and blocks LAN integration URLs (such as Immich) as SSRF. (#2522)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,11 +19,16 @@ class ApplicationController < ActionController::Base
     @current_user_safe_settings ||= current_user&.safe_settings
   end
 
+  # Ordering is on unless this instance turned the flag off, so an install
+  # that never registered the flag — or lost it — still offers prints rather
+  # than silently hiding a shipped feature.
   def poster_ordering_enabled?
+    return true unless Flipper.exist?(:poster_ordering)
+
     Flipper.enabled?(:poster_ordering, current_user)
   rescue StandardError => e
     Rails.logger.warn("[poster_ordering] Flipper unavailable: #{e.class}: #{e.message}")
-    false
+    true
   end
 
   protected

--- a/app/services/feature_flags.rb
+++ b/app/services/feature_flags.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Keeps the Flipper store in step with the flags the code actually reads, so a
+# flag appears in the admin UI on both fresh installs and upgrades.
+module FeatureFlags
+  # Flags the code reads, mapped to the state a brand-new install starts in.
+  # An existing flag is never touched, so an instance that switched one off
+  # keeps it off.
+  DEFAULTS = { poster_ordering: true }.freeze
+
+  # Flags whose feature shipped unconditionally and no longer gates anything.
+  RETIRED = %i[posters stay_point_detection].freeze
+
+  def self.apply_defaults!
+    DEFAULTS.each do |flag, enabled|
+      next if Flipper.exist?(flag)
+
+      Flipper.add(flag)
+      Flipper.enable(flag) if enabled
+    end
+
+    RETIRED.each { |flag| Flipper.remove(flag) if Flipper.exist?(flag) }
+  end
+end

--- a/app/views/posters/_studio.html.erb
+++ b/app/views/posters/_studio.html.erb
@@ -295,9 +295,11 @@
           </button>
           <p class="text-xs text-warning hidden" data-poster-studio-editor-target="saveNotice"></p>
 
-          <%# ── Order a print ── rendered only behind the poster_ordering flag,
-              then hidden until PRINT_ORDER_URL is set; only one of
-              {CTA, size picker, dialog} shows at a time. %>
+          <%# ── Order a print ── ships on: the poster_ordering flag drops this
+              block on an instance that turns it off, and the controller hides
+              it when PRINT_ORDER_URL is blanked (it otherwise defaults to the
+              hosted service); only one of {CTA, size picker, dialog} shows at
+              a time. %>
           <% if poster_ordering_enabled? %>
           <div class="hidden space-y-2" data-poster-studio-editor-target="orderSection">
             <div class="divider my-0 text-xs font-medium opacity-50">Order a print</div>

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
 # Register feature flags so they appear in the Flipper admin UI for both fresh
-# installs and existing instances on upgrade. Guarded with `exist?` so it only
-# writes when missing, and rescued so boot never fails when the Flipper tables
-# aren't present yet (e.g. during `db:migrate` on a brand-new database).
+# installs and existing instances on upgrade. Rescued so boot never fails when
+# the Flipper tables aren't present yet (e.g. during `db:migrate` on a
+# brand-new database).
 Rails.application.config.after_initialize do
-  Flipper.add(:poster_ordering) unless Flipper.exist?(:poster_ordering)
-
-  # Retired flags — the features shipped unconditionally.
-  Flipper.remove(:posters) if Flipper.exist?(:posters)
-  Flipper.remove(:stay_point_detection) if Flipper.exist?(:stay_point_detection)
+  FeatureFlags.apply_defaults!
 rescue StandardError => e
   Rails.logger.warn("[feature_flags] could not register flags: #{e.class}: #{e.message}")
 end

--- a/db/migrate/20260730200000_enable_poster_ordering_flag.rb
+++ b/db/migrate/20260730200000_enable_poster_ordering_flag.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Instances upgrading from a release that registered :poster_ordering already
+# carry the flag row, so FeatureFlags.apply_defaults! leaves it alone and they
+# would stay opted out of a feature that now ships on. Switch them on once
+# here; turning it back off at /admin/flipper afterwards sticks.
+class EnablePosterOrderingFlag < ActiveRecord::Migration[8.0]
+  def up
+    Flipper.enable(:poster_ordering)
+  end
+
+  def down
+    Flipper.disable(:poster_ordering)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"

--- a/spec/requests/map/maplibre_spec.rb
+++ b/spec/requests/map/maplibre_spec.rb
@@ -70,6 +70,14 @@ RSpec.describe 'Map v2 (maplibre)', type: :request do
       expect(response.body).to include('Order a printed poster')
     end
 
+    it 'renders the order section on an instance carrying no flag at all' do
+      Flipper.remove(:poster_ordering)
+
+      get map_v2_path
+
+      expect(response.body).to include('Order a printed poster')
+    end
+
     it 'omits the order section when the poster_ordering flag is disabled' do
       Flipper.disable(:poster_ordering)
 

--- a/spec/services/feature_flags_spec.rb
+++ b/spec/services/feature_flags_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FeatureFlags do
+  describe '.apply_defaults!' do
+    it 'ships poster ordering enabled on an install that has never seen the flag' do
+      Flipper.remove(:poster_ordering)
+
+      described_class.apply_defaults!
+
+      expect(Flipper.enabled?(:poster_ordering)).to be true
+    end
+
+    it 'leaves an instance that turned poster ordering off alone' do
+      Flipper.add(:poster_ordering)
+      Flipper.disable(:poster_ordering)
+
+      described_class.apply_defaults!
+
+      expect(Flipper.enabled?(:poster_ordering)).to be false
+    end
+
+    it 'drops flags whose feature shipped unconditionally' do
+      Flipper.add(:posters)
+
+      described_class.apply_defaults!
+
+      expect(Flipper.exist?(:posters)).to be false
+    end
+  end
+end


### PR DESCRIPTION
Print ordering has sat behind the `:poster_ordering` Flipper flag since it landed, off by default everywhere. This ships it on for everyone while keeping the switch: an instance that would rather not offer prints turns `poster_ordering` off at `/admin/flipper`.

## Why the default is carried in three places

Flipper cannot express "on unless someone said otherwise" — `Flipper.disable` clears a flag's boolean gate, leaving exactly the state registering it produces, so a registered-but-off flag is indistinguishable from one an operator deliberately switched off. The default is therefore applied wherever it can be told apart:

| Case | Ordering |
|---|---|
| Fresh install | on — `FeatureFlags.apply_defaults!` registers the flag enabled |
| No flag row at all | on — the gate returns true when nothing is registered |
| Upgrade, before `db:migrate` | off — the stale registered-off row |
| Upgrade, after `db:migrate` | on — `EnablePosterOrderingFlag` |
| Instance switches it off | off, and stays off |

The one remaining off is inherent rather than a bug, and the migration closes it at deploy. **This PR carries a migration, so it needs `db:migrate` on deploy.**

## What changes

- `app/services/feature_flags.rb` (new) — `DEFAULTS` / `RETIRED` lists plus `apply_defaults!`, extracted from the initializer so the behaviour is testable rather than only observable at boot. Never touches a flag that already exists.
- `app/controllers/application_controller.rb` — the gate returns true when no flag is registered, and its rescue now fails open: a Flipper hiccup hiding a shipped feature everywhere is a worse surprise than briefly showing it on an instance that opted out.
- `config/initializers/feature_flags.rb` — now just calls the service; the rescue that keeps boot alive before the Flipper tables exist is unchanged.
- `db/migrate/20260730200000_enable_poster_ordering_flag.rb` (new) — one-shot enable for existing instances.
- `db/schema.rb` — version line only.
- `CHANGELOG.md` — entry under Unreleased naming both opt-outs.

The studio view and the Stimulus controller are untouched. `PRINT_ORDER_URL` still gates the section client-side and defaults to `https://prints.dawarich.app/api/orders`.

## Testing

- `spec/services/feature_flags_spec.rb` (new) — a fresh install ends up enabled, an instance that turned the flag off is left alone, retired flags are dropped.
- `spec/requests/map/maplibre_spec.rb` — adds "renders on an instance carrying no flag at all" alongside the existing enabled/disabled pair.
- `spec/services/feature_flags_spec.rb`, `spec/requests/map`, `spec/requests/posters_spec.rb`: 42 examples, 0 failures. RuboCop clean.

## Not included

`PRINT_ORDER_URL` is still absent from `docker/docker-compose.yml`, so self-hosters can only learn about that opt-out from the changelog entry.