### PR TITLE
Skip Google rawSignals when the export also has semanticSegments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Google phone Timeline exports taken after mid-June 2026 contain the same period twice, and importing both copies merged separate trips into one continuous track that showed journeys on days they didn't happen. The raw signal stream is now skipped when the export also contains the aggregated timeline, with a notification saying how much was skipped; exports carrying only raw signals are unaffected.
 - Family members no longer keep Pro access after the family owner's subscription lapses. Access was inherited from the owner's plan alone, so an expired trial or a cancelled Family subscription left every member on full access indefinitely; members now revert to their own plan once the owner's paid period ends. Cancelling still leaves members with access until the period they paid for is over.
 - Self-hosted mode is now recognised from common `SELF_HOSTED` values (quoted `"true"`, `TRUE`, whitespace-padded, `1`, `yes`, `on`), not only the exact string `true`, so a non-canonical value no longer silently flips a self-hosted instance into cloud mode and blocks LAN integration URLs (such as Immich) as SSRF. (#2522)
 - Outgoing email no longer fails against slower SMTP servers: the default connection open/read timeouts now match net-smtp's own 30s and 60s instead of a 5-second cap that made digest reports and other emails fail with `Net::OpenTimeout`. Tune with `SMTP_OPEN_TIMEOUT`/`SMTP_READ_TIMEOUT` if needed (#3096)

--- a/app/services/google_maps/phone_takeout_importer.rb
+++ b/app/services/google_maps/phone_takeout_importer.rb
@@ -16,15 +16,20 @@ class GoogleMaps::PhoneTakeoutImporter
 
   BATCH_SIZE = 1000
   MAX_TIE_OFFSET = 59
+  SEMANTIC_SEGMENTS_KEY = '"semanticSegments"'.b.freeze
+  SCAN_CHUNK_BYTES = 1.megabyte
 
   def call
     path = resolve_file_path
     validate_json(path)
     initialize_stream
     ActiveRecord::Base.transaction do
-      stream_entries(path)
+      @skipped_sections = skipped_sections(path)
+      stream_entries(path, skip_sections: @skipped_sections)
+      replay_skipped_raw_signals(path) if raw_signals_fallback_needed?
       process_user_location_profile
       flush_batch
+      notify_skipped_raw_signals
     end
   ensure
     cleanup_temp_file
@@ -49,12 +54,17 @@ class GoogleMaps::PhoneTakeoutImporter
     @assigned_timestamps = {}
     @previous_tied_timestamp = nil
     @tie_offset = 0
+    @semantic_points = 0
+    @skipped_sections = []
+    @skipped_counts = {}
   end
 
-  def stream_entries(path)
+  def stream_entries(path, skip_sections:)
     handler = GoogleMaps::PhoneTakeoutStreamHandler.new(
       on_entry: ->(section, value) { process_stream_entry(section, value) },
-      on_profile: ->(profile) { @user_location_profile = profile }
+      on_profile: ->(profile) { @user_location_profile = profile },
+      skip_sections: skip_sections,
+      on_skipped: ->(section, count) { @skipped_counts[section] = count }
     )
 
     File.open(path, 'rb') do |io|
@@ -64,6 +74,65 @@ class GoogleMaps::PhoneTakeoutImporter
         Oj::Parser.new(:saj, handler:).load(io)
       end
     end
+  end
+
+  # The presence of a `semanticSegments` key does not guarantee it holds usable data —
+  # Google's server-side aggregation can lag behind fresher on-device signals, leaving an
+  # empty or coordinate-less array. Skipping rawSignals on key presence alone would then
+  # import nothing at all, so replay them when the aggregated pass produced no points.
+  def raw_signals_fallback_needed?
+    @skipped_sections.include?(:raw_signal) && @semantic_points.zero?
+  end
+
+  def replay_skipped_raw_signals(path)
+    Rails.logger.info(
+      "[#{importer_name}] semanticSegments produced no points; falling back to rawSignals"
+    )
+
+    @skipped_counts.delete(:raw_signal)
+    stream_entries(path, skip_sections: [:semantic_segment])
+  end
+
+  # Exports since mid-2026 carry far more raw signals than aggregated segments, so an
+  # import that legitimately drops most of the file would otherwise look like data loss.
+  def notify_skipped_raw_signals
+    skipped = @skipped_counts[:raw_signal].to_i
+    return unless skipped.positive?
+
+    Rails.logger.info("[#{importer_name}] skipped #{skipped} rawSignals entries")
+
+    Notification.create!(
+      user_id: import.user_id,
+      title: 'Raw location signals skipped',
+      content: "Your file #{import.name} contained both Google's aggregated timeline and " \
+               "#{skipped} raw location signals for the same period. The aggregated timeline " \
+               'was imported and the raw signals were skipped, because combining them merges ' \
+               'separate trips into one continuous track. No timeline data was lost.',
+      kind: :info
+    )
+  end
+
+  # Exports taken after mid-June 2026 carry rawSignals alongside semanticSegments for
+  # the same period. The two are sampled independently, so their gaps do not line up and
+  # merging them erases the pauses track segmentation splits on.
+  def skipped_sections(path)
+    semantic_segments_present?(path) ? [:raw_signal] : []
+  end
+
+  def semantic_segments_present?(path)
+    overlap = SEMANTIC_SEGMENTS_KEY.bytesize - 1
+    carry = +''.b
+
+    File.open(path, 'rb') do |io|
+      while (chunk = io.read(SCAN_CHUNK_BYTES))
+        window = carry << chunk
+        return true if window.include?(SEMANTIC_SEGMENTS_KEY)
+
+        carry = window.byteslice(-overlap, overlap) || +''.b
+      end
+    end
+
+    false
   end
 
   def process_stream_entry(section, value)
@@ -78,6 +147,9 @@ class GoogleMaps::PhoneTakeoutImporter
              else
                []
              end
+
+    points = Array(points).flatten.compact
+    @semantic_points += points.size if section == :semantic_segment
 
     enqueue_points(points)
   end

--- a/app/services/google_maps/phone_takeout_stream_handler.rb
+++ b/app/services/google_maps/phone_takeout_stream_handler.rb
@@ -10,11 +10,16 @@ class GoogleMaps::PhoneTakeoutStreamHandler < Oj::Saj
   ArrayState = Struct.new(:data, :key)
   StreamState = Data.define(:section)
   DiscardState = Class.new
+  # Counts the entries of a skipped section without materializing them, so callers can
+  # report how much data was passed over.
+  SkippedState = Struct.new(:section, :seen)
 
-  def initialize(on_entry:, on_profile:)
+  def initialize(on_entry:, on_profile:, skip_sections: [], on_skipped: nil)
     super()
     @on_entry = on_entry
     @on_profile = on_profile
+    @skip_sections = Array(skip_sections).to_set
+    @on_skipped = on_skipped
     @stack = []
   end
 
@@ -32,7 +37,12 @@ class GoogleMaps::PhoneTakeoutStreamHandler < Oj::Saj
 
   def hash_end(key = nil, *_)
     state = @stack.pop
-    return if state.is_a?(DiscardState) || state.root
+    if state.is_a?(DiscardState)
+      parent = @stack.last
+      parent.seen += 1 if parent.is_a?(SkippedState)
+      return
+    end
+    return if state.root
 
     dispatch_to_parent(@stack.last, state.data, normalize_string(key) || state.key)
   end
@@ -47,7 +57,13 @@ class GoogleMaps::PhoneTakeoutStreamHandler < Oj::Saj
               DiscardState.new
             elsif parent.is_a?(HashState) && parent.root
               section = STREAMED_ARRAYS[normalized_key]
-              section ? StreamState.new(section) : DiscardState.new
+              if section.nil?
+                DiscardState.new
+              elsif @skip_sections.include?(section)
+                SkippedState.new(section, 0)
+              else
+                StreamState.new(section)
+              end
             else
               ArrayState.new([], normalized_key)
             end
@@ -56,6 +72,10 @@ class GoogleMaps::PhoneTakeoutStreamHandler < Oj::Saj
 
   def array_end(key = nil, *_)
     state = @stack.pop
+    if state.is_a?(SkippedState)
+      @on_skipped&.call(state.section, state.seen)
+      return
+    end
     return if state.is_a?(StreamState) || state.is_a?(DiscardState)
 
     dispatch_to_parent(@stack.last, state.data, normalize_string(key) || state.key)
@@ -68,7 +88,7 @@ class GoogleMaps::PhoneTakeoutStreamHandler < Oj::Saj
   private
 
   def discard_collection?(parent, key)
-    return true if parent.is_a?(DiscardState)
+    return true if parent.is_a?(DiscardState) || parent.is_a?(SkippedState)
 
     parent.is_a?(HashState) && parent.root && key != 'userLocationProfile'
   end

--- a/spec/fixtures/files/google/edge_cases/phone_takeout_empty_semantic_with_raw_signals.json
+++ b/spec/fixtures/files/google/edge_cases/phone_takeout_empty_semantic_with_raw_signals.json
@@ -1,0 +1,25 @@
+{
+  "semanticSegments": [],
+  "rawSignals": [
+    {
+      "position": {
+        "LatLng": "52.520500°, 13.405500°",
+        "accuracyMeters": 8,
+        "altitudeMeters": 40.0,
+        "source": "UNKNOWN",
+        "timestamp": "2026-06-20T10:00:31.000+02:00",
+        "speedMetersPerSecond": 0.5
+      }
+    },
+    {
+      "position": {
+        "LatLng": "52.520700°, 13.405700°",
+        "accuracyMeters": 9,
+        "altitudeMeters": 41.0,
+        "source": "WIFI_ONLY",
+        "timestamp": "2026-06-20T10:01:22.000+02:00",
+        "speedMetersPerSecond": 0.4
+      }
+    }
+  ]
+}

--- a/spec/fixtures/files/google/edge_cases/phone_takeout_raw_signals_before_semantic.json
+++ b/spec/fixtures/files/google/edge_cases/phone_takeout_raw_signals_before_semantic.json
@@ -1,0 +1,40 @@
+{
+  "rawSignals": [
+    {
+      "position": {
+        "LatLng": "52.520500°, 13.405500°",
+        "accuracyMeters": 8,
+        "altitudeMeters": 40.0,
+        "source": "UNKNOWN",
+        "timestamp": "2026-06-20T10:00:31.000+02:00",
+        "speedMetersPerSecond": 0.5
+      }
+    },
+    {
+      "position": {
+        "LatLng": "52.520700°, 13.405700°",
+        "accuracyMeters": 9,
+        "altitudeMeters": 41.0,
+        "source": "WIFI_ONLY",
+        "timestamp": "2026-06-20T10:01:22.000+02:00",
+        "speedMetersPerSecond": 0.4
+      }
+    }
+  ],
+  "semanticSegments": [
+    {
+      "startTime": "2026-06-20T10:00:00.000+02:00",
+      "endTime": "2026-06-20T10:02:00.000+02:00",
+      "timelinePath": [
+        {
+          "point": "52.520000°, 13.405000°",
+          "time": "2026-06-20T10:00:00.000+02:00"
+        },
+        {
+          "point": "52.521000°, 13.406000°",
+          "time": "2026-06-20T10:01:00.000+02:00"
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/files/google/edge_cases/phone_takeout_raw_signals_only.json
+++ b/spec/fixtures/files/google/edge_cases/phone_takeout_raw_signals_only.json
@@ -1,0 +1,24 @@
+{
+  "rawSignals": [
+    {
+      "position": {
+        "LatLng": "52.520500°, 13.405500°",
+        "accuracyMeters": 8,
+        "altitudeMeters": 40.0,
+        "source": "UNKNOWN",
+        "timestamp": "2026-06-20T10:00:31.000+02:00",
+        "speedMetersPerSecond": 0.5
+      }
+    },
+    {
+      "position": {
+        "LatLng": "52.520700°, 13.405700°",
+        "accuracyMeters": 9,
+        "altitudeMeters": 41.0,
+        "source": "WIFI_ONLY",
+        "timestamp": "2026-06-20T10:01:22.000+02:00",
+        "speedMetersPerSecond": 0.4
+      }
+    }
+  ]
+}

--- a/spec/fixtures/files/google/edge_cases/phone_takeout_semantic_and_raw_signals.json
+++ b/spec/fixtures/files/google/edge_cases/phone_takeout_semantic_and_raw_signals.json
@@ -1,0 +1,40 @@
+{
+  "semanticSegments": [
+    {
+      "startTime": "2026-06-20T10:00:00.000+02:00",
+      "endTime": "2026-06-20T10:02:00.000+02:00",
+      "timelinePath": [
+        {
+          "point": "52.520000°, 13.405000°",
+          "time": "2026-06-20T10:00:00.000+02:00"
+        },
+        {
+          "point": "52.521000°, 13.406000°",
+          "time": "2026-06-20T10:01:00.000+02:00"
+        }
+      ]
+    }
+  ],
+  "rawSignals": [
+    {
+      "position": {
+        "LatLng": "52.520500°, 13.405500°",
+        "accuracyMeters": 8,
+        "altitudeMeters": 40.0,
+        "source": "UNKNOWN",
+        "timestamp": "2026-06-20T10:00:31.000+02:00",
+        "speedMetersPerSecond": 0.5
+      }
+    },
+    {
+      "position": {
+        "LatLng": "52.520700°, 13.405700°",
+        "accuracyMeters": 9,
+        "altitudeMeters": 41.0,
+        "source": "WIFI_ONLY",
+        "timestamp": "2026-06-20T10:01:22.000+02:00",
+        "speedMetersPerSecond": 0.4
+      }
+    }
+  ]
+}

--- a/spec/regressions/google_phone_takeout_invalid_utf8_spec.rb
+++ b/spec/regressions/google_phone_takeout_invalid_utf8_spec.rb
@@ -38,11 +38,16 @@ RSpec.describe 'Google phone takeout import with invalid UTF-8 bytes' do
   end
 
   it 'imports without raising when content comes from storage download' do
-    downloader = instance_double(
-      Imports::SecureFileDownloader, download_with_verification: json_with_latin1_degree_signs
-    )
+    downloaded = Tempfile.new(['downloaded_timeline', '.json'])
+    downloaded.binmode
+    downloaded.write(json_with_latin1_degree_signs)
+    downloaded.close
+
+    downloader = instance_double(Imports::SecureFileDownloader, download_to_temp_file: downloaded.path)
     allow(Imports::SecureFileDownloader).to receive(:new).and_return(downloader)
 
     expect { GoogleMaps::PhoneTakeoutImporter.new(import, user.id).call }.not_to raise_error
+  ensure
+    downloaded&.unlink
   end
 end

--- a/spec/regressions/google_phone_takeout_rawsignals_overlap_spec.rb
+++ b/spec/regressions/google_phone_takeout_rawsignals_overlap_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Google phone Timeline exports taken after mid-June 2026 carry both the
+# aggregated `semanticSegments` and the raw `rawSignals` stream for the same
+# period. Ingesting both interleaves two independently sampled timelines whose
+# gaps do not line up, which erases the pauses track segmentation relies on and
+# welds whole weeks into a single track.
+RSpec.describe 'Google phone takeout with overlapping rawSignals' do
+  subject(:import_file) { GoogleMaps::PhoneTakeoutImporter.new(import, user.id).call }
+
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user:, name: 'phone_takeout.json') }
+
+  before do
+    import.file.attach(
+      io: File.open(file_path), filename: 'phone_takeout.json', content_type: 'application/json'
+    )
+  end
+
+  def imported_latitudes
+    Point.where(user_id: user.id).pluck(Arel.sql('ST_Y(lonlat::geometry)')).map { |lat| lat.round(4) }.sort
+  end
+
+  context 'when the export contains both semanticSegments and rawSignals' do
+    let(:file_path) do
+      Rails.root.join('spec/fixtures/files/google/edge_cases/phone_takeout_semantic_and_raw_signals.json')
+    end
+
+    it 'imports only the semanticSegments points' do
+      expect { import_file }.to change { Point.count }.by(2)
+    end
+
+    it 'keeps the timelinePath coordinates and drops the raw positions' do
+      import_file
+
+      expect(imported_latitudes).to eq([52.52, 52.521])
+    end
+
+    it 'tells the user how many raw signals were skipped and that nothing was lost' do
+      import_file
+
+      notification = Notification.find_by(user_id: user.id, title: 'Raw location signals skipped')
+      expect(notification).to be_present
+      expect(notification.content).to include('2 raw location signals')
+      expect(notification.content).to include('No timeline data was lost')
+    end
+  end
+
+  context 'when rawSignals appear before semanticSegments in the file' do
+    let(:file_path) do
+      Rails.root.join('spec/fixtures/files/google/edge_cases/phone_takeout_raw_signals_before_semantic.json')
+    end
+
+    it 'still drops the raw positions regardless of key order' do
+      import_file
+
+      expect(imported_latitudes).to eq([52.52, 52.521])
+    end
+  end
+
+  # The key can be present while the array is empty — Google's server-side aggregation
+  # lags behind fresher on-device signals. Skipping rawSignals on mere key presence would
+  # import nothing at all, and the import would report success.
+  context 'when semanticSegments is present but empty' do
+    let(:file_path) do
+      Rails.root.join('spec/fixtures/files/google/edge_cases/phone_takeout_empty_semantic_with_raw_signals.json')
+    end
+
+    it 'falls back to the raw positions instead of importing nothing' do
+      expect { import_file }.to change { Point.count }.by(2)
+    end
+
+    it 'keeps the raw position coordinates' do
+      import_file
+
+      expect(imported_latitudes).to eq([52.5205, 52.5207])
+    end
+
+    it 'does not claim raw signals were skipped once they have been replayed' do
+      import_file
+
+      expect(Notification.where(user_id: user.id, title: 'Raw location signals skipped')).to be_empty
+    end
+  end
+
+  context 'when the export contains rawSignals only' do
+    let(:file_path) do
+      Rails.root.join('spec/fixtures/files/google/edge_cases/phone_takeout_raw_signals_only.json')
+    end
+
+    it 'imports the raw positions' do
+      expect { import_file }.to change { Point.count }.by(2)
+    end
+
+    it 'keeps the raw position coordinates' do
+      import_file
+
+      expect(imported_latitudes).to eq([52.5205, 52.5207])
+    end
+  end
+end

--- a/spec/services/google_maps/phone_takeout_importer_spec.rb
+++ b/spec/services/google_maps/phone_takeout_importer_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe GoogleMaps::PhoneTakeoutImporter do
       context 'when file exists' do
         it 'creates points' do
           # 2 timelinePath + 1 visit from semanticSegments
-          # 1 rawSignal position
           # 2 frequentPlaces from userLocationProfile
-          expect { parser }.to change { Point.count }.by(6)
+          # rawSignals are skipped because semanticSegments cover the same period
+          expect { parser }.to change { Point.count }.by(5)
         end
 
         it 'stamps the per-import tracker id on every point' do
@@ -106,13 +106,11 @@ RSpec.describe GoogleMaps::PhoneTakeoutImporter do
         expect(end_point.lon).to eq(2.3376)
       end
 
-      it 'parses rawSignals with plain decimal coordinates (no degree symbol)' do
+      it 'skips rawSignals because semanticSegments cover the same period' do
         parser
 
         raw_signal_point = Point.find_by(timestamp: DateTime.parse('2024-06-15T09:05:00.000Z').utc.to_i)
-        expect(raw_signal_point).to be_present
-        expect(raw_signal_point.lat).to eq(48.8566)
-        expect(raw_signal_point.lon).to eq(2.3522)
+        expect(raw_signal_point).to be_nil
       end
 
       it 'does not persist raw_data for imported points' do
@@ -142,7 +140,7 @@ RSpec.describe GoogleMaps::PhoneTakeoutImporter do
       it 'creates two points from the userLocationProfile frequentPlaces branch' do
         parser
 
-        expect(Point.where(user_id: user.id).count).to eq(8)
+        expect(Point.where(user_id: user.id).count).to eq(7)
       end
 
       it 'parses timelinePath points with timestamps' do
@@ -195,18 +193,13 @@ RSpec.describe GoogleMaps::PhoneTakeoutImporter do
     context 'when coordinate formats vary across the file' do
       let(:json_data) do
         {
-          'semanticSegments' => [
-            {
-              'startTime' => '2024-06-15T09:00:00.000+02:00',
-              'endTime' => '2024-06-15T10:00:00.000+02:00',
-              'visit' => {
-                'topCandidate' => {
-                  'placeLocation' => { 'latLng' => '48.8566°, 2.3522°' }
-                }
-              }
-            }
-          ],
           'rawSignals' => [
+            {
+              'position' => {
+                'LatLng' => '48.8566°, 2.3522°',
+                'timestamp' => '2024-06-15T09:00:00.000Z'
+              }
+            },
             {
               'position' => {
                 'LatLng' => '48.8566,2.3522',
@@ -407,7 +400,7 @@ RSpec.describe GoogleMaps::PhoneTakeoutImporter do
       it 'does not load the complete JSON document into memory' do
         allow(service).to receive(:load_json_data).and_raise('full document load attempted')
 
-        expect { service.call }.to change { Point.count }.by(8)
+        expect { service.call }.to change { Point.count }.by(7)
       end
 
       it 'flushes points in bounded batches' do


### PR DESCRIPTION
Reported by a user whose 204 MB Google phone Timeline export produced "ghost tracks": opening 4 July showed bike commutes from 2 and 3 July, days he was home all day.

## Cause

Google switched on the `rawSignals` stream around mid-June 2026 and now emits **both** formats in the same export. In the reported file:

| Section | Coverage | Size |
|---|---|---|
| `semanticSegments` | 2011-02-13 → 2026-07-15 | 38,900 segments |
| `rawSignals` | 2026-06-15 → 2026-07-15 | 64,556 positions |

These are not duplicate rows — only 739 of 64,556 raw positions share an exact `(timestamp, lat, lon)` with a `timelinePath` point, so the unique index legitimately cannot dedupe them (`timelinePath` is minute-snapped to `:00` seconds; `rawSignals` land on arbitrary seconds).

The damage is temporal **density**, not row count. Track segmentation splits only on time gaps (`minutes_between_routes`, default 30). The two sources are sampled independently, so their gaps do not coincide and merging them cancels nearly all of them. Measured on the reporter's real 28 Jun – 7 Jul data:

| Input | Gaps > 30 min | Tracks |
|---|---|---|
| `semanticSegments` only | 22 | **23** |
| both merged (current behaviour) | 1 | **2** |

`Tracks::IndexQuery` returns any track *overlapping* the requested range and the serializer emits its full unclipped geometry, so one 10-day mega-track paints its entire path onto every day it touches.

## Fix

Skip `rawSignals` when `semanticSegments` is present. The decision comes from a chunked byte scan, because Oj's SAJ streaming cannot know a later key exists and JSON key order is not guaranteed. The section is discarded at `array_start`, so its entries are never materialised into hashes.

Presence of the key does not guarantee usable data — Google's server-side aggregation can lag behind fresher on-device signals. Skipping on key presence alone would make an export with an empty `semanticSegments` array import **nothing at all** while still reporting success, so the skipped signals are replayed when the aggregated pass yields no points.

The user is told how many signals were skipped. Dropping most of a file silently is indistinguishable from data loss, and the count is free — the handler counts entries of the discarded section without building them.

## Verification

Real-data behaviour, reporter's export:

```
real slice (both formats)      points=  9928  tracks= 23  notified=yes
empty semantic + rawSignals    points=     2  tracks=  1  notified=no
rawSignals only                points=     2  tracks=  1  notified=no
key straddling scan boundary   points=     2  tracks=  1  notified=yes
```

Before this change the same slice imported 31,276 points as **2 tracks**; it now imports 9,928 as **23**.

Also covered: a `"semanticSegments"` literal appearing inside a *value* does not false-positive, and a key straddling the 1 MB scan boundary is still found.

1202 examples, 0 failures (three consecutive runs). RuboCop clean on changed files.

## Notes

- Exports carrying only `rawSignals` are unaffected and still import.
- Existing imports already contain merged mega-tracks; re-running `Tracks::Reprocessor` for affected users is **not** part of this PR.
- The second commit repairs `google_phone_takeout_invalid_utf8_spec.rb:40`, which stubbed `download_with_verification` while the importer calls `download_to_temp_file` — it fails on `dev` today.
