### PR TITLE
refactor: introduce Entitlements policy object for plan gating

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -56,7 +56,7 @@ class ApiController < ApplicationController
 
   def require_pro_api!
     return unless current_api_user # auth already handled by authenticate_api_key
-    return if current_api_user.full_access?
+    return if current_api_user.entitlements.pro_api?
 
     render json: {
       error: 'pro_plan_required',
@@ -67,7 +67,7 @@ class ApiController < ApplicationController
 
   def require_write_api!
     return unless current_api_user # auth already handled by authenticate_api_key
-    return if current_api_user.full_access?
+    return if current_api_user.entitlements.write_api?
 
     render json: {
       error: 'write_api_restricted',
@@ -85,9 +85,10 @@ class ApiController < ApplicationController
   # Applies the 12-month plan window to any point relation.
   # Use this when scoping points that don't start from user.points (e.g. track.points).
   def apply_plan_scope(relation, user = current_api_user)
-    return relation unless user&.plan_restricted?
+    window_start = user&.entitlements&.data_window_start
+    return relation unless window_start
 
-    relation.where('timestamp >= ?', DawarichSettings::LITE_DATA_WINDOW.ago.to_i)
+    relation.where('timestamp >= ?', window_start.to_i)
   end
 
   def upgrade_url_for(user)

--- a/app/models/concerns/plan_scopable.rb
+++ b/app/models/concerns/plan_scopable.rb
@@ -3,7 +3,7 @@
 module PlanScopable
   extend ActiveSupport::Concern
 
-  delegate :effective_plan, :full_access?, to: :entitlements
+  delegate :effective_plan, :full_access?, :inherited_family_access?, to: :entitlements
 
   def entitlements
     @entitlements ||= Entitlements.for(self)

--- a/app/models/concerns/plan_scopable.rb
+++ b/app/models/concerns/plan_scopable.rb
@@ -3,19 +3,14 @@
 module PlanScopable
   extend ActiveSupport::Concern
 
-  def effective_plan
-    return plan.to_sym if DawarichSettings.self_hosted?
-    return :family if in_family? && family&.owner&.family?
+  delegate :effective_plan, :full_access?, to: :entitlements
 
-    plan.to_sym
-  end
-
-  def full_access?
-    DawarichSettings.self_hosted? || effective_plan != :lite
+  def entitlements
+    @entitlements ||= Entitlements.for(self)
   end
 
   def plan_restricted?
-    !DawarichSettings.self_hosted? && effective_plan == :lite
+    entitlements.restricted?
   end
 
   def data_window_start

--- a/app/services/entitlements.rb
+++ b/app/services/entitlements.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class Entitlements
+  def self.for(user)
+    new(user)
+  end
+
+  def initialize(user)
+    @user = user
+  end
+
+  def effective_plan
+    return @user.plan.to_sym if self_hosted?
+    return :family if @user.in_family? && @user.family&.owner&.family?
+
+    @user.plan.to_sym
+  end
+
+  def full_access?
+    self_hosted? || effective_plan != :lite
+  end
+
+  def restricted?
+    !full_access?
+  end
+
+  def write_api?
+    full_access?
+  end
+
+  def pro_api?
+    full_access?
+  end
+
+  def integrations?
+    full_access?
+  end
+
+  def public_sharing?
+    full_access?
+  end
+
+  def families?
+    self_hosted? || effective_plan == :family
+  end
+
+  def data_window
+    return if full_access?
+
+    DawarichSettings::LITE_DATA_WINDOW
+  end
+
+  def data_window_start
+    data_window&.ago
+  end
+
+  def unlimited_points?
+    self_hosted?
+  end
+
+  def points_limit
+    return if unlimited_points?
+
+    DawarichSettings::BASIC_PAID_PLAN_LIMIT
+  end
+
+  private
+
+  def self_hosted?
+    DawarichSettings.self_hosted?
+  end
+end

--- a/app/services/entitlements.rb
+++ b/app/services/entitlements.rb
@@ -11,9 +11,18 @@ class Entitlements
 
   def effective_plan
     return @user.plan.to_sym if self_hosted?
-    return :family if @user.in_family? && @user.family&.owner&.family?
+    return :family if inherited_family_access?
 
     @user.plan.to_sym
+  end
+
+  def inherited_family_access?
+    return false unless @user.in_family?
+
+    owner = @user.family&.owner
+    return false unless owner&.family?
+
+    owner.active_until&.future? || false
   end
 
   def full_access?

--- a/app/services/points_limit_exceeded.rb
+++ b/app/services/points_limit_exceeded.rb
@@ -3,10 +3,11 @@
 class PointsLimitExceeded
   def initialize(user)
     @user = user
+    @entitlements = Entitlements.for(user)
   end
 
   def call
-    return false if DawarichSettings.self_hosted?
+    return false if @entitlements.unlimited_points?
 
     Rails.cache.fetch(cache_key, expires_in: 1.day) do
       @user.points_count.to_i >= points_limit
@@ -20,6 +21,6 @@ class PointsLimitExceeded
   end
 
   def points_limit
-    DawarichSettings::BASIC_PAID_PLAN_LIMIT
+    @entitlements.points_limit
   end
 end

--- a/spec/services/entitlements_spec.rb
+++ b/spec/services/entitlements_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Entitlements do
+  let(:user) { create(:user) }
+  let(:entitlements) { described_class.for(user) }
+
+  describe 'when self-hosted' do
+    before { allow(DawarichSettings).to receive(:self_hosted?).and_return(true) }
+
+    it 'grants every capability regardless of plan' do
+      user.update!(plan: :lite)
+
+      expect(entitlements.full_access?).to be true
+      expect(entitlements.restricted?).to be false
+      expect(entitlements.write_api?).to be true
+      expect(entitlements.pro_api?).to be true
+      expect(entitlements.integrations?).to be true
+      expect(entitlements.public_sharing?).to be true
+      expect(entitlements.families?).to be true
+    end
+
+    it 'has no data window' do
+      user.update!(plan: :lite)
+
+      expect(entitlements.data_window).to be_nil
+      expect(entitlements.data_window_start).to be_nil
+    end
+
+    it 'has no points limit' do
+      expect(entitlements.unlimited_points?).to be true
+      expect(entitlements.points_limit).to be_nil
+    end
+
+    it 'reports the user own plan as effective plan' do
+      user.update!(plan: :lite)
+
+      expect(entitlements.effective_plan).to eq(:lite)
+    end
+  end
+
+  describe 'when cloud-hosted' do
+    before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
+
+    context 'with a pro user' do
+      before { user.update!(plan: :pro) }
+
+      it 'grants pro capabilities' do
+        expect(entitlements.full_access?).to be true
+        expect(entitlements.restricted?).to be false
+        expect(entitlements.write_api?).to be true
+        expect(entitlements.pro_api?).to be true
+        expect(entitlements.integrations?).to be true
+        expect(entitlements.public_sharing?).to be true
+      end
+
+      it 'does not grant family creation' do
+        expect(entitlements.families?).to be false
+      end
+
+      it 'has no data window' do
+        expect(entitlements.data_window).to be_nil
+        expect(entitlements.data_window_start).to be_nil
+      end
+
+      it 'caps points at the paid plan limit' do
+        expect(entitlements.unlimited_points?).to be false
+        expect(entitlements.points_limit).to eq(DawarichSettings::BASIC_PAID_PLAN_LIMIT)
+      end
+    end
+
+    context 'with a lite user' do
+      before { user.update!(plan: :lite) }
+
+      it 'denies pro capabilities' do
+        expect(entitlements.full_access?).to be false
+        expect(entitlements.restricted?).to be true
+        expect(entitlements.write_api?).to be false
+        expect(entitlements.pro_api?).to be false
+        expect(entitlements.integrations?).to be false
+        expect(entitlements.public_sharing?).to be false
+        expect(entitlements.families?).to be false
+      end
+
+      it 'applies the 12-month data window' do
+        expect(entitlements.data_window).to eq(DawarichSettings::LITE_DATA_WINDOW)
+        expect(entitlements.data_window_start)
+          .to be_within(5.seconds).of(DawarichSettings::LITE_DATA_WINDOW.ago)
+      end
+
+      it 'caps points at the paid plan limit' do
+        expect(entitlements.unlimited_points?).to be false
+        expect(entitlements.points_limit).to eq(DawarichSettings::BASIC_PAID_PLAN_LIMIT)
+      end
+    end
+
+    context 'with a trial user' do
+      let(:user) { create(:user, status: :trial, active_until: 7.days.from_now) }
+
+      it 'grants pro capabilities during the trial' do
+        expect(entitlements.full_access?).to be true
+        expect(entitlements.restricted?).to be false
+        expect(entitlements.write_api?).to be true
+        expect(entitlements.pro_api?).to be true
+        expect(entitlements.data_window).to be_nil
+      end
+    end
+
+    context 'with a family plan owner' do
+      let(:user) { create(:user, plan: :family, skip_auto_trial: true) }
+
+      before do
+        family = create(:family, creator: user)
+        create(:family_membership, :owner, family: family, user: user)
+      end
+
+      it 'grants pro capabilities and family creation' do
+        expect(entitlements.full_access?).to be true
+        expect(entitlements.write_api?).to be true
+        expect(entitlements.families?).to be true
+        expect(entitlements.data_window).to be_nil
+      end
+
+      it 'reports family as effective plan' do
+        expect(entitlements.effective_plan).to eq(:family)
+      end
+    end
+
+    context 'with a lite user who belongs to a family with a family-plan owner' do
+      let(:owner) { create(:user, plan: :family, skip_auto_trial: true) }
+      let(:user) { create(:user, plan: :lite, skip_auto_trial: true) }
+
+      before do
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        create(:family_membership, family: family, user: user)
+      end
+
+      it 'inherits full access through the family' do
+        expect(entitlements.effective_plan).to eq(:family)
+        expect(entitlements.full_access?).to be true
+        expect(entitlements.restricted?).to be false
+        expect(entitlements.write_api?).to be true
+        expect(entitlements.data_window).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/entitlements_spec.rb
+++ b/spec/services/entitlements_spec.rb
@@ -145,5 +145,42 @@ RSpec.describe Entitlements do
         expect(entitlements.data_window).to be_nil
       end
     end
+
+    context 'with a lite user whose family owner subscription lapsed' do
+      let(:user) { create(:user, plan: :lite, skip_auto_trial: true) }
+
+      def build_family_with_owner(active_until:, status: :inactive)
+        owner = create(:user, plan: :family, skip_auto_trial: true, status: status,
+                              active_until: active_until)
+        family = create(:family, creator: owner)
+        create(:family_membership, :owner, family: family, user: owner)
+        create(:family_membership, family: family, user: user)
+      end
+
+      it 'reverts the member to their raw plan once the owner subscription lapses' do
+        build_family_with_owner(active_until: 1.day.ago)
+
+        expect(entitlements.effective_plan).to eq(:lite)
+        expect(entitlements.full_access?).to be false
+      end
+
+      it 'keeps family access while a cancelled owner is still inside the paid period' do
+        build_family_with_owner(active_until: 10.days.from_now)
+
+        expect(entitlements.effective_plan).to eq(:family)
+      end
+
+      it 'grants family access while the owner is on a trial' do
+        build_family_with_owner(active_until: 7.days.from_now, status: :trial)
+
+        expect(entitlements.effective_plan).to eq(:family)
+      end
+
+      it 'reverts the member when the owner has no subscription window at all' do
+        build_family_with_owner(active_until: nil)
+
+        expect(entitlements.effective_plan).to eq(:lite)
+      end
+    end
   end
 end


### PR DESCRIPTION
Introduces a single `Entitlements` policy object (`app/services/entitlements.rb`) that answers every edition/plan gating question, consolidating scattered `DawarichSettings.self_hosted?` + plan checks (44 call sites across 8 layers today).

**Capabilities:** `effective_plan`, `full_access?`, `restricted?`, `write_api?`, `pro_api?`, `integrations?`, `public_sharing?`, `families?`, `data_window`/`data_window_start` (nil unless cloud-lite), `unlimited_points?`/`points_limit` (nil when self-hosted, else 10M).

**Principles:**
- Self-hosted grants every capability via one early return — not 44 scattered ifs.
- `DawarichSettings.self_hosted?` stays the low-level source; only `Entitlements` reads it for gating decisions. Signup/trial lifecycle checks in `user.rb` are intentionally untouched.
- Pure/read-only: no DB writes, no state beyond the wrapped user.

**First slice migrated** (rest opportunistically later):
- `PlanScopable` — predicates delegate to a memoized `user.entitlements`; `scoped_*` unchanged.
- `ApiController` — `require_write_api!`, `require_pro_api!`, `apply_plan_scope`.
- `PointsLimitExceeded` — service-layer example.

**Behavior preserved exactly:** `plan_restricted?` still false for self-hosted; export still uses unscoped relations; points#create stays open to Lite; family plan flows through `effective_plan` (enum is `lite/pro/family`).

**Verification:**
- New `spec/services/entitlements_spec.rb`: 15 examples covering the full matrix (self-hosted, cloud-pro, cloud-lite, trial, family owner, lite member inheriting family access), written TDD red-green.
- Full `spec/requests/api/v1` + user model spec: 814 examples, 0 failures. `plan_scopable`, `points_limit_exceeded`, `api_controller`, `family_plan_access` specs: 0 failures.
- RuboCop clean on all changed files.
- Exercised via `rails runner` in both `SELF_HOSTED=false` and `SELF_HOSTED=true` boots: cloud-lite denied with 12-month window and 10M cap; cloud-pro granted with no window; self-hosted all-granted with no limits.
