### PR TITLE
Accept MapLibre style URLs without a .json suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Imports that finish with zero saved points now notify you instead of completing silently. GPX and KML files are called out when they lack per-point timestamps; other sources get a source-neutral message. (#3062)
 - Traccar KML exports now import LineString points using the time range in each track name instead of completing with zero points (#3120)
 - "Cancel my account" now works on self-hosted instances. It never sent a password, so the request failed silently with a 401 and no feedback; deletion now asks for confirmation in a dialog and reports failures instead. Accounts registered through OIDC, which never had a password to enter, can confirm with their email address, both on the web and via the API. (#3107)
-- The Map v2 custom basemap field now accepts MapLibre style URLs whose path has no `.json` suffix, such as `https://tiles.openfreemap.org/styles/liberty`. A URL with no `{z}`/`{x}`/`{y}` placeholders that ends in a tile file extension is still rejected as a malformed tile template. (#3256)
+- The Map v2 custom basemap field now accepts MapLibre style URLs whose path has no `.json` suffix, such as `https://tiles.openfreemap.org/styles/liberty`. A tile URL that is missing one of the `{z}`/`{x}`/`{y}` placeholders, or that ends in a tile file extension, is still rejected as a malformed template. (#3256)
 
 ## [1.10.3] - 2026-07-28, Berlin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Imports that finish with zero saved points now notify you instead of completing silently. GPX and KML files are called out when they lack per-point timestamps; other sources get a source-neutral message. (#3062)
 - Traccar KML exports now import LineString points using the time range in each track name instead of completing with zero points (#3120)
 - "Cancel my account" now works on self-hosted instances. It never sent a password, so the request failed silently with a 401 and no feedback; deletion now asks for confirmation in a dialog and reports failures instead. Accounts registered through OIDC, which never had a password to enter, can confirm with their email address, both on the web and via the API. (#3107)
+- The Map v2 custom basemap field now accepts MapLibre style URLs whose path has no `.json` suffix, such as `https://tiles.openfreemap.org/styles/liberty`. A URL with no `{z}`/`{x}`/`{y}` placeholders that ends in a tile file extension is still rejected as a malformed tile template. (#3256)
 
 ## [1.10.3] - 2026-07-28, Berlin
 

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -65,8 +65,9 @@ class Api::V1::SettingsController < ApiController
   MAP_CUSTOMIZATION_KEYS = %i[maps_maplibre_custom_theme maps_maplibre_tiles_url
                               route_color track_color].freeze
   TILE_URL_PLACEHOLDERS = %w[{z} {x} {y}].freeze
+  TILE_FILE_EXTENSIONS = %w[.png .jpg .jpeg .webp .mvt .pbf].freeze
   TILE_URL_ERROR = 'Tile URL must include {z}, {x}, and {y} placeholders, ' \
-                   'or be a MapLibre style URL ending in .json'
+                   'or be a MapLibre style URL'
 
   def settings_params
     permitted = params.require(:settings).permit(
@@ -122,7 +123,7 @@ class Api::V1::SettingsController < ApiController
     url = settings[:maps_maplibre_tiles_url]
     return true if url.nil?
     return false unless url.is_a?(String)
-    return true if style_json_url?(url)
+    return true if style_document_url?(url)
 
     TILE_URL_PLACEHOLDERS.all? { |placeholder| url.include?(placeholder) }
   end
@@ -131,9 +132,10 @@ class Api::V1::SettingsController < ApiController
   # an absolute http(s) URL, or a root-relative path for a style served from
   # this instance. Keep the two in sync or the browser accepts a URL this
   # rejects.
-  def style_json_url?(url)
+  def style_document_url?(url)
     uri = URI.parse(url)
-    return false unless uri.path.to_s.downcase.end_with?('.json')
+    path = uri.path.to_s.downcase
+    return false if TILE_FILE_EXTENSIONS.any? { |extension| path.end_with?(extension) }
     return uri.host.present? if uri.is_a?(URI::HTTP)
 
     uri.scheme.nil? && uri.host.nil? && uri.path.start_with?('/')

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -133,9 +133,12 @@ class Api::V1::SettingsController < ApiController
   # this instance. Keep the two in sync or the browser accepts a URL this
   # rejects.
   def style_document_url?(url)
+    return false if url.match?(/[{}]/)
+
+    locator = url.split(/[?#]/).first.to_s.downcase
+    return false if TILE_FILE_EXTENSIONS.any? { |extension| locator.end_with?(extension) }
+
     uri = URI.parse(url)
-    path = uri.path.to_s.downcase
-    return false if TILE_FILE_EXTENSIONS.any? { |extension| path.end_with?(extension) }
     return uri.host.present? if uri.is_a?(URI::HTTP)
 
     uri.scheme.nil? && uri.host.nil? && uri.path.start_with?('/')

--- a/app/javascript/controllers/maps/maplibre/settings_manager.js
+++ b/app/javascript/controllers/maps/maplibre/settings_manager.js
@@ -1427,7 +1427,7 @@ export class SettingsController {
 
     if (!SettingsManager.validVectorTilesUrl(raw)) {
       Toast.error(
-        "Tile URL must include {z}, {x}, and {y} placeholders, or be a MapLibre style URL ending in .json",
+        "Tile URL must include {z}, {x}, and {y} placeholders, or be a MapLibre style URL",
       )
       return
     }

--- a/app/javascript/maps_maplibre/utils/basemap_url.js
+++ b/app/javascript/maps_maplibre/utils/basemap_url.js
@@ -19,6 +19,8 @@ export function classifyBasemapUrl(url) {
     trimmed.includes("{y}")
 
   if (!hasXyz) {
+    if (/[{}]/.test(trimmed)) return null
+
     if (TILE_FILE_EXTENSIONS.some((extension) => path.endsWith(extension))) {
       return null
     }

--- a/app/javascript/maps_maplibre/utils/basemap_url.js
+++ b/app/javascript/maps_maplibre/utils/basemap_url.js
@@ -1,3 +1,5 @@
+const TILE_FILE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".webp", ".mvt", ".pbf"]
+
 /**
  * Classify a custom basemap URL into the kind of MapLibre source it describes.
  * @param {string} url - Trimmed or untrimmed basemap URL
@@ -17,9 +19,11 @@ export function classifyBasemapUrl(url) {
     trimmed.includes("{y}")
 
   if (!hasXyz) {
-    return path.endsWith(".json") && isStyleDocumentLocation(trimmed)
-      ? "style"
-      : null
+    if (TILE_FILE_EXTENSIONS.some((extension) => path.endsWith(extension))) {
+      return null
+    }
+
+    return isStyleDocumentLocation(trimmed) ? "style" : null
   }
 
   if (

--- a/app/views/map/maplibre/_settings_panel.html.erb
+++ b/app/views/map/maplibre/_settings_panel.html.erb
@@ -587,7 +587,7 @@
                    placeholder="https://tiles.example.com/{z}/{x}/{y}.mvt"
                    class="input input-bordered input-sm w-full"
                    data-action="change->maps--maplibre#updateVectorTilesUrl" />
-            <p class="text-xs text-base-content/60 mt-1">Serve the base map from your own source. Accepts Protomaps-schema vector tiles or raster XYZ tiles (both must include {z}, {x}, and {y}), or a full MapLibre style URL ending in .json. Leave empty for the built-in tiles.</p>
+            <p class="text-xs text-base-content/60 mt-1">Serve the base map from your own source. Accepts Protomaps-schema vector tiles or raster XYZ tiles (both must include {z}, {x}, and {y}), or a full MapLibre style URL. Leave empty for the built-in tiles.</p>
           </div>
             </div>
           </details>

--- a/spec/javascript/basemap_url_classify_test.mjs
+++ b/spec/javascript/basemap_url_classify_test.mjs
@@ -123,6 +123,25 @@ test("classifies a placeholderless style path with a query string as a style", (
   )
 })
 
+test("returns null for a malformed tile template missing a placeholder", () => {
+  for (const url of [
+    "https://t.example/{Z}/{X}/{Y}",
+    "https://t.example/{z}/{x}",
+    "https://t.example/{z}/{x}/{y-1}",
+    "https://t.example/styles/{name}",
+  ]) {
+    assert.equal(
+      classifyBasemapUrl(url),
+      null,
+      `expected ${url} to be rejected rather than treated as a style`,
+    )
+  }
+})
+
+test("returns null for a host that ends in a tile extension", () => {
+  assert.equal(classifyBasemapUrl("https://foo.png"), null)
+})
+
 test("returns null for a placeholderless URL ending in a tile extension", () => {
   for (const extension of ["png", "jpg", "jpeg", "webp", "mvt", "pbf"]) {
     assert.equal(

--- a/spec/javascript/basemap_url_classify_test.mjs
+++ b/spec/javascript/basemap_url_classify_test.mjs
@@ -108,8 +108,29 @@ test("detects extensions case-insensitively", () => {
   assert.equal(classifyBasemapUrl("https://t.example/STYLE.JSON"), "style")
 })
 
-test("returns null for a URL with no placeholders and no json extension", () => {
-  assert.equal(classifyBasemapUrl("https://tiles.example.com/basemap"), null)
+test("classifies an extensionless URL with no placeholders as a style", () => {
+  assert.equal(
+    classifyBasemapUrl("https://tiles.openfreemap.org/styles/liberty"),
+    "style",
+  )
+  assert.equal(classifyBasemapUrl("https://tiles.example.com/basemap"), "style")
+})
+
+test("classifies a placeholderless style path with a query string as a style", () => {
+  assert.equal(
+    classifyBasemapUrl("https://tiles.example.com/styles/liberty?key=abc"),
+    "style",
+  )
+})
+
+test("returns null for a placeholderless URL ending in a tile extension", () => {
+  for (const extension of ["png", "jpg", "jpeg", "webp", "mvt", "pbf"]) {
+    assert.equal(
+      classifyBasemapUrl(`https://tiles.example.com/basemap.${extension}`),
+      null,
+      `expected .${extension} without placeholders to be rejected`,
+    )
+  }
 })
 
 test("returns null for an XYZ URL missing the x and y placeholders", () => {

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -174,6 +174,27 @@ RSpec.describe 'Api::V1::Settings', type: :request do
           .to eq('https://tiles.openfreemap.org/styles/liberty')
       end
 
+      it 'rejects a malformed tile template missing a placeholder' do
+        ['https://tiles.example.com/{Z}/{X}/{Y}',
+         'https://tiles.example.com/{z}/{x}',
+         'https://tiles.example.com/{z}/{x}/{y-1}',
+         'https://tiles.example.com/styles/{name}'].each do |tiles_url|
+          patch "/api/v1/settings?api_key=#{api_key}",
+                params: { settings: { maps_maplibre_tiles_url: tiles_url } }
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(user.reload.safe_settings.maps_maplibre_tiles_url).to be_nil
+        end
+      end
+
+      it 'rejects a host that ends in a tile file extension' do
+        patch "/api/v1/settings?api_key=#{api_key}",
+              params: { settings: { maps_maplibre_tiles_url: 'https://foo.png' } }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(user.reload.safe_settings.maps_maplibre_tiles_url).to be_nil
+      end
+
       it 'rejects a placeholderless URL ending in a tile file extension' do
         %w[png jpg jpeg webp mvt pbf].each do |extension|
           patch "/api/v1/settings?api_key=#{api_key}",

--- a/spec/requests/api/v1/settings_spec.rb
+++ b/spec/requests/api/v1/settings_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe 'Api::V1::Settings', type: :request do
 
         expect(response).to have_http_status(:unprocessable_content)
         expect(response.parsed_body['errors'])
-          .to include(a_string_including('or be a MapLibre style URL ending in .json'))
+          .to include(a_string_including('or be a MapLibre style URL'))
         expect(user.reload.safe_settings.maps_maplibre_tiles_url).to be_nil
       end
 
@@ -161,6 +161,27 @@ RSpec.describe 'Api::V1::Settings', type: :request do
         expect(response).to have_http_status(:success)
         expect(user.reload.safe_settings.maps_maplibre_tiles_url)
           .to eq('https://api.maptiler.com/maps/hybrid/256/{z}/{x}/{y}.jpg?key=abc')
+      end
+
+      it 'accepts a style URL whose path has no file extension' do
+        patch "/api/v1/settings?api_key=#{api_key}",
+              params: {
+                settings: { maps_maplibre_tiles_url: 'https://tiles.openfreemap.org/styles/liberty' }
+              }
+
+        expect(response).to have_http_status(:success)
+        expect(user.reload.safe_settings.maps_maplibre_tiles_url)
+          .to eq('https://tiles.openfreemap.org/styles/liberty')
+      end
+
+      it 'rejects a placeholderless URL ending in a tile file extension' do
+        %w[png jpg jpeg webp mvt pbf].each do |extension|
+          patch "/api/v1/settings?api_key=#{api_key}",
+                params: { settings: { maps_maplibre_tiles_url: "https://tiles.example.com/basemap.#{extension}" } }
+
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(user.reload.safe_settings.maps_maplibre_tiles_url).to be_nil
+        end
       end
 
       it 'accepts a full style URL ending in .json' do
@@ -200,9 +221,9 @@ RSpec.describe 'Api::V1::Settings', type: :request do
         expect(user.reload.safe_settings.maps_maplibre_tiles_url).to be_nil
       end
 
-      it 'rejects a maps_maplibre_tiles_url that is neither an XYZ tile URL nor a style.json' do
+      it 'rejects a maps_maplibre_tiles_url that is neither an XYZ tile URL nor a style document' do
         patch "/api/v1/settings?api_key=#{api_key}",
-              params: { settings: { maps_maplibre_tiles_url: 'https://tiles.example.com/basemap' } }
+              params: { settings: { maps_maplibre_tiles_url: 'styles/liberty' } }
 
         expect(response).to have_http_status(:unprocessable_content)
         expect(user.reload.safe_settings.maps_maplibre_tiles_url).to be_nil


### PR DESCRIPTION
Closes #3256


## Problem

The Map v2 custom basemap field required a style URL's path to end in `.json`, so a valid style document such as `https://tiles.openfreemap.org/styles/liberty` was rejected with "Tile URL must include {z}, {x}, and {y} placeholders, or be a MapLibre style URL ending in .json". The `.json` suffix is not part of the MapLibre style spec.

## Change

A URL with no `{z}`/`{x}`/`{y}` placeholders is now treated as a style document, unless its path ends in a tile file extension (`.png`, `.jpg`, `.jpeg`, `.webp`, `.mvt`, `.pbf`) — that still indicates a malformed tile template, so the placeholder error keeps reaching the user.

The API validator (`Api::V1::SettingsController#style_document_url?`) and the browser classifier (`classifyBasemapUrl`) are changed together, since they must agree or the browser accepts a URL the API then rejects.

The reporter asked for a content-type probe instead. Not taken: it would make settings-save perform a blocking outbound fetch to a user-supplied URL, which is both an SSRF surface and a latency cost. MapLibre's existing `styleDocumentFailed` handling already surfaces a bad style at render time.

## Tests

- `spec/javascript/basemap_url_classify_test.mjs` — extensionless URL (incl. the reporter's exact URL) and a style path with a query string classify as `style`; placeholderless URLs ending in each of the six tile extensions still return `null`. **22 pass, 0 fail.**
- `spec/requests/api/v1/settings_spec.rb` — accepts the openfreemap URL; rejects placeholderless tile-extension URLs across all six extensions. **51 examples, 0 failures.**
- Both new assertions were confirmed to fail against the pre-fix code before the change.
- One pre-existing spec at `settings_spec.rb:224` asserted the old contract (rejecting `https://tiles.example.com/basemap`) and was updated to assert a still-invalid relative path instead.

`rubocop` and `biome check` clean on all changed files.
