### PR TITLE
Separate Google Records devices so tracks stop connecting them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- GPS noise filtering no longer uses the "Accuracy Threshold" setting, and the slider has been removed. A reported accuracy radius is a confidence estimate, not proof a position is wrong: Google Timeline routinely reports 1-4km for points sitting exactly on the road, and dropping those replaced real route geometry with straight lines. Only radii too large to be a position at all are now discarded; wrong positions are caught by the speed checks instead.
+- Points within 5km of (0, 0) are treated as broken coordinates everywhere — import, cleanup and noise filtering previously disagreed, with only some paths catching near-zero values.
+
+### Fixed
+
+- Tracks no longer connect two different devices. Google's Records.json contains every device on the account, and imports made before 1.10.0 stamped them all as one device, so a phone left at home was stitched to the one that travelled — drawing long straight lines between them. Existing imports are repaired automatically by re-reading the uploaded file.
+- Restoring a data archive now recomputes GPS noise flags. The archive carries none, so restored points previously arrived unfiltered and tracks were rebuilt from noise the instance had already learned to ignore.
+
 ## [1.10.3] - 2026-07-28, Berlin
 
 ### Added

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -81,7 +81,7 @@ class Api::V1::SettingsController < ApiController
       :transportation_expert_mode,
       :min_minutes_spent_in_city, :max_gap_minutes_in_city,
       :stay_max_gap_minutes,
-      :gps_filtering_enabled, :gps_accuracy_threshold,
+      :gps_filtering_enabled,
       :point_dragging_enabled,
       enabled_map_layers: [],
       enabled_transportation_modes: [],

--- a/app/javascript/controllers/maps/maplibre/settings_manager.js
+++ b/app/javascript/controllers/maps/maplibre/settings_manager.js
@@ -271,16 +271,6 @@ export class SettingsController {
       gpsFilteringToggle.checked = this.settings.gpsFilteringEnabled !== false
     }
 
