### PR TITLE
chore: keep dependabot off ubuntu major/minor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,14 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 5
+    ignore:
+      # The mbgl_libs stage must stay on 24.04: the prebuilt
+      # @maplibre/maplibre-gl-native binding links libicuuc/libicudata/
+      # libicui18n .so.74, and no later Ubuntu ships ICU 74.
+      - dependency-name: 'ubuntu'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
The `mbgl_libs` stage must stay on Ubuntu 24.04: the prebuilt `@maplibre/maplibre-gl-native` binding links `libicuuc`, `libicudata` and `libicui18n` `.so.74`, and no later Ubuntu ships ICU 74. A dependabot bump of the base image therefore breaks the map renderer at runtime rather than at build time.

Adds an `ignore` rule for major and minor `ubuntu` updates so the pin holds. Patch updates are still offered.
