### PR TITLE
test: expect suffixless basemap URLs to validate

### DIFF
--- a/spec/javascript/settings_manager_test.mjs
+++ b/spec/javascript/settings_manager_test.mjs
@@ -71,7 +71,7 @@ test("vector tile URLs require z, x, and y placeholders", () => {
   assert.equal(SettingsManager.validVectorTilesUrl(""), true)
 })
 
-test("basemap URLs also accept raster XYZ and full style.json URLs", () => {
+test("basemap URLs also accept raster XYZ, style.json and suffixless style URLs", () => {
   assert.equal(
     SettingsManager.validVectorTilesUrl("https://t.example/{z}/{x}/{y}.png"),
     true,
@@ -82,6 +82,10 @@ test("basemap URLs also accept raster XYZ and full style.json URLs", () => {
   )
   assert.equal(
     SettingsManager.validVectorTilesUrl("https://t.example/basemap"),
+    true,
+  )
+  assert.equal(
+    SettingsManager.validVectorTilesUrl("//t.example/style.json"),
     false,
   )
 })


### PR DESCRIPTION
The JS suite is currently **red on `dev`**: `settings_manager_test.mjs` expects `validVectorTilesUrl("https://t.example/basemap")` to be `false`.

That expectation was correct until cd5c2826 ("accept MapLibre style URLs without a .json suffix") deliberately made an extensionless absolute URL classify as a style document. `basemap_url_classify_test.mjs` was updated to assert exactly that (`classifyBasemapUrl("https://tiles.example.com/basemap") === "style"`); this validator test was not, and has been failing since.

Flips the assertion to `true` and swaps in a protocol-relative URL for the negative case, which `isStyleDocumentLocation` and `Api::V1::SettingsController#style_json_url?` both still reject — so the test keeps a real rejection case instead of losing one.

**Tests:** `npm test` → 58/58 green (was 57/58).

Worth merging first: the suite is red for every branch off `dev` until this lands.
