### PR TITLE
fix: keep the replay photo stack clear of the map button cluster

### DIFF
--- a/app/assets/stylesheets/maps_maplibre_replay.css
+++ b/app/assets/stylesheets/maps_maplibre_replay.css
@@ -614,11 +614,15 @@
 
 /* Replay corner photo stack (tilted pile revealed during replay) */
 .replay-photo-stack {
+  /* Single source of truth for the stack's scale. The fan offset is derived
+     from it so cards keep their spacing ratio at any size. */
+  --stack-size: 140px;
+  --stack-fan-step: calc(var(--stack-size) * 0.078);
   position: absolute;
   top: 16px;
   left: 16px;
-  width: 90px;
-  height: 90px;
+  width: var(--stack-size);
+  height: var(--stack-size);
   z-index: 450;
   pointer-events: none;
 }
@@ -627,11 +631,14 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: 90px;
-  height: 90px;
+  width: var(--stack-size);
+  height: var(--stack-size);
   cursor: pointer;
   pointer-events: auto;
-  transform: translate(calc(var(--depth, 0) * 7px), calc(var(--depth, 0) * 7px))
+  transform: translate(
+      calc(var(--depth, 0) * var(--stack-fan-step)),
+      calc(var(--depth, 0) * var(--stack-fan-step))
+    )
     rotate(var(--rot, 0deg));
   transition: transform 0.25s cubic-bezier(0.18, 0.89, 0.32, 1.28);
 }

--- a/app/javascript/maps_maplibre/components/replay_photo_stack.js
+++ b/app/javascript/maps_maplibre/components/replay_photo_stack.js
@@ -1,7 +1,9 @@
 import maplibregl from "maplibre-gl"
 import { PhotoPopupFactory } from "maps_maplibre/components/photo_popup"
+import { stackLeftOffset } from "maps_maplibre/components/replay_photo_stack_offset"
 
 const MAX_CARDS = 5
+const CLUSTER_SELECTOR = ".map-button-cluster"
 
 export class ReplayPhotoStack {
   constructor(map, options = {}) {
@@ -13,7 +15,23 @@ export class ReplayPhotoStack {
     this.map.getContainer().appendChild(this.container)
   }
 
+  // Keep the stack clear of the button cluster where one exists. Measured on
+  // every sync rather than once, because the cluster shifts right when the
+  // settings panel opens, and the trip map has no cluster at all.
+  _positionClearOfCluster() {
+    const mapEl = this.map.getContainer()
+    if (!mapEl) return
+    const cluster =
+      mapEl.closest("body")?.querySelector(CLUSTER_SELECTOR) ?? null
+    const left = stackLeftOffset({
+      container: mapEl.getBoundingClientRect(),
+      cluster: cluster ? cluster.getBoundingClientRect() : null,
+    })
+    this.container.style.left = `${left}px`
+  }
+
   sync(revealedPhotos) {
+    this._positionClearOfCluster()
     const visible = (revealedPhotos || []).slice(-MAX_CARDS)
     const visibleIds = new Set(visible.map((photo) => photo.id))
 

--- a/app/javascript/maps_maplibre/components/replay_photo_stack_offset.js
+++ b/app/javascript/maps_maplibre/components/replay_photo_stack_offset.js
@@ -1,0 +1,12 @@
+// Horizontal placement for the replay photo stack.
+//
+// The stack sits in the map's top-left corner, which on the main map is already
+// occupied by the button cluster. The trip map renders no cluster, so the offset
+// has to be derived from what is actually on screen rather than hardcoded - and
+// the cluster itself moves right when the settings panel opens.
+
+export function stackLeftOffset({ container, cluster, base = 16, gap = 10 }) {
+  if (!cluster || !cluster.width || !cluster.height) return base
+  const clearsCluster = cluster.right - container.left + gap
+  return Math.max(base, clearsCluster)
+}

--- a/spec/javascript/replay_photo_stack_offset_test.mjs
+++ b/spec/javascript/replay_photo_stack_offset_test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { stackLeftOffset } from "../../app/javascript/maps_maplibre/components/replay_photo_stack_offset.js"
+
+const container = { left: 0, top: 0 }
+
+test("falls back to the base inset when no button cluster is present", () => {
+  // The trip map renders no button cluster, so the stack must stay in the corner.
+  assert.equal(
+    stackLeftOffset({ container, cluster: null, base: 16, gap: 10 }),
+    16,
+  )
+})
+
+test("clears the cluster when one is present", () => {
+  const cluster = { left: 12, right: 66, width: 54, height: 300 }
+
+  assert.equal(stackLeftOffset({ container, cluster, base: 16, gap: 10 }), 76)
+})
+
+test("follows the cluster when the settings panel shifts it right", () => {
+  const cluster = { left: 492, right: 546, width: 54, height: 300 }
+
+  assert.equal(stackLeftOffset({ container, cluster, base: 16, gap: 10 }), 556)
+})
+
+test("measures relative to the map container, not the viewport", () => {
+  const offsetContainer = { left: 200, top: 0 }
+  const cluster = { left: 212, right: 266, width: 54, height: 300 }
+
+  assert.equal(
+    stackLeftOffset({ container: offsetContainer, cluster, base: 16, gap: 10 }),
+    76,
+  )
+})
+
+test("ignores a cluster that is present but not rendered", () => {
+  // A hidden cluster reports a zero-size rect; offsetting past it would push the
+  // stack toward the middle of an otherwise empty map.
+  const hidden = { left: 0, right: 0, width: 0, height: 0 }
+
+  assert.equal(
+    stackLeftOffset({ container, cluster: hidden, base: 16, gap: 10 }),
+    16,
+  )
+})
+
+test("never returns less than the base inset", () => {
+  const cluster = { left: -80, right: -20, width: 60, height: 300 }
+
+  assert.equal(stackLeftOffset({ container, cluster, base: 16, gap: 10 }), 16)
+})


### PR DESCRIPTION
The replay photo stack sits in the map's top-left corner, which on the main map is already occupied by the button cluster, so the two overlapped.

The offset cannot be hardcoded: the trip map renders no cluster at all, and the cluster itself shifts right when the settings panel opens. `stackLeftOffset` therefore measures the cluster on every `sync()` and clears it by a fixed gap, falling back to the plain 16px inset when there is no cluster.

Also drives the card size from a single `--stack-size` custom property with the fan step derived from it, so the spacing keeps its ratio now that the stack is 140px rather than 90px.

**Tests:** `spec/javascript/replay_photo_stack_offset_test.mjs` — 6 cases covering no cluster, a cluster to clear, a shifted cluster, and zero-size rects. `npm test` green.

> [!WARNING]
> Not yet verified in a browser — the offset maths is unit-tested, but the visual result on the main map and the trip map has not been checked.