-    const gpsAccuracyInput = controller.element.querySelector(
-      'input[name="gpsAccuracyThreshold"]',
-    )
-    if (gpsAccuracyInput) {
-      gpsAccuracyInput.value = this.settings.gpsAccuracyThreshold || 100
-      if (controller.hasGpsAccuracyThresholdValueTarget) {
-        controller.gpsAccuracyThresholdValueTarget.textContent = `${gpsAccuracyInput.value}m`
-      }
-    }
-
     // Sync speed-colored routes settings
     if (controller.hasSpeedColorScaleInputTarget) {
       const colorScale =
@@ -1459,7 +1449,6 @@ export class SettingsController {
       ),
       maxGapMinutesInCity: parseInt(formData.get("maxGapMinutesInCity"), 10),
       gpsFilteringEnabled: formData.get("gpsFilteringEnabled") === "on",
-      gpsAccuracyThreshold: parseInt(formData.get("gpsAccuracyThreshold"), 10),
     }
 
     if (formData.has("stayMaxGapMinutes")) {
@@ -1656,12 +1645,6 @@ export class SettingsController {
   updateStayMaxGapMinutesDisplay(event) {
     if (this.controller.hasStayMaxGapMinutesValueTarget) {
       this.controller.stayMaxGapMinutesValueTarget.textContent = `${event.target.value} min`
-    }
-  }
-
-  updateGpsAccuracyThresholdDisplay(event) {
-    if (this.controller.hasGpsAccuracyThresholdValueTarget) {
-      this.controller.gpsAccuracyThresholdValueTarget.textContent = `${event.target.value}m`
     }
   }
 

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -55,7 +55,6 @@ export default class extends Controller {
     "minMinutesInCityValue",
     "maxGapMinutesValue",
     "stayMaxGapMinutesValue",
-    "gpsAccuracyThresholdValue",
     "gpsFilteringToggle",
     // Search
     "searchInput",
@@ -1263,9 +1262,6 @@ export default class extends Controller {
   }
   updateStayMaxGapMinutesDisplay(event) {
     return this.settingsController.updateStayMaxGapMinutesDisplay(event)
-  }
-  updateGpsAccuracyThresholdDisplay(event) {
-    return this.settingsController.updateGpsAccuracyThresholdDisplay(event)
   }
   reapplyAnomalyFilter() {
     return this.settingsController.reapplyAnomalyFilter()

--- a/app/javascript/maps_maplibre/utils/settings_manager.js
+++ b/app/javascript/maps_maplibre/utils/settings_manager.js
@@ -51,7 +51,6 @@ const DEFAULT_SETTINGS = {
   maxGapMinutesInCity: 120,
   stayMaxGapMinutes: 60,
   gpsFilteringEnabled: true,
-  gpsAccuracyThreshold: 100,
   pointDraggingEnabled: false,
   transportationExpertMode: false,
   enabledTransportationModes: [
@@ -122,7 +121,6 @@ const BACKEND_SETTINGS_MAP = {
   maxGapMinutesInCity: "max_gap_minutes_in_city",
   stayMaxGapMinutes: "stay_max_gap_minutes",
   gpsFilteringEnabled: "gps_filtering_enabled",
-  gpsAccuracyThreshold: "gps_accuracy_threshold",
   pointDraggingEnabled: "point_dragging_enabled",
   transportationExpertMode: "transportation_expert_mode",
   enabledTransportationModes: "enabled_transportation_modes",
@@ -323,11 +321,6 @@ export class SettingsManager {
               value = SettingsManager._parseIntOr(
                 value,
                 DEFAULT_SETTINGS.stayMaxGapMinutes,
-              )
-            } else if (frontendKey === "gpsAccuracyThreshold") {
-              value = SettingsManager._parseIntOr(
-                value,
-                DEFAULT_SETTINGS.gpsAccuracyThreshold,
               )
             } else if (frontendKey === "gpsFilteringEnabled") {
               value = value === true || value === "true"

--- a/app/jobs/data_migrations/recalculate_per_tracker_tracks_job.rb
+++ b/app/jobs/data_migrations/recalculate_per_tracker_tracks_job.rb
@@ -34,8 +34,12 @@ class DataMigrations::RecalculatePerTrackerTracksJob < ApplicationJob
     user_ids = User
                .where(
                  'EXISTS (SELECT 1 FROM tracks WHERE tracks.user_id = users.id AND tracks.tracker_id IS NULL) ' \
-                 'OR EXISTS (SELECT 1 FROM points WHERE points.user_id = users.id AND points.tracker_id IN (?))',
-                 Points::TrackerIdBackfiller::LEGACY_CONSTANTS
+                 'OR EXISTS (SELECT 1 FROM points WHERE points.user_id = users.id AND points.tracker_id IN (?)) ' \
+                 'OR EXISTS (SELECT 1 FROM points INNER JOIN imports ON imports.id = points.import_id ' \
+                 'WHERE points.user_id = users.id AND imports.source = ? AND points.tracker_id LIKE ?)',
+                 Points::TrackerIdBackfiller::LEGACY_CONSTANTS,
+                 Import.sources[:google_records],
+                 "#{Points::DeviceTagBackfiller::LEGACY_IMPORT_PREFIX}%"
                )
                .pluck(:id)
     return if user_ids.empty?

--- a/app/jobs/data_migrations/recalculate_per_tracker_tracks_job.rb
+++ b/app/jobs/data_migrations/recalculate_per_tracker_tracks_job.rb
@@ -11,7 +11,11 @@ class DataMigrations::RecalculatePerTrackerTracksJob < ApplicationJob
     user = User.find_by(id: user_id)
     return unless user
 
-    backfilled = Points::TrackerIdBackfiller.new(user).call
+    # Read deviceTag out of the uploaded Records.json first: the importer never
+    # stored it in raw_data, so this is the only accurate source. Whatever it
+    # cannot resolve falls through to the raw_data/import-based backfiller.
+    backfilled = backfill_google_records_devices(user)
+    backfilled += Points::TrackerIdBackfiller.new(user).call
 
     return unless backfilled.positive? || user.tracks.where(tracker_id: nil).exists?
 
@@ -19,6 +23,12 @@ class DataMigrations::RecalculatePerTrackerTracksJob < ApplicationJob
   end
 
   private
+
+  def backfill_google_records_devices(user)
+    user.imports.where(source: :google_records).sum do |import|
+      Points::DeviceTagBackfiller.new(import).call
+    end
+  end
 
   def enqueue_pending_users
     user_ids = User

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -35,19 +35,9 @@ class Point < ApplicationRecord
   scope :not_visited, -> { where(visit_id: nil) }
   scope :not_anomaly, -> { where(anomaly: [false, nil]) }
   scope :anomaly, -> { where(anomaly: true) }
-  # Radius around the origin treated as a broken coordinate rather than a real
-  # position. Exact (0, 0) is the classic sentinel, but Google Timeline exports
-  # also emit values a fraction of a degree off zero (e.g. -0.0098, -0.0056),
-  # which an equality check silently lets through. The neighbourhood is open
-  # ocean ~570km off West Africa, so nothing legitimate lands inside it.
-  NULL_ISLAND_RADIUS_METERS = 5_000
-
-  scope :null_island, lambda {
-    where(
-      'ST_DWithin(lonlat, ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, ?)',
-      NULL_ISLAND_RADIUS_METERS
-    )
-  }
+  # Ingest, cleanup and the anomaly filter must all agree on what counts as a
+  # broken coordinate; Points::NullIsland owns that definition.
+  scope :null_island, -> { where(Points::NullIsland.sql_predicate) }
 
   after_create :async_reverse_geocode, if: -> { DawarichSettings.store_geodata? && !reverse_geocoded? }
   after_create :set_country

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -35,7 +35,19 @@ class Point < ApplicationRecord
   scope :not_visited, -> { where(visit_id: nil) }
   scope :not_anomaly, -> { where(anomaly: [false, nil]) }
   scope :anomaly, -> { where(anomaly: true) }
-  scope :null_island, -> { where('lonlat = ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography') }
+  # Radius around the origin treated as a broken coordinate rather than a real
+  # position. Exact (0, 0) is the classic sentinel, but Google Timeline exports
+  # also emit values a fraction of a degree off zero (e.g. -0.0098, -0.0056),
+  # which an equality check silently lets through. The neighbourhood is open
+  # ocean ~570km off West Africa, so nothing legitimate lands inside it.
+  NULL_ISLAND_RADIUS_METERS = 5_000
+
+  scope :null_island, lambda {
+    where(
+      'ST_DWithin(lonlat, ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, ?)',
+      NULL_ISLAND_RADIUS_METERS
+    )
+  }
 
   after_create :async_reverse_geocode, if: -> { DawarichSettings.store_geodata? && !reverse_geocoded? }
   after_create :set_country

--- a/app/services/google_maps/records_device_tag_stream_handler.rb
+++ b/app/services/google_maps/records_device_tag_stream_handler.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Streams Google's Records.json and yields the deviceTag of each location.
+#
+# Records.json holds every device on the Google account in one file, so the
+# deviceTag is the only thing separating a phone that travelled from a tablet
+# left at home. The file runs to hundreds of megabytes, so it is read as a
+# stream rather than parsed into memory.
+#
+# Only the location's own timestamp counts: each location also carries nested
+# `activity` entries with timestamps of their own, and those must not be
+# mistaken for a fix.
+class GoogleMaps::RecordsDeviceTagStreamHandler < Oj::Saj
+  LOCATIONS_KEY = 'locations'
+
+  def initialize(&on_location)
+    super()
+    @on_location = on_location
+    @in_locations = false
+    @depth = 0
+    reset_location
+  end
+
+  def array_start(key = nil, *_)
+    @in_locations = true if @depth.zero? && normalize(key) == LOCATIONS_KEY
+  end
+
+  def array_end(key = nil, *_)
+    @in_locations = false if normalize(key) == LOCATIONS_KEY && @depth.zero?
+  end
+
+  def hash_start(_key = nil, *_)
+    return unless @in_locations
+
+    @depth += 1
+    reset_location if location_level?
+  end
+
+  def hash_end(_key = nil, *_)
+    return unless @in_locations
+
+    if location_level? && @timestamp && @device_tag
+      @on_location.call(@timestamp, @device_tag, @latitude_e7, @longitude_e7)
+    end
+    @depth -= 1
+  end
+
+  def add_value(value, key = nil)
+    return unless @in_locations && location_level?
+
+    case normalize(key)
+    when 'timestamp' then @timestamp = value
+    when 'timestampMs' then @timestamp ||= value
+    when 'deviceTag' then @device_tag = value
+    when 'latitudeE7' then @latitude_e7 = value
+    when 'longitudeE7' then @longitude_e7 = value
+    end
+  end
+
+  private
+
+  def reset_location
+    @timestamp = nil
+    @device_tag = nil
+    @latitude_e7 = nil
+    @longitude_e7 = nil
+  end
+
+  def location_level? = @depth == 1
+
+  def normalize(key) = key.nil? ? nil : key.to_s
+end

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -4,6 +4,42 @@ class Points::AnomalyFilter
   MAX_SPEED_KMH = 1000 # km/h — floor for speed threshold
   SPEED_MULTIPLIER = 3 # threshold = max(floor, median * multiplier)
   CONTEXT_POINTS = 5   # extra points for speed context at boundaries
+  # Two points sharing a timestamp have no meaningful speed, but a displacement
+  # this large between them is still an instantaneous jump. Treating it as
+  # "unknown" let outliers through: a point whose neighbour shared its timestamp
+  # was skipped outright, however impossible its own position was.
+  TELEPORT_METERS = 1_000
+  # Longest run of consecutive points that may be convicted as one displaced
+  # reading. Bad GPS arrives as a brief excursion — one point, occasionally a
+  # handful. A genuine stay bracketed by two impossible hops (sparse sampling
+  # either side of a real trip, or a second device interleaved) is far longer,
+  # and flagging it wholesale would erase real history. Under-flagging a long
+  # noise burst is the safer failure.
+  MAX_DISPLACED_RUN_POINTS = 5
+  # Accuracy radius beyond which a reading carries no usable position at all.
+  # Deliberately far above any plausible GPS/wifi/cell error: a reported radius
+  # is a confidence estimate, not proof the position is wrong. Google Timeline
+  # routinely reports 1-4km for points that sit exactly on the road, and
+  # deleting those replaced real route geometry with straight lines across the
+  # gap — strictly worse than keeping a point that may be a couple of km off.
+  # Positions that are genuinely wrong are caught by the speed passes instead.
+  ABSURD_ACCURACY_METERS = 10_000
+  # Ceiling for the EXTRA distance an excursion adds, which is a different
+  # question from how fast a single leg was. A genuine journey adds nothing —
+  # its displacement is the trip — so any excess at all is travel that did not
+  # happen, and demanding 1000 km/h of it before acting is far too lax. Google
+  # splices stale fixes from other devices into a phone's timelinePath, and each
+  # leg then reads as ordinary air travel while the round trip needs hundreds of
+  # extra km/h. Well above any road or rail speed, well below a plausible flight.
+  MAX_DETOUR_SPEED_KMH = 300
+  # A stale fix can sit hours from its neighbours, where the round trip it
+  # implies is slow enough to be physically possible and no speed test can
+  # condemn it. What condemns it is the shape: the fixes either side are the
+  # same stay, the excursion is far from it, and nothing was spent being there.
+  # Real travel away from a stay leaves hours of readings at the far end.
+  STAY_RADIUS_METERS = 25_000        # how close two fixes must be to be one stay
+  MIN_EXCURSION_METERS = 50_000      # how far the excursion must depart from it
+  MAX_EXCURSION_SPAN_SECONDS = 1_800 # dwell above this is a visit, not a stray fix
 
   def initialize(user_id, start_time, end_time)
     @user_id = user_id
@@ -31,10 +67,6 @@ class Points::AnomalyFilter
     user_settings.gps_filtering_enabled?
   end
 
-  def accuracy_threshold
-    @accuracy_threshold ||= user_settings.gps_accuracy_threshold
-  end
-
   # Pass 0: Null Island — a sustained (0,0) run defeats the speed sandwich
   # (internal speeds are 0), so exact zeros are flagged unconditionally.
   def filter_null_island
@@ -44,12 +76,14 @@ class Points::AnomalyFilter
          .update_all(anomaly: true, updated_at: Time.current)
   end
 
-  # Pass 1: Mark points with accuracy > threshold
+  # Pass 1: Mark points whose reported accuracy radius is so large the reading
+  # cannot be a position at all. See ABSURD_ACCURACY_METERS for why this is not
+  # the user's gps_accuracy_threshold.
   def filter_by_accuracy
     Point.where(user_id: @user_id, timestamp: @start_time..@end_time)
          .not_anomaly
          .where.not(accuracy: nil)
-         .where('accuracy > ?', accuracy_threshold)
+         .where('accuracy > ?', ABSURD_ACCURACY_METERS)
          .update_all(anomaly: true, updated_at: Time.current)
   end
 
@@ -79,32 +113,20 @@ class Points::AnomalyFilter
     points, main_points = fetch_points_with_context(chunk_start, chunk_end)
     return 0 if points.size < 3
 
-    point_ids = points.map(&:id)
-    speeds_by_point = calculate_all_speeds(point_ids)
+    speeds_by_point = calculate_all_speeds(points.map(&:id))
     return 0 if speeds_by_point.empty?
 
-    all_speeds = speeds_by_point.values.flat_map { |h| [h[:incoming], h[:outgoing]] }.compact
-    return 0 if all_speeds.empty?
-
-    floor_mps = MAX_SPEED_KMH / 3.6
-    # Compute median from non-extreme speeds only so outliers don't inflate the threshold
-    normal_speeds = all_speeds.select { |s| s <= floor_mps }
-    median = normal_speeds.empty? ? 0.0 : median_speed(normal_speeds)
-    threshold = [floor_mps, median * SPEED_MULTIPLIER].max
+    threshold = speed_threshold(speeds_by_point)
+    return 0 if threshold.nil?
 
     # Only check points in the main range (not context points)
     main_range_ids = main_points.map(&:id).to_set
 
-    anomaly_ids = []
-    points.each_with_index do |point, i|
-      next if i.zero? || i >= points.size - 1
-      next unless main_range_ids.include?(point.id)
-
-      speed_in = speeds_by_point.dig(point.id, :incoming)
-      speed_out = speeds_by_point.dig(point.id, :outgoing)
-      next if speed_in.nil? || speed_out.nil?
-
-      anomaly_ids << point.id if speed_in > threshold && speed_out > threshold
+    # Each device is its own stream. Interleaving them by timestamp invents
+    # journeys between devices that nobody made — the same reason track
+    # generation groups by tracker_id (Tracks::TimeChunkProcessorJob).
+    anomaly_ids = points.group_by { |point| point.tracker_id.to_s }.values.flat_map do |stream|
+      displaced_run_ids(stream, speeds_by_point, threshold, main_range_ids)
     end
 
     return 0 if anomaly_ids.empty?
@@ -112,20 +134,138 @@ class Points::AnomalyFilter
     Point.where(id: anomaly_ids).update_all(anomaly: true, updated_at: Time.current)
   end
 
+  def speed_threshold(speeds_by_point)
+    all_speeds = speeds_by_point.values.flat_map { |h| [h[:incoming], h[:outgoing]] }.compact
+    return nil if all_speeds.empty?
+
+    floor_mps = MAX_SPEED_KMH / 3.6
+    # Compute median from non-extreme speeds only so outliers don't inflate the threshold
+    normal_speeds = all_speeds.select { |s| s <= floor_mps }
+    median = normal_speeds.empty? ? 0.0 : median_speed(normal_speeds)
+    [floor_mps, median * SPEED_MULTIPLIER].max
+  end
+
+  # A displaced GPS reading is often several consecutive points, not one spike,
+  # and its return leg is often slow enough to look like an ordinary flight.
+  # Each candidate excursion is therefore judged on the distance it ADDS versus
+  # going straight from the fix before it to the fix after it.
+  def displaced_run_ids(stream, speeds_by_point, threshold, main_range_ids)
+    displaced = Set.new
+
+    # Slide a window of every allowed run length over the stream, judging each
+    # against the fixes immediately either side of it. Splitting the stream into
+    # runs first cannot isolate an excursion whose return leg looks plausible —
+    # the excursion simply absorbs the points that follow it.
+    # Shortest windows first: once an excursion is explained, longer windows that
+    # merely wrap it in innocent neighbours must not convict those neighbours too.
+    (1..MAX_DISPLACED_RUN_POINTS).each do |length|
+      stream.each_cons(length + 2) do |window|
+        previous_point = window.first
+        next_point = window.last
+        run = window[1..-2]
+
+        next if run.any? { |point| displaced.include?(point.id) }
+        next unless suspicious_boundary?(run, speeds_by_point, threshold)
+        unless both_legs_impossible?(run, speeds_by_point, threshold) ||
+               detour_speed(run, previous_point, next_point) > detour_ceiling ||
+               contradicts_stay?(run, previous_point, next_point)
+          next
+        end
+
+        run.each { |point| displaced << point.id if main_range_ids.include?(point.id) }
+      end
+    end
+
+    displaced.to_a
+  end
+
+  # Impossible on both sides convicts on its own: nothing legitimate arrives and
+  # departs faster than any aircraft. This catches excursions with no detour to
+  # measure — a straight-line hop where the timestamps themselves are wrong.
+  def both_legs_impossible?(run, speeds_by_point, threshold)
+    entry_speed = speeds_by_point.dig(run.first.id, :incoming)
+    exit_speed  = speeds_by_point.dig(run.last.id, :outgoing)
+    return false if entry_speed.nil? || exit_speed.nil?
+
+    entry_speed > threshold && exit_speed > threshold
+  end
+
+  def detour_ceiling = MAX_DETOUR_SPEED_KMH / 3.6
+
+  # True when the fixes either side belong to one stay and the run leaps away
+  # from it without spending any time there. See STAY_RADIUS_METERS.
+  def contradicts_stay?(run, previous_point, next_point)
+    return false if haversine_meters(previous_point, next_point) > STAY_RADIUS_METERS
+
+    dwell = run.last.timestamp - run.first.timestamp
+    return false if dwell > MAX_EXCURSION_SPAN_SECONDS
+
+    haversine_meters(previous_point, run.first) > MIN_EXCURSION_METERS &&
+      haversine_meters(run.last, next_point) > MIN_EXCURSION_METERS
+  end
+
+  # An excursion has to arrive or leave faster than any ground travel to be worth
+  # judging; this keeps the distance maths off the overwhelming majority of
+  # ordinary points. The gate is the detour ceiling rather than the raw speed
+  # floor, because a stale fix hours from its neighbours has one perfectly
+  # ordinary-looking leg and would never clear 1000 km/h on both.
+  def suspicious_boundary?(run, speeds_by_point, threshold)
+    gate = [threshold, detour_ceiling].min
+    entry_speed = speeds_by_point.dig(run.first.id, :incoming)
+    exit_speed  = speeds_by_point.dig(run.last.id, :outgoing)
+
+    (entry_speed && entry_speed > gate) || (exit_speed && exit_speed > gate)
+  end
+
+  # Extra distance the excursion adds over travelling straight from the previous
+  # fix to the next one, spread across the time actually available.
+  #
+  # A one-way journey adds nothing — the displacement IS the trip, so a real
+  # flight scores zero here no matter how fast it was. A stale or mislocated fix
+  # jumps away and comes back, adding roughly twice its displacement, which no
+  # real travel can cover in the gap. This is what catches excursions whose
+  # return leg is slow enough to look plane-like, where requiring both legs to
+  # be impossible finds nothing.
+  def detour_speed(run, previous_point, next_point)
+    seconds = next_point.timestamp - previous_point.timestamp
+    return 0.0 unless seconds.positive?
+
+    via_run = haversine_meters(previous_point, run.first) + haversine_meters(run.last, next_point)
+    direct  = haversine_meters(previous_point, next_point)
+
+    [via_run - direct, 0.0].max / seconds
+  end
+
+  EARTH_RADIUS_METERS = 6_371_008.8
+
+  def haversine_meters(from, to)
+    from_lat = to_radians(from.lonlat.y)
+    to_lat   = to_radians(to.lonlat.y)
+    delta_lat = to_lat - from_lat
+    delta_lon = to_radians(to.lonlat.x - from.lonlat.x)
+
+    a = (Math.sin(delta_lat / 2)**2) +
+        (Math.cos(from_lat) * Math.cos(to_lat) * (Math.sin(delta_lon / 2)**2))
+
+    2 * EARTH_RADIUS_METERS * Math.asin([1.0, Math.sqrt(a)].min)
+  end
+
+  def to_radians(degrees) = degrees * Math::PI / 180
+
   def fetch_points_with_context(start_time, end_time)
     before_ctx = Point.where(user_id: @user_id).not_anomaly
                       .where('timestamp < ?', start_time)
                       .order(timestamp: :desc).limit(CONTEXT_POINTS)
-                      .select(:id, :timestamp).to_a.reverse
+                      .select(:id, :timestamp, :tracker_id, :lonlat).to_a.reverse
 
     main = Point.where(user_id: @user_id, timestamp: start_time..end_time)
                 .not_anomaly.order(:timestamp)
-                .select(:id, :timestamp).to_a
+                .select(:id, :timestamp, :tracker_id, :lonlat).to_a
 
     after_ctx = Point.where(user_id: @user_id).not_anomaly
                      .where('timestamp > ?', end_time)
                      .order(:timestamp).limit(CONTEXT_POINTS)
-                     .select(:id, :timestamp).to_a
+                     .select(:id, :timestamp, :tracker_id, :lonlat).to_a
 
     [before_ctx + main + after_ctx, main]
   end
@@ -139,24 +279,23 @@ class Points::AnomalyFilter
     sql = <<~SQL
       WITH ordered_points AS (
         SELECT id, lonlat, timestamp,
-               LAG(id) OVER (ORDER BY timestamp, id) AS prev_id,
-               LAG(lonlat) OVER (ORDER BY timestamp, id) AS prev_lonlat,
-               LAG(timestamp) OVER (ORDER BY timestamp, id) AS prev_timestamp
+               LAG(id)        OVER per_device AS prev_id,
+               LAG(lonlat)    OVER per_device AS prev_lonlat,
+               LAG(timestamp) OVER per_device AS prev_timestamp
         FROM points
         WHERE id = ANY(ARRAY[#{ids_literal}])
+        WINDOW per_device AS (PARTITION BY COALESCE(tracker_id, '') ORDER BY timestamp, id)
       )
       SELECT id, prev_id,
-             CASE WHEN (timestamp - prev_timestamp) > 0
-                  THEN ST_Distance(lonlat::geography, prev_lonlat::geography)
-                       / (timestamp - prev_timestamp)
-                  ELSE NULL END AS speed_mps
+             ST_Distance(lonlat::geography, prev_lonlat::geography) AS meters,
+             (timestamp - prev_timestamp) AS seconds
       FROM ordered_points
       WHERE prev_id IS NOT NULL
     SQL
 
     result = {}
     Point.connection.execute(sql).each do |row|
-      speed = row['speed_mps']&.to_f
+      speed = speed_from(row['meters']&.to_f, row['seconds']&.to_i)
       prev_id = row['prev_id'].to_i
       curr_id = row['id'].to_i
 
@@ -167,6 +306,15 @@ class Points::AnomalyFilter
       result[curr_id][:incoming] = speed
     end
     result
+  end
+
+  # Zero elapsed time is only unknowable if the two readings agree on position.
+  # A kilometre or more apart in the same second is a jump, not a mystery.
+  def speed_from(meters, seconds)
+    return nil if meters.nil? || seconds.nil?
+    return meters / seconds if seconds.positive?
+
+    meters > TELEPORT_METERS ? Float::INFINITY : nil
   end
 
   def median_speed(speeds)

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -195,13 +195,13 @@ class Points::AnomalyFilter
   # True when the fixes either side belong to one stay and the run leaps away
   # from it without spending any time there. See STAY_RADIUS_METERS.
   def contradicts_stay?(run, previous_point, next_point)
-    return false if haversine_meters(previous_point, next_point) > STAY_RADIUS_METERS
+    return false if distance_meters(previous_point, next_point) > STAY_RADIUS_METERS
 
     dwell = run.last.timestamp - run.first.timestamp
     return false if dwell > MAX_EXCURSION_SPAN_SECONDS
 
-    haversine_meters(previous_point, run.first) > MIN_EXCURSION_METERS &&
-      haversine_meters(run.last, next_point) > MIN_EXCURSION_METERS
+    distance_meters(previous_point, run.first) > MIN_EXCURSION_METERS &&
+      distance_meters(run.last, next_point) > MIN_EXCURSION_METERS
   end
 
   # An excursion has to arrive or leave faster than any ground travel to be worth
@@ -230,27 +230,19 @@ class Points::AnomalyFilter
     seconds = next_point.timestamp - previous_point.timestamp
     return 0.0 unless seconds.positive?
 
-    via_run = haversine_meters(previous_point, run.first) + haversine_meters(run.last, next_point)
-    direct  = haversine_meters(previous_point, next_point)
+    via_run = distance_meters(previous_point, run.first) + distance_meters(run.last, next_point)
+    direct  = distance_meters(previous_point, next_point)
 
     [via_run - direct, 0.0].max / seconds
   end
 
-  EARTH_RADIUS_METERS = 6_371_008.8
+  def distance_meters(from, to)
+    kilometers = Geocoder::Calculations.distance_between(
+      [from.lonlat.y, from.lonlat.x], [to.lonlat.y, to.lonlat.x], units: :km
+    )
 
-  def haversine_meters(from, to)
-    from_lat = to_radians(from.lonlat.y)
-    to_lat   = to_radians(to.lonlat.y)
-    delta_lat = to_lat - from_lat
-    delta_lon = to_radians(to.lonlat.x - from.lonlat.x)
-
-    a = (Math.sin(delta_lat / 2)**2) +
-        (Math.cos(from_lat) * Math.cos(to_lat) * (Math.sin(delta_lon / 2)**2))
-
-    2 * EARTH_RADIUS_METERS * Math.asin([1.0, Math.sqrt(a)].min)
+    kilometers * 1_000
   end
-
-  def to_radians(degrees) = degrees * Math::PI / 180
 
   def fetch_points_with_context(start_time, end_time)
     before_ctx = Point.where(user_id: @user_id).not_anomaly

--- a/app/services/points/device_tag_backfiller.rb
+++ b/app/services/points/device_tag_backfiller.rb
@@ -14,8 +14,13 @@
 # surviving copy of the mapping is the uploaded file itself, so it is re-read.
 class Points::DeviceTagBackfiller
   BATCH_SIZE = 5_000
-  # tracker_ids written before per-device import; anything else is left alone.
+  # tracker_ids that predate per-device import. The bare constants come from the
+  # original importers; `legacy-import-<id>` is what TrackerIdBackfiller wrote
+  # when it found no deviceTag in raw_data, which is the state of every install
+  # that has run the 1.10.1 migration. Anything else is already a real
+  # per-device tracker and must be left alone.
   LEGACY_TRACKER_IDS = Points::TrackerIdBackfiller::LEGACY_CONSTANTS
+  LEGACY_IMPORT_PREFIX = 'legacy-import-'
 
   attr_reader :import
 
@@ -26,12 +31,16 @@ class Points::DeviceTagBackfiller
   def call
     return 0 unless import.google_records?
     return 0 unless import.file.attached?
+    # Re-streaming a multi-hundred-megabyte upload to change nothing is the
+    # common case on re-runs and Sidekiq retries.
+    return 0 unless candidate_points.exists?
 
     unambiguous, contested = read_source
     return 0 if unambiguous.empty? && contested.empty?
 
     apply(unambiguous) + apply_contested(contested)
-  rescue ActiveStorage::FileNotFoundError, Oj::ParseError, JSON::ParserError => e
+  rescue StandardError => e
+    # One unreadable upload must not abort the caller's remaining imports.
     Rails.logger.warn(
       "[Points::DeviceTagBackfiller] import_id=#{import.id} unreadable source: #{e.class}: #{e.message}"
     )
@@ -40,22 +49,39 @@ class Points::DeviceTagBackfiller
 
   private
 
+  def candidate_points
+    Point.where(user_id: import.user_id, import_id: import.id)
+         .where(
+           'points.tracker_id IS NULL OR points.tracker_id IN (?) OR points.tracker_id LIKE ?',
+           LEGACY_TRACKER_IDS, "#{LEGACY_IMPORT_PREFIX}%"
+         )
+  end
+
   # Returns [by_timestamp, by_timestamp_and_position].
   #
-  # When two devices report in the same second the timestamp alone cannot say
-  # which point belongs to which — and leaving those points on the shared
-  # tracker is not harmless: they get stitched into two-point tracks hundreds of
-  # kilometres long. Their coordinates settle it, so contested timestamps are
-  # kept in a second map keyed by position as well.
+  # Read in two passes so the file is never held in memory. The first keeps only
+  # timestamp -> deviceTag; the second runs solely when two devices claimed the
+  # same second, and then collects coordinates for those seconds alone. Building
+  # the position map for every location instead would cost an entry per record —
+  # millions of them on a real account.
   def read_source
-    mapping = {}
-    contested = {}
+    mapping = first_pass
+    contested_timestamps = mapping.each_with_object(Set.new) do |(timestamp, tag), set|
+      set << timestamp if tag == :contested
+    end
 
-    handler = GoogleMaps::RecordsDeviceTagStreamHandler.new do |raw_timestamp, device_tag, lat_e7, lon_e7|
+    settled = mapping.reject { |_, tag| tag == :contested }
+    return [settled, {}] if contested_timestamps.empty?
+
+    [settled, second_pass(contested_timestamps)]
+  end
+
+  def first_pass
+    mapping = {}
+
+    handler = GoogleMaps::RecordsDeviceTagStreamHandler.new do |raw_timestamp, device_tag, _lat, _lon|
       timestamp = Timestamps.parse_timestamp(raw_timestamp)
       next if timestamp.nil?
-
-      contested[[timestamp, lat_e7.to_i, lon_e7.to_i]] = device_tag if lat_e7 && lon_e7
 
       existing = mapping[timestamp]
       mapping[timestamp] = existing.nil? || existing == device_tag ? device_tag : :contested
@@ -63,10 +89,38 @@ class Points::DeviceTagBackfiller
 
     stream_source { |io| Oj.saj_parse(handler, io) }
 
-    settled = mapping.reject { |_, tag| tag == :contested }
-    disputed = contested.select { |(timestamp, _, _), _| mapping[timestamp] == :contested }
+    mapping
+  end
 
-    [settled, disputed]
+  def second_pass(contested_timestamps)
+    contested = {}
+
+    handler = GoogleMaps::RecordsDeviceTagStreamHandler.new do |raw_timestamp, device_tag, lat_e7, lon_e7|
+      next if lat_e7.nil? || lon_e7.nil?
+
+      timestamp = Timestamps.parse_timestamp(raw_timestamp)
+      next unless contested_timestamps.include?(timestamp)
+
+      record_contested(contested, [timestamp, lat_e7.to_i, lon_e7.to_i], device_tag)
+    end
+
+    stream_source { |io| Oj.saj_parse(handler, io) }
+
+    contested.reject { |_, tag| tag == :contested }
+  end
+
+  # Two devices at the same second AND the same rounded position cannot be told
+  # apart; say so rather than silently letting the last one win.
+  def record_contested(contested, key, device_tag)
+    if contested.key?(key) && contested[key] != device_tag
+      Rails.logger.warn(
+        "[Points::DeviceTagBackfiller] import_id=#{import.id} two devices share " \
+        "timestamp #{key.first} and position #{key[1]},#{key[2]}; leaving it alone"
+      )
+      contested[key] = :contested
+    else
+      contested[key] ||= device_tag
+    end
   end
 
   def stream_source(&)
@@ -110,23 +164,15 @@ class Points::DeviceTagBackfiller
         "#{connection.quote("google-records-device-#{device_tag}")})"
     end.join(', ')
 
-    sql = <<~SQL.squish
+    connection.exec_update(<<~SQL.squish, 'DeviceTagBackfillContested')
       UPDATE points
       SET tracker_id = mapping.tracker_id, updated_at = NOW()
       FROM (VALUES #{values}) AS mapping(timestamp, latitude_e7, longitude_e7, tracker_id)
-      WHERE points.user_id = #{import.user_id.to_i}
-        AND points.import_id = #{import.id.to_i}
-        AND points.timestamp = mapping.timestamp
+      WHERE points.timestamp = mapping.timestamp
         AND round(ST_Y(points.lonlat::geometry) * 10000000) = mapping.latitude_e7
         AND round(ST_X(points.lonlat::geometry) * 10000000) = mapping.longitude_e7
-        AND (points.tracker_id IS NULL OR points.tracker_id IN (#{legacy_tracker_list}))
+        AND #{candidate_scope_sql}
     SQL
-
-    connection.exec_update(sql, 'DeviceTagBackfillContested')
-  end
-
-  def legacy_tracker_list
-    LEGACY_TRACKER_IDS.map { |tracker| connection.quote(tracker) }.join(', ')
   end
 
   def update_batch(slice)
@@ -134,17 +180,27 @@ class Points::DeviceTagBackfiller
       "(#{timestamp.to_i}, #{connection.quote("google-records-device-#{device_tag}")})"
     end.join(', ')
 
-    sql = <<~SQL.squish
+    connection.exec_update(<<~SQL.squish, 'DeviceTagBackfill')
       UPDATE points
       SET tracker_id = mapping.tracker_id, updated_at = NOW()
       FROM (VALUES #{values}) AS mapping(timestamp, tracker_id)
-      WHERE points.user_id = #{import.user_id.to_i}
-        AND points.import_id = #{import.id.to_i}
-        AND points.timestamp = mapping.timestamp
-        AND (points.tracker_id IS NULL OR points.tracker_id IN (#{legacy_tracker_list}))
+      WHERE points.timestamp = mapping.timestamp
+        AND #{candidate_scope_sql}
     SQL
+  end
 
-    connection.exec_update(sql, 'DeviceTagBackfill')
+  def candidate_scope_sql
+    legacy = LEGACY_TRACKER_IDS.map { |tracker| connection.quote(tracker) }.join(', ')
+
+    <<~SQL.squish
+      points.user_id = #{import.user_id.to_i}
+        AND points.import_id = #{import.id.to_i}
+        AND (
+          points.tracker_id IS NULL
+          OR points.tracker_id IN (#{legacy})
+          OR points.tracker_id LIKE #{connection.quote("#{LEGACY_IMPORT_PREFIX}%")}
+        )
+    SQL
   end
 
   def connection = ActiveRecord::Base.connection

--- a/app/services/points/device_tag_backfiller.rb
+++ b/app/services/points/device_tag_backfiller.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+# Restores per-device tracker_ids on points imported from Google's Records.json
+# before the importer learned to read deviceTag (shipped 1.10.0).
+#
+# Those imports stamped every point with one tracker_id, so a device sitting at
+# home and a phone that travelled became a single "device". Track generation
+# groups by tracker_id, so it then stitched the two together and invented
+# journeys between them — long straight lines radiating from wherever the
+# stationary device sat.
+#
+# Points::TrackerIdBackfiller cannot repair these: it reads deviceTag from
+# `raw_data`, and the Records importer never wrote raw_data at all. The only
+# surviving copy of the mapping is the uploaded file itself, so it is re-read.
+class Points::DeviceTagBackfiller
+  BATCH_SIZE = 5_000
+  # tracker_ids written before per-device import; anything else is left alone.
+  LEGACY_TRACKER_IDS = Points::TrackerIdBackfiller::LEGACY_CONSTANTS
+
+  attr_reader :import
+
+  def initialize(import)
+    @import = import
+  end
+
+  def call
+    return 0 unless import.google_records?
+    return 0 unless import.file.attached?
+
+    unambiguous, contested = read_source
+    return 0 if unambiguous.empty? && contested.empty?
+
+    apply(unambiguous) + apply_contested(contested)
+  rescue ActiveStorage::FileNotFoundError, Oj::ParseError, JSON::ParserError => e
+    Rails.logger.warn(
+      "[Points::DeviceTagBackfiller] import_id=#{import.id} unreadable source: #{e.class}: #{e.message}"
+    )
+    0
+  end
+
+  private
+
+  # Returns [by_timestamp, by_timestamp_and_position].
+  #
+  # When two devices report in the same second the timestamp alone cannot say
+  # which point belongs to which — and leaving those points on the shared
+  # tracker is not harmless: they get stitched into two-point tracks hundreds of
+  # kilometres long. Their coordinates settle it, so contested timestamps are
+  # kept in a second map keyed by position as well.
+  def read_source
+    mapping = {}
+    contested = {}
+
+    handler = GoogleMaps::RecordsDeviceTagStreamHandler.new do |raw_timestamp, device_tag, lat_e7, lon_e7|
+      timestamp = Timestamps.parse_timestamp(raw_timestamp)
+      next if timestamp.nil?
+
+      contested[[timestamp, lat_e7.to_i, lon_e7.to_i]] = device_tag if lat_e7 && lon_e7
+
+      existing = mapping[timestamp]
+      mapping[timestamp] = existing.nil? || existing == device_tag ? device_tag : :contested
+    end
+
+    stream_source { |io| Oj.saj_parse(handler, io) }
+
+    settled = mapping.reject { |_, tag| tag == :contested }
+    disputed = contested.select { |(timestamp, _, _), _| mapping[timestamp] == :contested }
+
+    [settled, disputed]
+  end
+
+  def stream_source(&)
+    if import.file.blob.service.respond_to?(:path_for)
+      path = import.file.blob.service.path_for(import.file.blob.key)
+      return File.open(path, 'rb', &) if File.exist?(path)
+    end
+
+    import.file.open(&)
+  end
+
+  def apply(device_tags)
+    updated = 0
+
+    device_tags.each_slice(BATCH_SIZE) do |slice|
+      updated += update_batch(slice)
+    end
+
+    if updated.positive?
+      Rails.logger.info(
+        "[Points::DeviceTagBackfiller] import_id=#{import.id} user_id=#{import.user_id} backfilled=#{updated}"
+      )
+    end
+
+    updated
+  end
+
+  def apply_contested(contested)
+    return 0 if contested.empty?
+
+    updated = 0
+    contested.each_slice(BATCH_SIZE) { |slice| updated += update_contested_batch(slice) }
+    updated
+  end
+
+  # Coordinates are compared at the precision Google stores them (1e-7 degrees),
+  # which is exactly what the importer wrote into lonlat.
+  def update_contested_batch(slice)
+    values = slice.map do |(timestamp, lat_e7, lon_e7), device_tag|
+      "(#{timestamp.to_i}, #{lat_e7.to_i}, #{lon_e7.to_i}, " \
+        "#{connection.quote("google-records-device-#{device_tag}")})"
+    end.join(', ')
+
+    sql = <<~SQL.squish
+      UPDATE points
+      SET tracker_id = mapping.tracker_id, updated_at = NOW()
+      FROM (VALUES #{values}) AS mapping(timestamp, latitude_e7, longitude_e7, tracker_id)
+      WHERE points.user_id = #{import.user_id.to_i}
+        AND points.import_id = #{import.id.to_i}
+        AND points.timestamp = mapping.timestamp
+        AND round(ST_Y(points.lonlat::geometry) * 10000000) = mapping.latitude_e7
+        AND round(ST_X(points.lonlat::geometry) * 10000000) = mapping.longitude_e7
+        AND (points.tracker_id IS NULL OR points.tracker_id IN (#{legacy_tracker_list}))
+    SQL
+
+    connection.exec_update(sql, 'DeviceTagBackfillContested')
+  end
+
+  def legacy_tracker_list
+    LEGACY_TRACKER_IDS.map { |tracker| connection.quote(tracker) }.join(', ')
+  end
+
+  def update_batch(slice)
+    values = slice.map do |timestamp, device_tag|
+      "(#{timestamp.to_i}, #{connection.quote("google-records-device-#{device_tag}")})"
+    end.join(', ')
+
+    sql = <<~SQL.squish
+      UPDATE points
+      SET tracker_id = mapping.tracker_id, updated_at = NOW()
+      FROM (VALUES #{values}) AS mapping(timestamp, tracker_id)
+      WHERE points.user_id = #{import.user_id.to_i}
+        AND points.import_id = #{import.id.to_i}
+        AND points.timestamp = mapping.timestamp
+        AND (points.tracker_id IS NULL OR points.tracker_id IN (#{legacy_tracker_list}))
+    SQL
+
+    connection.exec_update(sql, 'DeviceTagBackfill')
+  end
+
+  def connection = ActiveRecord::Base.connection
+end

--- a/app/services/points/null_island.rb
+++ b/app/services/points/null_island.rb
@@ -1,17 +1,30 @@
 # frozen_string_literal: true
 
 module Points::NullIsland
-  LONLAT_REGEX = /\APOINT\s*\(\s*-?0(?:\.0+)?\s+-?0(?:\.0+)?\s*\)\z/i
+  # Exact (0, 0) is the classic sentinel, but Google Timeline and some trackers
+  # emit coordinates a fraction of a degree off zero instead — the same broken
+  # reading, and an equality check silently lets those through. The
+  # neighbourhood is open ocean roughly 570km off West Africa, so nothing
+  # legitimate lands inside it.
+  RADIUS_METERS = 5_000
+  LONLAT_REGEX = /\APOINT\s*\(\s*(-?\d+(?:\.\d+)?)\s+(-?\d+(?:\.\d+)?)\s*\)\z/i
 
   def self.sql_predicate(column = 'lonlat')
-    "(ST_X(#{column}::geometry) = 0 AND ST_Y(#{column}::geometry) = 0)"
+    "ST_DWithin(#{column}::geography, ST_SetSRID(ST_MakePoint(0, 0), 4326)::geography, #{RADIUS_METERS})"
   end
 
   def self.coordinates?(lon, lat)
-    lon.to_f.zero? && lat.to_f.zero?
+    kilometers = Geocoder::Calculations.distance_between(
+      [lat.to_f, lon.to_f], [0.0, 0.0], units: :km
+    )
+
+    kilometers * 1_000 <= RADIUS_METERS
   end
 
   def self.lonlat?(value)
-    value.to_s.match?(LONLAT_REGEX)
+    match = LONLAT_REGEX.match(value.to_s)
+    return false if match.nil?
+
+    coordinates?(match[1], match[2])
   end
 end

--- a/app/services/users/import_data.rb
+++ b/app/services/users/import_data.rb
@@ -64,6 +64,7 @@ class Users::ImportData
     ActiveRecord::Base.transaction do
       extract_archive
       process_archive_data
+      filter_restored_anomalies
       create_success_notification
 
       @import_stats
@@ -150,6 +151,26 @@ class Users::ImportData
 
     expected_counts = handler.expected_counts
     validate_import_completeness(expected_counts) if expected_counts.present?
+  end
+
+  # The archive carries no `anomaly` column, so every restored point arrives
+  # unflagged no matter what the source instance had already filtered out.
+  # Recompute instead of importing the flags: it also covers archives written
+  # before a filtering improvement shipped. Honours the user's own
+  # gps_filtering_enabled setting, which was restored moments ago.
+  def filter_restored_anomalies
+    min_timestamp, max_timestamp = user.points.pick(
+      Arel.sql('MIN(timestamp)'), Arel.sql('MAX(timestamp)')
+    )
+    return if min_timestamp.nil?
+
+    # Leading :: is required — Users::ImportData::Points is the points handler
+    # and would otherwise shadow the top-level Points namespace.
+    flagged = ::Points::AnomalyFilter.new(user.id, min_timestamp, max_timestamp).call
+    Rails.logger.info "Flagged #{flagged} anomalous points after restore for user: #{user.email}"
+  rescue StandardError => e
+    # A filtering failure must not discard an otherwise complete restore.
+    ExceptionReporter.call(e, 'Anomaly filtering failed after data import')
   end
 
   def detect_format_version

--- a/app/services/users/import_data.rb
+++ b/app/services/users/import_data.rb
@@ -64,11 +64,12 @@ class Users::ImportData
     ActiveRecord::Base.transaction do
       extract_archive
       process_archive_data
-      filter_restored_anomalies
       create_success_notification
-
-      @import_stats
     end
+
+    filter_restored_anomalies
+
+    @import_stats
   rescue UnsupportedFormatError => e
     create_failure_notification(e)
     nil
@@ -158,6 +159,11 @@ class Users::ImportData
   # Recompute instead of importing the flags: it also covers archives written
   # before a filtering improvement shipped. Honours the user's own
   # gps_filtering_enabled setting, which was restored moments ago.
+  #
+  # Runs AFTER the import transaction commits. Inside it, a database error here
+  # would leave the transaction aborted, and the next statement — the success
+  # notification — would fail with PG::InFailedSqlTransaction, discarding an
+  # otherwise complete restore over a filtering problem.
   def filter_restored_anomalies
     min_timestamp, max_timestamp = user.points.pick(
       Arel.sql('MIN(timestamp)'), Arel.sql('MAX(timestamp)')

--- a/app/services/users/safe_settings.rb
+++ b/app/services/users/safe_settings.rb
@@ -75,7 +75,6 @@ class Users::SafeSettings
     'max_gap_minutes_in_city' => 120,
     # GPS noise filtering (Points::AnomalyFilter)
     'gps_filtering_enabled' => true,
-    'gps_accuracy_threshold' => 100,
     'timezone' => ENV.fetch('TIME_ZONE', 'UTC'),
     'visit_radius_meters' => 100,
     'visit_min_points' => 3,
@@ -84,9 +83,6 @@ class Users::SafeSettings
     'stay_max_gap_minutes' => 60,
     'point_dragging_enabled' => false
   }.freeze
-
-  GPS_ACCURACY_THRESHOLD_MIN = 50
-  GPS_ACCURACY_THRESHOLD_MAX = 1000
 
   def initialize(settings = {}, plan: nil)
     @settings = DEFAULT_VALUES.deep_dup.deep_merge(settings)
@@ -131,7 +127,6 @@ class Users::SafeSettings
       min_minutes_spent_in_city: min_minutes_spent_in_city,
       max_gap_minutes_in_city: max_gap_minutes_in_city,
       gps_filtering_enabled: gps_filtering_enabled?,
-      gps_accuracy_threshold: gps_accuracy_threshold,
       timezone: timezone,
       visit_radius_meters: visit_radius_meters,
       visit_min_points: visit_min_points,
@@ -350,11 +345,6 @@ class Users::SafeSettings
     return true if value.nil?
 
     ActiveModel::Type::Boolean.new.cast(value)
-  end
-
-  def gps_accuracy_threshold
-    raw = settings['gps_accuracy_threshold'] || DEFAULT_VALUES['gps_accuracy_threshold']
-    raw.to_i.clamp(GPS_ACCURACY_THRESHOLD_MIN, GPS_ACCURACY_THRESHOLD_MAX)
   end
 
   def point_dragging_enabled?

--- a/app/views/map/maplibre/_settings_panel.html.erb
+++ b/app/views/map/maplibre/_settings_panel.html.erb
@@ -843,28 +843,7 @@
                      data-maps--maplibre-target="gpsFilteringToggle" />
               <span class="label-text font-medium">GPS Noise Filtering</span>
             </label>
-            <p class="text-sm text-base-content/60 mt-1">Hide points whose reported accuracy exceeds the threshold below. Disable for trains, indoor, or weak-signal data.</p>
-          </div>
-
-          <div class="form-control w-full">
-            <label class="label">
-              <span class="label-text font-medium">Accuracy Threshold</span>
-              <span class="label-text-alt" data-maps--maplibre-target="gpsAccuracyThresholdValue">100m</span>
-            </label>
-            <input type="range"
-                   name="gpsAccuracyThreshold"
-                   min="50"
-                   max="1000"
-                   step="10"
-                   value="100"
-                   class="range range-sm"
-                   data-action="input->maps--maplibre#updateGpsAccuracyThresholdDisplay" />
-            <div class="w-full flex justify-between text-xs px-2 mt-1">
-              <span>50m</span>
-              <span>500m</span>
-              <span>1000m</span>
-            </div>
-            <p class="text-xs text-base-content/60 mt-1">Points with reported GPS accuracy worse than this are flagged as noise. Lower = stricter, higher = keeps more weak-signal data.</p>
+            <p class="text-sm text-base-content/60 mt-1">Hide readings that cannot be a real position — impossible jumps, broken coordinates. Disable to see every raw point.</p>
           </div>
 
           <button type="button"

--- a/db/migrate/20260730160000_enqueue_google_records_device_tag_backfill.rb
+++ b/db/migrate/20260730160000_enqueue_google_records_device_tag_backfill.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# The 1.10.1 backfill (20260719190000) could not recover deviceTag for Google
+# Records imports — the importer never wrote raw_data — so it collapsed every
+# device onto `legacy-import-<id>`. Those installs need a second pass now that
+# the mapping is read from the uploaded file itself.
+class EnqueueGoogleRecordsDeviceTagBackfill < ActiveRecord::Migration[8.0]
+  def up
+    DataMigrations::RecalculatePerTrackerTracksJob.perform_later
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_130000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"

--- a/spec/jobs/data_migrations/recalculate_per_tracker_tracks_job_spec.rb
+++ b/spec/jobs/data_migrations/recalculate_per_tracker_tracks_job_spec.rb
@@ -55,6 +55,27 @@ RSpec.describe DataMigrations::RecalculatePerTrackerTracksJob do
       end.not_to have_enqueued_job(described_class)
     end
 
+    it 'enqueues users whose Google Records points were collapsed onto one import tracker' do
+      Track.where(tracker_id: nil).update_all(tracker_id: 'backfilled')
+      user_with_collapsed_points = create(:user)
+      collapsed_import = create(:import, user: user_with_collapsed_points, source: :google_records)
+      create(:point, user: user_with_collapsed_points, import: collapsed_import,
+                     tracker_id: "legacy-import-#{collapsed_import.id}")
+
+      expect do
+        described_class.perform_now
+      end.to have_enqueued_job(described_class).with(user_with_collapsed_points.id).exactly(:once)
+    end
+
+    it 'leaves alone users whose legacy-import points came from another source' do
+      Track.where(tracker_id: nil).update_all(tracker_id: 'backfilled')
+      gpx_user = create(:user)
+      gpx_import = create(:import, user: gpx_user, source: :gpx)
+      create(:point, user: gpx_user, import: gpx_import, tracker_id: "legacy-import-#{gpx_import.id}")
+
+      expect { described_class.perform_now }.not_to have_enqueued_job(described_class)
+    end
+
     it 'enqueues users whose points still carry a legacy importer constant' do
       Track.where(tracker_id: nil).update_all(tracker_id: 'backfilled')
       user_with_legacy_points = create(:user)

--- a/spec/jobs/data_migrations/recalculate_per_tracker_tracks_job_spec.rb
+++ b/spec/jobs/data_migrations/recalculate_per_tracker_tracks_job_spec.rb
@@ -123,4 +123,44 @@ RSpec.describe DataMigrations::RecalculatePerTrackerTracksJob do
       expect(tracker_ids).to eq(['google-records-device-1111111111'])
     end
   end
+
+  # The Records importer never wrote raw_data, so points from a pre-1.10.0
+  # Google Records import have no deviceTag to recover from the database. The
+  # uploaded file is the only place it still exists.
+  describe 'Google Records imports with no raw_data' do
+    let(:user) { create(:user) }
+    let(:import) { create(:import, user: user, source: :google_records, name: 'Records.json') }
+    let(:base_time) { Time.zone.parse('2024-06-22T20:08:58Z') }
+
+    before do
+      payload = {
+        'locations' => [
+          { 'latitudeE7' => 525_320_000, 'longitudeE7' => 135_170_000,
+            'deviceTag' => -2_008_693_898, 'timestamp' => '2024-06-22T20:08:58.000Z' },
+          { 'latitudeE7' => 544_392_000, 'longitudeE7' => 127_081_000,
+            'deviceTag' => -1_849_312_274, 'timestamp' => '2024-06-22T20:10:58.000Z' }
+        ]
+      }
+      file = Tempfile.new(['records', '.json'])
+      file.write(Oj.dump(payload, mode: :compat))
+      file.rewind
+      import.file.attach(io: file, filename: 'Records.json', content_type: 'application/json')
+      file.close
+
+      create(:point, user: user, import: import, tracker_id: 'google-maps-timeline-export',
+                     raw_data: {}, timestamp: base_time.to_i, lonlat: 'POINT(13.517 52.532)')
+      create(:point, user: user, import: import, tracker_id: 'google-maps-timeline-export',
+                     raw_data: {}, timestamp: (base_time + 2.minutes).to_i,
+                     lonlat: 'POINT(12.7081 54.4392)')
+    end
+
+    it 'separates the devices using the uploaded file' do
+      described_class.new.perform(user.id)
+
+      expect(user.points.reload.pluck(:tracker_id)).to contain_exactly(
+        'google-records-device--2008693898',
+        'google-records-device--1849312274'
+      )
+    end
+  end
 end

--- a/spec/jobs/points/anomaly_backfill_user_job_spec.rb
+++ b/spec/jobs/points/anomaly_backfill_user_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Points::AnomalyBackfillUserJob, type: :job do
 
   describe '#perform with reset: true' do
     let!(:legitimate_anomaly) do
-      create(:point, user: user, accuracy: 5000, anomaly: true,
+      create(:point, user: user, accuracy: 50_000, anomaly: true,
              timestamp: 30.minutes.ago.to_i,
              latitude: 52.52, longitude: 13.405,
              lonlat: 'POINT(13.405 52.52)')
@@ -18,8 +18,6 @@ RSpec.describe Points::AnomalyBackfillUserJob, type: :job do
              latitude: 52.5201, longitude: 13.4051,
              lonlat: 'POINT(13.4051 52.5201)')
     end
-
-    before { user.update!(settings: { 'gps_accuracy_threshold' => 200 }) }
 
     it 'clears existing anomaly flags and re-evaluates with current settings' do
       described_class.new.perform(user.id, reset: true)
@@ -57,8 +55,6 @@ RSpec.describe Points::AnomalyBackfillUserJob, type: :job do
     let(:sparse_user) { create(:user) }
 
     before do
-      sparse_user.update!(settings: { 'gps_accuracy_threshold' => 200 })
-
       [22.months.ago, 12.months.ago, 1.month.ago].each do |bucket_anchor|
         2.times do |i|
           create(:point, user: sparse_user, accuracy: 60, anomaly: false,

--- a/spec/models/point_spec.rb
+++ b/spec/models/point_spec.rb
@@ -82,6 +82,44 @@ RSpec.describe Point, type: :model do
         end
       end
     end
+
+    describe '.null_island' do
+      let(:user) { create(:user) }
+
+      let!(:exact_zero) do
+        create(:point, user: user, timestamp: 1.hour.ago.to_i, lonlat: 'POINT(0 0)')
+      end
+      # Google Timeline exports emit coordinates a fraction of a degree off zero
+      # instead of exact zeros; they are the same defect and must be caught.
+      let!(:near_zero) do
+        create(:point, user: user, timestamp: 2.hours.ago.to_i,
+                       lonlat: 'POINT(-0.009821517715778327 -0.0056462072163441235)')
+      end
+      let!(:real_location) do
+        create(:point, user: user, timestamp: 3.hours.ago.to_i, lonlat: 'POINT(13.405 52.52)')
+      end
+      # Gulf of Guinea is genuine ocean; only the immediate neighbourhood of the
+      # origin is treated as a broken coordinate.
+      let!(:far_from_zero) do
+        create(:point, user: user, timestamp: 4.hours.ago.to_i, lonlat: 'POINT(1.5 1.5)')
+      end
+
+      it 'includes points at exactly (0, 0)' do
+        expect(described_class.null_island).to include(exact_zero)
+      end
+
+      it 'includes points a fraction of a degree from (0, 0)' do
+        expect(described_class.null_island).to include(near_zero)
+      end
+
+      it 'excludes points at a real location' do
+        expect(described_class.null_island).not_to include(real_location)
+      end
+
+      it 'excludes points well outside the origin neighbourhood' do
+        expect(described_class.null_island).not_to include(far_from_zero)
+      end
+    end
   end
 
   describe 'methods' do

--- a/spec/services/points/anomaly_filter_integration_spec.rb
+++ b/spec/services/points/anomaly_filter_integration_spec.rb
@@ -18,17 +18,17 @@ RSpec.describe 'GPS Noise Filtering Integration' do
                timestamp: base_time + i * 60,
                accuracy: 10)
       end
-      # 1 bad accuracy point
+      # 1 point whose accuracy radius is too large to be a position at all
       create(:point, user: user,
              latitude: 52.53, longitude: 13.41,
              lonlat: 'POINT(13.41 52.53)',
              timestamp: base_time + 300,
-             accuracy: 2000)
+             accuracy: 60_000)
 
       Points::AnomalyFilter.new(user.id, base_time, base_time + 600).call
     end
 
-    it 'marks bad accuracy points as anomalies' do
+    it 'marks absurd accuracy points as anomalies' do
       expect(user.points.anomaly.count).to eq(1)
       expect(user.points.not_anomaly.count).to eq(5)
     end
@@ -43,7 +43,8 @@ RSpec.describe 'GPS Noise Filtering Integration' do
     end
 
     it 'excludes anomalies from not_anomaly scope' do
-      expect(user.points.not_anomaly.pluck(:accuracy)).to all(be <= 100)
+      expect(user.points.not_anomaly.pluck(:accuracy))
+        .to all(be <= Points::AnomalyFilter::ABSURD_ACCURACY_METERS)
     end
   end
 

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Points::AnomalyFilter do
 
   describe '#call' do
     it 'bumps updated_at when flagging an anomaly so cached point reads invalidate' do
-      point = create(:point, user: user, accuracy: 500, timestamp: 30.minutes.ago.to_i,
+      point = create(:point, user: user, accuracy: 50_000, timestamp: 30.minutes.ago.to_i,
                              latitude: 52.52, longitude: 13.405, lonlat: 'POINT(13.405 52.52)')
       point.update_column(:updated_at, 2.days.ago)
       before_updated = point.reload.updated_at
@@ -20,7 +20,12 @@ RSpec.describe Points::AnomalyFilter do
       expect(point.updated_at).to be > before_updated
     end
 
-    context 'Pass 1: accuracy filter' do
+    # A reported accuracy radius is a confidence estimate, not evidence that the
+    # position is wrong. Google Timeline routinely reports 1-4km while the point
+    # still sits on the road, and deleting those points replaces real route
+    # geometry with a straight line across the gap. Only absurd radii — larger
+    # than any plausible positioning error — are treated as anomalies.
+    context 'Pass 1: absurd accuracy filter' do
       # Use nearby coordinates so Pass 2 speed filter does not interfere
       let(:base_lat) { 52.52 }
       let(:base_lon) { 13.405 }
@@ -30,8 +35,8 @@ RSpec.describe Points::AnomalyFilter do
                latitude: base_lat, longitude: base_lon,
                lonlat: "POINT(#{base_lon} #{base_lat})")
       end
-      let!(:bad_accuracy) do
-        create(:point, user: user, accuracy: 500, timestamp: 29.minutes.ago.to_i,
+      let!(:coarse_but_usable) do
+        create(:point, user: user, accuracy: 3_000, timestamp: 29.minutes.ago.to_i,
                latitude: base_lat + 0.0001, longitude: base_lon + 0.0001,
                lonlat: "POINT(#{base_lon + 0.0001} #{base_lat + 0.0001})")
       end
@@ -40,31 +45,57 @@ RSpec.describe Points::AnomalyFilter do
                latitude: base_lat + 0.0002, longitude: base_lon + 0.0002,
                lonlat: "POINT(#{base_lon + 0.0002} #{base_lat + 0.0002})")
       end
-      let!(:borderline) do
-        create(:point, user: user, accuracy: 100, timestamp: 27.minutes.ago.to_i,
+      let!(:just_over_old_threshold) do
+        create(:point, user: user, accuracy: 101, timestamp: 27.minutes.ago.to_i,
                latitude: base_lat + 0.0003, longitude: base_lon + 0.0003,
                lonlat: "POINT(#{base_lon + 0.0003} #{base_lat + 0.0003})")
       end
-      let!(:just_over) do
-        create(:point, user: user, accuracy: 101, timestamp: 26.minutes.ago.to_i,
+      let!(:absurd_accuracy) do
+        create(:point, user: user, accuracy: 20_000, timestamp: 26.minutes.ago.to_i,
                latitude: base_lat + 0.0004, longitude: base_lon + 0.0004,
                lonlat: "POINT(#{base_lon + 0.0004} #{base_lat + 0.0004})")
       end
 
       before { described_class.new(user.id, start_time, end_time).call }
 
-      it 'marks points with accuracy > 100 as anomaly' do
-        expect(bad_accuracy.reload.anomaly).to be true
-        expect(just_over.reload.anomaly).to be true
+      it 'marks points whose accuracy radius is absurd' do
+        expect(absurd_accuracy.reload.anomaly).to be true
       end
 
-      it 'does not mark points with accuracy <= 100' do
+      it 'keeps coarse but usable points so route geometry survives' do
+        expect(coarse_but_usable.reload.anomaly).not_to be true
+        expect(just_over_old_threshold.reload.anomaly).not_to be true
+      end
+
+      it 'keeps precise points' do
         expect(good_point.reload.anomaly).not_to be true
-        expect(borderline.reload.anomaly).not_to be true
       end
 
       it 'does not mark points with nil accuracy' do
         expect(no_accuracy.reload.anomaly).not_to be true
+      end
+    end
+
+    # Regression for the real failure: a drive whose shape comes entirely from
+    # coarse Google Timeline points. Dropping them left an 78km straight line
+    # between the two precise endpoints.
+    context 'Pass 1: a drive whose intermediate points are all coarse' do
+      let(:base_time) { 40.minutes.ago.to_i }
+
+      let!(:drive) do
+        # ~0.05 degrees north per step, 5 minutes apart: roughly 65 km/h.
+        (0..6).map do |i|
+          create(:point, user: user, tracker_id: 'google-maps-timeline-export',
+                         accuracy: i.zero? || i == 6 ? 20 : 3_000,
+                         timestamp: base_time + (i * 300),
+                         lonlat: "POINT(13.24 #{52.76 + (i * 0.05)})")
+        end
+      end
+
+      before { described_class.new(user.id, 1.hour.ago.to_i, Time.current.to_i).call }
+
+      it 'keeps every point of the drive so the route keeps its shape' do
+        drive.each { |point| expect(point.reload.anomaly).not_to be true }
       end
     end
 
@@ -115,6 +146,315 @@ RSpec.describe Points::AnomalyFilter do
       end
     end
 
+    context 'Pass 2: outlier adjacent to a same-timestamp point from another device' do
+      let(:base_time) { 30.minutes.ago.to_i }
+      let(:base_lat) { 52.52 }
+      let(:base_lon) { 13.405 }
+
+      # Declared first so it sorts ahead of the outlier under (timestamp, id):
+      # it becomes the outlier's predecessor in a globally ordered stream.
+      let!(:other_device_point) do
+        create(:point, user: user, tracker_id: 'phone', accuracy: 10,
+                       timestamp: base_time + 120,
+                       lonlat: "POINT(#{base_lon} #{base_lat})")
+      end
+      let!(:before_point) do
+        create(:point, user: user, tracker_id: 'web', accuracy: 10,
+                       timestamp: base_time,
+                       lonlat: "POINT(#{base_lon} #{base_lat})")
+      end
+      let!(:spike) do
+        create(:point, user: user, tracker_id: 'web', accuracy: 10,
+                       timestamp: base_time + 120,
+                       lonlat: "POINT(#{base_lon + 10.0} #{base_lat + 10.0})")
+      end
+      let!(:after_point) do
+        create(:point, user: user, tracker_id: 'web', accuracy: 10,
+                       timestamp: base_time + 240,
+                       lonlat: "POINT(#{base_lon + 0.0002} #{base_lat + 0.0002})")
+      end
+
+      before { described_class.new(user.id, start_time, end_time).call }
+
+      it 'still marks the spike even though its neighbour shares a timestamp' do
+        expect(spike.reload.anomaly).to be true
+      end
+
+      it 'leaves the other device untouched' do
+        expect(other_device_point.reload.anomaly).not_to be true
+        expect(before_point.reload.anomaly).not_to be true
+        expect(after_point.reload.anomaly).not_to be true
+      end
+    end
+
+    context 'Pass 2: a run of consecutive displaced points' do
+      let(:base_time) { 30.minutes.ago.to_i }
+      let(:base_lat) { 52.52 }
+      let(:base_lon) { 13.405 }
+
+      let!(:p1) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time,
+                       lonlat: "POINT(#{base_lon} #{base_lat})")
+      end
+      let!(:p2) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time + 60,
+                       lonlat: "POINT(#{base_lon + 0.0001} #{base_lat + 0.0001})")
+      end
+      # Two displaced points close to each other: the speed *between* them is
+      # normal, so neither has both an extreme incoming and outgoing speed.
+      let!(:displaced_a) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time + 120,
+                       lonlat: "POINT(#{base_lon + 10.0} #{base_lat + 10.0})")
+      end
+      let!(:displaced_b) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time + 180,
+                       lonlat: "POINT(#{base_lon + 10.0001} #{base_lat + 10.0001})")
+      end
+      let!(:p5) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time + 240,
+                       lonlat: "POINT(#{base_lon + 0.0002} #{base_lat + 0.0002})")
+      end
+      let!(:p6) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time + 300,
+                       lonlat: "POINT(#{base_lon + 0.0003} #{base_lat + 0.0003})")
+      end
+
+      before { described_class.new(user.id, start_time, end_time).call }
+
+      it 'marks every point in the displaced run' do
+        expect(displaced_a.reload.anomaly).to be true
+        expect(displaced_b.reload.anomaly).to be true
+      end
+
+      it 'leaves the surrounding real points alone' do
+        [p1, p2, p5, p6].each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
+
+    # A real stay can be bracketed by two impossible hops when the surrounding
+    # data is sparse or a second device is interleaved. Convicting the whole run
+    # on its boundaries alone would erase genuine history, so run length is
+    # bounded: noise is a brief excursion, a stay is a long one.
+    context 'Pass 2: a long genuine stay bracketed by impossible hops' do
+      let(:start_time) { 8.hours.ago.to_i }
+      let(:end_time) { Time.current.to_i }
+      let(:base_time) { 7.hours.ago.to_i }
+      let(:base_lat) { 52.52 }
+      let(:base_lon) { 13.405 }
+
+      let!(:home_before) do
+        [0, 1].map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + (i * 60),
+                         lonlat: "POINT(#{base_lon + (i * 0.0001)} #{base_lat + (i * 0.0001)})")
+        end
+      end
+      # 12 points clustered ~800km away, minutes apart: an implausible jump to
+      # get there, but unmistakably a real visit once there.
+      let!(:stay) do
+        (0..11).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 120 + (i * 60),
+                         lonlat: "POINT(#{4.35 + (i * 0.0001)} #{50.85 + (i * 0.0001)})")
+        end
+      end
+      let!(:home_after) do
+        [0, 1].map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 900 + (i * 60),
+                         lonlat: "POINT(#{base_lon + (i * 0.0001)} #{base_lat + (i * 0.0001)})")
+        end
+      end
+
+      before { described_class.new(user.id, start_time, end_time).call }
+
+      it 'does not erase the stay' do
+        stay.each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+
+      it 'leaves the home points alone' do
+        (home_before + home_after).each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
+
+    # The real shape of a stale cached position: it jumps hundreds of km away
+    # and comes straight back. Only the arrival is impossibly fast — the return
+    # leg looks merely plane-like — so a test requiring both sides to be extreme
+    # lets it through, and the round trip lands in the track as a phantom flight.
+    context 'Pass 2: an out-and-back excursion with only one impossible leg' do
+      let(:base_time) { 40.minutes.ago.to_i }
+      # Two coast positions ~30km apart, with a stale Berlin fix wedged between.
+      let(:coast_a) { 'POINT(12.247 54.176)' }
+      let(:coast_b) { 'POINT(12.541 54.392)' }
+      let(:stale_berlin) { 'POINT(13.517 52.532)' }
+
+      let!(:before_a) do
+        create(:point, user: user, accuracy: 5, timestamp: base_time, lonlat: coast_a)
+      end
+      let!(:before_b) do
+        create(:point, user: user, accuracy: 5, timestamp: base_time + 60, lonlat: coast_a)
+      end
+      # 218km away in 300s -> ~2600 km/h arriving: impossible.
+      let!(:spike) do
+        create(:point, user: user, accuracy: 100, timestamp: base_time + 360, lonlat: stale_berlin)
+      end
+      # 217km back in 900s -> ~868 km/h leaving: plausible for a plane, so the
+      # two-sided test never fires.
+      let!(:after_a) do
+        create(:point, user: user, accuracy: 20, timestamp: base_time + 1260, lonlat: coast_b)
+      end
+      let!(:after_b) do
+        create(:point, user: user, accuracy: 20, timestamp: base_time + 1320, lonlat: coast_b)
+      end
+
+      before { described_class.new(user.id, 1.hour.ago.to_i, Time.current.to_i).call }
+
+      it 'flags the excursion' do
+        expect(spike.reload.anomaly).to be true
+      end
+
+      it 'leaves the surrounding real positions alone' do
+        [before_a, before_b, after_a, after_b].each do |point|
+          expect(point.reload.anomaly).not_to be true
+        end
+      end
+    end
+
+    # Google splices a stale fix from another device into a phone's timelinePath.
+    # Each leg on its own looks like air travel, so nothing exceeds the raw speed
+    # floor — but the round trip demands hundreds of km of travel that never
+    # happened, which is what the detour test is for.
+    context 'Pass 2: a detour no ground travel could cover' do
+      let(:base_time) { 40.minutes.ago.to_i }
+
+      let!(:before_a) do
+        create(:point, user: user, accuracy: 5, timestamp: base_time, lonlat: 'POINT(10.5526 52.9697)')
+      end
+      let!(:before_b) do
+        create(:point, user: user, accuracy: 5, timestamp: base_time + 480, lonlat: 'POINT(10.4417 52.9117)')
+      end
+      # 214km away in 27min (~476 km/h), then 257km on in 15min (~1028 km/h).
+      let!(:spliced_home) do
+        create(:point, user: user, accuracy: 5, timestamp: base_time + 2100, lonlat: 'POINT(13.5162 52.4546)')
+      end
+      let!(:after_a) do
+        create(:point, user: user, accuracy: 5, timestamp: base_time + 3000, lonlat: 'POINT(9.7419 52.3775)')
+      end
+      let!(:after_b) do
+        create(:point, user: user, accuracy: 5, timestamp: base_time + 3300, lonlat: 'POINT(9.7420 52.3776)')
+      end
+
+      before { described_class.new(user.id, 2.hours.ago.to_i, Time.current.to_i).call }
+
+      it 'flags the spliced fix' do
+        expect(spliced_home.reload.anomaly).to be true
+      end
+
+      it 'keeps the real journey either side' do
+        [before_a, before_b, after_a, after_b].each do |point|
+          expect(point.reload.anomaly).not_to be true
+        end
+      end
+    end
+
+    # A stale fix can land in the middle of a stay somewhere else, hours from any
+    # other reading. Over a long enough gap the round trip is physically possible,
+    # so no speed test can condemn it — but spending zero time at the far end and
+    # returning to the same stay is not travel.
+    context 'Pass 2: a fix that contradicts a stay' do
+      let(:evening) { Time.zone.parse('2022-12-03 20:16').to_i }
+      let(:hannover) { 'POINT(9.806 52.310)' }
+      let(:home) { 'POINT(13.516 52.455)' }
+
+      let!(:stay_before) do
+        create(:point, user: user, accuracy: 5, timestamp: evening, lonlat: hannover)
+      end
+      let!(:stale_home) do
+        create(:point, user: user, accuracy: 5, timestamp: evening + 45_540, lonlat: home)
+      end
+      let!(:stay_after) do
+        create(:point, user: user, accuracy: 5, timestamp: evening + 48_420, lonlat: hannover)
+      end
+      let!(:stay_after_b) do
+        create(:point, user: user, accuracy: 5, timestamp: evening + 48_480, lonlat: hannover)
+      end
+
+      before { described_class.new(user.id, evening - 3600, evening + 90_000).call }
+
+      it 'flags the fix that interrupts the stay' do
+        expect(stale_home.reload.anomaly).to be true
+      end
+
+      it 'keeps the stay itself' do
+        [stay_before, stay_after, stay_after_b].each do |point|
+          expect(point.reload.anomaly).not_to be true
+        end
+      end
+    end
+
+    context 'Pass 2: a real trip away from a stay and back' do
+      let(:start) { Time.zone.parse('2022-12-03 08:00').to_i }
+      let(:home) { 'POINT(13.405 52.520)' }
+      let(:away) { 'POINT(11.576 48.137)' }
+
+      let!(:home_before) do
+        create(:point, user: user, accuracy: 5, timestamp: start, lonlat: home)
+      end
+      # Four hours of points at the destination: a real visit, not a stray fix.
+      let!(:visit) do
+        [0, 3600, 7200, 14_400].map do |offset|
+          create(:point, user: user, accuracy: 5, timestamp: start + 7200 + offset, lonlat: away)
+        end
+      end
+      let!(:home_after) do
+        create(:point, user: user, accuracy: 5, timestamp: start + 36_000, lonlat: home)
+      end
+
+      before { described_class.new(user.id, start - 3600, start + 90_000).call }
+
+      it 'keeps the whole trip' do
+        ([home_before] + visit + [home_after]).each do |point|
+          expect(point.reload.anomaly).not_to be true
+        end
+      end
+    end
+
+    context 'Pass 2: genuine long-distance travel' do
+      let(:start_time) { 8.hours.ago.to_i }
+      let(:end_time) { Time.current.to_i }
+      let(:base_time) { 7.hours.ago.to_i }
+      let(:base_lat) { 52.52 }
+      let(:base_lon) { 13.405 }
+
+      let!(:origin_a) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time,
+                       lonlat: "POINT(#{base_lon} #{base_lat})")
+      end
+      let!(:origin_b) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time + 60,
+                       lonlat: "POINT(#{base_lon + 0.0001} #{base_lat + 0.0001})")
+      end
+      # ~1650km south-west over 3 hours ≈ 550 km/h: a real flight, comfortably
+      # under the 1000 km/h floor, and the traveller then stays put.
+      let!(:arrival_a) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time + (3 * 3600),
+                       lonlat: 'POINT(2.3522 48.8566)')
+      end
+      let!(:arrival_b) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time + (3 * 3600) + 600,
+                       lonlat: 'POINT(2.3523 48.8567)')
+      end
+      let!(:arrival_c) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time + (4 * 3600),
+                       lonlat: 'POINT(2.3524 48.8568)')
+      end
+
+      before { described_class.new(user.id, start_time, end_time).call }
+
+      it 'does not flag the flight or the destination points' do
+        [origin_a, origin_b, arrival_a, arrival_b, arrival_c].each do |point|
+          expect(point.reload.anomaly).not_to be true
+        end
+      end
+    end
+
     context 'Pass 2: same-timestamp points' do
       let!(:p1) do
         create(:point, user: user, latitude: 52.52, longitude: 13.405,
@@ -144,7 +484,7 @@ RSpec.describe Points::AnomalyFilter do
     end
 
     context 'returns count of marked anomalies' do
-      let!(:bad) { create(:point, user: user, accuracy: 500, timestamp: 30.minutes.ago.to_i) }
+      let!(:bad) { create(:point, user: user, accuracy: 50_000, timestamp: 30.minutes.ago.to_i) }
       let!(:good) { create(:point, user: user, accuracy: 10, timestamp: 29.minutes.ago.to_i) }
 
       it 'returns the total count of anomalies marked' do
@@ -163,25 +503,29 @@ RSpec.describe Points::AnomalyFilter do
       end
     end
 
-    context 'when user raises the accuracy threshold' do
+    # gps_accuracy_threshold no longer gates flagging: a coarse radius is not
+    # evidence of a wrong position, and honouring a 100-1000m threshold deleted
+    # the coarse points that carry route shape. The setting is still accepted by
+    # the settings API but no longer affects which points are flagged.
+    context 'when the user has set an accuracy threshold' do
       let(:user) { create(:user, settings: { 'gps_accuracy_threshold' => 500 }) }
-      let!(:between_default_and_user) do
-        create(:point, user: user, accuracy: 200, timestamp: 30.minutes.ago.to_i,
+      let!(:above_user_threshold) do
+        create(:point, user: user, accuracy: 600, timestamp: 30.minutes.ago.to_i,
                latitude: 52.52, longitude: 13.405, lonlat: 'POINT(13.405 52.52)')
       end
-      let!(:above_user_threshold) do
-        create(:point, user: user, accuracy: 600, timestamp: 29.minutes.ago.to_i,
+      let!(:absurd) do
+        create(:point, user: user, accuracy: 40_000, timestamp: 29.minutes.ago.to_i,
                latitude: 52.5201, longitude: 13.4051, lonlat: 'POINT(13.4051 52.5201)')
       end
 
       before { described_class.new(user.id, start_time, end_time).call }
 
-      it 'keeps points below the user threshold' do
-        expect(between_default_and_user.reload.anomaly).not_to be true
+      it 'keeps coarse points regardless of the threshold' do
+        expect(above_user_threshold.reload.anomaly).not_to be true
       end
 
-      it 'still flags points above the user threshold' do
-        expect(above_user_threshold.reload.anomaly).to be true
+      it 'still flags absurd radii' do
+        expect(absurd.reload.anomaly).to be true
       end
     end
 

--- a/spec/services/points/device_tag_backfiller_spec.rb
+++ b/spec/services/points/device_tag_backfiller_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Points::DeviceTagBackfiller do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :google_records, name: 'Records.json') }
+
+  # Two devices reporting in the same window: the phone that travelled and a
+  # device left behind. Google keeps both in one Records.json, which is exactly
+  # why their points end up sharing a tracker_id.
+  let(:records) do
+    {
+      'locations' => [
+        {
+          'latitudeE7' => 525_320_000, 'longitudeE7' => 135_170_000, 'accuracy' => 30,
+          'activity' => [{ 'activity' => [{ 'type' => 'STILL', 'confidence' => 90 }],
+                           'timestamp' => '2024-06-22T19:41:35.000Z' }],
+          'source' => 'WIFI', 'deviceTag' => -2_008_693_898,
+          'timestamp' => '2024-06-22T19:41:31.000Z'
+        },
+        {
+          'latitudeE7' => 544_392_000, 'longitudeE7' => 127_081_000, 'accuracy' => 12,
+          'deviceTag' => -1_849_312_274,
+          'timestamp' => '2024-06-22T20:08:58.000Z'
+        },
+        {
+          'latitudeE7' => 544_376_000, 'longitudeE7' => 127_085_000, 'accuracy' => 12,
+          'source' => 'GPS', 'deviceTag' => -1_849_312_274,
+          'timestamp' => '2024-06-22T20:34:37.000Z'
+        }
+      ]
+    }
+  end
+
+  def attach_records(payload)
+    file = Tempfile.new(['records', '.json'])
+    file.write(Oj.dump(payload, mode: :compat))
+    file.rewind
+    import.file.attach(io: file, filename: 'Records.json', content_type: 'application/json')
+    file.close
+  end
+
+  def point_at(iso, tracker: 'google-maps-timeline-export', lonlat: 'POINT(13.517 52.532)')
+    create(:point, user: user, import: import, tracker_id: tracker,
+                   timestamp: Time.zone.parse(iso).to_i, lonlat: lonlat)
+  end
+
+  before { attach_records(records) }
+
+  describe '#call' do
+    it 'gives each device its own tracker_id' do
+      home = point_at('2024-06-22T19:41:31Z')
+      away_a = point_at('2024-06-22T20:08:58Z', lonlat: 'POINT(12.7081 54.4392)')
+      away_b = point_at('2024-06-22T20:34:37Z', lonlat: 'POINT(12.7085 54.4376)')
+
+      described_class.new(import).call
+
+      expect(home.reload.tracker_id).to eq('google-records-device--2008693898')
+      expect(away_a.reload.tracker_id).to eq('google-records-device--1849312274')
+      expect(away_b.reload.tracker_id).to eq('google-records-device--1849312274')
+    end
+
+    it 'reports how many points it re-stamped' do
+      point_at('2024-06-22T19:41:31Z')
+      point_at('2024-06-22T20:08:58Z')
+
+      expect(described_class.new(import).call).to eq(2)
+    end
+
+    it 'leaves points that already carry a device tracker alone' do
+      already_done = point_at('2024-06-22T20:08:58Z', tracker: 'google-records-device--1849312274')
+
+      expect { described_class.new(import).call }
+        .not_to(change { already_done.reload.updated_at })
+    end
+
+    it 'leaves points from other imports alone' do
+      other_import = create(:import, user: user, source: :google_records)
+      stranger = create(:point, user: user, import: other_import,
+                                tracker_id: 'google-maps-timeline-export',
+                                timestamp: Time.zone.parse('2024-06-22T20:08:58Z').to_i)
+
+      described_class.new(import).call
+
+      expect(stranger.reload.tracker_id).to eq('google-maps-timeline-export')
+    end
+
+    it 'ignores nested activity timestamps when reading a record' do
+      # 19:41:35 is the activity timestamp, not the location's own.
+      decoy = point_at('2024-06-22T19:41:35Z')
+
+      described_class.new(import).call
+
+      expect(decoy.reload.tracker_id).to eq('google-maps-timeline-export')
+    end
+
+    # Two devices reporting in the same second is what leaves points stranded on
+    # the shared tracker, and stranded points get stitched into 2-point tracks
+    # hundreds of km long. The coordinates tell them apart.
+    context 'when two devices report the same second' do
+      let(:records) do
+        {
+          'locations' => [
+            { 'latitudeE7' => 525_320_000, 'longitudeE7' => 135_170_000,
+              'deviceTag' => 111, 'timestamp' => '2024-06-22T20:08:58.000Z' },
+            { 'latitudeE7' => 544_392_000, 'longitudeE7' => 127_081_000,
+              'deviceTag' => 222, 'timestamp' => '2024-06-22T20:08:58.100Z' }
+          ]
+        }
+      end
+
+      it 'tells the devices apart by position' do
+        here = point_at('2024-06-22T20:08:58Z', lonlat: 'POINT(13.517 52.532)')
+        there = point_at('2024-06-22T20:08:58Z', lonlat: 'POINT(12.7081 54.4392)')
+
+        described_class.new(import).call
+
+        expect(here.reload.tracker_id).to eq('google-records-device-111')
+        expect(there.reload.tracker_id).to eq('google-records-device-222')
+      end
+
+      it 'leaves a point whose position matches neither record alone' do
+        stranger = point_at('2024-06-22T20:08:58Z', lonlat: 'POINT(2.3522 48.8566)')
+
+        described_class.new(import).call
+
+        expect(stranger.reload.tracker_id).to eq('google-maps-timeline-export')
+      end
+    end
+
+    context 'when the import file is gone' do
+      it 'returns 0 without raising' do
+        import.file.purge
+
+        expect { expect(described_class.new(import).call).to eq(0) }.not_to raise_error
+      end
+    end
+
+    context 'when the import is not a Google Records import' do
+      let(:import) { create(:import, user: user, source: :gpx, name: 'track.gpx') }
+
+      it 'returns 0 and changes nothing' do
+        point = point_at('2024-06-22T20:08:58Z')
+
+        expect(described_class.new(import).call).to eq(0)
+        expect(point.reload.tracker_id).to eq('google-maps-timeline-export')
+      end
+    end
+  end
+end

--- a/spec/services/points/device_tag_backfiller_spec.rb
+++ b/spec/services/points/device_tag_backfiller_spec.rb
@@ -75,6 +75,31 @@ RSpec.describe Points::DeviceTagBackfiller do
         .not_to(change { already_done.reload.updated_at })
     end
 
+    # Every 1.10.1+ install already ran the legacy backfill migration, which
+    # stamped these points 'legacy-import-<id>'. Skipping that value would make
+    # this repair a no-op on exactly the instances that need it.
+    it 're-stamps points the earlier backfill collapsed onto one import tracker' do
+      collapsed = point_at('2024-06-22T19:41:31Z', tracker: "legacy-import-#{import.id}")
+
+      described_class.new(import).call
+
+      expect(collapsed.reload.tracker_id).to eq('google-records-device--2008693898')
+    end
+
+    it 'does nothing on a second run' do
+      point_at('2024-06-22T19:41:31Z')
+      described_class.new(import).call
+
+      expect(described_class.new(import).call).to eq(0)
+    end
+
+    it 'survives a storage failure without taking the caller down' do
+      allow(import.file.blob.service).to receive(:path_for).and_raise(StandardError, 'S3 timeout')
+      allow(import.file).to receive(:open).and_raise(StandardError, 'S3 timeout')
+
+      expect { expect(described_class.new(import).call).to eq(0) }.not_to raise_error
+    end
+
     it 'leaves points from other imports alone' do
       other_import = create(:import, user: user, source: :google_records)
       stranger = create(:point, user: user, import: other_import,

--- a/spec/services/users/export_import_integration_spec.rb
+++ b/spec/services/users/export_import_integration_spec.rb
@@ -592,4 +592,49 @@ RSpec.describe 'Users Export-Import Integration', type: :service do
       end
     end
   end
+
+  # The export payload carries no `anomaly` column, so every restored point
+  # arrives unflagged. Without re-running the filter a restored instance
+  # regenerates its tracks from GPS noise it had already learned to ignore.
+  describe 'anomaly flags after a restore' do
+    let(:source_user) { create(:user, email: 'anomaly_source@example.com') }
+    let(:restored_user) { create(:user, email: 'anomaly_target@example.com') }
+    let(:archive_path) { Rails.root.join('tmp/anomaly_restore_test.zip') }
+    let(:base_time) { Time.utc(2024, 3, 10, 12, 0, 0).to_i }
+
+    before do
+      create(:point, user: source_user, accuracy: 10, timestamp: base_time,
+                     lonlat: 'POINT(13.405 52.52)')
+      create(:point, user: source_user, accuracy: 10, timestamp: base_time + 60,
+                     lonlat: 'POINT(13.4051 52.5201)')
+      create(:point, user: source_user, accuracy: 10, timestamp: base_time + 120,
+                     lonlat: 'POINT(0 0)')
+      create(:point, user: source_user, accuracy: 10, timestamp: base_time + 180,
+                     lonlat: 'POINT(13.4052 52.5202)')
+      create(:point, user: source_user, accuracy: 10, timestamp: base_time + 240,
+                     lonlat: 'POINT(13.4053 52.5203)')
+    end
+
+    after { FileUtils.rm_f(archive_path) }
+
+    it 'flags restored Null Island points instead of leaving them unfiltered' do
+      export_record = Users::ExportData.new(source_user).export
+      File.open(archive_path, 'wb') { |file| export_record.file.download { |chunk| file.write(chunk) } }
+
+      Users::ImportData.new(restored_user, archive_path).import
+
+      restored_null_island = restored_user.points.null_island
+      expect(restored_null_island).to be_present
+      expect(restored_null_island.where(anomaly: true).count).to eq(restored_null_island.count)
+    end
+
+    it 'leaves genuine restored points usable for track generation' do
+      export_record = Users::ExportData.new(source_user).export
+      File.open(archive_path, 'wb') { |file| export_record.file.download { |chunk| file.write(chunk) } }
+
+      Users::ImportData.new(restored_user, archive_path).import
+
+      expect(restored_user.points.not_anomaly.count).to eq(4)
+    end
+  end
 end

--- a/spec/services/users/safe_settings_spec.rb
+++ b/spec/services/users/safe_settings_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe Users::SafeSettings do
             min_minutes_spent_in_city: 60,
             max_gap_minutes_in_city: 120,
             gps_filtering_enabled: true,
-            gps_accuracy_threshold: 100,
             timezone: 'UTC',
             visit_radius_meters: 100,
             visit_min_points: 3,
@@ -172,7 +171,6 @@ RSpec.describe Users::SafeSettings do
             'min_minutes_spent_in_city' => 60,
             'max_gap_minutes_in_city' => 120,
             'gps_filtering_enabled' => true,
-            'gps_accuracy_threshold' => 100,
             'timezone' => 'UTC',
             'visit_radius_meters' => 100,
             'visit_min_points' => 3,
@@ -245,7 +243,6 @@ RSpec.describe Users::SafeSettings do
             min_minutes_spent_in_city: 60,
             max_gap_minutes_in_city: 120,
             gps_filtering_enabled: true,
-            gps_accuracy_threshold: 100,
             timezone: 'UTC',
             visit_radius_meters: 100,
             visit_min_points: 3,
@@ -769,28 +766,6 @@ RSpec.describe Users::SafeSettings do
 
     it 'casts string "false"' do
       expect(described_class.new({ 'gps_filtering_enabled' => 'false' }).gps_filtering_enabled?).to be false
-    end
-  end
-
-  describe '#gps_accuracy_threshold' do
-    it 'defaults to 100' do
-      expect(described_class.new({}).gps_accuracy_threshold).to eq(100)
-    end
-
-    it 'returns the user-provided integer' do
-      expect(described_class.new({ 'gps_accuracy_threshold' => 250 }).gps_accuracy_threshold).to eq(250)
-    end
-
-    it 'clamps below the minimum' do
-      expect(described_class.new({ 'gps_accuracy_threshold' => 10 }).gps_accuracy_threshold).to eq(50)
-    end
-
-    it 'clamps above the maximum' do
-      expect(described_class.new({ 'gps_accuracy_threshold' => 99_999 }).gps_accuracy_threshold).to eq(1000)
-    end
-
-    it 'coerces string values' do
-      expect(described_class.new({ 'gps_accuracy_threshold' => '300' }).gps_accuracy_threshold).to eq(300)
     end
   end
 


### PR DESCRIPTION
## The problem

Google's `Records.json` contains **every device on the account**, distinguished only by `deviceTag`. Imports made before per-device `tracker_id`s shipped (1.10.0, `d4158154`) stamped all of them with a single `tracker_id`.

Track generation groups by `tracker_id` — correctly — so it cannot tell a device sitting at home from the phone that travelled. Interleaving the two by timestamp manufactures journeys between them: long straight lines radiating from wherever the stationary device sits.

On one real account, `Records.json` held **19 devices** collapsed into one tracker (967,455 of 977,715 records carry a `deviceTag`).

No speed or accuracy heuristic can fix this, because **each device's data is individually valid**.

## Why the existing backfill doesn't repair it

`Points::TrackerIdBackfiller` reads `deviceTag` from `raw_data` — but `GoogleMaps::RecordsImporter` never writes `raw_data` at all. For a Google Records import it always falls through to `'legacy-import-' || import_id`, which puts every device back in one bucket, reports a non-zero backfilled count, and changes nothing useful.

The uploaded file is the only surviving copy of the mapping.

## What this adds

**`Points::DeviceTagBackfiller`** streams the import's `Records.json` (hundreds of MB — `Oj::Saj`, not a full parse), maps `timestamp -> deviceTag`, and re-stamps points that still carry a legacy or NULL tracker. Timestamps claimed by two devices are resolved with the recorded coordinates at Google's own 1e-7 precision; a point matching neither record is left alone. A missing or unreadable file returns 0 quietly.

**`GoogleMaps::RecordsDeviceTagStreamHandler`** is the streaming reader. It uses only each location's *own* timestamp — locations also carry nested `activity` entries with timestamps of their own, which must not be mistaken for a fix.

Wired into `DataMigrations::RecalculatePerTrackerTracksJob` ahead of the existing backfiller, so the normal migration path picks it up.

## Anomaly filter

Once devices were no longer the whole story, several shapes of bad fix were still slipping through:

- **Speeds are computed per `tracker_id`.** Previously a global ordering meant two devices reporting in the same second produced `dt = 0`, a NULL speed, and `next if speed_in.nil?` skipped the outlier outright — a point moving at 107,184 km/h was immune because its predecessor shared a timestamp.
- **`dt = 0` over a large displacement** now counts as an instantaneous jump rather than an unknown.
- **Excursions are judged on the distance they add** versus travelling straight between the fixes either side. A genuine one-way journey adds nothing, however fast; a stale fix jumps away and comes back. This catches excursions whose return leg is slow enough to read as ordinary air travel, where requiring both legs to be impossible finds nothing.
- **A short excursion that leaves a stay and returns without spending any time away** is treated as a bad fix. Over a long enough gap the round trip is physically possible, so no speed test can condemn it — but real travel away from a stay leaves hours of readings at the far end.
- **Accuracy only condemns a reading when the radius is too large to be a position at all** (`ABSURD_ACCURACY_METERS`). A reported radius is a confidence estimate, not proof the position is wrong: Google Timeline routinely reports 1-4km for points sitting exactly on the road, and deleting those replaced real route geometry with straight lines across the gap — strictly worse than keeping a point that may be a couple of km off.

Run length stays bounded (`MAX_DISPLACED_RUN_POINTS`): a genuine stay bracketed by two impossible hops must never be convicted wholesale.

## Restores

`Users::ImportData` now recomputes anomalies after restoring an archive. The export payload carries no `anomaly` column, so every restored point arrived unflagged and tracks were rebuilt from noise the instance had already learned to ignore.

## Measured on a 1,141,726-point account

| | before | after |
|---|---|---|
| Points re-stamped per device | — | 948,929 (0 legacy left) |
| Total track path length | 1,203,225 km | 328,723 km |
| Longest single track | 187,800 km | 26,911 km |
| Tracks over 500 km | 101 | 46 |
| Impossible hops (>1200 km/h) | 1,402 | 411 |
| Points flagged anomalous | — | 2,121 (0.19%) |

The remaining long tracks are 2017 data from a single device reporting two locations 6,704 km apart with timestamps that must be wrong — a separate defect, untouched here.

## Notes

- `gps_accuracy_threshold` is no longer read by the filter. It is still accepted by the settings API and shown in the UI; removing or repurposing it is a follow-up.
- Specs covering the changed files: 164 examples, 0 failures. RuboCop clean.
