### PR TITLE
Show the 30x40 print at its current price

### DIFF
--- a/app/javascript/poster_studio/data/print_products.js
+++ b/app/javascript/poster_studio/data/print_products.js
@@ -1,6 +1,6 @@
 // Display prices only — Stripe charges the price configured server-side.
 export const PRINT_PRODUCTS = {
-  "print-30x40": { sku: "poster-30x40", priceLabel: "€34.99" },
+  "print-30x40": { sku: "poster-30x40", priceLabel: "€44.99" },
   "print-50x70": { sku: "poster-50x70", priceLabel: "€54.99" },
   "print-70x100": { sku: "poster-70x100", priceLabel: "€74.99" },
 }


### PR DESCRIPTION
The Stripe price for `poster-30x40` is already €44.99. The studio still displayed €34.99, so the order dialog quoted one number and the customer was charged another.

## Why the price moved

Live `gelato:verify_margins` quotes put the 30x40 supplier cost at **€14.70–19.47** across the 27 shipping countries, against the €10–14 the pricing design assumed. Once VAT (19%, seller of record) and Stripe fees (1.5% + €0.25) come off the top, every country landed **under** the €15/unit floor:

| SKU | Margin range at old price | Result |
|---|---|---|
| 30x40 @ €34.99 | €9.16 – €13.93 | 27/27 below floor |
| 50x70 @ €54.99 | €18.53 – €26.66 | fine |
| 70x100 @ €74.99 | €28.42 – €41.18 | fine |

At €44.99 the worst case is Ireland at **€17.42** and the best is Sweden at €22.19 — all 27 clear. The other two sizes were costed correctly and are untouched.

## Scope

Display only. `PRINT_PRODUCTS` drives the label in the studio order dialog; the charge itself comes from `stripe_price_id` in the prints service, which is already updated.