### PR TITLE
Let the browser follow the cannot-delete redirect

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -60,7 +60,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def destroy
     unless resource.can_delete_account?
       set_flash_message! :alert, :cannot_delete
-      redirect_to edit_user_registration_path, status: :unprocessable_content
+      redirect_to edit_user_registration_path
       return
     end
 

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -730,11 +730,11 @@ RSpec.describe 'Users::Registrations', type: :request do
         end.not_to(change { user.reload.deleted_at })
       end
 
-      it 'returns unprocessable content with error message' do
+      it 'redirects back with an error message the browser can follow' do
         delete user_registration_path
 
-        expect(response).to have_http_status(:unprocessable_content)
-        expect(response.location).to eq(edit_user_registration_url)
+        expect(response).to redirect_to(edit_user_registration_path)
+        expect(response).to have_http_status(:found)
         expect(flash[:alert]).to eq('Cannot delete your account while you own a family with other members.')
       end
 
@@ -757,7 +757,7 @@ RSpec.describe 'Users::Registrations', type: :request do
           delete user_registration_path, params: { password: 'password123456' }
         end.not_to have_enqueued_job(Users::DestroyJob)
 
-        expect(response).to have_http_status(:unprocessable_content)
+        expect(response).to redirect_to(edit_user_registration_path)
         expect(user.reload.deleted_at).to be_nil
       end
     end


### PR DESCRIPTION
## Problem

A family owner with other members who tries to delete their account lands on the browser's own error page (`HTTP ERROR 422`) instead of the account settings page. The flash explaining why the account can't be deleted is never shown.

## Cause

The guard in `Users::RegistrationsController#destroy` answers with a redirect on a non-3xx status:

```ruby
redirect_to edit_user_registration_path, status: :unprocessable_content
```

Browsers only follow a `Location` header on 3xx, so nothing follows it.

That line is older than #3107, but it was harmless until then: the delete control was a `link_to` with `turbo_method: :delete`, and Turbo absorbed the 422 and left the user on the page. #3107 replaced it with a confirmation dialog whose form sets `data: { turbo: false }`, so the submit is now a native form post and the 422 surfaces directly to the browser.

Verified in a browser against both revisions:

| | Result |
| --- | --- |
| before #3107 | stays on `/users/edit`, alert shown |
| after #3107 | Chrome error page, no alert |

## Fix

Drop the status override so the guard redirects with the default 302. The `Api::V1::Users::DestroyController` equivalent keeps returning 422 with a JSON body, which is correct for an API client.

## Testing

- `bundle exec rspec spec/requests/users spec/requests/api/v1/users` — 238 examples, 0 failures
- RuboCop clean on both changed files
- Manually re-ran the delete flow as a family owner with one other member: now returns to the account page showing "Cannot delete your account while you own a family with other members."

Follow-up to #3107.
