### PR TITLE
fix(family): revoke inherited access when the owner subscription lapses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Family members no longer keep Pro access after the family owner's subscription lapses. Access was inherited from the owner's plan alone, so an expired trial or a cancelled Family subscription left every member on full access indefinitely; members now revert to their own plan once the owner's paid period ends. Cancelling still leaves members with access until the period they paid for is over.
 - Self-hosted mode is now recognised from common `SELF_HOSTED` values (quoted `"true"`, `TRUE`, whitespace-padded, `1`, `yes`, `on`), not only the exact string `true`, so a non-canonical value no longer silently flips a self-hosted instance into cloud mode and blocks LAN integration URLs (such as Immich) as SSRF. (#2522)
 - Outgoing email no longer fails against slower SMTP servers: the default connection open/read timeouts now match net-smtp's own 30s and 60s instead of a 5-second cap that made digest reports and other emails fail with `Net::OpenTimeout`. Tune with `SMTP_OPEN_TIMEOUT`/`SMTP_READ_TIMEOUT` if needed (#3096)
 - FIT files that carry developer data fields (such as those from Wahoo devices) now import their location records instead of failing to parse. (#2945)

--- a/app/models/concerns/plan_scopable.rb
+++ b/app/models/concerns/plan_scopable.rb
@@ -5,9 +5,18 @@ module PlanScopable
 
   def effective_plan
     return plan.to_sym if DawarichSettings.self_hosted?
-    return :family if in_family? && family&.owner&.family?
+    return :family if inherited_family_access?
 
     plan.to_sym
+  end
+
+  def inherited_family_access?
+    return false unless in_family?
+
+    owner = family&.owner
+    return false unless owner&.family?
+
+    owner.active_until&.future? || false
   end
 
   def full_access?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -166,6 +166,50 @@ RSpec.describe User, type: :model do
         expect(member.effective_plan).to eq(:lite)
       end
 
+      it 'reverts members to their raw plan once the owner subscription lapses' do
+        owner = create(:user, plan: :family, skip_auto_trial: true, status: :inactive,
+                              active_until: 1.day.ago)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        member = create(:user, plan: :lite, skip_auto_trial: true)
+        create(:family_membership, family: family, user: member)
+
+        expect(member.effective_plan).to eq(:lite)
+        expect(member.full_access?).to be false
+      end
+
+      it 'keeps members on family access while a cancelled owner is still inside the paid period' do
+        owner = create(:user, plan: :family, skip_auto_trial: true, status: :inactive,
+                              active_until: 10.days.from_now)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        member = create(:user, plan: :lite, skip_auto_trial: true)
+        create(:family_membership, family: family, user: member)
+
+        expect(member.effective_plan).to eq(:family)
+      end
+
+      it 'grants members family access while the owner is on a trial' do
+        owner = create(:user, plan: :family, skip_auto_trial: true, status: :trial,
+                              active_until: 7.days.from_now)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        member = create(:user, plan: :lite, skip_auto_trial: true)
+        create(:family_membership, family: family, user: member)
+
+        expect(member.effective_plan).to eq(:family)
+      end
+
+      it 'reverts members when the owner has no subscription window at all' do
+        owner = create(:user, plan: :family, skip_auto_trial: true, active_until: nil)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        member = create(:user, plan: :lite, skip_auto_trial: true)
+        create(:family_membership, family: family, user: member)
+
+        expect(member.effective_plan).to eq(:lite)
+      end
+
       it 'reverts to the raw plan after the member leaves the family' do
         owner = create(:user, plan: :family, skip_auto_trial: true)
         family = create(:family, creator: owner)


### PR DESCRIPTION
## Problem

A family member's access was inherited from the family owner's **plan alone**:

```ruby
return :family if in_family? && family&.owner&.family?
```

Nothing ever resets the `plan` enum on cancellation — Manager only assigns it from the current Paddle price, and cancellation just flips `status` to `inactive` and stops extending `active_until`. No job downgrades a lapsed plan.

So once a Family owner's subscription ended, every member kept full Pro access **indefinitely, for free**. With the 7-day Family trial now live, the cheapest path to this is: start a Family trial, invite 4 people, let it lapse.

The owner themselves was mostly contained (`api_controller` returns 401 on `inactive?`, `authenticate_active_user!` blocks write paths), but members were not — their own `status` is untouched, so nothing gated them.

## Fix

`effective_plan` now also requires the owner's paid period to still be open:

```ruby
def inherited_family_access?
  return false unless in_family?
  owner = family&.owner
  return false unless owner&.family?
  owner.active_until&.future? || false
end
```

Keyed on `active_until` rather than `status` deliberately, so it's fair in both directions:

- **Cancelled** owner → members keep access until the period they already paid for ends.
- **Lapsed / expired trial** owner → members revert to their own plan immediately.
- **Owner on trial** → members get access (guards the Family trial flow).

The owner's own access is unchanged: their raw `plan` stays `family`, exactly as a lapsed Pro user's stays `pro`. They remain blocked by the existing status gates.

## Tests

4 specs added to the `#effective_plan` matrix. Verified red first — the two revocation cases failed while trial and cancelled-in-period already passed.

- `user_spec` + `plan_scopable_spec` + `family_plan_access_spec` + `family_policy_spec` + `services/families/` → **272 examples, 0 failures**
- Regression sweep (`archival_warning_job`, `api/v1/plan`, `families`, `application_helper`, `rate_limiting`) → **145 examples, 0 failures**
- Rubocop clean.