### PR TITLE
chore: extract UI strings to Rails I18n

### DIFF
--- a/app/controllers/api/v1/areas_controller.rb
+++ b/app/controllers/api/v1/areas_controller.rb
@@ -34,7 +34,7 @@ class Api::V1::AreasController < ApiController
   def destroy
     @area.destroy!
 
-    render json: { message: 'Area was successfully deleted' }, status: :ok
+    render json: { message: I18n.t('controllers.api.v1.areas.area_was_successfully_deleted') }, status: :ok
   end
 
   private

--- a/app/controllers/api/v1/auth/apple_controller.rb
+++ b/app/controllers/api/v1/auth/apple_controller.rb
@@ -2,19 +2,17 @@
 
 class Api::V1::Auth::AppleController < Api::V1::Auth::BaseController
   PROVIDER = 'apple'
-  PROVIDER_LABEL = 'Sign in with Apple'
-
   def create
     claims =
       begin
         Auth::VerifyAppleToken.new(params[:id_token], nonce: params[:nonce]).call
       rescue Auth::VerifyAppleToken::InvalidToken => e
-        return render_auth_error("Apple token verification failed: #{e.message}")
+        return render_auth_error(I18n.t('controllers.api.v1.auth.apple.token_verification_failed', message: e.message))
       end
 
     user, created = Auth::FindOrCreateOauthUser.new(
       provider: PROVIDER,
-      provider_label: PROVIDER_LABEL,
+      provider_label: I18n.t('oauth_providers.sign_in_with_apple'),
       claims: claims,
       email_verified: email_verified?(claims)
     ).call
@@ -23,22 +21,18 @@ class Api::V1::Auth::AppleController < Api::V1::Auth::BaseController
   rescue Auth::FindOrCreateOauthUser::UnverifiedEmail
     render json: {
       error: 'email_not_verified',
-      message: 'Apple has not verified this email. Sign in with password and link from settings.'
+      message: I18n.t('controllers.api.v1.auth.apple.apple_has_not_verified_this_email_sign_in_with_password')
     }, status: :forbidden
   rescue Auth::FindOrCreateOauthUser::LinkVerificationSent
     render json: {
       error: 'verification_sent',
-      message: 'This email already has a Dawarich account. ' \
-               'We sent a confirmation link to that address — click it to link your Apple ID.'
+      message: I18n.t('controllers.api.v1.auth.apple.this_email_already_has_a_dawarich_account_we_sent_a')
     }, status: :accepted
   rescue Auth::FindOrCreateOauthUser::MissingOauthEmail => e
     Rails.logger.warn("apple.auth.missing_email uid=#{e.uid}")
     render json: {
       error: 'apple_email_missing',
-      message: "We couldn't find your existing account, and Apple didn't share your email " \
-               'with us this time. Apple only shares it once. Please go to ' \
-               'appleid.apple.com → Sign in with Apple, find Dawarich, choose ' \
-               '"Stop using Sign in with Apple", then try signing in again.'
+      message: I18n.t('controllers.api.v1.auth.apple.we_couldn_t_find_your_existing_account_and_apple_didn')
     }, status: :unprocessable_entity
   end
 

--- a/app/controllers/api/v1/auth/google_controller.rb
+++ b/app/controllers/api/v1/auth/google_controller.rb
@@ -2,19 +2,17 @@
 
 class Api::V1::Auth::GoogleController < Api::V1::Auth::BaseController
   PROVIDER = 'google_oauth2'
-  PROVIDER_LABEL = 'Google'
-
   def create
     claims =
       begin
         Auth::VerifyGoogleToken.new(params[:id_token], nonce: params[:nonce]).call
       rescue Auth::VerifyGoogleToken::InvalidToken => e
-        return render_auth_error("Google token verification failed: #{e.message}")
+        return render_auth_error(I18n.t('controllers.api.v1.auth.google.token_verification_failed', message: e.message))
       end
 
     user, created = Auth::FindOrCreateOauthUser.new(
       provider: PROVIDER,
-      provider_label: PROVIDER_LABEL,
+      provider_label: I18n.t('oauth_providers.google'),
       claims: claims,
       email_verified: email_verified?(claims)
     ).call
@@ -23,13 +21,12 @@ class Api::V1::Auth::GoogleController < Api::V1::Auth::BaseController
   rescue Auth::FindOrCreateOauthUser::UnverifiedEmail
     render json: {
       error: 'email_not_verified',
-      message: 'Google has not verified this email. Sign in with password and link from settings.'
+      message: I18n.t('controllers.api.v1.auth.google.google_has_not_verified_this_email_sign_in_with_password')
     }, status: :forbidden
   rescue Auth::FindOrCreateOauthUser::LinkVerificationSent
     render json: {
       error: 'verification_sent',
-      message: 'This email already has a Dawarich account. ' \
-               'We sent a confirmation link to that address — click it to link your Google sign-in.'
+      message: I18n.t('controllers.api.v1.auth.google.this_email_already_has_a_dawarich_account_we_sent_a')
     }, status: :accepted
   end
 

--- a/app/controllers/api/v1/auth/otp_challenges_controller.rb
+++ b/app/controllers/api/v1/auth/otp_challenges_controller.rb
@@ -5,7 +5,7 @@ class Api::V1::Auth::OtpChallengesController < Api::V1::Auth::BaseController
     verifier = Auth::VerifyOtpChallengeToken.new(params[:challenge_token])
     user = verifier.call
   rescue Auth::VerifyOtpChallengeToken::InvalidToken => e
-    render_auth_error("Invalid or expired challenge: #{e.message}")
+    render_auth_error(I18n.t('controllers.api.v1.auth.otp_challenges.invalid_challenge', message: e.message))
   else
     otp_code = params[:otp_code].to_s.strip
 
@@ -15,13 +15,12 @@ class Api::V1::Auth::OtpChallengesController < Api::V1::Auth::BaseController
       render_auth_success(user)
     elsif user.otp_locked?
       render_auth_error(
-        'Account temporarily locked due to too many failed 2FA attempts. ' \
-        'Use a backup code, wait 30 minutes, or reset your password.',
+        I18n.t('controllers.api.v1.auth.otp_challenges.account_locked'),
         http_status: :locked
       )
     else
       user.register_failed_otp_attempt!
-      render_auth_error('Invalid two-factor code')
+      render_auth_error(I18n.t('controllers.api.v1.auth.otp_challenges.invalid_two_factor_code'))
     end
   end
 

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::Auth::SessionsController < Api::V1::Auth::BaseController
 
     authenticated = constant_time_authenticate(user, params[:password].to_s)
 
-    return render_auth_error('Invalid email or password') unless authenticated
+    return render_auth_error(I18n.t('controllers.api.v1.auth.sessions.invalid_credentials')) unless authenticated
 
     if DawarichSettings.two_factor_available? && user.otp_required_for_login?
       challenge_token = Auth::IssueOtpChallengeToken.new(user).call

--- a/app/controllers/api/v1/digests_controller.rb
+++ b/app/controllers/api/v1/digests_controller.rb
@@ -23,17 +23,18 @@ class Api::V1::DigestsController < ApiController
     year = params[:year].to_i
 
     unless valid_year?(year)
-      render json: { error: 'Invalid year' }, status: :unprocessable_entity
+      render json: { error: I18n.t('controllers.api.v1.digests.invalid_year') }, status: :unprocessable_entity
       return
     end
 
     if current_api_user.digests.yearly.exists?(year: year)
-      render json: { error: 'Digest already exists' }, status: :conflict
+      render json: { error: I18n.t('controllers.api.v1.digests.digest_already_exists') }, status: :conflict
       return
     end
 
     Users::Digests::Yearly::CalculatingJob.perform_later(current_api_user.id, year)
-    render json: { message: "Digest for #{year} is being generated" }, status: :accepted
+    render json: { message: I18n.t('controllers.api.v1.digests.digest_for_year_is_being_generated', year: year) },
+           status: :accepted
   end
 
   def destroy

--- a/app/controllers/api/v1/families/locations_controller.rb
+++ b/app/controllers/api/v1/families/locations_controller.rb
@@ -19,13 +19,17 @@ class Api::V1::Families::LocationsController < ApiController
     end_at = params[:end_at]
 
     if start_at.blank? || end_at.blank?
-      return render json: { error: 'start_at and end_at are required' }, status: :bad_request
+      return render json: { error: I18n.t('controllers.api.v1.families.locations.start_at_and_end_at_are_required') },
+                    status: :bad_request
     end
 
     parsed_start = Time.zone.parse(start_at)
     parsed_end = Time.zone.parse(end_at)
 
-    return render json: { error: 'Invalid date format' }, status: :bad_request if parsed_start.nil? || parsed_end.nil?
+    if parsed_start.nil? || parsed_end.nil?
+      return render json: { error: I18n.t('controllers.api.v1.families.locations.invalid_date_format') },
+                    status: :bad_request
+    end
 
     members = Families::Locations.new(current_api_user).history(
       start_at: parsed_start,
@@ -34,7 +38,7 @@ class Api::V1::Families::LocationsController < ApiController
 
     render json: { members: members }
   rescue ArgumentError
-    render json: { error: 'Invalid date format' }, status: :bad_request
+    render json: { error: I18n.t('controllers.api.v1.families.locations.invalid_date_format') }, status: :bad_request
   end
 
   private
@@ -42,6 +46,7 @@ class Api::V1::Families::LocationsController < ApiController
   def ensure_user_in_family!
     return if current_api_user&.in_family?
 
-    render json: { error: 'User is not part of a family' }, status: :not_found
+    render json: { error: I18n.t('controllers.api.v1.families.locations.user_is_not_part_of_a_family') },
+           status: :not_found
   end
 end

--- a/app/controllers/api/v1/imports/pending_controller.rb
+++ b/app/controllers/api/v1/imports/pending_controller.rb
@@ -14,15 +14,32 @@ class Api::V1::Imports::PendingController < ApiController
   STORAGE_QUOTA_BYTES = 10.gigabytes
 
   def create
-    return render_error(:bad_request, 'Missing file') unless file_param.is_a?(ActionDispatch::Http::UploadedFile)
-    return render_error(:bad_request, 'Missing original_filename') if params[:original_filename].blank?
-    return render_error(:unprocessable_entity, 'File is empty') unless file_param.size.positive?
-    return render_error(:payload_too_large, 'File exceeds 100MB limit') if file_param.size > MAX_BYTE_SIZE
-    return render_error(:unprocessable_entity, "Unsupported file type '#{file_extension}'") unless allowed_extension?
+    unless file_param.is_a?(ActionDispatch::Http::UploadedFile)
+      return render_error(:bad_request,
+                          I18n.t('controllers.api.v1.imports.pending.missing_file'))
+    end
+    if params[:original_filename].blank?
+      return render_error(:bad_request,
+                          I18n.t('controllers.api.v1.imports.pending.missing_filename'))
+    end
+    unless file_param.size.positive?
+      return render_error(:unprocessable_entity,
+                          I18n.t('controllers.api.v1.imports.pending.empty_file'))
+    end
+    if file_param.size > MAX_BYTE_SIZE
+      return render_error(:payload_too_large,
+                          I18n.t('controllers.api.v1.imports.pending.file_too_large'))
+    end
+    unless allowed_extension?
+      return render_error(
+        :unprocessable_entity,
+        I18n.t('controllers.api.v1.imports.pending.unsupported_file_type', extension: file_extension)
+      )
+    end
 
     quota_key = storage_quota_key
     unless reserve_storage(file_param.size, quota_key)
-      return render_error(:too_many_requests, 'Pending import storage capacity exceeded')
+      return render_error(:too_many_requests, I18n.t('controllers.api.v1.imports.pending.storage_capacity_exceeded'))
     end
 
     storage_reservation = [file_param.size, quota_key]
@@ -49,7 +66,8 @@ class Api::V1::Imports::PendingController < ApiController
     release_storage(*storage_reservation) if storage_reservation
     Rails.logger.error("PendingImport create failed: #{e.message}")
     ExceptionReporter.call(e) if defined?(ExceptionReporter)
-    render json: { error: 'An error occurred' }, status: :internal_server_error
+    render json: { error: I18n.t('controllers.api.v1.imports.pending.an_error_occurred') },
+           status: :internal_server_error
   end
 
   private

--- a/app/controllers/api/v1/imports_controller.rb
+++ b/app/controllers/api/v1/imports_controller.rb
@@ -30,7 +30,8 @@ class Api::V1::ImportsController < ApiController
 
   def create
     unless params[:file].is_a?(ActionDispatch::Http::UploadedFile)
-      render json: { error: 'Missing required parameter: file' }, status: :unprocessable_entity and return
+      render json: { error: I18n.t('controllers.api.v1.imports.missing_required_parameter_file') },
+             status: :unprocessable_entity and return
     end
 
     uploaded_file = params[:file]
@@ -53,7 +54,8 @@ class Api::V1::ImportsController < ApiController
   rescue StandardError => e
     Rails.logger.error "API Import error: #{e.message}\n#{e.backtrace&.first(5)&.join("\n")}"
     ExceptionReporter.call(e)
-    render json: { error: 'An error occurred while processing the import' }, status: :internal_server_error
+    render json: { error: I18n.t('controllers.api.v1.imports.an_error_occurred_while_processing_the_import') },
+           status: :internal_server_error
   end
 
   private
@@ -74,7 +76,11 @@ class Api::V1::ImportsController < ApiController
     return if ALLOWED_EXTENSIONS.include?(ext)
 
     render json: {
-      error: "Unsupported file type '#{ext}'. Allowed: #{ALLOWED_EXTENSIONS.join(', ')}"
+      error: I18n.t(
+        'controllers.api.v1.imports.unsupported_file_type_ext_allowed_join',
+        ext: ext,
+        allowed: ALLOWED_EXTENSIONS.join(', ')
+      )
     }, status: :unprocessable_entity
   end
 

--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -10,12 +10,14 @@ class Api::V1::LocationsController < ApiController
 
       render json: Api::LocationSearchResultSerializer.new(search_results).call
     else
-      render json: { error: 'Coordinates (lat, lon) are required' }, status: :bad_request
+      render json: { error: I18n.t('controllers.api.v1.locations.coordinates_lat_lon_are_required') },
+             status: :bad_request
     end
   rescue StandardError => e
     Rails.logger.error "Location search error: #{e.message}"
     Rails.logger.error e.backtrace.join("\n")
-    render json: { error: 'Search failed. Please try again.' }, status: :internal_server_error
+    render json: { error: I18n.t('controllers.api.v1.locations.search_failed_please_try_again') },
+           status: :internal_server_error
   end
 
   def suggestions
@@ -64,7 +66,8 @@ class Api::V1::LocationsController < ApiController
 
   def validate_search_params
     unless coordinate_search?
-      render json: { error: 'Coordinates (lat, lon) are required' }, status: :bad_request
+      render json: { error: I18n.t('controllers.api.v1.locations.coordinates_lat_lon_are_required') },
+             status: :bad_request
       return false
     end
 
@@ -72,7 +75,7 @@ class Api::V1::LocationsController < ApiController
     lon = params[:lon]&.to_f
 
     if lat.abs > 90 || lon.abs > 180
-      render json: { error: 'Invalid coordinates: lat must be -90..90, lon must be -180..180' },
+      render json: { error: I18n.t('controllers.api.v1.locations.invalid_coordinates_lat_must_be_90_90_lon_must_be') },
              status: :bad_request
       return false
     end
@@ -82,7 +85,8 @@ class Api::V1::LocationsController < ApiController
 
   def validate_suggestion_params
     if search_query.present? && search_query.length > 200
-      render json: { error: 'Search query too long (max 200 characters)' }, status: :bad_request
+      render json: { error: I18n.t('controllers.api.v1.locations.search_query_too_long_max_200_characters') },
+             status: :bad_request
       return false
     end
 

--- a/app/controllers/api/v1/maps/hexagons_controller.rb
+++ b/app/controllers/api/v1/maps/hexagons_controller.rb
@@ -19,11 +19,14 @@ class Api::V1::Maps::HexagonsController < ApiController
 
     render json: result
   rescue ActionController::ParameterMissing => e
-    render json: { error: "Missing required parameter: #{e.param}" }, status: :bad_request
+    error = I18n.t('controllers.api.v1.maps.hexagons.missing_required_parameter_param', parameter: e.param)
+    render json: { error: error },
+           status: :bad_request
   rescue ActionController::BadRequest => e
     render json: { error: e.message }, status: :bad_request
   rescue ActiveRecord::RecordNotFound
-    render json: { error: 'Shared stats not found or no longer available' }, status: :not_found
+    render json: { error: I18n.t('controllers.api.v1.maps.hexagons.shared_stats_not_found_or_no_longer_available') },
+           status: :not_found
   rescue Stats::CalculateMonth::PostGISError => e
     render json: { error: e.message }, status: :bad_request
   rescue StandardError => _e
@@ -48,7 +51,8 @@ class Api::V1::Maps::HexagonsController < ApiController
       }, status: :not_found
     end
   rescue ActiveRecord::RecordNotFound
-    render json: { error: 'Shared stats not found or no longer available' }, status: :not_found
+    render json: { error: I18n.t('controllers.api.v1.maps.hexagons.shared_stats_not_found_or_no_longer_available') },
+           status: :not_found
   rescue ArgumentError => e
     render json: { error: e.message }, status: :bad_request
   rescue Maps::BoundsCalculator::NoUserFoundError => e
@@ -65,9 +69,11 @@ class Api::V1::Maps::HexagonsController < ApiController
 
     render json: result
   rescue ActionController::ParameterMissing => e
-    render json: { error: "Missing required parameter: #{e.param}" }, status: :bad_request
+    error = I18n.t('controllers.api.v1.maps.hexagons.missing_required_parameter_param', parameter: e.param)
+    render json: { error: error },
+           status: :bad_request
   rescue ArgumentError
-    render json: { error: 'Invalid date format' }, status: :bad_request
+    render json: { error: I18n.t('controllers.api.v1.maps.hexagons.invalid_date_format') }, status: :bad_request
   rescue StandardError => _e
     handle_service_error
   end
@@ -106,7 +112,8 @@ class Api::V1::Maps::HexagonsController < ApiController
   end
 
   def handle_service_error
-    render json: { error: 'Failed to generate hexagon grid' }, status: :internal_server_error
+    render json: { error: I18n.t('controllers.api.v1.maps.hexagons.failed_to_generate_hexagon_grid') },
+           status: :internal_server_error
   end
 
   def public_sharing_request?

--- a/app/controllers/api/v1/notes_controller.rb
+++ b/app/controllers/api/v1/notes_controller.rb
@@ -38,7 +38,7 @@ class Api::V1::NotesController < ApiController
   def destroy
     @note.destroy!
 
-    render json: { message: 'Note was successfully deleted' }, status: :ok
+    render json: { message: I18n.t('controllers.api.v1.notes.note_was_successfully_deleted') }, status: :ok
   end
 
   private

--- a/app/controllers/api/v1/overland/batches_controller.rb
+++ b/app/controllers/api/v1/overland/batches_controller.rb
@@ -12,7 +12,8 @@ class Api::V1::Overland::BatchesController < ApiController
     Rails.logger.error("Batch creation failed: #{e.class}: #{e.message}")
     Sentry.capture_exception(e) if defined?(Sentry)
 
-    render json: { error: 'Batch creation failed' }, status: :internal_server_error
+    render json: { error: I18n.t('controllers.api.v1.overland.batches.batch_creation_failed') },
+           status: :internal_server_error
   end
 
   private

--- a/app/controllers/api/v1/owntracks/points_controller.rb
+++ b/app/controllers/api/v1/owntracks/points_controller.rb
@@ -12,7 +12,8 @@ class Api::V1::Owntracks::PointsController < ApiController
     Rails.logger.error("Point creation failed: #{e.class}: #{e.message}")
     Sentry.capture_exception(e) if defined?(Sentry)
 
-    render json: { error: 'Point creation failed' }, status: :internal_server_error
+    render json: { error: I18n.t('controllers.api.v1.owntracks.points.point_creation_failed') },
+           status: :internal_server_error
   end
 
   private

--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::PhotosController < ApiController
     render json: @photos, status: :ok
   rescue StandardError => e
     Rails.logger.error("Photo search failed: #{e.message}")
-    render json: { error: 'Failed to fetch photos' }, status: :bad_gateway
+    render json: { error: I18n.t('controllers.api.v1.photos.failed_to_fetch_photos') }, status: :bad_gateway
   end
 
   def thumbnail
@@ -41,7 +41,7 @@ class Api::V1::PhotosController < ApiController
   def thumbnail_error(response)
     return Immich::ResponseAnalyzer.new(response).error_message if params[:source] == 'immich'
 
-    'Failed to fetch thumbnail'
+    I18n.t('controllers.api.v1.photos.failed_to_fetch_thumbnail')
   end
 
   def integration_configured?
@@ -57,7 +57,11 @@ class Api::V1::PhotosController < ApiController
   end
 
   def unauthorized_integration
-    render json: { error: "#{params[:source]&.capitalize} integration not configured" },
+    error = I18n.t(
+      'controllers.api.v1.photos.capitalize_integration_not_configured',
+      source: params[:source]&.capitalize
+    )
+    render json: { error: error },
            status: :unauthorized
   end
 end

--- a/app/controllers/api/v1/places_controller.rb
+++ b/app/controllers/api/v1/places_controller.rb
@@ -100,7 +100,8 @@ module Api
 
       def nearby
         unless params[:latitude].present? && params[:longitude].present?
-          return render json: { error: 'latitude and longitude are required' }, status: :bad_request
+          return render json: { error: I18n.t('controllers.api.v1.places.latitude_and_longitude_are_required') },
+                        status: :bad_request
         end
 
         results = Places::NearbySearch.new(
@@ -115,13 +116,14 @@ module Api
 
       def search
         unless params[:lat].present? && params[:lon].present?
-          return render json: { error: 'lat and lon are required' }, status: :bad_request
+          return render json: { error: I18n.t('controllers.api.v1.places.lat_and_lon_are_required') },
+                        status: :bad_request
         end
 
         lat = params[:lat].to_f
         lon = params[:lon].to_f
         unless lat.between?(-90, 90) && lon.between?(-180, 180)
-          return render json: { error: 'Invalid coordinates' }, status: :bad_request
+          return render json: { error: I18n.t('controllers.api.v1.places.invalid_coordinates') }, status: :bad_request
         end
 
         radius = [[params[:radius]&.to_f || 1.0, 0.01].max, 5.0].min

--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -31,7 +31,10 @@ class Api::V1::PointsController < ApiController
     if params[:min_longitude].present? && params[:max_longitude].present? &&
        params[:min_latitude].present? && params[:max_latitude].present?
       bbox = parse_bbox(params)
-      return render(json: { error: 'Invalid bounding box' }, status: :bad_request) unless bbox
+      unless bbox
+        return render(json: { error: I18n.t('controllers.api.v1.points.invalid_bounding_box') },
+                      status: :bad_request)
+      end
 
       envelope = 'ST_MakeEnvelope(?, ?, ?, ?, 4326)'
       points = points.where(
@@ -91,7 +94,7 @@ class Api::V1::PointsController < ApiController
     Rails.logger.error("Point creation failed: #{e.class}: #{e.message}")
     Sentry.capture_exception(e) if defined?(Sentry)
 
-    render json: { error: 'Point creation failed' }, status: :internal_server_error
+    render json: { error: I18n.t('controllers.api.v1.points.point_creation_failed') }, status: :internal_server_error
   end
 
   def update
@@ -115,17 +118,21 @@ class Api::V1::PointsController < ApiController
     point = current_api_user.points.without_raw_data.find(params[:id])
     Points::Destroyer.new(current_api_user, point.id).call
 
-    render json: { message: 'Point deleted successfully' }
+    render json: { message: I18n.t('controllers.api.v1.points.point_deleted_successfully') }
   end
 
   def bulk_destroy
     point_ids = bulk_destroy_params[:point_ids]
 
-    render json: { error: 'No points selected' }, status: :unprocessable_entity and return if point_ids.blank?
+    if point_ids.blank?
+      render json: { error: I18n.t('controllers.api.v1.points.no_points_selected') },
+             status: :unprocessable_entity and return
+    end
 
     if point_ids.size > BULK_DESTROY_MAX
       render json: {
-        error: "Too many points selected. Maximum is #{BULK_DESTROY_MAX} per request.",
+        error: I18n.t('controllers.api.v1.points.too_many_points_selected_maximum_is_bulk_destroy_max_per',
+                      limit: BULK_DESTROY_MAX),
         limit: BULK_DESTROY_MAX,
         requested: point_ids.size
       }, status: :unprocessable_entity and return
@@ -133,14 +140,16 @@ class Api::V1::PointsController < ApiController
 
     destroyed = Points::Destroyer.new(current_api_user, point_ids).call
 
-    render json: { message: 'Points were successfully destroyed', count: destroyed.count }, status: :ok
+    message = I18n.t('controllers.api.v1.points.points_were_successfully_destroyed')
+    render json: { message: message, count: destroyed.count },
+           status: :ok
   end
 
   def reapply_anomaly_filter
     pending_key = "anomaly_backfill_pending:#{current_api_user.id}"
     if Rails.cache.read(pending_key)
       return render(
-        json: { error: 'Anomaly re-evaluation already in progress.' },
+        json: { error: I18n.t('controllers.api.v1.points.anomaly_re_evaluation_already_in_progress') },
         status: :conflict
       )
     end
@@ -149,7 +158,7 @@ class Api::V1::PointsController < ApiController
     Points::AnomalyBackfillUserJob.perform_later(current_api_user.id, reset: true)
 
     render json: {
-      message: 'Re-evaluation queued. Existing anomaly flags will be cleared and recomputed.'
+      message: I18n.t('controllers.api.v1.points.re_evaluation_queued_existing_anomaly_flags_will_be_cleared_and')
     }, status: :accepted
   end
 

--- a/app/controllers/api/v1/recalculations_controller.rb
+++ b/app/controllers/api/v1/recalculations_controller.rb
@@ -10,13 +10,13 @@ class Api::V1::RecalculationsController < ApiController
     year = params[:year].presence&.to_i
 
     if year && (year < 2000 || year > Date.current.year + 1)
-      return render(json: { error: 'Invalid year' }, status: :bad_request)
+      return render(json: { error: I18n.t('controllers.api.v1.recalculations.invalid_year') }, status: :bad_request)
     end
 
     pending_key = "recalculation_pending:#{current_api_user.id}"
     if Rails.cache.read(pending_key)
       return render(
-        json: { error: 'Recalculation already in progress for this user.' },
+        json: { error: I18n.t('controllers.api.v1.recalculations.recalculation_already_in_progress_for_this_user') },
         status: :conflict
       )
     end
@@ -25,7 +25,9 @@ class Api::V1::RecalculationsController < ApiController
     Users::RecalculateDataJob.perform_later(current_api_user.id, year: year)
 
     render json: {
-      message: 'Recalculation queued. Tracks, stats, and digests will be regenerated in the background.'
+      message: I18n.t(
+        'controllers.api.v1.recalculations.recalculation_queued_tracks_stats_and_digests_will_be_regenerated_in'
+      )
     }, status: :accepted
   end
 end

--- a/app/controllers/api/v1/settings/mobile_controller.rb
+++ b/app/controllers/api/v1/settings/mobile_controller.rb
@@ -33,10 +33,12 @@ class Api::V1::Settings::MobileController < ApiController
       Rails.logger.info(
         "Mobile settings updated for user #{current_api_user.id}: #{sanitized.keys.join(', ')}"
       )
-      render json: mobile_settings_response.merge(message: 'Settings updated'), status: :ok
+      message = I18n.t('controllers.api.v1.settings.mobile.settings_updated')
+      render json: mobile_settings_response.merge(message: message),
+             status: :ok
     else
       render json: {
-        message: 'Something went wrong',
+        message: I18n.t('controllers.api.v1.settings.mobile.something_went_wrong'),
         errors: current_api_user.errors.full_messages
       }, status: :unprocessable_content
     end

--- a/app/controllers/api/v1/settings_controller.rb
+++ b/app/controllers/api/v1/settings_controller.rb
@@ -17,8 +17,8 @@ class Api::V1::SettingsController < ApiController
     settings = settings_params
     unless valid_tiles_url?(settings)
       return render json: {
-        message: 'Something went wrong',
-        errors: [TILE_URL_ERROR]
+        message: I18n.t('controllers.api.v1.settings.something_went_wrong'),
+        errors: [I18n.t('controllers.api.v1.settings.tile_url_error')]
       }, status: :unprocessable_content
     end
 
@@ -26,7 +26,7 @@ class Api::V1::SettingsController < ApiController
 
     if result.success?
       render json: {
-        message: 'Settings updated',
+        message: I18n.t('controllers.api.v1.settings.settings_updated'),
         settings: current_api_user.safe_settings.config,
         status: 'success',
         recalculation_triggered: result.recalculation_triggered?
@@ -34,7 +34,8 @@ class Api::V1::SettingsController < ApiController
     elsif result.error&.include?('recalculation is in progress')
       render json: { message: result.error, status: 'locked' }, status: :locked
     else
-      render json: { message: 'Something went wrong', errors: [result.error] }, status: :unprocessable_content
+      render json: { message: I18n.t('controllers.api.v1.settings.something_went_wrong'), errors: [result.error] },
+             status: :unprocessable_content
     end
   end
 
@@ -66,9 +67,6 @@ class Api::V1::SettingsController < ApiController
                               route_color track_color].freeze
   TILE_URL_PLACEHOLDERS = %w[{z} {x} {y}].freeze
   TILE_FILE_EXTENSIONS = %w[.png .jpg .jpeg .webp .mvt .pbf].freeze
-  TILE_URL_ERROR = 'Tile URL must include {z}, {x}, and {y} placeholders, ' \
-                   'or be a MapLibre style URL'
-
   def settings_params
     permitted = params.require(:settings).permit(
       :timezone,

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -7,19 +7,29 @@ class Api::V1::SubscriptionsController < ApiController
   def callback
     if ENV['SUBSCRIPTION_WEBHOOK_SECRET'].blank?
       Rails.logger.error('[Subscriptions#callback] SUBSCRIPTION_WEBHOOK_SECRET is not configured')
-      return render(json: { message: 'Configuration error' }, status: :service_unavailable)
+      return render(json: { message: I18n.t('controllers.api.v1.subscriptions.configuration_error') },
+                    status: :service_unavailable)
     end
-    return render(json: { message: 'Invalid webhook secret' }, status: :unauthorized) unless valid_manager_secret?
+    unless valid_manager_secret?
+      return render(json: { message: I18n.t('controllers.api.v1.subscriptions.invalid_webhook_secret') },
+                    status: :unauthorized)
+    end
 
     decoded = Subscription::DecodeJwtToken.new(params[:token]).call
 
-    return render(json: { message: 'Missing event_id' }, status: :unprocessable_content) if decoded[:event_id].blank?
+    if decoded[:event_id].blank?
+      return render(json: { message: I18n.t('controllers.api.v1.subscriptions.missing_event_id') },
+                    status: :unprocessable_content)
+    end
 
-    return render(json: { message: 'Stale event' }, status: :ok) unless claim_event!(decoded)
+    unless claim_event!(decoded)
+      return render(json: { message: I18n.t('controllers.api.v1.subscriptions.stale_event') },
+                    status: :ok)
+    end
 
     if event_older_than_last_seen?(decoded)
       Rails.cache.delete("manager_callback:processed:#{decoded[:event_id]}")
-      return render(json: { message: 'Stale event' }, status: :ok)
+      return render(json: { message: I18n.t('controllers.api.v1.subscriptions.stale_event') }, status: :ok)
     end
 
     user = User.find_by(id: decoded[:user_id])
@@ -60,7 +70,7 @@ class Api::V1::SubscriptionsController < ApiController
       raise
     end
 
-    return render(json: { message: 'Stale event' }, status: :ok) unless applied
+    return render(json: { message: I18n.t('controllers.api.v1.subscriptions.stale_event') }, status: :ok) unless applied
 
     Rails.cache.delete("rack_attack/plan/#{user.api_key}") if user.previous_changes.any?
 
@@ -72,13 +82,15 @@ class Api::V1::SubscriptionsController < ApiController
       source: user.subscription_source
     )
 
-    render json: { message: 'Subscription updated successfully' }
+    render json: { message: I18n.t('controllers.api.v1.subscriptions.subscription_updated_successfully') }
   rescue JWT::DecodeError => e
     ExceptionReporter.call(e)
-    render json: { message: 'Failed to verify subscription update.' }, status: :unauthorized
+    render json: { message: I18n.t('controllers.api.v1.subscriptions.failed_to_verify_subscription_update') },
+           status: :unauthorized
   rescue ArgumentError => e
     ExceptionReporter.call(e)
-    render json: { message: 'Invalid subscription data received.' }, status: :unprocessable_content
+    render json: { message: I18n.t('controllers.api.v1.subscriptions.invalid_subscription_data_received') },
+           status: :unprocessable_content
   end
 
   private

--- a/app/controllers/api/v1/timeline_controller.rb
+++ b/app/controllers/api/v1/timeline_controller.rb
@@ -7,11 +7,16 @@ module Api
 
       def index
         unless date_params_present?
-          return render json: { error: 'start_at and end_at are required' }, status: :bad_request
+          return render json: { error: I18n.t('controllers.api.v1.timeline.start_at_and_end_at_are_required') },
+                        status: :bad_request
         end
 
         if range_too_large?
-          return render json: { error: "Date range cannot exceed #{MAX_RANGE_DAYS} days" },
+          error = I18n.t(
+            'controllers.api.v1.timeline.date_range_cannot_exceed_max_range_days_days',
+            max_days: MAX_RANGE_DAYS
+          )
+          return render json: { error: error },
                         status: :bad_request
         end
 

--- a/app/controllers/api/v1/traccar/points_controller.rb
+++ b/app/controllers/api/v1/traccar/points_controller.rb
@@ -12,7 +12,8 @@ class Api::V1::Traccar::PointsController < ApiController
     Rails.logger.error("Point creation failed: #{e.class}: #{e.message}")
     Sentry.capture_exception(e) if defined?(Sentry)
 
-    render json: { error: 'Point creation failed' }, status: :internal_server_error
+    render json: { error: I18n.t('controllers.api.v1.traccar.points.point_creation_failed') },
+           status: :internal_server_error
   end
 
   private

--- a/app/controllers/api/v1/users/destroy_controller.rb
+++ b/app/controllers/api/v1/users/destroy_controller.rb
@@ -5,15 +5,10 @@ class Api::V1::Users::DestroyController < ApiController
 
   skip_before_action :reject_pending_payment!
 
-  SUBSCRIPTION_NOTE = ' If you have an active Apple or Google subscription, cancel it in your ' \
-                      'platform settings to avoid further charges.'
-  SELF_HOSTED_DELETED_MESSAGE = 'Your account has been scheduled for deletion.'
-  CANNOT_DELETE_MESSAGE = 'You own a family with other members. Transfer ownership or remove ' \
-                          'members before deleting your account.'
-
   def destroy
     unless current_api_user.can_delete_account?
-      return render(json: { error: 'cannot_delete_account', message: CANNOT_DELETE_MESSAGE },
+      message = I18n.t('controllers.api.v1.users.destroy.cannot_delete')
+      return render(json: { error: 'cannot_delete_account', message: message },
                     status: :unprocessable_content)
     end
 
@@ -34,7 +29,7 @@ class Api::V1::Users::DestroyController < ApiController
     Users::DestroyJob.perform_later(current_api_user.id) \
       if current_api_user.mark_as_deleted_atomically!
 
-    render json: { message: SELF_HOSTED_DELETED_MESSAGE }
+    render json: { message: I18n.t('controllers.api.v1.users.destroy.deletion_scheduled') }
   end
 
   def destroy_cloud
@@ -46,7 +41,9 @@ class Api::V1::Users::DestroyController < ApiController
 
     case result.status
     when :sent
-      render json: { message: result.message + SUBSCRIPTION_NOTE }, status: :accepted
+      render json: {
+        message: I18n.t('controllers.api.v1.users.destroy.request_sent', message: result.message)
+      }, status: :accepted
     when :throttled
       render json: { error: 'rate_limited', message: result.message }, status: :too_many_requests
     else

--- a/app/controllers/api/v1/users/two_factor_controller.rb
+++ b/app/controllers/api/v1/users/two_factor_controller.rb
@@ -9,8 +9,9 @@ class Api::V1::Users::TwoFactorController < ApiController
 
   def setup
     if current_api_user.otp_required_for_login?
+      message = I18n.t('controllers.api.v1.users.two_factor.disable_2fa_first_to_re_provision_the_secret')
       render json: { error: 'two_factor_already_enabled',
-                     message: 'Disable 2FA first to re-provision the secret.' },
+                     message: message },
              status: :conflict
       return
     end
@@ -49,7 +50,7 @@ class Api::V1::Users::TwoFactorController < ApiController
       otp_required_for_login: false,
       otp_backup_codes: []
     )
-    render json: { message: 'Two-factor authentication disabled' }
+    render json: { message: I18n.t('controllers.api.v1.users.two_factor.two_factor_authentication_disabled') }
   end
 
   private
@@ -63,15 +64,17 @@ class Api::V1::Users::TwoFactorController < ApiController
   def ensure_otp_or_backup_provided
     return if consume_otp_or_backup!
 
+    message = I18n.t('controllers.api.v1.users.two_factor.provide_a_valid_two_factor_code_or_backup_code_to')
     render json: { error: 'otp_required',
-                   message: 'Provide a valid two-factor code (or backup code) to disable 2FA.' },
+                   message: message },
            status: :unauthorized
   end
 
   def ensure_password_provided
     return if valid_password?
 
-    render json: { error: 'password_required', message: 'Provide your current password.' },
+    message = I18n.t('controllers.api.v1.users.two_factor.provide_your_current_password')
+    render json: { error: 'password_required', message: message },
            status: :unauthorized
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -11,11 +11,18 @@ class Api::V1::UsersController < ApiController
   def exist
     if ENV['SUBSCRIPTION_WEBHOOK_SECRET'].blank?
       Rails.logger.error('[Users#exist] SUBSCRIPTION_WEBHOOK_SECRET is not configured')
-      return render(json: { error: 'Configuration error' }, status: :service_unavailable)
+      return render(json: { error: I18n.t('controllers.api.v1.users.configuration_error') },
+                    status: :service_unavailable)
     end
-    return render(json: { error: 'Invalid webhook secret' }, status: :unauthorized) unless valid_manager_secret?
+    unless valid_manager_secret?
+      return render(json: { error: I18n.t('controllers.api.v1.users.invalid_webhook_secret') },
+                    status: :unauthorized)
+    end
 
-    return render(json: { error: 'ids is required' }, status: :unprocessable_content) if params[:ids].nil?
+    if params[:ids].nil?
+      return render(json: { error: I18n.t('controllers.api.v1.users.ids_is_required') },
+                    status: :unprocessable_content)
+    end
 
     ids = Array(params[:ids]).filter_map { |raw| safe_integer(raw) }.uniq
     existing = ids.empty? ? [] : User.where(id: ids).pluck(:id)

--- a/app/controllers/api/v1/visits/possible_places_controller.rb
+++ b/app/controllers/api/v1/visits/possible_places_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::Visits::PossiblePlacesController < ApiController
     suggestions = prepend_current_place(visit, suggestions)
     render json: suggestions
   rescue ActiveRecord::RecordNotFound
-    render json: { error: 'Visit not found' }, status: :not_found
+    render json: { error: I18n.t('controllers.api.v1.visits.possible_places.visit_not_found') }, status: :not_found
   end
 
   private

--- a/app/controllers/api/v1/visits/select_place_controller.rb
+++ b/app/controllers/api/v1/visits/select_place_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::Visits::SelectPlaceController < ApiController
     place = Visits::SelectPlace.new(user: current_api_user, visit: visit, photon: photon_params).call
     render json: serialize_place(place), status: :created
   rescue ActiveRecord::RecordNotFound
-    render json: { error: 'Visit not found' }, status: :not_found
+    render json: { error: I18n.t('controllers.api.v1.visits.select_place.visit_not_found') }, status: :not_found
   rescue ActiveRecord::RecordInvalid, ActionController::ParameterMissing => e
     render json: { error: e.message }, status: :unprocessable_entity
   end

--- a/app/controllers/api/v1/visits_controller.rb
+++ b/app/controllers/api/v1/visits_controller.rb
@@ -34,7 +34,7 @@ class Api::V1::VisitsController < ApiController
     if result
       render json: Api::VisitSerializer.new(service.visit).call
     else
-      error_message = service.errors || 'Failed to create visit'
+      error_message = service.errors || I18n.t('controllers.api.v1.visits.failed_to_create_visit')
       render json: { error: error_message }, status: :unprocessable_content
     end
   end
@@ -45,13 +45,19 @@ class Api::V1::VisitsController < ApiController
     if visit_params[:place_id].present?
       place = current_api_user.places.find_by(id: visit_params[:place_id]) ||
               visit.suggested_places.find_by(id: visit_params[:place_id])
-      return render json: { error: 'Invalid place' }, status: :unprocessable_content if place.nil?
+      if place.nil?
+        return render json: { error: I18n.t('controllers.api.v1.visits.invalid_place') },
+                      status: :unprocessable_content
+      end
     end
 
     area = nil
     if visit_params[:area_id].present?
       area = current_api_user.areas.find_by(id: visit_params[:area_id])
-      return render json: { error: 'Invalid area' }, status: :unprocessable_content if area.nil?
+      if area.nil?
+        return render json: { error: I18n.t('controllers.api.v1.visits.invalid_area') },
+                      status: :unprocessable_content
+      end
     end
 
     visit = update_visit(visit, area: area)
@@ -63,7 +69,8 @@ class Api::V1::VisitsController < ApiController
     # Validate that we have at least 2 visit IDs
     visit_ids = params[:visit_ids]
     if visit_ids.blank? || visit_ids.length < 2
-      return render json: { error: 'At least 2 visits must be selected for merging' }, status: :unprocessable_content
+      return render json: { error: I18n.t('controllers.api.v1.visits.at_least_2_visits_must_be_selected_for_merging') },
+                    status: :unprocessable_content
     end
 
     # Find all visits that belong to the current user
@@ -71,7 +78,8 @@ class Api::V1::VisitsController < ApiController
 
     # Ensure we found all the visits
     if visits.length != visit_ids.length
-      return render json: { error: 'One or more visits not found' }, status: :not_found
+      return render json: { error: I18n.t('controllers.api.v1.visits.one_or_more_visits_not_found') },
+                    status: :not_found
     end
 
     # Use the service to merge the visits
@@ -96,7 +104,7 @@ class Api::V1::VisitsController < ApiController
 
     if result
       render json: {
-        message: "#{result[:count]} visits updated successfully",
+        message: I18n.t('controllers.api.v1.visits.count_visits_updated_successfully', count: result[:count]),
         updated_count: result[:count]
       }, status: :ok
     else
@@ -111,12 +119,12 @@ class Api::V1::VisitsController < ApiController
       head :no_content
     else
       render json: {
-        error: 'Failed to delete visit',
+        error: I18n.t('controllers.api.v1.visits.failed_to_delete_visit'),
         errors: visit.errors.full_messages
       }, status: :unprocessable_content
     end
   rescue ActiveRecord::RecordNotFound
-    render json: { error: 'Visit not found' }, status: :not_found
+    render json: { error: I18n.t('controllers.api.v1.visits.visit_not_found') }, status: :not_found
   end
 
   private

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -23,7 +23,7 @@ class ApiController < ApplicationController
   end
 
   def record_not_found
-    render json: { error: 'Record not found' }, status: :not_found
+    render json: { error: I18n.t('controllers.api.record_not_found') }, status: :not_found
   end
 
   def set_version_header
@@ -49,7 +49,7 @@ class ApiController < ApplicationController
 
     render json: {
       error: 'payment_required',
-      message: 'Complete your subscription to continue.',
+      message: I18n.t('controllers.api.complete_your_subscription_to_continue'),
       resume_url: upgrade_url_for(current_api_user)
     }, status: :payment_required
   end
@@ -60,7 +60,7 @@ class ApiController < ApplicationController
 
     render json: {
       error: 'pro_plan_required',
-      message: 'This feature requires a Pro plan.',
+      message: I18n.t('controllers.api.this_feature_requires_a_pro_plan'),
       upgrade_url: upgrade_url_for(current_api_user)
     }, status: :forbidden
   end
@@ -71,7 +71,7 @@ class ApiController < ApplicationController
 
     render json: {
       error: 'write_api_restricted',
-      message: 'Write API access requires a Pro plan. Your data was not modified.',
+      message: I18n.t('controllers.api.write_api_access_requires_a_pro_plan_your_data_was'),
       upgrade_url: upgrade_url_for(current_api_user)
     }, status: :forbidden
   end
@@ -84,7 +84,7 @@ class ApiController < ApplicationController
 
     render json: {
       error: 'family_plan_required',
-      message: FAMILY_PLAN_REQUIRED_MESSAGE,
+      message: I18n.t('controllers.application.family_plan_required'),
       upgrade_url: upgrade_url_for(current_api_user)
     }, status: :forbidden
   end
@@ -112,19 +112,20 @@ class ApiController < ApplicationController
 
   def authenticate_active_api_user!
     if current_api_user.nil?
-      render json: { error: 'User account is not active or has been deleted' }, status: :unauthorized
+      render json: { error: I18n.t('controllers.api.user_account_is_not_active_or_has_been_deleted') },
+             status: :unauthorized
 
       return false
     end
 
     if current_api_user.inactive?
-      render json: { error: 'User account is not active' }, status: :unauthorized
+      render json: { error: I18n.t('controllers.api.user_account_is_not_active') }, status: :unauthorized
 
       return false
     end
 
     if current_api_user.active_until&.past?
-      render json: { error: 'User subscription is not active' }, status: :unauthorized
+      render json: { error: I18n.t('controllers.api.user_subscription_is_not_active') }, status: :unauthorized
 
       return false
     end
@@ -151,7 +152,7 @@ class ApiController < ApplicationController
 
     if missing_params.any?
       render json: {
-        error: "Missing required parameters: #{missing_params.join(', ')}"
+        error: I18n.t('controllers.api.missing_required_parameters_join', parameters: missing_params.join(', '))
       }, status: :bad_request and return
     end
 
@@ -165,7 +166,7 @@ class ApiController < ApplicationController
   def validate_points_limit
     limit_exceeded = PointsLimitExceeded.new(current_api_user).call
 
-    render json: { error: 'Points limit exceeded' }, status: :unauthorized if limit_exceeded
+    render json: { error: I18n.t('controllers.api.points_limit_exceeded') }, status: :unauthorized if limit_exceeded
   end
 
   def set_rate_limit_headers

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,7 +76,7 @@ class ApplicationController < ActionController::Base
   def authenticate_active_user!
     return if current_user&.active_until&.future?
 
-    redirect_to root_path, notice: 'Your account is not active.', status: :see_other
+    redirect_to root_path, notice: I18n.t('controllers.application.your_account_is_not_active'), status: :see_other
   end
 
   def authenticate_non_self_hosted!
@@ -117,10 +117,16 @@ class ApplicationController < ActionController::Base
 
     unless current_user
       respond_to do |format|
-        format.html { redirect_to new_user_session_path, alert: 'Please sign in to continue.', status: :see_other }
-        format.json { render json: { error: 'You need to sign in first.' }, status: :unauthorized }
+        format.html do
+          redirect_to new_user_session_path, alert: I18n.t('controllers.application.please_sign_in_to_continue'),
+         status: :see_other
+        end
+        format.json do
+          render json: { error: I18n.t('controllers.application.you_need_to_sign_in_first') }, status: :unauthorized
+        end
         format.turbo_stream do
-          redirect_to new_user_session_path, alert: 'Please sign in to continue.', status: :see_other
+          redirect_to new_user_session_path, alert: I18n.t('controllers.application.please_sign_in_to_continue'),
+status: :see_other
         end
       end
       return
@@ -131,19 +137,19 @@ class ApplicationController < ActionController::Base
     respond_to do |format|
       format.html do
         redirect_back fallback_location: root_path,
-                      alert: 'This feature requires a Pro plan.',
+                      alert: I18n.t('controllers.application.this_feature_requires_a_pro_plan'),
                       status: :see_other
       end
-      format.json { render json: { error: 'This feature requires a Pro plan.' }, status: :forbidden }
+      format.json do
+        render json: { error: I18n.t('controllers.application.this_feature_requires_a_pro_plan') }, status: :forbidden
+      end
       format.turbo_stream do
         redirect_back fallback_location: root_path,
-                      alert: 'This feature requires a Pro plan.',
+                      alert: I18n.t('controllers.application.this_feature_requires_a_pro_plan'),
                       status: :see_other
       end
     end
   end
-
-  FAMILY_PLAN_REQUIRED_MESSAGE = 'This feature requires a Family plan.'
 
   # Family routes exist on every instance; access is decided per user. Send web
   # visitors to the family landing page, which explains the plan and carries the
@@ -151,13 +157,14 @@ class ApplicationController < ActionController::Base
   def ensure_family_feature_available!
     return if family_feature_available?
 
+    message = I18n.t('controllers.application.family_plan_required')
     respond_to do |format|
-      format.html { redirect_to new_family_path, alert: FAMILY_PLAN_REQUIRED_MESSAGE, status: :see_other }
+      format.html { redirect_to new_family_path, alert: message, status: :see_other }
       format.turbo_stream do
-        redirect_to new_family_path, alert: FAMILY_PLAN_REQUIRED_MESSAGE, status: :see_other
+        redirect_to new_family_path, alert: message, status: :see_other
       end
       format.json do
-        render json: { error: 'family_plan_required', message: FAMILY_PLAN_REQUIRED_MESSAGE },
+        render json: { error: 'family_plan_required', message: message },
                status: :forbidden
       end
     end
@@ -169,7 +176,7 @@ class ApplicationController < ActionController::Base
     return unless current_user&.deleted?
 
     sign_out current_user
-    redirect_to root_path, alert: 'Your account has been deleted.'
+    redirect_to root_path, alert: I18n.t('controllers.application.your_account_has_been_deleted')
   end
 
   def set_user_time_zone(&block)
@@ -199,7 +206,7 @@ class ApplicationController < ActionController::Base
 
   def user_not_authorized
     redirect_back fallback_location: root_path,
-                  alert: 'You are not authorized to perform this action.',
+                  alert: I18n.t('controllers.application.you_are_not_authorized_to_perform_this_action'),
                   status: :see_other
   end
 end

--- a/app/controllers/areas_controller.rb
+++ b/app/controllers/areas_controller.rb
@@ -12,7 +12,7 @@ class AreasController < ApplicationController
     if @area.save
       respond_to do |format|
         format.turbo_stream do
-          render turbo_stream: stream_flash(:success, 'Area created successfully!')
+          render turbo_stream: stream_flash(:success, I18n.t('controllers.areas.created'))
         end
       end
     else
@@ -28,7 +28,7 @@ class AreasController < ApplicationController
     if @area.update(area_params)
       respond_to do |format|
         format.turbo_stream do
-          render turbo_stream: stream_flash(:success, 'Area updated successfully!')
+          render turbo_stream: stream_flash(:success, I18n.t('controllers.areas.updated'))
         end
       end
     else

--- a/app/controllers/auth/account_links_controller.rb
+++ b/app/controllers/auth/account_links_controller.rb
@@ -12,20 +12,26 @@ class Auth::AccountLinksController < ApplicationController
       begin
         Auth::VerifyAccountLinkToken.new(params[:token]).call
       rescue Auth::VerifyAccountLinkToken::TokenReplayed
-        return redirect_to(new_user_session_path, alert: 'This link has already been used.')
+        return redirect_to(new_user_session_path,
+                           alert: I18n.t('controllers.auth.account_links.this_link_has_already_been_used'))
       rescue Auth::VerifyAccountLinkToken::InvalidToken
-        return redirect_to(new_user_session_path, alert: 'Link invalid or expired.')
+        return redirect_to(new_user_session_path,
+                           alert: I18n.t('controllers.auth.account_links.link_invalid_or_expired'))
       end
 
     user = result.user
 
     if user.provider.present? && (user.provider != result.provider || user.uid != result.uid)
       return redirect_to(new_user_session_path,
-                         alert: "This account is already linked to a different #{user.provider} identity.")
+                         alert: I18n.t(
+                           'controllers.auth.account_links.already_linked_to_different_identity',
+                           provider: user.provider
+                         ))
     end
 
     unless Auth::VerifyAccountLinkToken.consume!(result.jti)
-      return redirect_to(new_user_session_path, alert: 'This link has already been used.')
+      return redirect_to(new_user_session_path,
+                         alert: I18n.t('controllers.auth.account_links.this_link_has_already_been_used'))
     end
 
     user.update!(provider: result.provider, uid: result.uid)
@@ -33,22 +39,32 @@ class Auth::AccountLinksController < ApplicationController
     if user.otp_required_for_login?
       redirect_to(
         new_user_session_path,
-        notice: "#{provider_label(result.provider)} is now linked to your account. " \
-                'Sign in with your password and 2FA code to continue.'
+        notice: I18n.t(
+          'controllers.auth.account_links.linked_sign_in_with_two_factor',
+          provider: provider_label(result.provider)
+        )
       )
     else
       sign_in(user)
       claim_pending_import_for(user)
-      redirect_to root_path, notice: "#{provider_label(result.provider)} is now linked to your account."
+      redirect_to root_path,
+                  notice: I18n.t('controllers.auth.account_links.provider_is_now_linked_to_your_account',
+                                 provider: provider_label(result.provider))
     end
   end
 
   def challenge
     pending = pending_oauth_link
-    return redirect_to(new_user_session_path, alert: 'No pending account link.') unless pending
+    unless pending
+      return redirect_to(new_user_session_path,
+                         alert: I18n.t('controllers.auth.account_links.no_pending_account_link'))
+    end
 
     user = User.find_by(id: pending['user_id'])
-    return redirect_to(new_user_session_path, alert: 'Account no longer exists.') unless user
+    unless user
+      return redirect_to(new_user_session_path,
+                         alert: I18n.t('controllers.auth.account_links.account_no_longer_exists'))
+    end
 
     @user_email = user.email
     @provider_label = label_for(pending)
@@ -56,21 +72,28 @@ class Auth::AccountLinksController < ApplicationController
 
   def confirm
     pending = pending_oauth_link
-    return redirect_to(new_user_session_path, alert: 'No pending account link.') unless pending
+    unless pending
+      return redirect_to(new_user_session_path,
+                         alert: I18n.t('controllers.auth.account_links.no_pending_account_link'))
+    end
 
     user = User.find_by(id: pending['user_id'])
-    return redirect_to(new_user_session_path, alert: 'Account no longer exists.') unless user
+    unless user
+      return redirect_to(new_user_session_path,
+                         alert: I18n.t('controllers.auth.account_links.account_no_longer_exists'))
+    end
 
     unless user.valid_password?(params[:password].to_s)
       session[:pending_oauth_link_attempts] = (session[:pending_oauth_link_attempts] || 0) + 1
 
       if session[:pending_oauth_link_attempts] >= MAX_FAILED_PASSWORD_ATTEMPTS
         clear_pending_oauth_link
+        alert = I18n.t('controllers.auth.account_links.too_many_invalid_attempts_start_the_linking_flow_again')
         return redirect_to new_user_session_path,
-                           alert: 'Too many invalid attempts. Start the linking flow again.'
+                           alert: alert
       end
 
-      flash.now[:alert] = 'Incorrect password.'
+      flash.now[:alert] = I18n.t('controllers.auth.account_links.incorrect_password')
       @user_email = user.email
       @provider_label = label_for(pending)
       return render :challenge, status: :unprocessable_entity
@@ -81,22 +104,31 @@ class Auth::AccountLinksController < ApplicationController
 
     if user.otp_required_for_login?
       redirect_to new_user_session_path,
-                  notice: "#{label_for(pending)} is now linked to your account. " \
-                          'Sign in with your password and 2FA code to continue.'
+                  notice: I18n.t(
+                    'controllers.auth.account_links.linked_sign_in_with_two_factor',
+                    provider: label_for(pending)
+                  )
     else
       sign_in(user)
       claim_pending_import_for(user)
       redirect_to root_path,
-                  notice: "#{label_for(pending)} is now linked to your account."
+                  notice: I18n.t('controllers.auth.account_links.pending_is_now_linked_to_your_account',
+                                 pending: label_for(pending))
     end
   end
 
   def email_fallback
     pending = pending_oauth_link
-    return redirect_to(new_user_session_path, alert: 'No pending account link.') unless pending
+    unless pending
+      return redirect_to(new_user_session_path,
+                         alert: I18n.t('controllers.auth.account_links.no_pending_account_link'))
+    end
 
     user = User.find_by(id: pending['user_id'])
-    return redirect_to(new_user_session_path, alert: 'Account no longer exists.') unless user
+    unless user
+      return redirect_to(new_user_session_path,
+                         alert: I18n.t('controllers.auth.account_links.account_no_longer_exists'))
+    end
 
     cache_key = "#{Auth::FindOrCreateOauthUser::LINK_EMAIL_RATE_LIMIT_KEY_PREFIX}#{user.id}"
     acquired = Rails.cache.write(cache_key, true,
@@ -115,8 +147,7 @@ class Auth::AccountLinksController < ApplicationController
     end
 
     redirect_to new_user_session_path,
-                notice: "We sent a confirmation link to #{user.email}. " \
-                        'Click it to link your account.'
+                notice: I18n.t('controllers.auth.account_links.confirmation_link_sent', email: user.email)
   end
 
   private
@@ -145,11 +176,11 @@ class Auth::AccountLinksController < ApplicationController
 
   def provider_label(provider)
     {
-      'apple' => 'Sign in with Apple',
-      'google' => 'Google',
-      'google_oauth2' => 'Google',
-      'github' => 'GitHub',
-      'openid_connect' => defined?(OIDC_PROVIDER_NAME) ? OIDC_PROVIDER_NAME : 'OpenID Connect'
+      'apple' => I18n.t('oauth_providers.sign_in_with_apple'),
+      'google' => I18n.t('oauth_providers.google'),
+      'google_oauth2' => I18n.t('oauth_providers.google'),
+      'github' => I18n.t('oauth_providers.github'),
+      'openid_connect' => defined?(OIDC_PROVIDER_NAME) ? OIDC_PROVIDER_NAME : I18n.t('oauth_providers.openid_connect')
     }.fetch(provider.to_s, provider.to_s.titleize)
   end
 end

--- a/app/controllers/auth/ios_controller.rb
+++ b/app/controllers/auth/ios_controller.rb
@@ -6,12 +6,12 @@ module Auth
       # If token is provided, this is the final callback for ASWebAuthenticationSession
       if params[:token].present?
         # ASWebAuthenticationSession will capture this URL and extract the token
-        render plain: 'Authentication successful! You can close this window.', status: :ok
+        render plain: I18n.t('controllers.auth.ios.authentication_successful_you_can_close_this_window'), status: :ok
       else
         # This should not happen with our current flow, but keeping for safety
         render json: {
           success: true,
-          message: 'iOS authentication successful',
+          message: I18n.t('controllers.auth.ios.ios_authentication_successful'),
           redirect_url: root_url
         }, status: :ok
       end

--- a/app/controllers/concerns/account_deletion_confirmable.rb
+++ b/app/controllers/concerns/account_deletion_confirmable.rb
@@ -13,9 +13,9 @@ module AccountDeletionConfirmable
 
   def account_deletion_confirmation_error(user)
     if user.oauth_user?
-      'Type your email address to confirm deletion.'
+      I18n.t('controllers.concerns.account_deletion_confirmable.confirm_with_email')
     else
-      'Provide your current password to delete your account.'
+      I18n.t('controllers.concerns.account_deletion_confirmable.confirm_with_password')
     end
   end
 

--- a/app/controllers/concerns/pending_import_claimable.rb
+++ b/app/controllers/concerns/pending_import_claimable.rb
@@ -3,9 +3,6 @@
 module PendingImportClaimable
   extend ActiveSupport::Concern
 
-  EXPIRED_MESSAGE =
-    'Your import link has expired or already been used. You can re-upload from your dashboard.'
-
   private
 
   def claim_pending_import_for(user)
@@ -14,17 +11,20 @@ module PendingImportClaimable
 
     pending = PendingImport.claimable.find_by(claim_ticket: ticket)
     unless pending
-      flash[:alert] = EXPIRED_MESSAGE
+      flash[:alert] = I18n.t('controllers.concerns.pending_import_claimable.expired')
       return
     end
 
     case attempt_claim(pending, user)
     when :claimed
-      flash[:notice] = "Importing #{pending.original_filename}... You'll see it in your dashboard shortly."
+      flash[:notice] = I18n.t(
+        'controllers.concerns.pending_import_claimable.importing',
+        filename: pending.original_filename
+      )
     when :already_claimed
-      flash[:alert] = EXPIRED_MESSAGE
+      flash[:alert] = I18n.t('controllers.concerns.pending_import_claimable.expired')
     else
-      flash[:alert] = "Your import couldn't be queued. Please upload the file from your dashboard."
+      flash[:alert] = I18n.t('controllers.concerns.pending_import_claimable.queue_failed')
     end
   end
 

--- a/app/controllers/concerns/share_links/managable.rb
+++ b/app/controllers/concerns/share_links/managable.rb
@@ -26,7 +26,9 @@ module ShareLinks
       end
 
       if saved
-        respond_with_hub_or(redirect_after_action_path, active_tab: hub_tab, notice: 'Share link created.')
+        notice = I18n.t('controllers.concerns.share_links.managable.created')
+        respond_with_hub_or(redirect_after_action_path, active_tab: hub_tab,
+                                                        notice: notice)
       elsif hub_request?
         render turbo_stream: render_hub_streams(hub_tab, errors: @shared_link.errors.full_messages),
                status: :unprocessable_content
@@ -40,7 +42,9 @@ module ShareLinks
       return ensure_share! unless @share
 
       @share.destroy!
-      respond_with_hub_or(redirect_after_action_path, active_tab: hub_tab, notice: 'Share link deleted.')
+      notice = I18n.t('controllers.concerns.share_links.managable.deleted')
+      respond_with_hub_or(redirect_after_action_path, active_tab: hub_tab,
+                                                      notice: notice)
     end
 
     def revoke
@@ -48,7 +52,9 @@ module ShareLinks
 
       @share.update!(revoked_at: Time.current)
       broadcast_live_share_ended(@share)
-      respond_with_hub_or(redirect_after_action_path, active_tab: hub_tab, notice: 'Share link revoked.')
+      notice = I18n.t('controllers.concerns.share_links.managable.revoked')
+      respond_with_hub_or(redirect_after_action_path, active_tab: hub_tab,
+                                                      notice: notice)
     end
 
     def regenerate
@@ -66,7 +72,9 @@ module ShareLinks
         broadcast_live_share_ended(@share)
         @share.destroy!
       end
-      respond_with_hub_or(redirect_after_action_path, active_tab: hub_tab, notice: 'URL regenerated.')
+      notice = I18n.t('controllers.concerns.share_links.managable.url_regenerated')
+      respond_with_hub_or(redirect_after_action_path, active_tab: hub_tab,
+                                                      notice: notice)
     end
 
     def regenerate_phrase
@@ -74,7 +82,11 @@ module ShareLinks
 
       @share.update!(magic_phrase: SharedLink::PhraseGenerator.call)
       broadcast_live_share_ended(@share)
-      respond_with_hub_or(redirect_after_action_path, active_tab: hub_tab, notice: 'Magic phrase regenerated.')
+      respond_with_hub_or(
+        redirect_after_action_path,
+        active_tab: hub_tab,
+        notice: I18n.t('controllers.concerns.share_links.managable.magic_phrase_regenerated')
+      )
     end
 
     private
@@ -103,7 +115,7 @@ module ShareLinks
     end
 
     def ensure_share!
-      redirect_to fallback_path, alert: 'No active share link.'
+      redirect_to fallback_path, alert: I18n.t('controllers.concerns.share_links.managable.no_active_share_link')
     end
 
     def revoke_existing_active_shares!

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -25,19 +25,21 @@ class ExportsController < ApplicationController
       end_at: params[:end_at]
     )
 
-    redirect_to exports_url, notice: 'Export was successfully initiated. Please wait until it\'s finished.'
+    redirect_to exports_url,
+                notice: I18n.t('controllers.exports.export_was_successfully_initiated_please_wait_until_it_s_finished')
   rescue StandardError => e
     export&.destroy
 
     ExceptionReporter.call(e)
 
-    redirect_to exports_url, alert: 'Export failed to initiate. Please try again.', status: :unprocessable_content
+    redirect_to exports_url, alert: I18n.t('controllers.exports.export_failed_to_initiate_please_try_again'),
+status: :unprocessable_content
   end
 
   def destroy
     @export.destroy
 
-    redirect_to exports_url, notice: 'Export was successfully destroyed.', status: :see_other
+    redirect_to exports_url, notice: I18n.t('controllers.exports.export_was_successfully_destroyed'), status: :see_other
   end
 
   private

--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -56,7 +56,7 @@ class FamiliesController < ApplicationController
     )
 
     if service.call
-      redirect_to family_path, notice: 'Family created successfully!'
+      redirect_to family_path, notice: I18n.t('controllers.families.family_created_successfully')
     else
       @family = Family.new(family_params)
 
@@ -68,7 +68,7 @@ class FamiliesController < ApplicationController
 
       @family.errors.add(:base, service.error_message) if service.error_message.present?
 
-      flash.now[:alert] = service.error_message || 'Failed to create family'
+      flash.now[:alert] = service.error_message || I18n.t('controllers.families.failed_to_create_family')
       render :new, status: :unprocessable_content
     end
   end
@@ -81,7 +81,7 @@ class FamiliesController < ApplicationController
     authorize @family
 
     if @family.update(family_params)
-      redirect_to family_path, notice: 'Family updated successfully!'
+      redirect_to family_path, notice: I18n.t('controllers.families.family_updated_successfully')
     else
       render :edit, status: :unprocessable_content
     end
@@ -91,10 +91,11 @@ class FamiliesController < ApplicationController
     authorize @family
 
     if @family.members.count > 1
-      redirect_to family_home_path, alert: 'Cannot delete family with members. Remove all members first.'
+      redirect_to family_home_path,
+                  alert: I18n.t('controllers.families.cannot_delete_family_with_members_remove_all_members_first')
     else
       @family.destroy
-      redirect_to new_family_path, notice: 'Family deleted successfully!'
+      redirect_to new_family_path, notice: I18n.t('controllers.families.family_deleted_successfully')
     end
   end
 
@@ -102,7 +103,7 @@ class FamiliesController < ApplicationController
 
   def set_family
     @family = current_user.family
-    redirect_to new_family_path, alert: 'You are not in a family' unless @family
+    redirect_to new_family_path, alert: I18n.t('controllers.families.you_are_not_in_a_family') unless @family
   end
 
   def family_params

--- a/app/controllers/family/invitations_controller.rb
+++ b/app/controllers/family/invitations_controller.rb
@@ -18,9 +18,15 @@ class Family::InvitationsController < ApplicationController
     token = params[:token] || params[:id]
     @invitation = Family::Invitation.find_by!(token: token)
 
-    redirect_to root_path, alert: 'This invitation has expired.' and return if @invitation.expired?
+    if @invitation.expired?
+      redirect_to root_path,
+                  alert: I18n.t('controllers.family.invitations.this_invitation_has_expired') and return
+    end
 
-    redirect_to root_path, alert: 'This invitation is no longer valid.' and return unless @invitation.pending?
+    unless @invitation.pending?
+      redirect_to root_path,
+                  alert: I18n.t('controllers.family.invitations.this_invitation_is_no_longer_valid') and return
+    end
 
     # Warns the invitee up front instead of letting them click Accept only to
     # be refused by the plan validation in Families::AcceptInvitation.
@@ -37,9 +43,10 @@ class Family::InvitationsController < ApplicationController
     )
 
     if service.call
-      redirect_to family_path, notice: 'Invitation sent successfully!'
+      redirect_to family_path, notice: I18n.t('controllers.family.invitations.invitation_sent_successfully')
     else
-      redirect_to family_path, alert: service.error_message || 'Failed to send invitation'
+      redirect_to family_path,
+                  alert: service.error_message || I18n.t('controllers.family.invitations.failed_to_send_invitation')
     end
   end
 
@@ -48,13 +55,16 @@ class Family::InvitationsController < ApplicationController
 
     begin
       if @invitation.update(status: :cancelled)
-        redirect_to family_home_path, notice: 'Invitation cancelled'
+        redirect_to family_home_path, notice: I18n.t('controllers.family.invitations.invitation_cancelled')
       else
-        redirect_to family_home_path, alert: 'Failed to cancel invitation. Please try again'
+        redirect_to family_home_path,
+                    alert: I18n.t('controllers.family.invitations.failed_to_cancel_invitation_please_try_again')
       end
     rescue StandardError => e
       Rails.logger.error "Error cancelling family invitation: #{e.message}"
-      redirect_to family_home_path, alert: 'An unexpected error occurred while cancelling the invitation'
+      alert = I18n.t('controllers.family.invitations.an_unexpected_error_occurred_while_cancelling_the_invitation')
+      redirect_to family_home_path,
+                  alert: alert
     end
   end
 
@@ -63,7 +73,10 @@ class Family::InvitationsController < ApplicationController
   def set_family
     @family = current_user.family
 
-    redirect_to new_family_path, alert: 'You are not in a family' and return unless @family
+    return if @family
+
+    redirect_to new_family_path,
+                alert: I18n.t('controllers.family.invitations.you_are_not_in_a_family') and return
   end
 
   def set_invitation_by_id_and_family

--- a/app/controllers/family/location_requests_controller.rb
+++ b/app/controllers/family/location_requests_controller.rb
@@ -11,14 +11,14 @@ class Family::LocationRequestsController < ApplicationController
     target = current_user.family&.members&.find_by(id: params[:target_user_id])
 
     unless target
-      redirect_to family_path, alert: 'User not found in your family'
+      redirect_to family_path, alert: I18n.t('controllers.family.location_requests.user_not_found_in_your_family')
       return
     end
 
     result = Families::CreateLocationRequest.new(requester: current_user, target_user: target).call
 
     if result.success?
-      redirect_to family_path, notice: 'Location request sent successfully'
+      redirect_to family_path, notice: I18n.t('controllers.family.location_requests.location_request_sent_successfully')
     else
       redirect_to family_path, alert: result.payload[:message]
     end
@@ -30,7 +30,9 @@ class Family::LocationRequestsController < ApplicationController
 
   def accept
     unless actionable?
-      redirect_to family_path, alert: 'This request has expired or already been responded to'
+      alert = I18n.t('controllers.family.location_requests.this_request_has_expired_or_already_been_responded_to')
+      redirect_to family_path,
+                  alert: alert
       return
     end
 
@@ -40,18 +42,20 @@ class Family::LocationRequestsController < ApplicationController
       @request.update!(status: :accepted, responded_at: Time.current)
     end
 
-    redirect_to family_path, notice: 'Location sharing enabled'
+    redirect_to family_path, notice: I18n.t('controllers.family.location_requests.location_sharing_enabled')
   end
 
   def decline
     unless actionable?
-      redirect_to family_path, alert: 'This request has expired or already been responded to'
+      alert = I18n.t('controllers.family.location_requests.this_request_has_expired_or_already_been_responded_to')
+      redirect_to family_path,
+                  alert: alert
       return
     end
 
     @request.update!(status: :declined, responded_at: Time.current)
 
-    redirect_to family_path, notice: 'Location request declined'
+    redirect_to family_path, notice: I18n.t('controllers.family.location_requests.location_request_declined')
   end
 
   private
@@ -63,13 +67,14 @@ class Family::LocationRequestsController < ApplicationController
   def authorize_target_user!
     return if @request.target_user == current_user
 
-    redirect_to family_path, alert: 'You are not authorized to view this request'
+    redirect_to family_path,
+                alert: I18n.t('controllers.family.location_requests.you_are_not_authorized_to_view_this_request')
   end
 
   def ensure_user_in_family!
     return if current_user&.in_family?
 
-    redirect_to root_path, alert: 'You must be part of a family'
+    redirect_to root_path, alert: I18n.t('controllers.family.location_requests.you_must_be_part_of_a_family')
   end
 
   def actionable?

--- a/app/controllers/family/location_sharing_controller.rb
+++ b/app/controllers/family/location_sharing_controller.rb
@@ -46,9 +46,15 @@ class Family::LocationSharingController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: stream_flash(:error, 'User is not part of a family'), status: :not_found
+        render turbo_stream: stream_flash(
+          :error,
+          I18n.t('controllers.family.location_sharing.user_is_not_part_of_a_family')
+        ), status: :not_found
       end
-      format.json { render json: { error: 'User is not part of a family' }, status: :not_found }
+      format.json do
+        render json: { error: I18n.t('controllers.family.location_sharing.user_is_not_part_of_a_family') },
+               status: :not_found
+      end
     end
   end
 end

--- a/app/controllers/family/memberships_controller.rb
+++ b/app/controllers/family/memberships_controller.rb
@@ -21,26 +21,28 @@ class Family::MembershipsController < ApplicationController
     )
 
     if service.call
-      redirect_to family_path, notice: 'Welcome to the family!'
+      redirect_to family_path, notice: I18n.t('controllers.family.memberships.welcome_to_the_family')
     else
-      redirect_to root_path, alert: service.error_message || 'Unable to accept invitation'
+      redirect_to root_path,
+                  alert: service.error_message || I18n.t('controllers.family.memberships.unable_to_accept_invitation')
     end
   rescue Pundit::NotAuthorizedError
     alert = if @invitation.expired?
-              'This invitation is no longer valid or has expired'
+              I18n.t('controllers.family.memberships.invitation_expired')
             elsif !@invitation.pending?
-              'This invitation has already been processed'
+              I18n.t('controllers.family.memberships.invitation_processed')
             elsif @invitation.email != current_user.email
-              'This invitation is not for your email address'
+              I18n.t('controllers.family.memberships.invitation_email_mismatch')
             else
-              'You are not authorized to accept this invitation'
+              I18n.t('controllers.family.memberships.not_authorized_to_accept')
             end
 
     redirect_to root_path, alert: alert
   rescue StandardError => e
     Rails.logger.error "Error accepting family invitation: #{e.message}"
 
-    redirect_to root_path, alert: 'An unexpected error occurred. Please try again later'
+    redirect_to root_path,
+                alert: I18n.t('controllers.family.memberships.an_unexpected_error_occurred_please_try_again_later')
   end
 
   def destroy
@@ -51,12 +53,15 @@ class Family::MembershipsController < ApplicationController
 
     if service.call
       if member_user == current_user
-        redirect_to new_family_path, notice: 'You have left the family'
+        redirect_to new_family_path, notice: I18n.t('controllers.family.memberships.you_have_left_the_family')
       else
-        redirect_to family_home_path, notice: "#{member_user.email} has been removed from the family"
+        redirect_to family_home_path,
+                    notice: I18n.t('controllers.family.memberships.email_has_been_removed_from_the_family',
+                                   email: member_user.email)
       end
     else
-      redirect_to family_home_path, alert: service.error_message || 'Failed to remove member'
+      redirect_to family_home_path,
+                  alert: service.error_message || I18n.t('controllers.family.memberships.failed_to_remove_member')
     end
   end
 
@@ -65,7 +70,10 @@ class Family::MembershipsController < ApplicationController
   def set_family
     @family = current_user.family
 
-    redirect_to new_family_path, alert: 'You are not in a family' and return unless @family
+    return if @family
+
+    redirect_to new_family_path,
+                alert: I18n.t('controllers.family.memberships.you_are_not_in_a_family') and return
   end
 
   def set_membership

--- a/app/controllers/imports/extractions_controller.rb
+++ b/app/controllers/imports/extractions_controller.rb
@@ -19,7 +19,9 @@ module Imports
 
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to import_path(@import), notice: 'Extraction queued.' }
+        format.html do
+          redirect_to import_path(@import), notice: I18n.t('controllers.imports.extractions.extraction_queued')
+        end
       end
     end
 
@@ -35,7 +37,9 @@ module Imports
 
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to import_path(@import), notice: 'Removing extracted data…' }
+        format.html do
+          redirect_to import_path(@import), notice: I18n.t('controllers.imports.extractions.removing_extracted_data')
+        end
       end
     end
 

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -37,7 +37,7 @@ class ImportsController < ApplicationController
   def update
     @import.update(import_params)
 
-    redirect_to imports_url, notice: 'Import was successfully updated.', status: :see_other
+    redirect_to imports_url, notice: I18n.t('controllers.imports.import_was_successfully_updated'), status: :see_other
   end
 
   def create
@@ -47,7 +47,8 @@ class ImportsController < ApplicationController
 
     raw_files = extract_raw_files
     if raw_files.empty?
-      redirect_to new_import_path, alert: 'No files were selected for upload', status: :unprocessable_content and return
+      redirect_to new_import_path, alert: I18n.t('controllers.imports.no_files_were_selected_for_upload'),
+status: :unprocessable_content and return
     end
 
     @created_imports = []
@@ -55,12 +56,13 @@ class ImportsController < ApplicationController
 
     unless @created_imports.any?
       redirect_to(new_import_path,
-                  alert: 'No valid file references were found. Please upload files using the file selector.',
+                  alert: I18n.t('controllers.imports.no_valid_file_references_were_found_please_upload_files_using'),
                   status: :unprocessable_content) and return
     end
 
     redirect_to imports_url,
-                notice: "#{@created_imports.size} files are queued to be imported in background",
+                notice: I18n.t('controllers.imports.size_files_are_queued_to_be_imported_in_background',
+                               size: @created_imports.size),
                 status: :see_other
   rescue StandardError => e
     cleanup_failed_imports
@@ -74,7 +76,9 @@ class ImportsController < ApplicationController
     Imports::DestroyJob.perform_later(@import.id)
 
     respond_to do |format|
-      format.html { redirect_to imports_url, notice: 'Import is being deleted.', status: :see_other }
+      format.html do
+        redirect_to imports_url, notice: I18n.t('controllers.imports.import_is_being_deleted'), status: :see_other
+      end
       format.turbo_stream
     end
   end
@@ -149,6 +153,9 @@ class ImportsController < ApplicationController
   def validate_points_limit
     limit_exceeded = PointsLimitExceeded.new(current_user).call
 
-    redirect_to imports_path, alert: 'Points limit exceeded', status: :unprocessable_content if limit_exceeded
+    return unless limit_exceeded
+
+    redirect_to imports_path, alert: I18n.t('controllers.imports.points_limit_exceeded'),
+status: :unprocessable_content
   end
 end

--- a/app/controllers/insights_controller.rb
+++ b/app/controllers/insights_controller.rb
@@ -58,13 +58,13 @@ class InsightsController < ApplicationController
     if @all_time
       @year_stats = current_user.scoped_stats.order(year: :desc, month: :desc)
       @previous_year_stats = Stat.none
-      @display_label = 'All Time'
+      @display_label = I18n.t('controllers.insights.all_time')
     else
       @selected_year = @selected_year.to_i
       @previous_year = @selected_year - 1
       @year_stats = current_user.scoped_stats.where(year: @selected_year).order(:month)
       @previous_year_stats = current_user.scoped_stats.where(year: @previous_year).order(:month)
-      @display_label = "#{@selected_year} Overview"
+      @display_label = I18n.t('controllers.insights.year_overview', year: @selected_year)
     end
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -15,17 +15,22 @@ class NotificationsController < ApplicationController
 
   def mark_as_read
     current_user.notifications.unread.update_all(read_at: Time.zone.now)
-    redirect_to notifications_url, notice: 'All notifications marked as read.', status: :see_other
+    redirect_to notifications_url, notice: I18n.t('controllers.notifications.all_notifications_marked_as_read'),
+status: :see_other
   end
 
   def destroy_all
     current_user.notifications.destroy_all
-    redirect_to notifications_url, notice: 'All notifications where successfully destroyed.', status: :see_other
+    notice = I18n.t('controllers.notifications.all_notifications_where_successfully_destroyed')
+    redirect_to notifications_url,
+                notice: notice, status: :see_other
   end
 
   def destroy
     @notification.destroy!
-    redirect_to notifications_url, notice: 'Notification was successfully destroyed.', status: :see_other
+    notice = I18n.t('controllers.notifications.notification_was_successfully_destroyed')
+    redirect_to notifications_url, notice: notice,
+status: :see_other
   end
 
   private

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -29,7 +29,7 @@ class PlacesController < ApplicationController
         format.turbo_stream do
           render turbo_stream: [
             turbo_stream.replace('place-creation-data', html: place_data_element),
-            stream_flash(:success, 'Place created successfully!')
+            stream_flash(:success, I18n.t('controllers.places.created'))
           ]
         end
       end
@@ -58,12 +58,12 @@ class PlacesController < ApplicationController
                 partial: 'places/drawer',
                 locals: { place: @place, recent_visits: recent_visits }
               ),
-              stream_flash(:success, 'Place updated successfully!')
+              stream_flash(:success, I18n.t('controllers.places.updated'))
             ]
           else
             render turbo_stream: [
               turbo_stream.replace('place-creation-data', html: place_data_element(updated: true)),
-              stream_flash(:success, 'Place updated successfully!')
+              stream_flash(:success, I18n.t('controllers.places.updated'))
             ]
           end
         end
@@ -97,7 +97,8 @@ class PlacesController < ApplicationController
   def destroy
     @place.destroy!
 
-    redirect_to places_url(page: params[:page]), notice: 'Place was successfully destroyed.', status: :see_other
+    redirect_to places_url(page: params[:page]), notice: I18n.t('controllers.places.place_was_successfully_destroyed'),
+status: :see_other
   end
 
   private

--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -29,14 +29,14 @@ class PointsController < ApplicationController
 
     if point_ids.blank?
       redirect_to points_url(preserved_params),
-                  alert: 'No points selected.',
+                  alert: I18n.t('controllers.points.no_points_selected'),
                   status: :see_other and return
     end
 
     Points::Destroyer.new(current_user, point_ids).call
 
     redirect_to points_url(preserved_params),
-                notice: 'Points were successfully destroyed.',
+                notice: I18n.t('controllers.points.points_were_successfully_destroyed'),
                 status: :see_other
   end
 

--- a/app/controllers/posters_controller.rb
+++ b/app/controllers/posters_controller.rb
@@ -7,7 +7,7 @@ class PostersController < ApplicationController
 
   def create
     poster = current_user.posters.create!(
-      name: poster_params[:name].presence || 'Untitled poster',
+      name: poster_params[:name].presence || I18n.t('controllers.posters.untitled'),
       status: :created,
       settings: poster_params.except(:name).to_h
     )
@@ -16,21 +16,25 @@ class PostersController < ApplicationController
       format.turbo_stream do
         render turbo_stream: [
           turbo_stream.prepend('poster-gallery-list', partial: 'posters/poster', locals: { poster: poster }),
-          stream_flash(:notice, 'Poster generation started. This takes about a minute.')
+          stream_flash(:notice, I18n.t('controllers.posters.poster_generation_started_this_takes_about_a_minute'))
         ]
       end
-      format.html { redirect_to map_v2_path, notice: 'Poster generation started. This takes about a minute.' }
+      format.html do
+        redirect_to map_v2_path,
+                    notice: I18n.t('controllers.posters.poster_generation_started_this_takes_about_a_minute')
+      end
     end
   rescue StandardError => e
     ExceptionReporter.call(e, 'Poster creation failed')
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: stream_flash(:error, 'Failed to start poster generation.'),
+        render turbo_stream: stream_flash(:error, I18n.t('controllers.posters.failed_to_start_poster_generation')),
                status: :unprocessable_content
       end
       format.html do
-        redirect_to map_v2_path, alert: 'Failed to start poster generation.', status: :unprocessable_content
+        redirect_to map_v2_path, alert: I18n.t('controllers.posters.failed_to_start_poster_generation'),
+status: :unprocessable_content
       end
     end
   end
@@ -43,7 +47,7 @@ class PostersController < ApplicationController
       format.turbo_stream do
         render turbo_stream: turbo_stream.remove(ActionView::RecordIdentifier.dom_id(poster))
       end
-      format.html { redirect_to map_v2_path, notice: 'Poster deleted.', status: :see_other }
+      format.html { redirect_to map_v2_path, notice: I18n.t('controllers.posters.poster_deleted'), status: :see_other }
     end
   end
 

--- a/app/controllers/settings/background_jobs_controller.rb
+++ b/app/controllers/settings/background_jobs_controller.rb
@@ -14,16 +14,17 @@ class Settings::BackgroundJobsController < ApplicationController
     updated_settings = existing_settings.merge(settings_params)
 
     if current_user.update(settings: updated_settings)
-      redirect_to settings_background_jobs_path, notice: 'Settings updated'
+      redirect_to settings_background_jobs_path, notice: I18n.t('controllers.settings.background_jobs.settings_updated')
     else
-      redirect_to settings_background_jobs_path, alert: 'Settings could not be updated'
+      redirect_to settings_background_jobs_path,
+                  alert: I18n.t('controllers.settings.background_jobs.settings_could_not_be_updated')
     end
   end
 
   def create
     EnqueueBackgroundJob.perform_later(params[:job_name], current_user.id)
 
-    flash.now[:notice] = 'Job was successfully created.'
+    flash.now[:notice] = I18n.t('controllers.settings.background_jobs.job_was_successfully_created')
 
     redirect_path =
       case params[:job_name]
@@ -35,7 +36,7 @@ class Settings::BackgroundJobsController < ApplicationController
         settings_background_jobs_path
       end
 
-    redirect_to redirect_path, notice: 'Job was successfully created.'
+    redirect_to redirect_path, notice: I18n.t('controllers.settings.background_jobs.job_was_successfully_created')
   end
 
   private

--- a/app/controllers/settings/general_controller.rb
+++ b/app/controllers/settings/general_controller.rb
@@ -11,9 +11,9 @@ class Settings::GeneralController < ApplicationController
     update_supporter_settings
 
     if current_user.save
-      redirect_to settings_general_index_path, notice: 'Settings updated'
+      redirect_to settings_general_index_path, notice: I18n.t('controllers.settings.general.settings_updated')
     else
-      redirect_to settings_general_index_path, alert: 'Failed to update settings'
+      redirect_to settings_general_index_path, alert: I18n.t('controllers.settings.general.failed_to_update_settings')
     end
   end
 
@@ -23,7 +23,7 @@ class Settings::GeneralController < ApplicationController
 
     if email.blank? && github_username.blank?
       return redirect_to settings_general_index_path,
-                         alert: 'Please enter an email address or GitHub username'
+                         alert: I18n.t('controllers.settings.general.please_enter_an_email_address_or_github_username')
     end
 
     current_user.settings['supporter_email'] = email if email.present?
@@ -36,12 +36,15 @@ class Settings::GeneralController < ApplicationController
 
     if current_user.reload.supporter?
       platform = current_user.supporter_platform&.titleize
+      notice = I18n.t(
+        'controllers.settings.general.verified_thank_you_for_supporting_dawarich_via_platform',
+        platform: platform
+      )
       redirect_to settings_general_index_path,
-                  notice: "Verified! Thank you for supporting Dawarich via #{platform}."
+                  notice: notice
     else
       redirect_to settings_general_index_path,
-                  alert: 'Not found in supporter list. '\
-                         'Make sure you\'re using the same email or GitHub username as your donation platform.'
+                  alert: I18n.t('controllers.settings.general.not_found_in_supporter_list_make_sure_you_re_using')
     end
   end
 

--- a/app/controllers/settings/maps_controller.rb
+++ b/app/controllers/settings/maps_controller.rb
@@ -15,7 +15,7 @@ class Settings::MapsController < ApplicationController
       current_user.settings['maps'].to_h.merge(settings_params.to_h)
     current_user.save!
 
-    redirect_to settings_maps_path, notice: 'Settings updated'
+    redirect_to settings_maps_path, notice: I18n.t('controllers.settings.maps.settings_updated')
   end
 
   private

--- a/app/controllers/settings/onboardings_controller.rb
+++ b/app/controllers/settings/onboardings_controller.rb
@@ -15,11 +15,12 @@ module Settings
 
       case result[:status]
       when :created
-        redirect_to demo_data_landing_path, notice: 'Demo data loaded.'
+        redirect_to demo_data_landing_path, notice: I18n.t('controllers.settings.onboardings.demo_data_loaded')
       when :exists
-        redirect_to demo_data_landing_path, notice: 'Demo data is already loaded.'
+        redirect_to demo_data_landing_path,
+                    notice: I18n.t('controllers.settings.onboardings.demo_data_is_already_loaded')
       else
-        redirect_to root_path, alert: 'Something went wrong loading demo data.'
+        redirect_to root_path, alert: I18n.t('controllers.settings.onboardings.something_went_wrong_loading_demo_data')
       end
     end
 
@@ -28,11 +29,11 @@ module Settings
 
       case result[:status]
       when :destroyed
-        redirect_to root_path, notice: 'Demo data removed.'
+        redirect_to root_path, notice: I18n.t('controllers.settings.onboardings.demo_data_removed')
       when :no_demo_data
-        redirect_to root_path, notice: 'No demo data found.'
+        redirect_to root_path, notice: I18n.t('controllers.settings.onboardings.no_demo_data_found')
       else
-        redirect_to root_path, alert: 'Something went wrong removing demo data.'
+        redirect_to root_path, alert: I18n.t('controllers.settings.onboardings.something_went_wrong_removing_demo_data')
       end
     end
 

--- a/app/controllers/settings/two_factor_controller.rb
+++ b/app/controllers/settings/two_factor_controller.rb
@@ -26,14 +26,14 @@ class Settings::TwoFactorController < ApplicationController
     else
       @qr_code = generate_qr_code
       @otp_secret = current_user.otp_secret
-      flash.now[:alert] = 'Invalid verification code. Please try again.'
+      flash.now[:alert] = I18n.t('controllers.settings.two_factor.invalid_verification_code')
       render :verify, status: :unprocessable_entity
     end
   end
 
   def destroy
     unless current_user.valid_password?(params[:password])
-      redirect_to settings_two_factor_path, alert: 'Incorrect password.'
+      redirect_to settings_two_factor_path, alert: I18n.t('controllers.settings.two_factor.incorrect_password')
       return
     end
 
@@ -43,7 +43,7 @@ class Settings::TwoFactorController < ApplicationController
 
     unless otp_ok
       redirect_to settings_two_factor_path,
-                  alert: 'Provide a valid two-factor code (or backup code) to disable 2FA.'
+                  alert: I18n.t('controllers.settings.two_factor.provide_a_valid_two_factor_code_or_backup_code_to')
       return
     end
 
@@ -52,7 +52,8 @@ class Settings::TwoFactorController < ApplicationController
       otp_secret: nil,
       otp_backup_codes: nil
     )
-    redirect_to settings_two_factor_path, notice: 'Two-factor authentication disabled.'
+    redirect_to settings_two_factor_path,
+                notice: I18n.t('controllers.settings.two_factor.two_factor_authentication_disabled')
   end
 
   private
@@ -60,7 +61,9 @@ class Settings::TwoFactorController < ApplicationController
   def require_two_factor_available
     return if DawarichSettings.two_factor_available?
 
-    redirect_to settings_general_index_path, alert: 'Two-factor authentication is not configured on this instance.'
+    alert = I18n.t('controllers.settings.two_factor.two_factor_authentication_is_not_configured_on_this_instance')
+    redirect_to settings_general_index_path,
+                alert: alert
   end
 
   def generate_qr_code

--- a/app/controllers/settings/users_controller.rb
+++ b/app/controllers/settings/users_controller.rb
@@ -25,10 +25,11 @@ class Settings::UsersController < ApplicationController
     update_params = filtered_user_params
 
     if @user.update(update_params)
-      redirect_to settings_users_url, notice: 'User was successfully updated.'
+      redirect_to settings_users_url, notice: I18n.t('controllers.settings.users.user_was_successfully_updated')
     else
       redirect_to settings_users_url,
-                  alert: "User could not be updated: #{@user.errors.full_messages.to_sentence}",
+                  alert: I18n.t('controllers.settings.users.user_could_not_be_updated_to_sentence',
+                                errors: @user.errors.full_messages.to_sentence),
                   status: :see_other
     end
   end
@@ -41,10 +42,11 @@ class Settings::UsersController < ApplicationController
     )
 
     if @user.save
-      redirect_to settings_users_url, notice: 'User was successfully created'
+      redirect_to settings_users_url, notice: I18n.t('controllers.settings.users.user_was_successfully_created')
     else
       redirect_to settings_users_url,
-                  alert: "User could not be created: #{@user.errors.full_messages.to_sentence}",
+                  alert: I18n.t('controllers.settings.users.user_could_not_be_created_to_sentence',
+                                errors: @user.errors.full_messages.to_sentence),
                   status: :see_other
     end
   end
@@ -54,7 +56,7 @@ class Settings::UsersController < ApplicationController
 
     unless @user.can_delete_account?
       redirect_to settings_users_url,
-                  alert: 'Cannot delete account while being owner of a family which has other members.',
+                  alert: I18n.t('controllers.settings.users.cannot_delete_account_while_being_owner_of_a_family_which'),
                   status: :see_other
       return
     end
@@ -62,21 +64,22 @@ class Settings::UsersController < ApplicationController
     Users::DestroyJob.perform_later(@user.id) if @user.mark_as_deleted_atomically!
 
     redirect_to settings_users_url,
-                notice: 'User deletion has been initiated. The account will be fully removed shortly.'
+                notice: I18n.t('controllers.settings.users.user_deletion_has_been_initiated_the_account_will_be_fully')
   end
 
   def regenerate_api_key
     @user = User.find(params[:id])
     @user.update!(api_key: SecureRandom.hex(32))
 
-    redirect_to settings_user_url(@user), notice: 'API key has been regenerated.'
+    redirect_to settings_user_url(@user), notice: I18n.t('controllers.settings.users.api_key_has_been_regenerated')
   end
 
   def send_password_reset
     @user = User.find(params[:id])
     @user.send_reset_password_instructions
 
-    redirect_to settings_user_url(@user), notice: 'Password reset email has been sent.'
+    redirect_to settings_user_url(@user),
+                notice: I18n.t('controllers.settings.users.password_reset_email_has_been_sent')
   end
 
   def update_registration_settings
@@ -84,18 +87,21 @@ class Settings::UsersController < ApplicationController
     DawarichSettings.set_registration_enabled(enabled)
 
     status = enabled ? 'enabled' : 'disabled'
-    redirect_to settings_users_url, notice: "User registration has been #{status}."
+    redirect_to settings_users_url,
+                notice: I18n.t('controllers.settings.users.user_registration_has_been_status', status: status)
   end
 
   def export
     current_user.export_data
 
-    redirect_to exports_path, notice: 'Your data is being exported. You will receive a notification when it is ready.'
+    redirect_to exports_path,
+                notice: I18n.t('controllers.settings.users.your_data_is_being_exported_you_will_receive_a_notification')
   end
 
   def import
     if params[:archive].blank?
-      redirect_to edit_user_registration_path, alert: 'Please select a ZIP archive to import.'
+      redirect_to edit_user_registration_path,
+                  alert: I18n.t('controllers.settings.users.please_select_a_zip_archive_to_import')
       return
     end
 
@@ -104,15 +110,15 @@ class Settings::UsersController < ApplicationController
 
     if import.save
       redirect_to edit_user_registration_path,
-                  notice: 'Your data import has been started. You will receive a notification when it completes.'
+                  notice: I18n.t('controllers.settings.users.your_data_import_has_been_started_you_will_receive_a')
     else
       redirect_to edit_user_registration_path,
-                  alert: 'Failed to start import. Please try again.'
+                  alert: I18n.t('controllers.settings.users.failed_to_start_import_please_try_again')
     end
   rescue StandardError => e
     ExceptionReporter.call(e, 'User data import failed to start')
     redirect_to edit_user_registration_path,
-                alert: 'An error occurred while starting the import. Please try again.'
+                alert: I18n.t('controllers.settings.users.an_error_occurred_while_starting_the_import_please_try_again')
   end
 
   private
@@ -153,9 +159,9 @@ class Settings::UsersController < ApplicationController
 
   def last_admin_alert_message
     if removing_admin_role?
-      'Cannot remove admin role from the last admin user.'
+      I18n.t('controllers.settings.users.cannot_remove_last_admin_role')
     else
-      'Cannot disable the last admin user.'
+      I18n.t('controllers.settings.users.cannot_disable_last_admin')
     end
   end
 
@@ -193,7 +199,8 @@ class Settings::UsersController < ApplicationController
     unless ['application/zip', 'application/x-zip-compressed'].include?(archive_file.content_type) ||
            File.extname(archive_file.original_filename).downcase == '.zip'
 
-      redirect_to edit_user_registration_path, alert: 'Please upload a valid ZIP file.' and return
+      redirect_to edit_user_registration_path,
+                  alert: I18n.t('controllers.settings.users.please_upload_a_valid_zip_file') and return
     end
   end
 
@@ -201,7 +208,7 @@ class Settings::UsersController < ApplicationController
     unless ['application/zip', 'application/x-zip-compressed'].include?(blob.content_type) ||
            File.extname(blob.filename.to_s).downcase == '.zip'
 
-      raise StandardError, 'Please upload a valid ZIP file.'
+      raise StandardError, I18n.t('controllers.settings.users.please_upload_a_valid_zip_file')
     end
   end
 end

--- a/app/controllers/settings/visits_controller.rb
+++ b/app/controllers/settings/visits_controller.rb
@@ -9,7 +9,7 @@ class Settings::VisitsController < ApplicationController
     merged = (current_user.settings || {}).merge(coerced_settings_params)
     current_user.update!(settings: merged)
 
-    redirect_to settings_visits_path, notice: 'Visit detection settings updated'
+    redirect_to settings_visits_path, notice: I18n.t('controllers.settings.visits.visit_detection_settings_updated')
   end
 
   private

--- a/app/controllers/share_links/lives_controller.rb
+++ b/app/controllers/share_links/lives_controller.rb
@@ -26,7 +26,7 @@ module ShareLinks
       {
         user: current_user,
         resource_type: :live,
-        name: 'Live location'
+        name: I18n.t('controllers.share_links.lives.default_name')
       }
     end
 
@@ -34,7 +34,7 @@ module ShareLinks
       {
         resource_type: :live,
         resource_id:   nil,
-        name:          create_params[:name].presence || 'Live location',
+        name:          create_params[:name].presence || I18n.t('controllers.share_links.lives.default_name'),
         magic_phrase:  create_params[:magic_phrase].presence,
         expires_at:    expiry_from(create_params[:expires_at]),
         settings:      SharedLink.default_settings_for(:live).merge(extracted_settings)

--- a/app/controllers/share_links/timelines_controller.rb
+++ b/app/controllers/share_links/timelines_controller.rb
@@ -28,7 +28,8 @@ module ShareLinks
       {
         user: current_user,
         resource_type: :timeline,
-        name: "Timeline: #{start_date.iso8601} → #{end_date.iso8601}",
+        name: I18n.t('controllers.share_links.timelines.default_name', start_date: start_date.iso8601,
+end_date: end_date.iso8601),
         settings: SharedLink.default_settings_for(:timeline).merge(
           'start_date' => start_date.iso8601,
           'end_date'   => end_date.iso8601
@@ -65,11 +66,19 @@ module ShareLinks
     def default_name_from_params
       return nil unless params[:start_date].present? && params[:end_date].present?
 
-      "Timeline: #{params[:start_date]} → #{params[:end_date]}"
+      I18n.t(
+        'controllers.share_links.timelines.default_name',
+        start_date: params[:start_date],
+        end_date: params[:end_date]
+      )
     end
 
     def default_name_for(attrs)
-      "Timeline: #{attrs[:start_date]} → #{attrs[:end_date]}"
+      I18n.t(
+        'controllers.share_links.timelines.default_name',
+        start_date: attrs[:start_date],
+        end_date: attrs[:end_date]
+      )
     end
   end
 end

--- a/app/controllers/shared/digests_controller.rb
+++ b/app/controllers/shared/digests_controller.rb
@@ -14,7 +14,7 @@ class Shared::DigestsController < ApplicationController
 
     unless @digest&.public_accessible?
       return redirect_to root_path,
-                         alert: 'Shared digest not found or no longer available'
+                         alert: I18n.t('controllers.shared.digests.shared_digest_not_found_or_no_longer_available')
     end
 
     @year = @digest.year
@@ -35,11 +35,11 @@ class Shared::DigestsController < ApplicationController
     if params[:enabled] == '1'
       @digest.enable_sharing!(expiration: params[:expiration] || '24h')
       @sharing_url = shared_users_digest_url(@digest.sharing_uuid)
-      @message = 'Sharing enabled successfully'
+      @message = I18n.t('controllers.shared.digests.sharing_enabled')
     else
       @digest.disable_sharing!
       @sharing_url = ''
-      @message = 'Sharing disabled successfully'
+      @message = I18n.t('controllers.shared.digests.sharing_disabled')
     end
 
     respond_to do |format|
@@ -48,7 +48,7 @@ class Shared::DigestsController < ApplicationController
           turbo_stream.replace('sharing-link-display',
                                partial: 'shared/sharing_link',
                                locals: { sharing_url: @sharing_url }),
-          stream_flash(:success, 'Auto-saved')
+          stream_flash(:success, I18n.t('controllers.shared.digests.auto_saved'))
         ]
       end
       format.json do
@@ -58,10 +58,14 @@ class Shared::DigestsController < ApplicationController
   rescue StandardError
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: stream_flash(:error, 'Failed to update sharing settings')
+        render turbo_stream: stream_flash(
+          :error,
+          I18n.t('controllers.shared.digests.failed_to_update_sharing_settings')
+        )
       end
       format.json do
-        render json: { success: false, message: 'Failed to update sharing settings' },
+        message = I18n.t('controllers.shared.digests.failed_to_update_sharing_settings')
+        render json: { success: false, message: message },
                status: :unprocessable_content
       end
     end

--- a/app/controllers/shared/links_controller.rb
+++ b/app/controllers/shared/links_controller.rb
@@ -20,7 +20,7 @@ class Shared::LinksController < ApplicationController
       redirect_to public_shared_link_path(@link.id)
     else
       Rails.logger.warn("Shared link unlock failed: link=#{@link.id} ip=#{request.remote_ip}")
-      flash.now[:error] = "That phrase didn't work. Try again."
+      flash.now[:error] = I18n.t('controllers.shared.links.incorrect_phrase')
       render :phrase_prompt, status: :unauthorized
     end
   end

--- a/app/controllers/shared/stats_controller.rb
+++ b/app/controllers/shared/stats_controller.rb
@@ -12,7 +12,7 @@ class Shared::StatsController < ApplicationController
 
     unless @stat&.public_accessible?
       return redirect_to root_path,
-                         alert: 'Shared stats not found or no longer available'
+                         alert: I18n.t('controllers.shared.stats.shared_stats_not_found_or_no_longer_available')
     end
 
     @year = @stat.year
@@ -35,11 +35,11 @@ class Shared::StatsController < ApplicationController
     if params[:enabled] == '1'
       @stat.enable_sharing!(expiration: params[:expiration] || '24h')
       @sharing_url = shared_stat_url(@stat.sharing_uuid)
-      @message = 'Sharing enabled successfully'
+      @message = I18n.t('controllers.shared.stats.sharing_enabled')
     else
       @stat.disable_sharing!
       @sharing_url = ''
-      @message = 'Sharing disabled successfully'
+      @message = I18n.t('controllers.shared.stats.sharing_disabled')
     end
 
     respond_to do |format|
@@ -48,7 +48,7 @@ class Shared::StatsController < ApplicationController
           turbo_stream.replace('sharing-link-display',
                                partial: 'shared/sharing_link',
                                locals: { sharing_url: @sharing_url }),
-          stream_flash(:success, 'Auto-saved')
+          stream_flash(:success, I18n.t('controllers.shared.stats.auto_saved'))
         ]
       end
       format.json do
@@ -58,10 +58,13 @@ class Shared::StatsController < ApplicationController
   rescue StandardError
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: stream_flash(:error, 'Failed to update sharing settings')
+        render turbo_stream: stream_flash(
+          :error,
+          I18n.t('controllers.shared.stats.failed_to_update_sharing_settings')
+        )
       end
       format.json do
-        render json: { success: false, message: 'Failed to update sharing settings' },
+        render json: { success: false, message: I18n.t('controllers.shared.stats.failed_to_update_sharing_settings') },
                status: :unprocessable_content
       end
     end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -39,7 +39,8 @@ class StatsController < ApplicationController
       target = "#{Date::MONTHNAMES[params[:month].to_i]} of #{params[:year]}"
     end
 
-    redirect_to stats_path, notice: "Stats for #{target} are being updated", status: :see_other
+    redirect_to stats_path, notice: I18n.t('controllers.stats.stats_for_target_are_being_updated', target: target),
+status: :see_other
   end
 
   def update_all
@@ -51,7 +52,7 @@ class StatsController < ApplicationController
       end
     end
 
-    redirect_to stats_path, notice: 'Stats are being updated', status: :see_other
+    redirect_to stats_path, notice: I18n.t('controllers.stats.stats_are_being_updated'), status: :see_other
   end
 
   private

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -22,7 +22,7 @@ class TagsController < ApplicationController
     authorize @tag
 
     if @tag.save
-      redirect_to tags_path, notice: 'Tag was successfully created.'
+      redirect_to tags_path, notice: I18n.t('controllers.tags.tag_was_successfully_created')
     else
       render :new, status: :unprocessable_entity
     end
@@ -37,7 +37,7 @@ class TagsController < ApplicationController
 
     if @tag.update(tag_params)
       @tag.adopt!
-      redirect_to tags_path, notice: 'Tag was successfully updated.'
+      redirect_to tags_path, notice: I18n.t('controllers.tags.tag_was_successfully_updated')
     else
       render :edit, status: :unprocessable_entity
     end
@@ -48,7 +48,7 @@ class TagsController < ApplicationController
 
     @tag.destroy!
 
-    redirect_to tags_path, notice: 'Tag was successfully deleted.', status: :see_other
+    redirect_to tags_path, notice: I18n.t('controllers.tags.tag_was_successfully_deleted'), status: :see_other
   end
 
   private

--- a/app/controllers/tracks/recalculations_controller.rb
+++ b/app/controllers/tracks/recalculations_controller.rb
@@ -10,8 +10,16 @@ class Tracks::RecalculationsController < ApplicationController
 
     if status.in_progress?
       respond_to do |format|
-        format.turbo_stream { render turbo_stream: stream_flash(:notice, 'Re-classification already running') }
-        format.html { redirect_back(fallback_location: root_path, notice: 'Re-classification already running') }
+        format.turbo_stream do
+          render turbo_stream: stream_flash(
+            :notice,
+            I18n.t('controllers.tracks.recalculations.re_classification_already_running')
+          )
+        end
+        format.html do
+          redirect_back(fallback_location: root_path,
+                        notice: I18n.t('controllers.tracks.recalculations.re_classification_already_running'))
+        end
       end
     else
       Tracks::TransportationModeRecalculationJob.perform_later(current_user.id)
@@ -19,13 +27,16 @@ class Tracks::RecalculationsController < ApplicationController
         format.turbo_stream do
           render turbo_stream: stream_flash(
             :success,
-            'Re-classification started — your tracks will update over the next few minutes'
+            I18n.t('controllers.tracks.recalculations.re_classification_started_your_tracks_will_update_over_the_next')
           )
         end
         format.html do
+          notice = I18n.t(
+            'controllers.tracks.recalculations.re_classification_started_your_tracks_will_update_over_the_next'
+          )
           redirect_back(
             fallback_location: root_path,
-            notice: 'Re-classification started — your tracks will update over the next few minutes'
+            notice: notice
           )
         end
       end

--- a/app/controllers/tracks/segments_controller.rb
+++ b/app/controllers/tracks/segments_controller.rb
@@ -25,7 +25,7 @@ class Tracks::SegmentsController < ApplicationController
 
     if result.success?
       track = result.segment.track.reload
-      dominant_label = track.dominant_mode&.titleize || 'Unknown'
+      dominant_label = I18n.t("transportation_modes.#{track.dominant_mode || 'unknown'}")
 
       respond_to do |format|
         format.turbo_stream do
@@ -36,10 +36,12 @@ class Tracks::SegmentsController < ApplicationController
               locals: { segment: result.segment }
             ),
             turbo_stream.update("track-info-mode-#{track.id}", dominant_label),
-            stream_flash(:success, 'Segment updated')
+            stream_flash(:success, I18n.t('controllers.tracks.segments.segment_updated'))
           ]
         end
-        format.html { redirect_back(fallback_location: root_path, notice: 'Segment updated') }
+        format.html do
+          redirect_back(fallback_location: root_path, notice: I18n.t('controllers.tracks.segments.segment_updated'))
+        end
       end
     else
       respond_to do |format|
@@ -66,8 +68,8 @@ class Tracks::SegmentsController < ApplicationController
 
   def error_message_for(code)
     case code
-    when :mode_not_enabled then "That mode isn't enabled in your settings"
-    else 'Could not update segment'
+    when :mode_not_enabled then I18n.t('controllers.tracks.segments.mode_not_enabled')
+    else I18n.t('controllers.tracks.segments.update_failed')
     end
   end
 end

--- a/app/controllers/tracks/share_links_controller.rb
+++ b/app/controllers/tracks/share_links_controller.rb
@@ -10,7 +10,7 @@ module Tracks
       @track = current_user.tracks.find_by(id: params[:track_id])
       return if @track
 
-      render plain: 'Not found', status: :not_found
+      render plain: I18n.t('controllers.tracks.share_links.not_found'), status: :not_found
     end
 
     def active_share_scope

--- a/app/controllers/trial/welcome_controller.rb
+++ b/app/controllers/trial/welcome_controller.rb
@@ -9,19 +9,23 @@ class Trial::WelcomeController < ApplicationController
     decoded = Subscription::DecodeJwtToken.new(params[:token], expected_purpose: 'trial_welcome').call
 
     jti = decoded[:jti].to_s
-    return redirect_to(new_user_session_path, alert: 'Link invalid. Please sign in.') if jti.blank?
+    if jti.blank?
+      return redirect_to(new_user_session_path,
+                         alert: I18n.t('controllers.trial.welcome.link_invalid_please_sign_in'))
+    end
 
     @user = User.find(decoded[:user_id])
 
     if user_signed_in? && current_user != @user
-      return redirect_to(root_path, alert: 'Another user is already signed in.')
+      return redirect_to(root_path, alert: I18n.t('controllers.trial.welcome.another_user_is_already_signed_in'))
     end
 
     consumed = !mark_token_consumed!(jti, decoded[:exp])
     if consumed
       return redirect_to(helpers.preferred_map_path) if user_signed_in? && current_user == @user
 
-      return redirect_to(new_user_session_path, alert: 'This welcome link has already been used.')
+      return redirect_to(new_user_session_path,
+                         alert: I18n.t('controllers.trial.welcome.this_welcome_link_has_already_been_used'))
     end
 
     log_event('trial_welcome_consumed', user_id: @user.id, jti: jti, variant: @user.signup_variant)
@@ -29,9 +33,10 @@ class Trial::WelcomeController < ApplicationController
     sign_in(@user) unless current_user == @user
     redirect_to helpers.preferred_map_path, notice: welcome_notice(@user)
   rescue JWT::DecodeError
-    redirect_to new_user_session_path, alert: 'Link invalid or expired. Please sign in.'
+    redirect_to new_user_session_path, alert: I18n.t('controllers.trial.welcome.link_invalid_or_expired_please_sign_in')
   rescue ActiveRecord::RecordNotFound
-    redirect_to new_user_session_path, alert: 'Account no longer exists. Please sign up again.'
+    redirect_to new_user_session_path,
+                alert: I18n.t('controllers.trial.welcome.account_no_longer_exists_please_sign_up_again')
   end
 
   private
@@ -49,9 +54,12 @@ class Trial::WelcomeController < ApplicationController
 
   def welcome_notice(user)
     if user.active_until.present?
-      "Welcome to Dawarich — your 7-day free trial is active until #{user.active_until.strftime('%B %d, %Y')}."
+      I18n.t(
+        'controllers.trial.welcome.trial_active_until',
+        date: I18n.l(user.active_until.to_date, format: :long)
+      )
     else
-      'Welcome to Dawarich — your trial is being activated now.'
+      I18n.t('controllers.trial.welcome.trial_activating')
     end
   end
 

--- a/app/controllers/trips/notes_controller.rb
+++ b/app/controllers/trips/notes_controller.rb
@@ -107,7 +107,7 @@ module Trips
     def render_invalid_date
       respond_to do |format|
         format.turbo_stream { head :unprocessable_content }
-        format.html { redirect_to @trip, alert: 'Invalid date' }
+        format.html { redirect_to @trip, alert: I18n.t('controllers.trips.notes.invalid_date') }
       end
     end
   end

--- a/app/controllers/trips/share_links_controller.rb
+++ b/app/controllers/trips/share_links_controller.rb
@@ -10,7 +10,7 @@ module Trips
       @trip = current_user.trips.find_by(id: params[:trip_id])
       return if @trip
 
-      render plain: 'Not found', status: :not_found
+      render plain: I18n.t('controllers.trips.share_links.not_found'), status: :not_found
     end
 
     def active_share_scope
@@ -30,7 +30,7 @@ module Trips
         user: current_user,
         resource_type: :trip,
         resource_id: @trip.id,
-        name: "Trip: #{@trip.name}"
+        name: I18n.t('controllers.trips.share_links.default_name', trip: @trip.name)
       }
     end
 
@@ -38,7 +38,8 @@ module Trips
       {
         resource_type: :trip,
         resource_id:   @trip.id,
-        name:          create_params[:name].presence || "Trip: #{@trip.name}",
+        name:          create_params[:name].presence || I18n.t('controllers.trips.share_links.default_name',
+                                                               trip: @trip.name),
         magic_phrase:  create_params[:magic_phrase].presence,
         expires_at:    expiry_from(create_params[:expires_at]),
         settings:      SharedLink.default_settings_for(:trip).merge(extracted_settings)

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -38,7 +38,8 @@ class TripsController < ApplicationController
     @trip = current_user.trips.build(trip_params)
 
     if @trip.save
-      redirect_to @trip, notice: 'Trip was successfully created. Data is being calculated in the background.'
+      redirect_to @trip,
+                  notice: I18n.t('controllers.trips.trip_was_successfully_created_data_is_being_calculated_in_the')
     else
       render :new, status: :unprocessable_content
     end
@@ -47,7 +48,7 @@ class TripsController < ApplicationController
   def update
     if @trip.update(trip_params)
       @trip.adopt!
-      redirect_to @trip, notice: 'Trip was successfully updated.', status: :see_other
+      redirect_to @trip, notice: I18n.t('controllers.trips.trip_was_successfully_updated'), status: :see_other
     else
       render :edit, status: :unprocessable_content
     end
@@ -55,7 +56,7 @@ class TripsController < ApplicationController
 
   def destroy
     @trip.destroy!
-    redirect_to trips_url, notice: 'Trip was successfully destroyed.', status: :see_other
+    redirect_to trips_url, notice: I18n.t('controllers.trips.trip_was_successfully_destroyed'), status: :see_other
   end
 
   def recalculate
@@ -65,14 +66,14 @@ class TripsController < ApplicationController
                            .update_all(last_recalculated_at: Time.current)
 
     if affected.zero?
+      notice = I18n.t('controllers.trips.already_recalculating_this_page_will_update_when_it_s_done')
       respond_to do |format|
         format.turbo_stream do
-          render turbo_stream: stream_flash(:notice,
-                                            'Already recalculating — this page will update when it\'s done.')
+          render turbo_stream: stream_flash(:notice, notice)
         end
         format.html do
           redirect_to trip_path(@trip),
-                      notice: 'Already recalculating — this page will update when it\'s done.'
+                      notice: notice
         end
       end
       return
@@ -88,12 +89,15 @@ class TripsController < ApplicationController
           turbo_stream.replace('trip_recalculate_frame',
                                partial: 'trips/recalculate_button',
                                locals: { trip: @trip }),
-          stream_flash(:notice, 'Recalculating — the page will update automatically when it\'s ready.')
+          stream_flash(
+            :notice,
+            I18n.t('controllers.trips.recalculating_the_page_will_update_automatically_when_it_s_ready')
+          )
         ]
       end
       format.html do
         redirect_to trip_path(@trip),
-                    notice: 'Recalculating — the page will update automatically when it\'s ready.'
+                    notice: I18n.t('controllers.trips.recalculating_the_page_will_update_automatically_when_it_s_ready')
       end
     end
   end
@@ -105,7 +109,7 @@ class TripsController < ApplicationController
 
     unless EXPORTABLE_FORMATS.include?(file_format)
       redirect_to trip_path(@trip),
-                  alert: 'Unsupported export format. Choose GPX or GeoJSON.',
+                  alert: I18n.t('controllers.trips.unsupported_export_format_choose_gpx_or_geojson'),
                   status: :unprocessable_content
       return
     end
@@ -124,11 +128,11 @@ class TripsController < ApplicationController
     )
 
     redirect_to exports_url,
-                notice: "Trip export initiated. Check the Exports page when it's ready."
+                notice: I18n.t('controllers.trips.trip_export_initiated_check_the_exports_page_when_it_s')
   rescue StandardError => e
     ExceptionReporter.call(e)
     redirect_to trip_path(@trip),
-                alert: 'Export failed to initiate. Please try again.',
+                alert: I18n.t('controllers.trips.export_failed_to_initiate_please_try_again'),
                 status: :unprocessable_content
   end
 

--- a/app/controllers/users/apple_oauth_controller.rb
+++ b/app/controllers/users/apple_oauth_controller.rb
@@ -47,34 +47,33 @@ class Users::AppleOauthController < ApplicationController
 
     user, _created = Auth::FindOrCreateOauthUser.new(
       provider: 'apple',
-      provider_label: 'Sign in with Apple',
+      provider_label: I18n.t('oauth_providers.sign_in_with_apple'),
       claims: claims,
       email_verified: [true, 'true'].include?(claims[:email_verified]),
       name_attrs: extract_name_from_params
     ).call
 
-    flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: 'Apple')
+    flash[:notice] = I18n.t('devise.omniauth_callbacks.success', kind: I18n.t('oauth_providers.apple'))
     sign_in_and_redirect user, event: :authentication
   rescue Auth::VerifyAppleToken::InvalidToken => e
-    reject_with("Apple sign-in failed: #{e.message}")
+    reject_with(I18n.t('controllers.users.apple_oauth.sign_in_failed', message: e.message))
     capture_apple_breadcrumb('invalid_token', extra: { message: e.message })
   rescue Auth::FindOrCreateOauthUser::LinkVerificationSent => e
     session[:pending_oauth_link] = {
       'user_id' => e.user.id,
       'provider' => e.provider,
       'uid' => e.uid,
-      'provider_label' => 'Sign in with Apple',
+      'provider_label' => I18n.t('oauth_providers.sign_in_with_apple'),
       'expires_at' => 15.minutes.from_now.to_i
     }
     redirect_to auth_account_link_challenge_path
     capture_apple_breadcrumb('link_verification_sent', extra: { user_id: e.user.id, uid: e.uid })
   rescue Auth::FindOrCreateOauthUser::UnverifiedEmail
-    reject_with('Your Apple ID email is not verified. Verify it with Apple, then try again.')
+    reject_with(I18n.t('controllers.users.apple_oauth.email_not_verified'))
     capture_apple_breadcrumb('unverified_email')
   rescue Auth::FindOrCreateOauthUser::MissingOauthEmail => e
     reject_with(
-      "Apple didn't share your email this time and we couldn't find your existing account. " \
-      'Visit appleid.apple.com → Sign in with Apple → Dawarich → Stop using Sign in with Apple, then try again.'
+      I18n.t('controllers.users.apple_oauth.missing_email')
     )
     capture_apple_breadcrumb('missing_email', level: :warning, extra: { uid: e.uid })
   end
@@ -133,10 +132,11 @@ class Users::AppleOauthController < ApplicationController
 
   def handle_apple_error
     if params[:error].to_s == 'user_cancelled_authorize'
-      redirect_to new_user_session_path, notice: 'Sign in with Apple was cancelled.'
+      redirect_to new_user_session_path,
+                  notice: I18n.t('controllers.users.apple_oauth.sign_in_with_apple_was_cancelled')
     else
       capture_apple_breadcrumb('authorize_error', extra: { error: params[:error].to_s })
-      reject_with('Sign in with Apple did not complete. Please try again.')
+      reject_with(I18n.t('controllers.users.apple_oauth.did_not_complete'))
     end
   end
 
@@ -145,7 +145,7 @@ class Users::AppleOauthController < ApplicationController
   end
 
   def state_mismatch_message
-    'Sign in with Apple state mismatch — please try again.'
+    I18n.t('controllers.users.apple_oauth.state_mismatch')
   end
 
   def states_equal?(expected, submitted)

--- a/app/controllers/users/destroy_confirmations_controller.rb
+++ b/app/controllers/users/destroy_confirmations_controller.rb
@@ -8,31 +8,36 @@ class Users::DestroyConfirmationsController < ApplicationController
       begin
         Users::VerifyDestroyToken.new(params[:token]).call
       rescue Users::VerifyDestroyToken::TokenReplayed
-        return redirect_to(new_user_session_path, alert: 'This deletion link has already been used.')
+        alert = I18n.t('controllers.users.destroy_confirmations.this_deletion_link_has_already_been_used')
+        return redirect_to(new_user_session_path,
+                           alert: alert)
       rescue Users::VerifyDestroyToken::InvalidToken
-        return redirect_to(new_user_session_path, alert: 'Deletion link invalid or expired.')
+        return redirect_to(new_user_session_path,
+                           alert: I18n.t('controllers.users.destroy_confirmations.deletion_link_invalid_or_expired'))
       end
 
     user = result.user
 
     unless user.can_delete_account?
+      alert = I18n.t('controllers.users.destroy_confirmations.cannot_delete_account_while_you_own_a_family_with_other')
       return redirect_to(
         new_user_session_path,
-        alert: 'Cannot delete account while you own a family with other members. ' \
-               'Transfer ownership or remove members first.'
+        alert: alert
       )
     end
 
     unless Users::VerifyDestroyToken.consume!(result.jti)
-      return redirect_to(new_user_session_path, alert: 'This deletion link has already been used.')
+      alert = I18n.t('controllers.users.destroy_confirmations.this_deletion_link_has_already_been_used')
+      return redirect_to(new_user_session_path,
+                         alert: alert)
     end
 
     Users::DestroyJob.perform_later(user.id) if user.mark_as_deleted_atomically!
 
     sign_out(user) if user_signed_in? && current_user&.id == user.id
 
-    redirect_to new_user_session_path,
-                notice: 'Your account has been scheduled for deletion. We are sorry to see you go.'
+    notice = I18n.t('controllers.users.destroy_confirmations.your_account_has_been_scheduled_for_deletion_we_are_sorry')
+    redirect_to new_user_session_path, notice: notice
   end
 
   private

--- a/app/controllers/users/digests_controller.rb
+++ b/app/controllers/users/digests_controller.rb
@@ -24,17 +24,21 @@ class Users::DigestsController < ApplicationController
     if valid_year?(year)
       Users::Digests::Yearly::CalculatingJob.perform_later(current_user.id, year)
       redirect_to users_digests_path,
-                  notice: "Year-end digest for #{year} is being generated. Check back soon!",
+                  notice: I18n.t('controllers.users.digests.year_end_digest_for_year_is_being_generated_check_back',
+                                 year: year),
                   status: :see_other
     else
-      redirect_to users_digests_path, alert: 'Invalid year selected', status: :see_other
+      redirect_to users_digests_path, alert: I18n.t('controllers.users.digests.invalid_year_selected'),
+status: :see_other
     end
   end
 
   def destroy
     year = @digest.year
     @digest.destroy!
-    redirect_to users_digests_path, notice: "Year-end digest for #{year} has been deleted", status: :see_other
+    notice = I18n.t('controllers.users.digests.year_end_digest_for_year_has_been_deleted', year: year)
+    redirect_to users_digests_path,
+                notice: notice, status: :see_other
   end
 
   private
@@ -42,7 +46,7 @@ class Users::DigestsController < ApplicationController
   def set_digest
     @digest = current_user.digests.yearly.find_by!(year: params[:year])
   rescue ActiveRecord::RecordNotFound
-    redirect_to users_digests_path, alert: 'Digest not found'
+    redirect_to users_digests_path, alert: I18n.t('controllers.users.digests.digest_not_found')
   end
 
   def available_years_for_generation

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,15 +4,15 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include PendingImportClaimable
 
   def github
-    handle_auth('GitHub')
+    handle_auth(I18n.t('oauth_providers.github'))
   end
 
   def google_oauth2
-    handle_auth('Google')
+    handle_auth(I18n.t('oauth_providers.google'))
   end
 
   def openid_connect
-    handle_auth('OpenID Connect')
+    handle_auth(I18n.t('oauth_providers.openid_connect'))
   end
 
   def failure
@@ -23,18 +23,19 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     error_message =
       case error_type
       when :invalid_credentials
-        'Invalid credentials. Please check your username and password.'
+        I18n.t('controllers.users.omniauth_callbacks.invalid_credentials')
       when :timeout
-        'Connection timeout. Please try again.'
+        I18n.t('controllers.users.omniauth_callbacks.connection_timeout')
       when :csrf_detected
-        'Security error detected. Please try again.'
+        I18n.t('controllers.users.omniauth_callbacks.security_error')
       else
         if error&.message&.include?('Discovery')
-          'Unable to connect to authentication provider. Please contact your administrator.'
+          I18n.t('controllers.users.omniauth_callbacks.provider_unavailable')
         elsif error&.message&.include?('Issuer mismatch')
-          'Authentication provider configuration error. Please contact your administrator.'
+          I18n.t('controllers.users.omniauth_callbacks.provider_configuration_error')
         else
-          "Authentication failed: #{params[:message] || error&.message || 'Unknown error'}"
+          detail = params[:message] || error&.message || I18n.t('controllers.users.omniauth_callbacks.unknown_error')
+          I18n.t('controllers.users.omniauth_callbacks.authentication_failed', detail:)
         end
       end
 
@@ -58,11 +59,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user, event: :authentication
     elsif @user.nil?
       # User creation was rejected (e.g., OIDC auto-register disabled)
-      error_message = if provider == 'OpenID Connect' && !oidc_auto_register_enabled?
-                        'Your account must be created by an administrator before you can sign in with OIDC. ' \
-                        'Please contact your administrator.'
+      error_message = if provider == I18n.t('oauth_providers.openid_connect') && !oidc_auto_register_enabled?
+                        I18n.t('controllers.users.omniauth_callbacks.oidc_account_requires_administrator')
                       else
-                        'Unable to create your account. Please try again or contact support.'
+                        I18n.t('controllers.users.omniauth_callbacks.account_creation_failed')
                       end
       redirect_to root_path, alert: error_message
     else
@@ -79,8 +79,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     redirect_to auth_account_link_challenge_path
   rescue Auth::FindOrCreateOauthUser::UnverifiedEmail
     redirect_to new_user_session_path,
-                alert: "Your #{provider} email is not verified. Verify it with the provider, " \
-                       'then try again — or sign in with your existing password.'
+                alert: I18n.t('controllers.users.omniauth_callbacks.email_not_verified', provider:)
   end
 
   def oidc_auto_register_enabled?

--- a/app/controllers/users/otp_challenge_controller.rb
+++ b/app/controllers/users/otp_challenge_controller.rb
@@ -11,7 +11,8 @@ class Users::OtpChallengeController < ApplicationController
 
     unless user && otp_challenge_valid?
       clear_otp_session
-      redirect_to new_user_session_path, alert: 'Session expired. Please sign in again.'
+      redirect_to new_user_session_path,
+                  alert: I18n.t('controllers.users.otp_challenge.session_expired_please_sign_in_again')
       return
     end
 
@@ -21,24 +22,25 @@ class Users::OtpChallengeController < ApplicationController
       clear_otp_session
       user.reset_failed_otp_attempts!
       sign_in(user)
-      redirect_to after_sign_in_path_for(user), notice: 'Signed in successfully.'
+      redirect_to after_sign_in_path_for(user), notice: I18n.t('controllers.users.otp_challenge.signed_in_successfully')
     elsif user.otp_locked?
       clear_otp_session
+      alert = I18n.t('controllers.users.otp_challenge.account_temporarily_locked_due_to_too_many_failed_2fa_attempts')
       redirect_to new_user_session_path,
-                  alert: 'Account temporarily locked due to too many failed 2FA attempts. ' \
-                         'Use a backup code, wait 30 minutes, or reset your password.'
+                  alert: alert
     else
       user.register_failed_otp_attempt!
 
       session[:otp_failed_attempts] = (session[:otp_failed_attempts] || 0) + 1
       if session[:otp_failed_attempts] >= MAX_FAILED_ATTEMPTS
         clear_otp_session
+        alert = I18n.t('controllers.users.otp_challenge.too_many_invalid_two_factor_codes_please_sign_in_again')
         redirect_to new_user_session_path,
-                    alert: 'Too many invalid two-factor codes. Please sign in again.'
+                    alert: alert
         return
       end
 
-      flash.now[:alert] = 'Invalid two-factor code.'
+      flash.now[:alert] = I18n.t('controllers.users.otp_challenge.invalid_two_factor_code')
       render 'devise/sessions/otp_challenge', status: :unprocessable_entity
     end
   end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -81,7 +81,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
 
     redirect_to after_sign_out_path_for(resource_name),
-                notice: 'Your account has been scheduled for deletion.'
+                notice: I18n.t('controllers.users.registrations.your_account_has_been_scheduled_for_deletion')
   end
 
   def destroy_cloud
@@ -170,16 +170,19 @@ class Users::RegistrationsController < Devise::RegistrationsController
     # When OIDC is enabled and email/password registration is disabled,
     # block all email/password registration including family invitations
     if oidc_only_mode?
+      alert = I18n.t('controllers.users.registrations.email_password_registration_is_disabled_please_use_oidc_to_sign')
       redirect_to root_path,
-                  alert: 'Email/password registration is disabled. Please use OIDC to sign in.'
+                  alert: alert
       return
     end
 
     return if valid_invitation_token?
     return if email_password_registration_allowed?
 
-    redirect_to root_path,
-                alert: 'Registration is not available. Please contact your administrator for access.'
+    alert = I18n.t(
+      'controllers.users.registrations.registration_is_not_available_please_contact_your_administrator_for_acce'
+    )
+    redirect_to root_path, alert: alert
   end
 
   def set_invitation
@@ -211,15 +214,18 @@ class Users::RegistrationsController < Devise::RegistrationsController
     )
 
     if service.call
-      flash[:notice] = "Welcome to #{@invitation.family.name}! You're now part of the family."
+      flash[:notice] =
+        I18n.t('controllers.users.registrations.welcome_to_name_you_re_now_part_of_the_family',
+               name: @invitation.family.name)
     else
       flash[:alert] =
-        "Account created successfully, but there was an issue accepting the invitation: #{service.error_message}"
+        I18n.t('controllers.users.registrations.account_created_successfully_but_there_was_an_issue_accepting_the',
+               error_message: service.error_message)
     end
   rescue StandardError => e
     Rails.logger.error "Error accepting invitation during registration: #{e.message}"
     flash[:alert] =
-      'Account created successfully, but there was an issue accepting the invitation. Please try accepting it again.'
+      I18n.t('controllers.users.registrations.account_created_successfully_but_there_was_an_issue_accepting_the_2')
   end
 
   def sign_up_params

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -40,7 +40,8 @@ class Users::SessionsController < Devise::SessionsController
     return unless DawarichSettings.oidc_enabled?
     return if ALLOW_EMAIL_PASSWORD_LOGIN
 
-    redirect_to root_path, alert: 'Email/password login is disabled. Please use OIDC to sign in.'
+    redirect_to root_path,
+                alert: I18n.t('controllers.users.sessions.email_password_login_is_disabled_please_use_oidc_to_sign')
   end
 
   def load_invitation_context

--- a/app/controllers/visits/redetections_controller.rb
+++ b/app/controllers/visits/redetections_controller.rb
@@ -10,7 +10,7 @@ class Visits::RedetectionsController < ApplicationController
       respond_to do |format|
         format.html do
           redirect_to settings_visits_path,
-                      alert: 'Re-detect ran recently. Try again in an hour.',
+                      alert: I18n.t('controllers.visits.redetections.re_detect_ran_recently_try_again_in_an_hour'),
                       status: :too_many_requests
         end
         format.json { render json: { error: 'cooldown_active' }, status: :too_many_requests }
@@ -20,7 +20,7 @@ class Visits::RedetectionsController < ApplicationController
 
     Visits::FullHistoryRedetectJob.perform_later(current_user.id)
     redirect_to settings_visits_path,
-                notice: "Re-detection queued. We'll notify you when it finishes."
+                notice: I18n.t('controllers.visits.redetections.re_detection_queued_we_ll_notify_you_when_it_finishes')
   end
 
   private

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -42,15 +42,19 @@ class VisitsController < ApplicationController
         end
         format.html do
           redirect_to redirect_target,
-                      notice: "#{result[:count]} #{'visit'.pluralize(result[:count])} #{status}."
+                      notice: I18n.t(
+                        'controllers.visits.bulk_updated',
+                        count: result[:count],
+                        status: I18n.t("visit_statuses.#{status}")
+                      )
         end
       end
     else
       respond_to do |format|
         format.turbo_stream do
-          render turbo_stream: stream_flash(:error, 'Failed to update visits.')
+          render turbo_stream: stream_flash(:error, I18n.t('controllers.visits.failed_to_update_visits'))
         end
-        format.html { redirect_to redirect_target, alert: 'Failed to update visits.' }
+        format.html { redirect_to redirect_target, alert: I18n.t('controllers.visits.failed_to_update_visits') }
       end
     end
   end
@@ -74,9 +78,9 @@ class VisitsController < ApplicationController
       return render_unprocessable(too_many_visits_message) if scope.count > MAX_BULK_VISIT_IDS
 
       visit_ids = scope.pluck(:id)
-      return render_unprocessable('No matching visits found.') if visit_ids.empty?
+      return render_unprocessable(I18n.t('controllers.visits.no_matching_visits')) if visit_ids.empty?
     else
-      return render_unprocessable('Select at least one visit to delete.')
+      return render_unprocessable(I18n.t('controllers.visits.select_visit_to_delete'))
     end
 
     visits = current_user.scoped_visits.where(id: visit_ids)
@@ -95,7 +99,7 @@ class VisitsController < ApplicationController
         end
       end
     else
-      render_unprocessable(service.errors.join(', ').presence || 'Failed to delete visits.')
+      render_unprocessable(service.errors.join(', ').presence || I18n.t('controllers.visits.failed_to_delete_visits'))
     end
   end
 
@@ -114,13 +118,13 @@ class VisitsController < ApplicationController
       raw_place_id = params_to_update[:place_id]
       allowed = current_user.places.where(id: raw_place_id).exists? ||
                 @visit.suggested_places.where(id: raw_place_id).exists?
-      return render_unprocessable('Invalid place') unless allowed
+      return render_unprocessable(I18n.t('controllers.visits.invalid_place')) unless allowed
     end
 
     selected_area = nil
     if params_to_update[:area_id].present?
       selected_area = current_user.areas.find_by(id: params_to_update[:area_id])
-      return render_unprocessable('Invalid area') unless selected_area
+      return render_unprocessable(I18n.t('controllers.visits.invalid_area')) unless selected_area
     end
 
     # Capture both old and new month so cache busts cover edits that move
@@ -153,7 +157,7 @@ class VisitsController < ApplicationController
     else
       respond_to do |format|
         format.turbo_stream do
-          render turbo_stream: stream_flash(:error, 'Failed to update visit.')
+          render turbo_stream: stream_flash(:error, I18n.t('controllers.visits.failed_to_update_visit'))
         end
         format.html { render :edit, status: :unprocessable_content }
       end
@@ -176,12 +180,12 @@ class VisitsController < ApplicationController
 
   def merge
     visit_ids = parse_visit_ids(params[:visit_ids])
-    return render_unprocessable('Select at least 2 visits to merge.') if visit_ids.length < 2
+    return render_unprocessable(I18n.t('controllers.visits.select_visits_to_merge')) if visit_ids.length < 2
 
     visits = current_user.scoped_visits.where(id: visit_ids).order(:started_at)
     return render_not_found(message_for_missing_visits(visit_ids)) if visits.length != visit_ids.length
 
-    return render_unprocessable('Visits must be on the same day.') unless same_day?(visits)
+    return render_unprocessable(I18n.t('controllers.visits.visits_must_share_day')) unless same_day?(visits)
 
     @affected_started_at = visits.map(&:started_at)
 
@@ -194,7 +198,7 @@ class VisitsController < ApplicationController
         format.html { redirect_back(fallback_location: build_timeline_url(date: 'today')) }
       end
     else
-      render_unprocessable(service.errors.join(', ').presence || 'Failed to merge visits.')
+      render_unprocessable(service.errors.join(', ').presence || I18n.t('controllers.visits.failed_to_merge_visits'))
     end
   end
 
@@ -204,7 +208,7 @@ class VisitsController < ApplicationController
     return if params[:source_status].blank?
     return if ALLOWED_SOURCE_STATUSES.include?(params[:source_status].to_s)
 
-    render_unprocessable('Unsupported source status.')
+    render_unprocessable(I18n.t('controllers.visits.unsupported_source_status'))
   end
 
   def set_visit
@@ -312,7 +316,10 @@ class VisitsController < ApplicationController
                            locals: { status: 'suggested', count: status_counts['suggested'].to_i }),
       calendar_frame_stream(day_date),
       suggestions_badge_stream,
-      stream_flash(:notice, "Visit #{@visit.status}.")
+      stream_flash(
+        :notice,
+        I18n.t('controllers.visits.visit_updated', status: I18n.t("visit_statuses.#{@visit.status}"))
+      )
     ]
   end
 
@@ -406,7 +413,7 @@ class VisitsController < ApplicationController
                                     partial: 'map/timeline_feeds/filter_count',
                                     locals: { status: 'suggested', count: status_counts['suggested'].to_i })
     streams << suggestions_badge_stream
-    streams << stream_flash(:notice, 'Visits merged.')
+    streams << stream_flash(:notice, I18n.t('controllers.visits.visits_merged'))
     streams
   end
 
@@ -431,7 +438,7 @@ class VisitsController < ApplicationController
                            locals: { status: 'suggested', count: status_counts['suggested'].to_i }),
       calendar_frame_stream(day_date),
       suggestions_badge_stream,
-      stream_flash(:notice, 'Visit removed. Your location points are still here.')
+      stream_flash(:notice, I18n.t('controllers.visits.visit_removed'))
     ]
   end
 
@@ -500,7 +507,7 @@ class VisitsController < ApplicationController
   end
 
   def too_many_visits_message
-    "You can update up to #{MAX_BULK_VISIT_IDS} visits at once. Narrow your selection and try again."
+    I18n.t('controllers.visits.too_many_visits', count: MAX_BULK_VISIT_IDS)
   end
 
   def message_for_missing_visits(ids)
@@ -515,16 +522,15 @@ class VisitsController < ApplicationController
   end
 
   def missing_visits_message
-    "Some of those visits aren't here anymore — probably edited in another tab. Refresh and try again."
+    I18n.t('controllers.visits.missing_visits')
   end
 
   def plan_window_visits_message
-    "Some of those visits are outside your Lite plan's 12-month window. Upgrade to Pro to manage older data."
+    I18n.t('controllers.visits.plan_window_visits')
   end
 
   def bulk_destroy_success_message(count)
-    noun = 'visit'.pluralize(count)
-    "#{count} #{noun} removed. Your location points are still here."
+    I18n.t('controllers.visits.bulk_removed', count:)
   end
 
   def bust_timeline_month_cache

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def javascript_translations
+    translations = I18n.t('javascript', default: {}).merge(
+      transportation_modes: I18n.t('transportation_modes', default: {}),
+      visit_statuses: I18n.t('visit_statuses', default: {}),
+      battery_statuses: I18n.t('battery_statuses', default: {})
+    )
+    tag.script(
+      json_escape(translations.to_json).html_safe,
+      id: 'i18n-translations',
+      type: 'application/json',
+      data: { turbo_permanent: true }
+    )
+  end
+
   def show_plan_data_window_alert?
     current_user&.plan_restricted? || false
   end
@@ -29,8 +43,8 @@ module ApplicationHelper
   end
 
   def full_title(page_title = '')
-    base_title = 'Dawarich'
-    page_title.empty? ? base_title : "#{page_title} | #{base_title}"
+    base_title = I18n.t('common.app_name')
+    page_title.empty? ? base_title : I18n.t('helpers.application.full_title', page_title:, app_name: base_title)
   end
 
   def active_tab?(link_path)
@@ -57,7 +71,7 @@ module ApplicationHelper
   end
 
   def speed_label(unit = 'km')
-    unit == 'mi' ? 'mph' : 'km/h'
+    I18n.t(unit == 'mi' ? 'units.miles_per_hour' : 'units.kilometers_per_hour')
   end
 
   def onboarding_modal_showable?(user)
@@ -83,10 +97,10 @@ module ApplicationHelper
 
   def trial_days_remaining_compact(user)
     expiry = user.active_until
-    return 'Expired' if expiry.blank? || expiry.past?
+    return I18n.t('helpers.application.expired') if expiry.blank? || expiry.past?
 
     days_left = [(expiry.to_date - Time.zone.today).to_i, 0].max
-    "#{days_left}d left"
+    I18n.t('helpers.application.days_left', count: days_left)
   end
 
   def subscription_upgrade_url(user)
@@ -98,13 +112,13 @@ module ApplicationHelper
   end
 
   def subscription_button_label(user)
-    return 'Finish signup' if user.pending_payment?
+    return I18n.t('helpers.application.finish_signup') if user.pending_payment?
 
     trial_days_remaining_compact(user)
   end
 
   def subscription_cta_label(user)
-    user.pending_payment? ? 'Resume' : 'Subscribe'
+    I18n.t(user.pending_payment? ? 'helpers.application.resume' : 'helpers.application.subscribe')
   end
 
   def oauth_provider_name(provider)
@@ -115,8 +129,8 @@ module ApplicationHelper
 
   def oauth_provider_display_name(provider)
     case provider.to_s
-    when 'google_oauth2' then 'Google'
-    when 'apple' then 'Apple'
+    when 'google_oauth2' then I18n.t('oauth_providers.google')
+    when 'apple' then I18n.t('oauth_providers.apple')
     else oauth_provider_name(provider.to_sym)
     end
   end
@@ -124,17 +138,17 @@ module ApplicationHelper
   OAUTH_PROVIDERS = {
     google_oauth2: {
       icon_name: 'google',
-      label: 'Sign in with Google',
+      label_key: 'oauth_providers.sign_in_with_google',
       css_class: 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
     },
     github: {
       icon_name: 'github',
-      label: 'Sign in with GitHub',
+      label_key: 'oauth_providers.sign_in_with_github',
       css_class: 'bg-[#24292f] text-white hover:bg-[#383f47] border-[#24292f]'
     },
     apple: {
       icon_name: 'apple',
-      label: 'Sign in with Apple',
+      label_key: 'oauth_providers.sign_in_with_apple',
       css_class: 'bg-black text-white hover:bg-gray-900 border-black'
     }
   }.freeze
@@ -162,13 +176,13 @@ module ApplicationHelper
     if config
       {
         icon: icon(config[:icon_name], library: 'brands', class: 'size-5'),
-        label: config[:label],
+        label: I18n.t(config[:label_key]),
         css_class: config[:css_class]
       }
     else
       {
         icon: nil,
-        label: "Sign in with #{oauth_provider_name(provider)}",
+        label: I18n.t('oauth_providers.sign_in_with_provider', provider: oauth_provider_name(provider)),
         css_class: 'btn-primary'
       }
     end
@@ -224,13 +238,13 @@ module ApplicationHelper
   def pro_badge_tag(preview: true)
     return unless current_user&.plan_restricted?
 
-    tooltip = preview ? 'Available on Pro — click to preview' : 'Available on Pro'
+    tooltip = I18n.t(preview ? 'helpers.application.pro_preview' : 'helpers.application.pro_only')
     link_to upgrade_url(utm_medium: 'badge', utm_content: 'pro_badge'),
             target: '_blank', rel: 'noopener noreferrer',
             class: 'tooltip tooltip-bottom', 'data-tip': tooltip, tabindex: '0' do
       tag.span(class: 'badge badge-sm badge-outline gap-1') do
         concat icon('lock', class: 'w-3 h-3')
-        concat ' Pro'
+        concat I18n.t('helpers.application.pro_badge')
       end
     end
   end
@@ -266,7 +280,7 @@ module ApplicationHelper
     badge_class = STATUS_BADGE_CLASSES[record.status] || 'bg-base-200 text-base-content/50'
 
     badge_css = "inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium #{badge_class}"
-    badge = content_tag(:span, record.status.capitalize, class: badge_css)
+    badge = content_tag(:span, I18n.t("statuses.#{record.status}"), class: badge_css)
 
     if record.failed? && record.respond_to?(:error_message) && record.error_message.present?
       error_icon = content_tag(:span, icon('circle-alert', class: %w[w-3.5 h-3.5 text-error]),

--- a/app/helpers/datetime_formatting_helper.rb
+++ b/app/helpers/datetime_formatting_helper.rb
@@ -2,7 +2,7 @@
 
 module DatetimeFormattingHelper
   def human_date(date)
-    date.strftime('%e %B %Y')
+    I18n.l(date.to_date, format: :day_month_year)
   end
 
   def human_datetime(datetime, timezone = nil)
@@ -12,7 +12,7 @@ module DatetimeFormattingHelper
 
     content_tag(
       :span,
-      zoned.strftime('%e %b %Y, %H:%M'),
+      I18n.l(zoned, format: :human),
       class: 'tooltip',
       data: { tip: zoned.iso8601 }
     )
@@ -25,7 +25,7 @@ module DatetimeFormattingHelper
 
     content_tag(
       :span,
-      zoned.strftime('%e %b %Y, %H:%M:%S'),
+      I18n.l(zoned, format: :human_with_seconds),
       class: 'tooltip',
       data: { tip: zoned.iso8601 }
     )
@@ -40,23 +40,23 @@ module DatetimeFormattingHelper
       :span,
       time_words,
       class: 'tooltip',
-      data: { tip: "Expires on #{active_until.iso8601}" }
+      data: { tip: I18n.t('helpers.datetime_formatting.expires_on', date: I18n.l(active_until, format: :human)) }
     )
   end
 
   def format_duration_short(seconds)
-    return '0m' if seconds.nil? || seconds.to_i.zero?
+    return I18n.t('units.minutes_compact', value: 0) if seconds.nil? || seconds.to_i.zero?
 
     total = seconds.to_i
     days = total / 86_400
     hours = (total % 86_400) / 3600
     minutes = (total % 3600) / 60
 
-    return "#{days}d #{hours}h" if days.positive? && hours.positive?
-    return "#{days}d" if days.positive?
-    return "#{hours}h #{minutes}m" if hours.positive?
+    return I18n.t('units.days_hours_compact', days:, hours:) if days.positive? && hours.positive?
+    return I18n.t('units.days_compact', value: days) if days.positive?
+    return I18n.t('units.hours_minutes_compact', hours:, minutes:) if hours.positive?
 
-    "#{minutes}m"
+    I18n.t('units.minutes_compact', value: minutes)
   end
 
   private

--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -16,12 +16,12 @@ module ImportsHelper
   }.freeze
 
   EXTRACTION_STATUS_BADGES = {
-    'not_attempted' => { label: 'Not extracted', css: 'badge-ghost' },
-    'pending'       => { label: 'Queued',        css: 'badge-info' },
-    'running'       => { label: 'Extracting',    css: 'badge-info gap-1', spinner: true },
-    'completed'     => { label: 'Extracted',     css: 'badge-success' },
-    'failed'        => { label: 'Failed',        css: 'badge-error' },
-    'unsupported'   => { label: 'Not available', css: 'badge-ghost' }
+    'not_attempted' => { label_key: 'not_attempted', css: 'badge-ghost' },
+    'pending'       => { label_key: 'pending',       css: 'badge-info' },
+    'running'       => { label_key: 'running',       css: 'badge-info gap-1', spinner: true },
+    'completed'     => { label_key: 'completed',     css: 'badge-success' },
+    'failed'        => { label_key: 'failed',        css: 'badge-error' },
+    'unsupported'   => { label_key: 'unsupported',   css: 'badge-ghost' }
   }.freeze
 
   def extraction_status_badge(import)
@@ -30,7 +30,7 @@ module ImportsHelper
 
     tag.span(class: "badge badge-sm #{badge[:css]}") do
       concat(tag.span(nil, class: 'loading loading-dots loading-xs shrink-0')) if badge[:spinner]
-      concat(badge[:label])
+      concat(I18n.t("helpers.imports.extraction_status.#{badge[:label_key]}"))
     end
   end
 

--- a/app/helpers/insights_helper.rb
+++ b/app/helpers/insights_helper.rb
@@ -4,9 +4,10 @@ module InsightsHelper
   include CountryFlagHelper
 
   def monthly_digest_title(digest)
-    return 'Monthly Digest' unless digest
+    return I18n.t('helpers.insights.monthly_digest') unless digest
 
-    "#{digest.month_name} #{digest.year} Digest"
+    month = I18n.l(Date.new(digest.year, digest.month, 1), format: :month_name)
+    I18n.t('helpers.insights.monthly_digest_title', month:, year: digest.year)
   end
 
   def monthly_digest_distance(digest, user)
@@ -14,7 +15,7 @@ module InsightsHelper
 
     distance_unit = user.safe_settings.distance_unit
     value = Stat.convert_distance(digest.distance, distance_unit).round
-    "#{number_with_delimiter(value)} #{distance_unit}"
+    I18n.t(distance_unit == 'mi' ? 'units.miles' : 'units.kilometers', value: number_with_delimiter(value))
   end
 
   def monthly_digest_active_days(digest)
@@ -42,7 +43,7 @@ module InsightsHelper
   end
 
   def weekly_pattern_chart_data(digest, user)
-    day_names = %w[Mon Tue Wed Thu Fri Sat Sun]
+    day_names = I18n.t('calendar.abbreviated_weekdays')
     return day_names.map { |day| [day, 0] } unless digest
 
     pattern = digest.weekly_pattern
@@ -89,19 +90,19 @@ module InsightsHelper
 
   def format_location_time(minutes)
     total_minutes = minutes.to_i
-    return '0 min' if minutes.nil? || total_minutes.zero?
+    return I18n.t('helpers.insights.minute_count', count: 0) if minutes.nil? || total_minutes.zero?
 
     # ActiveSupport::Duration#parts decomposes into months/weeks/days/etc., so
     # `parts[:days]` only returns the day component within a month (max ~6) and
     # silently truncates large totals (e.g. 133 actual days renders as "4 days").
     # Compute the total day/hour count directly from the minutes input instead.
     days = total_minutes / 1440
-    return "#{days} #{'day'.pluralize(days)}" if days >= 1
+    return I18n.t('helpers.insights.day_count', count: days) if days >= 1
 
     hours = total_minutes / 60
-    return "#{hours} #{'hour'.pluralize(hours)}" if hours >= 1
+    return I18n.t('helpers.insights.hour_count', count: hours) if hours >= 1
 
-    "#{total_minutes} min"
+    I18n.t('helpers.insights.minute_count', count: total_minutes)
   end
 
   def first_time_visits_from_digest(digest)
@@ -123,14 +124,14 @@ module InsightsHelper
 
   # Format activity breakdown duration from seconds to human-readable hours
   def format_activity_hours(seconds)
-    return '0h' if seconds.nil? || seconds.to_i.zero?
+    return I18n.t('units.hours_compact', value: 0) if seconds.nil? || seconds.to_i.zero?
 
     hours = (seconds.to_i / 3600.0).round(1)
     if hours >= 1
-      "#{hours.to_i == hours ? hours.to_i : hours}h"
+      I18n.t('units.hours_compact', value: hours.to_i == hours ? hours.to_i : hours)
     else
       minutes = (seconds.to_i / 60.0).round
-      "#{minutes}min"
+      I18n.t('units.minutes_word_compact', value: minutes)
     end
   end
 
@@ -163,7 +164,7 @@ module InsightsHelper
 
   # Calculate activity ratio as "1:X" format (active vs sedentary)
   def activity_ratio(active_seconds, sedentary_seconds)
-    return 'N/A' if active_seconds.to_i.zero? || sedentary_seconds.to_i.zero?
+    return I18n.t('common.not_available') if active_seconds.to_i.zero? || sedentary_seconds.to_i.zero?
 
     ratio = sedentary_seconds.to_f / active_seconds
     "1:#{ratio.round}"
@@ -207,12 +208,12 @@ module InsightsHelper
     if converted < 1
       if unit == 'mi'
         feet = (converted * 5280).round
-        "#{feet} ft"
+        I18n.t('units.feet', value: feet)
       else
-        "#{meters.to_i} m"
+        I18n.t('units.meters', value: meters.to_i)
       end
     else
-      "#{converted.round(1)} #{unit}"
+      I18n.t(unit == 'mi' ? 'units.miles' : 'units.kilometers', value: converted.round(1))
     end
   end
 
@@ -256,7 +257,7 @@ module InsightsHelper
 
       if week_date.month != current_month
         current_month = week_date.month
-        labels << { index: index, name: Date::ABBR_MONTHNAMES[current_month] }
+        labels << { index: index, name: I18n.l(Date.new(year, current_month, 1), format: :abbreviated_month_name) }
       end
     end
 

--- a/app/helpers/places_helper.rb
+++ b/app/helpers/places_helper.rb
@@ -19,7 +19,7 @@ module PlacesHelper
     {
       visit_count: visit_count,
       total_hours: (total_minutes / 60.0).round(1),
-      avg_label: "#{avg_minutes / 60}h #{avg_minutes % 60}m",
+      avg_label: I18n.t('units.hours_minutes_compact', hours: avg_minutes / 60, minutes: avg_minutes % 60),
       primary_tag: place.tags.first,
       location_line: [place.city, place.country].compact_blank.join(', ')
     }
@@ -29,10 +29,10 @@ module PlacesHelper
   def place_visit_time_range(visit)
     duration = visit.duration.to_i
     {
-      start_label: visit.started_at.strftime('%H:%M'),
-      end_label: visit.ended_at.strftime('%H:%M'),
-      date_label: visit.started_at.strftime('%Y-%m-%d'),
-      duration_label: "#{duration / 60}h #{duration % 60}m"
+      start_label: I18n.l(visit.started_at, format: :hour_minute),
+      end_label: I18n.l(visit.ended_at, format: :hour_minute),
+      date_label: I18n.l(visit.started_at.to_date, format: :iso),
+      duration_label: I18n.t('units.hours_minutes_compact', hours: duration / 60, minutes: duration % 60)
     }
   end
 end

--- a/app/helpers/posters_helper.rb
+++ b/app/helpers/posters_helper.rb
@@ -2,13 +2,14 @@
 
 module PostersHelper
   RENDER_PHASES = {
-    'fetching_data' => { label: 'Fetching map data…', step: 1 },
-    'drawing_map' => { label: 'Drawing the map…', step: 2 },
-    'drawing_route' => { label: 'Drawing your route…', step: 3 },
-    'saving' => { label: 'Saving the image…', step: 4 }
+    'fetching_data' => { label_key: 'fetching_data', step: 1 },
+    'drawing_map' => { label_key: 'drawing_map', step: 2 },
+    'drawing_route' => { label_key: 'drawing_route', step: 3 },
+    'saving' => { label_key: 'saving', step: 4 }
   }.freeze
 
   def poster_render_phase(poster)
-    RENDER_PHASES.fetch(poster.settings['progress_phase'], { label: 'Queued…', step: 0 })
+    phase = RENDER_PHASES.fetch(poster.settings['progress_phase'], { label_key: 'queued', step: 0 })
+    phase.merge(label: I18n.t("helpers.posters.render_phases.#{phase[:label_key]}"))
   end
 end

--- a/app/helpers/shared_links_helper.rb
+++ b/app/helpers/shared_links_helper.rb
@@ -6,13 +6,25 @@ module SharedLinksHelper
     end_date   = Date.parse(end_date.to_s)   unless end_date.is_a?(Date)
 
     if start_date == end_date
-      start_date.strftime('%B %-d, %Y')
+      I18n.l(start_date, format: :long)
     elsif start_date.year == end_date.year && start_date.month == end_date.month
-      "#{start_date.strftime('%B %-d')}–#{end_date.strftime('%-d, %Y')}"
+      I18n.t(
+        'helpers.shared_links.date_ranges.same_month',
+        start_date: I18n.l(start_date, format: :month_day),
+        end_date: I18n.l(end_date, format: :day_year)
+      )
     elsif start_date.year == end_date.year
-      "#{start_date.strftime('%B %-d')} – #{end_date.strftime('%B %-d, %Y')}"
+      I18n.t(
+        'helpers.shared_links.date_ranges.same_year',
+        start_date: I18n.l(start_date, format: :month_day),
+        end_date: I18n.l(end_date, format: :long)
+      )
     else
-      "#{start_date.strftime('%b %-d, %Y')} – #{end_date.strftime('%b %-d, %Y')}"
+      I18n.t(
+        'helpers.shared_links.date_ranges.different_years',
+        start_date: I18n.l(start_date, format: :medium),
+        end_date: I18n.l(end_date, format: :medium)
+      )
     end
   end
 
@@ -20,19 +32,20 @@ module SharedLinksHelper
     return nil unless share&.timeline?
 
     range = formatted_date_range(share.settings['start_date'], share.settings['end_date'])
-    "#{range} is shared via a public link."
+    I18n.t('helpers.shared_links.timeline_subtitle', range:)
   end
 
   def trip_share_subtitle(trip)
-    "#{trip.name} is shared via a public link."
+    I18n.t('helpers.shared_links.trip_subtitle', trip: trip.name)
   end
 
   def track_share_label(track, unit)
-    mode = track.dominant_mode&.titleize.presence || 'Track'
+    mode = track.dominant_mode.presence
+    mode = mode ? I18n.t("transportation_modes.#{mode}") : I18n.t('helpers.shared_links.track')
     zone = track.user.timezone_iana.presence || 'UTC'
-    date = track.start_at.in_time_zone(zone).strftime('%-d %b %Y')
+    date = I18n.l(track.start_at.in_time_zone(zone).to_date, format: :day_month_year_abbreviated)
     distance = track.distance_in_unit(unit).round
-    "#{mode} · #{date} · #{distance} #{unit}"
+    I18n.t('helpers.shared_links.track_label', mode:, date:, distance:, unit:)
   end
 
   PUBLIC_SHARE_CTA_BASE = 'https://dawarich.app'

--- a/app/helpers/shared_links_helper.rb
+++ b/app/helpers/shared_links_helper.rb
@@ -6,7 +6,7 @@ module SharedLinksHelper
     end_date   = Date.parse(end_date.to_s)   unless end_date.is_a?(Date)
 
     if start_date == end_date
-      I18n.l(start_date, format: :long)
+      I18n.l(start_date, format: :month_day_year)
     elsif start_date.year == end_date.year && start_date.month == end_date.month
       I18n.t(
         'helpers.shared_links.date_ranges.same_month',
@@ -17,7 +17,7 @@ module SharedLinksHelper
       I18n.t(
         'helpers.shared_links.date_ranges.same_year',
         start_date: I18n.l(start_date, format: :month_day),
-        end_date: I18n.l(end_date, format: :long)
+        end_date: I18n.l(end_date, format: :month_day_year)
       )
     else
       I18n.t(

--- a/app/helpers/stats_comparison_helper.rb
+++ b/app/helpers/stats_comparison_helper.rb
@@ -8,8 +8,8 @@ module StatsComparisonHelper
     difference = current_km - average_distance_this_year.to_f
     percentage = ((difference / average_distance_this_year.to_f) * 100).round
 
-    more_or_less = difference.positive? ? 'more' : 'less'
-    "#{percentage.abs}% #{more_or_less} than your average this year"
+    direction = difference.positive? ? 'more' : 'less'
+    I18n.t("helpers.stats_comparison.distance.#{direction}", percentage: percentage.abs)
   end
 
   def x_than_previous_active_days(stat, previous_stat)
@@ -19,12 +19,10 @@ module StatsComparisonHelper
     current_active_days = stat.daily_distance.select { _1[1].positive? }.count
     difference = current_active_days - previous_active_days
 
-    return 'Same as previous month' if difference.zero?
+    return I18n.t('helpers.stats_comparison.same_as_previous_month') if difference.zero?
 
-    more_or_less = difference.positive? ? 'more' : 'less'
-    days_word = pluralize(difference.abs, 'day')
-
-    "#{days_word} #{more_or_less} than previous month"
+    direction = difference.positive? ? 'more' : 'less'
+    I18n.t("helpers.stats_comparison.active_days.#{direction}", count: difference.abs)
   end
 
   def x_than_previous_countries_visited(stat, previous_stat)
@@ -34,11 +32,9 @@ module StatsComparisonHelper
     current_countries = stat.toponyms.count { _1['country'] }
     difference = current_countries - previous_countries
 
-    return 'Same as previous month' if difference.zero?
+    return I18n.t('helpers.stats_comparison.same_as_previous_month') if difference.zero?
 
-    more_or_less = difference.positive? ? 'more' : 'less'
-    countries_word = pluralize(difference.abs, 'country')
-
-    "#{countries_word} #{more_or_less} than previous month"
+    direction = difference.positive? ? 'more' : 'less'
+    I18n.t("helpers.stats_comparison.countries.#{direction}", count: difference.abs)
   end
 end

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -55,7 +55,7 @@ module StatsHelper
     distance_value = Stat.convert_distance(peak[1], distance_unit).round
     text = I18n.t(
       'helpers.stats.peak_day',
-      date: I18n.l(date, format: :month_day),
+      date: I18n.l(date, format: :month_day_padded),
       distance: I18n.t('helpers.stats.distance', value: distance_value, unit: distance_unit)
     )
 
@@ -145,8 +145,8 @@ module StatsHelper
     end_date = start_date + 6.days
     I18n.t(
       'helpers.stats.week_range',
-      start_date: I18n.l(start_date, format: :short_month_day),
-      end_date: I18n.l(end_date, format: :short_month_day)
+      start_date: I18n.l(start_date, format: :short_month_day_padded),
+      end_date: I18n.l(end_date, format: :short_month_day_padded)
     )
   end
 end

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -24,14 +24,14 @@ module StatsHelper
     countries = visited.count
     cities = visited.sum { _1['cities'].count }
 
-    "#{countries} countries, #{cities} cities"
+    I18n.t('helpers.stats.countries_and_cities', countries:, cities:)
   end
 
   def distance_traveled(user, stat)
     distance_unit = user.safe_settings.distance_unit
     value = Stat.convert_distance(stat.distance, distance_unit).round
 
-    "#{number_with_delimiter(value)} #{distance_unit}"
+    I18n.t('helpers.stats.distance', value: number_with_delimiter(value), unit: distance_unit)
   end
 
   def active_days(stat)
@@ -47,24 +47,28 @@ module StatsHelper
 
   def peak_day(stat)
     peak = stat.daily_distance.max_by { _1[1] }
-    return 'N/A' unless peak && peak[1].positive?
+    return I18n.t('common.not_available') unless peak && peak[1].positive?
 
     date = Date.new(stat.year, stat.month, peak[0])
     distance_unit = stat.user.safe_settings.distance_unit
 
     distance_value = Stat.convert_distance(peak[1], distance_unit).round
-    text = "#{date.strftime('%B %d')} (#{distance_value} #{distance_unit})"
+    text = I18n.t(
+      'helpers.stats.peak_day',
+      date: I18n.l(date, format: :month_day),
+      distance: I18n.t('helpers.stats.distance', value: distance_value, unit: distance_unit)
+    )
 
     link_to text, preferred_map_path(start_at: date.beginning_of_day, end_at: date.end_of_day), class: 'underline'
   end
 
   def quietest_week(stat)
-    return 'N/A' if stat.daily_distance.empty?
+    return I18n.t('common.not_available') if stat.daily_distance.empty?
 
     distance_by_date = build_distance_by_date_hash(stat)
     quietest_start_date = find_quietest_week_start_date(stat, distance_by_date)
 
-    return 'N/A' unless quietest_start_date
+    return I18n.t('common.not_available') unless quietest_start_date
 
     format_week_range(quietest_start_date)
   end
@@ -139,8 +143,10 @@ module StatsHelper
 
   def format_week_range(start_date)
     end_date = start_date + 6.days
-    start_str = start_date.strftime('%b %d')
-    end_str = end_date.strftime('%b %d')
-    "#{start_str} - #{end_str}"
+    I18n.t(
+      'helpers.stats.week_range',
+      start_date: I18n.l(start_date, format: :short_month_day),
+      end_date: I18n.l(end_date, format: :short_month_day)
+    )
   end
 end

--- a/app/helpers/timeline_helper.rb
+++ b/app/helpers/timeline_helper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module TimelineHelper
-  WEEKDAY_HEADER_LABELS = %w[M T W T F S S].freeze
-
   # "YYYY-MM" for the calendar's initial month. Prefers, in order:
   #   1. `params[:date]` (the selected day, e.g. "2025-12-11")
   #   2. `params[:start_at]` (range start, e.g. "2025-12-11T00:00:00")
@@ -53,14 +51,14 @@ module TimelineHelper
   # minutes -> "Xh Ym" (or "Xm" when < 1h)
   def format_dwell_minutes(minutes)
     minutes = minutes.to_i
-    return '0m' if minutes <= 0
+    return I18n.t('units.minutes_compact', value: 0) if minutes <= 0
 
     h = minutes / 60
     m = minutes % 60
-    return "#{h}h" if m.zero? && h.positive?
-    return "#{m}m" if h.zero?
+    return I18n.t('units.hours_compact', value: h) if m.zero? && h.positive?
+    return I18n.t('units.minutes_compact', value: m) if h.zero?
 
-    "#{h}h #{m}m"
+    I18n.t('units.hours_minutes_compact', hours: h, minutes: m)
   end
 
   # Tracked seconds -> bucket index 0..5
@@ -85,7 +83,7 @@ module TimelineHelper
     entry[:name].presence ||
       entry[:place]&.dig(:name).presence ||
       entry[:area]&.dig(:name).presence ||
-      'Unnamed'
+      I18n.t('helpers.timeline.unnamed')
   end
 
   # Duration-based heuristic for hash entries. Avoids N+1 Visit lookups.
@@ -103,8 +101,8 @@ module TimelineHelper
     {
       start_at: started,
       ended_at: ended,
-      start_label: started.strftime('%H:%M'),
-      end_label: ended.strftime('%H:%M')
+      start_label: I18n.l(started, format: :hour_minute),
+      end_label: I18n.l(ended, format: :hour_minute)
     }
   end
 
@@ -113,7 +111,7 @@ module TimelineHelper
   end
 
   def day_label(day)
-    Date.parse(day[:date].to_s).strftime('%A, %B %-d')
+    I18n.l(Date.parse(day[:date].to_s), format: :weekday_month_day)
   end
 
   def day_total_visits_count(day)
@@ -130,12 +128,12 @@ module TimelineHelper
     {
       prev: (month_date - 1.month).strftime('%Y-%m'),
       next: (month_date + 1.month).strftime('%Y-%m'),
-      title: month_date.strftime('%B %Y')
+      title: I18n.l(month_date, format: :month_year)
     }
   end
 
   def calendar_weekday_labels
-    WEEKDAY_HEADER_LABELS
+    I18n.t('calendar.weekday_initials')
   end
 
   def calendar_day_number(cell)

--- a/app/helpers/tracks/segments_helper.rb
+++ b/app/helpers/tracks/segments_helper.rb
@@ -6,10 +6,14 @@ module Tracks::SegmentsHelper
     enabled = settings.enabled_transportation_modes
     current_mode = segment.transportation_mode.to_s
 
-    options = enabled.map { |m| [m.titleize, m] }
+    options = enabled.map { |mode| [I18n.t("transportation_modes.#{mode}"), mode] }
     return options if enabled.include?(current_mode)
 
-    options.unshift(["#{current_mode.titleize} (disabled in settings)", current_mode])
+    options.unshift([
+                      I18n.t('helpers.tracks.segments.mode_disabled',
+                             mode: I18n.t("transportation_modes.#{current_mode}")),
+                      current_mode
+                    ])
   end
 
   def mode_emoji(mode)
@@ -27,9 +31,9 @@ module Tracks::SegmentsHelper
     distance_km = segment.distance / 1000.0
     case current_user_safe_settings&.distance_unit
     when 'mi'
-      "#{(distance_km * 0.621371).round(2)} mi"
+      I18n.t('units.miles', value: (distance_km * 0.621371).round(2))
     else
-      "#{distance_km.round(2)} km"
+      I18n.t('units.kilometers', value: distance_km.round(2))
     end
   end
 
@@ -37,8 +41,8 @@ module Tracks::SegmentsHelper
     return '-' unless segment.duration
 
     minutes = segment.duration / 60
-    return "#{minutes} min" if minutes < 60
+    return I18n.t('units.minutes', value: minutes) if minutes < 60
 
-    "#{minutes / 60}h #{minutes % 60}m"
+    I18n.t('units.hours_minutes_compact', hours: minutes / 60, minutes: minutes % 60)
   end
 end

--- a/app/helpers/trips_helper.rb
+++ b/app/helpers/trips_helper.rb
@@ -51,11 +51,11 @@ module TripsHelper
     end
 
     parts = []
-    parts << "#{years} year#{'s' if years != 1}" if years.positive?
-    parts << "#{months} month#{'s' if months != 1}" if months.positive?
-    parts << "#{days} day#{'s' if days != 1}" if days.positive?
-    parts << "#{hours} hour#{'s' if hours != 1}" if hours.positive?
-    parts = ['0 hours'] if parts.empty?
+    parts << I18n.t('helpers.trips.duration.years', count: years) if years.positive?
+    parts << I18n.t('helpers.trips.duration.months', count: months) if months.positive?
+    parts << I18n.t('helpers.trips.duration.days', count: days) if days.positive?
+    parts << I18n.t('helpers.trips.duration.hours', count: hours) if hours.positive?
+    parts = [I18n.t('helpers.trips.duration.hours', count: 0)] if parts.empty?
     parts.join(', ')
   end
 end

--- a/app/helpers/users/digests_helper.rb
+++ b/app/helpers/users/digests_helper.rb
@@ -25,7 +25,7 @@ module Users
 
     def distance_with_unit(distance_meters, unit)
       value = Users::Digest.convert_distance(distance_meters, unit).round
-      "#{number_with_delimiter(value)} #{unit}"
+      I18n.t('helpers.users.digests.distance_with_unit', distance: number_with_delimiter(value), unit: unit)
     end
 
     def distance_comparison_text(distance_meters)
@@ -33,25 +33,25 @@ module Users
 
       if distance_km >= Users::Digest::MOON_DISTANCE_KM
         percentage = ((distance_km / Users::Digest::MOON_DISTANCE_KM) * 100).round(1)
-        "That's #{percentage}% of the distance to the Moon!"
+        I18n.t('helpers.users.digests.moon_distance', percentage: percentage)
       else
         percentage = ((distance_km / Users::Digest::EARTH_CIRCUMFERENCE_KM) * 100).round(1)
-        "That's #{percentage}% of Earth's circumference!"
+        I18n.t('helpers.users.digests.earth_circumference', percentage: percentage)
       end
     end
 
     def format_time_spent(minutes)
-      return "#{minutes} minutes" if minutes < 60
+      return I18n.t('units.minutes', value: minutes) if minutes < 60
 
       hours = minutes / 60
       remaining_minutes = minutes % 60
 
       if hours < 24
-        "#{hours}h #{remaining_minutes}m"
+        I18n.t('units.hours_minutes_compact', hours: hours, minutes: remaining_minutes)
       else
         days = hours / 24
         remaining_hours = hours % 24
-        "#{days}d #{remaining_hours}h"
+        I18n.t('units.days_hours_compact', days: days, hours: remaining_hours)
       end
     end
 

--- a/app/helpers/users/digests_mailer_helper.rb
+++ b/app/helpers/users/digests_mailer_helper.rb
@@ -93,8 +93,8 @@ module Users::DigestsMailerHelper
     current  = current.to_f
     previous = previous.to_f
 
-    return '→ same' if current == previous
-    return '↑ new' if previous.zero?
+    return I18n.t('helpers.users.digests_mailer.same') if current == previous
+    return I18n.t('helpers.users.digests_mailer.new') if previous.zero?
 
     delta = ((current - previous) / previous * 100).round
     sign  = delta.positive? ? '+' : ''
@@ -105,10 +105,12 @@ module Users::DigestsMailerHelper
   # Render a trend when only the percent-change is stored (e.g. month_over_month['distance_change_percent']).
   # Guards against percent == -100 which would make 1 + pct/100 == 0 → Infinity → NaN → FloatDomainError.
   def ascii_trend_from_pct(current, percent_change)
-    return '→ same' if percent_change.nil?
+    return I18n.t('helpers.users.digests_mailer.same') if percent_change.nil?
 
     denom = 1 + percent_change.to_f / 100.0
-    return current.to_f.positive? ? '↑ new' : '→ same' if denom.zero?
+    if denom.zero?
+      return I18n.t(current.to_f.positive? ? 'helpers.users.digests_mailer.new' : 'helpers.users.digests_mailer.same')
+    end
 
     ascii_trend(current, current.to_f / denom)
   end

--- a/app/javascript/controllers/activity_heatmap_controller.js
+++ b/app/javascript/controllers/activity_heatmap_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 
 export default class extends Controller {
   static targets = ["tooltip", "tooltipDate", "tooltipDistance"]
@@ -83,12 +84,15 @@ export default class extends Controller {
       day: "numeric",
       year: "numeric",
     }
-    return date.toLocaleDateString("en-US", options)
+    return date.toLocaleDateString(
+      document.documentElement.lang || undefined,
+      options,
+    )
   }
 
   formatDistance(distanceMeters) {
     if (distanceMeters === 0) {
-      return "No activity"
+      return translate("activity.no_activity")
     }
 
     const unit = this.unitValue || "km"

--- a/app/javascript/controllers/add_visit_controller.js
+++ b/app/javascript/controllers/add_visit_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import L from "leaflet"
 import {
   setAddVisitButtonActive,
@@ -141,7 +142,10 @@ export default class extends Controller {
       }
     }, 100)
 
-    Flash.show("notice", "Click on the map to place a visit")
+    Flash.show(
+      "notice",
+      translate("messages.click_on_the_map_to_place_a_visit"),
+    )
   }
 
   exitAddVisitMode(button) {
@@ -219,21 +223,21 @@ export default class extends Controller {
     // Create form HTML using DaisyUI classes for automatic theme support
     const formHTML = `
       <div class="visit-form" style="min-width: 280px;">
-        <h3 class="text-base font-semibold mb-4">Add New Visit</h3>
+        <h3 class="text-base font-semibold mb-4">${translate("visits.add_new")}</h3>
 
         <form id="add-visit-form" class="space-y-3">
           <div class="form-control">
             <label for="visit-name" class="label">
-              <span class="label-text font-medium">Name:</span>
+              <span class="label-text font-medium">${translate("common.name")}:</span>
             </label>
             <input type="text" id="visit-name" name="name" required
                    class="input input-bordered w-full"
-                   placeholder="Enter visit name">
+                   placeholder="${translate("visits.enter_name")}">
           </div>
 
           <div class="form-control">
             <label for="visit-start" class="label">
-              <span class="label-text font-medium">Start Time:</span>
+              <span class="label-text font-medium">${translate("visits.start_time")}:</span>
             </label>
             <input type="datetime-local" id="visit-start" name="started_at" required value="${startTime}"
                    max="9999-12-31T23:59" class="input input-bordered w-full">
@@ -241,7 +245,7 @@ export default class extends Controller {
 
           <div class="form-control">
             <label for="visit-end" class="label">
-              <span class="label-text font-medium">End Time:</span>
+              <span class="label-text font-medium">${translate("visits.end_time")}:</span>
             </label>
             <input type="datetime-local" id="visit-end" name="ended_at" required value="${endTime}"
                    max="9999-12-31T23:59" class="input input-bordered w-full">
@@ -252,10 +256,10 @@ export default class extends Controller {
 
           <div class="flex gap-2 mt-4">
             <button type="submit" class="btn btn-success flex-1">
-              Create Visit
+              ${translate("visits.create")}
             </button>
             <button type="button" id="cancel-visit" class="btn btn-error flex-1">
-              Cancel
+              ${translate("common.cancel")}
             </button>
           </div>
         </form>
@@ -322,7 +326,10 @@ export default class extends Controller {
     const endTime = new Date(visitData.visit.ended_at)
 
     if (endTime <= startTime) {
-      Flash.show("error", "End time must be after start time")
+      Flash.show(
+        "error",
+        translate("messages.end_time_must_be_after_start_time"),
+      )
       return
     }
 
@@ -330,7 +337,7 @@ export default class extends Controller {
     const submitButton = form.querySelector('button[type="submit"]')
     const originalText = submitButton.textContent
     submitButton.disabled = true
-    submitButton.textContent = "Creating..."
+    submitButton.textContent = translate("common.creating")
 
     try {
       const response = await fetch(`/api/v1/visits`, {
@@ -348,7 +355,7 @@ export default class extends Controller {
       if (response.ok) {
         Flash.show(
           "notice",
-          `Visit "${visitData.visit.name}" created successfully!`,
+          translate("visits.created", { name: visitData.visit.name }),
         )
 
         // Store the created visit data
@@ -364,12 +371,15 @@ export default class extends Controller {
         )
       } else {
         const errorMessage =
-          data.error || data.message || "Failed to create visit"
+          data.error || data.message || translate("visits.create_failed")
         Flash.show("error", errorMessage)
       }
     } catch (error) {
       console.error("Error creating visit:", error)
-      Flash.show("error", "Network error: Failed to create visit")
+      Flash.show(
+        "error",
+        translate("messages.network_error_failed_to_create_visit"),
+      )
     } finally {
       // Re-enable form
       submitButton.disabled = false

--- a/app/javascript/controllers/area_creation_v2_controller.js
+++ b/app/javascript/controllers/area_creation_v2_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 
 export default class extends Controller {
   static targets = [
@@ -57,16 +58,16 @@ export default class extends Controller {
       this.formTarget.action = `/areas/${this.editingAreaId}`
       this.addMethodOverride("patch")
       if (this.hasModalTitleTarget)
-        this.modalTitleTarget.textContent = "Edit Area"
+        this.modalTitleTarget.textContent = translate("areas.edit")
       if (this.hasSubmitButtonTarget)
-        this.submitButtonTarget.value = "Update Area"
+        this.submitButtonTarget.value = translate("areas.update")
     } else {
       this.formTarget.action = "/areas"
       this.removeMethodOverride()
       if (this.hasModalTitleTarget)
-        this.modalTitleTarget.textContent = "Create New Area"
+        this.modalTitleTarget.textContent = translate("areas.create_new")
       if (this.hasSubmitButtonTarget)
-        this.submitButtonTarget.value = "Create Area"
+        this.submitButtonTarget.value = translate("areas.create")
     }
   }
 

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import Flash from "./flash_controller"
 
 export default class extends Controller {
@@ -49,13 +50,16 @@ export default class extends Controller {
     if (succeeded) {
       this.handleSuccess()
     } else {
-      Flash.show("error", "Failed to copy. Please copy manually.")
+      Flash.show(
+        "error",
+        translate("messages.failed_to_copy_please_copy_manually"),
+      )
     }
   }
 
   handleSuccess() {
     this.showButtonFeedback()
-    Flash.show("notice", "Copied to clipboard!")
+    Flash.show("notice", translate("messages.copied_to_clipboard"))
   }
 
   showButtonFeedback() {

--- a/app/javascript/controllers/datetime_controller.js
+++ b/app/javascript/controllers/datetime_controller.js
@@ -2,6 +2,7 @@
 // - trips/new
 // - trips/edit
 
+import { translate } from "i18n"
 import BaseController from "./base_controller"
 
 export default class extends BaseController {
@@ -52,7 +53,7 @@ export default class extends BaseController {
 
     // Validate that start date is before end date
     if (startDate >= endDate) {
-      const errorMessage = "Start date must be earlier than end date"
+      const errorMessage = translate("datetime.start_before_end")
       this.endedAtTarget.setCustomValidity(errorMessage)
       if (showPopup) {
         this.endedAtTarget.reportValidity()

--- a/app/javascript/controllers/demo_banner_controller.js
+++ b/app/javascript/controllers/demo_banner_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 
 export default class extends Controller {
   static targets = ["deleteButton", "loadingState", "label"]
@@ -8,11 +9,7 @@ export default class extends Controller {
   }
 
   confirmDelete(event) {
-    const ok = window.confirm(
-      "Delete all demo data?\n\n" +
-        "This removes the demo points, visits, places, tags, tracks, and the Prague trip.\n\n" +
-        "Your real data — anything you've imported, edited, confirmed, or created yourself — will NOT be touched.",
-    )
+    const ok = window.confirm(translate("demo.confirm_delete"))
     if (!ok) {
       event.preventDefault()
       return
@@ -30,7 +27,7 @@ export default class extends Controller {
       this.deleteButtonTarget.classList.add("opacity-50", "pointer-events-none")
     }
     if (this.hasLabelTarget) {
-      this.labelTarget.textContent = "Removing demo data…"
+      this.labelTarget.textContent = translate("demo.removing_data")
     }
   }
 }

--- a/app/javascript/controllers/family_map_controller.js
+++ b/app/javascript/controllers/family_map_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import maplibregl from "maplibre-gl"
 import { escapeHtml } from "maps_maplibre/utils/geojson_transformers"
 import { getCurrentTheme } from "maps_maplibre/utils/popup_theme"
@@ -79,7 +80,7 @@ export default class extends Controller {
       },
       properties: {
         id: loc.user_id,
-        name: loc.email || "Unknown",
+        name: loc.email || translate("common.unknown"),
         color: MEMBER_COLORS[i % MEMBER_COLORS.length],
         lastUpdate: loc.timestamp,
       },

--- a/app/javascript/controllers/family_members_controller.js
+++ b/app/javascript/controllers/family_members_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import L from "leaflet"
 import Flash from "./flash_controller"
 
@@ -117,9 +118,12 @@ export default class extends Controller {
 
       // Format timestamp for display
       const timezone = this.timezoneValue || "UTC"
-      const lastSeen = new Date(location.updated_at).toLocaleString("en-US", {
-        timeZone: timezone,
-      })
+      const lastSeen = new Date(location.updated_at).toLocaleString(
+        document.documentElement.lang || undefined,
+        {
+          timeZone: timezone,
+        },
+      )
 
       // Create small tooltip that shows automatically
       const tooltipContent = this.createTooltipContent(
@@ -199,7 +203,7 @@ export default class extends Controller {
       // Update tooltip content
       const timezone = this.timezoneValue || "UTC"
       const lastSeen = new Date(locationData.updated_at).toLocaleString(
-        "en-US",
+        document.documentElement.lang || undefined,
         { timeZone: timezone },
       )
       const tooltipContent = this.createTooltipContent(
@@ -246,9 +250,12 @@ export default class extends Controller {
     })
 
     const timezone = this.timezoneValue || "UTC"
-    const lastSeen = new Date(location.updated_at).toLocaleString("en-US", {
-      timeZone: timezone,
-    })
+    const lastSeen = new Date(location.updated_at).toLocaleString(
+      document.documentElement.lang || undefined,
+      {
+        timeZone: timezone,
+      },
+    )
 
     const tooltipContent = this.createTooltipContent(lastSeen, location.battery)
     familyMarker.bindTooltip(tooltipContent, {
@@ -274,8 +281,10 @@ export default class extends Controller {
 
   createTooltipContent(lastSeen, battery) {
     const batteryInfo =
-      battery !== null && battery !== undefined ? ` | Battery: ${battery}%` : ""
-    return `Last seen: ${lastSeen}${batteryInfo}`
+      battery !== null && battery !== undefined
+        ? ` | ${translate("map_info.battery")}: ${battery}%`
+        : ""
+    return `${translate("live_share.last_seen_short")}: ${lastSeen}${batteryInfo}`
   }
 
   createPopupContent(location, lastSeen) {
@@ -335,7 +344,7 @@ export default class extends Controller {
 
       batteryDisplay = `
         <p style="margin: 0 0 8px 0; font-size: 13px;">
-          ${batteryIcon}<strong>Battery:</strong> ${battery}%${batteryStatus ? ` (${batteryStatus})` : ""}
+          ${batteryIcon}<strong>${translate("map_info.battery")}:</strong> ${battery}%${batteryStatus ? ` (${translate(`battery_statuses.${batteryStatus}`)})` : ""}
         </p>
       `
     }
@@ -344,18 +353,18 @@ export default class extends Controller {
       <div class="family-member-popup" style="background-color: ${bgColor}; color: ${textColor}; padding: 12px; border-radius: 8px; min-width: 220px;">
         <h3 style="margin: 0 0 12px 0; color: #10B981; font-size: 15px; font-weight: bold; display: flex; align-items: center; gap: 8px;">
           <span style="background-color: #10B981; color: white; border-radius: 50%; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; font-size: 14px; font-weight: bold;">${emailInitial}</span>
-          Family Member
+          ${translate("family.member")}
         </h3>
         <p style="margin: 0 0 8px 0; font-size: 13px;">
-          <strong>Email:</strong> ${location.email || "Unknown"}
+          <strong>${translate("map_info.email")}:</strong> ${location.email || translate("common.unknown")}
         </p>
         <p style="margin: 0 0 8px 0; font-size: 13px;">
-          <strong>Coordinates:</strong><br/>
+          <strong>${translate("map_info.coordinates")}:</strong><br/>
           ${location.latitude.toFixed(6)}, ${location.longitude.toFixed(6)}
         </p>
         ${batteryDisplay}
         <p style="margin: 0; font-size: 12px; color: ${mutedColor}; padding-top: 8px; border-top: 1px solid ${isDark ? "#374151" : "#e5e7eb"};">
-          <strong>Last seen:</strong> ${lastSeen}
+          <strong>${translate("live_share.last_seen_short")}:</strong> ${lastSeen}
         </p>
       </div>
     `
@@ -413,10 +422,7 @@ export default class extends Controller {
 
     // Listen for when the Family Members layer is added
     this.map.on("overlayadd", (event) => {
-      if (
-        event.name === "Family Members" &&
-        event.layer === this.familyMarkersLayer
-      ) {
+      if (event.layer === this.familyMarkersLayer) {
         // Refresh locations and zoom after data is loaded
         this.refreshFamilyLocations().then(() => {
           this.zoomToFitAllMembers()
@@ -429,10 +435,7 @@ export default class extends Controller {
 
     // Listen for when the Family Members layer is removed
     this.map.on("overlayremove", (event) => {
-      if (
-        event.name === "Family Members" &&
-        event.layer === this.familyMarkersLayer
-      ) {
+      if (event.layer === this.familyMarkersLayer) {
         // Stop periodic refresh when layer is disabled
         this.stopPeriodicRefresh()
       }
@@ -538,7 +541,7 @@ export default class extends Controller {
         const count = data.locations?.length || 0
         this.showFlashMessageToUser(
           "notice",
-          `Family locations updated (${count} members)`,
+          translate("family.locations_updated", { count }),
         )
         this.showUserFeedback = false // Reset flag
       }
@@ -547,10 +550,7 @@ export default class extends Controller {
 
       // Show error to user if this was a manual refresh
       if (this.showUserFeedback) {
-        this.showFlashMessageToUser(
-          "error",
-          "Failed to refresh family locations",
-        )
+        this.showFlashMessageToUser("error", translate("family.refresh_failed"))
         this.showUserFeedback = false // Reset flag
       }
     }

--- a/app/javascript/controllers/family_navbar_indicator_controller.js
+++ b/app/javascript/controllers/family_navbar_indicator_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 
 export default class extends Controller {
   static targets = ["indicator"]
@@ -50,13 +51,11 @@ export default class extends Controller {
     if (this.enabledValue) {
       this.indicatorTarget.className =
         "tooltip tooltip-bottom w-2 h-2 bg-green-500 rounded-full animate-pulse"
-      this.indicatorTarget.dataset.tip =
-        "Location is being shared with your family"
+      this.indicatorTarget.dataset.tip = translate("family.sharing_enabled")
     } else {
       this.indicatorTarget.className =
         "tooltip tooltip-bottom w-2 h-2 bg-gray-400 rounded-full"
-      this.indicatorTarget.dataset.tip =
-        "Location is not being shared with your family"
+      this.indicatorTarget.dataset.tip = translate("family.sharing_disabled")
     }
   }
 }

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 
 const ALERT_CLASSES = {
   error: "alert-error",
@@ -42,12 +43,15 @@ export default class extends Controller {
         </svg>
         <span></span>
       </div>
-      <button type="button" data-action="click->removals#remove" class="btn btn-sm btn-circle btn-ghost" aria-label="Close">
+      <button type="button" data-action="click->removals#remove" class="btn btn-sm btn-circle btn-ghost">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="${CLOSE_PATH}" />
         </svg>
       </button>
     `
+    div
+      .querySelector("button")
+      .setAttribute("aria-label", translate("common.close"))
     // Set message text safely (no innerHTML for user content)
     div.querySelector("span").textContent = message
 

--- a/app/javascript/controllers/location_sharing_toggle_controller.js
+++ b/app/javascript/controllers/location_sharing_toggle_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import Flash from "./flash_controller"
 
 export default class extends Controller {
@@ -97,7 +98,7 @@ export default class extends Controller {
         this.durationContainerTarget.classList.add("hidden")
       if (this.hasHistoryContainerTarget)
         this.historyContainerTarget.classList.add("hidden")
-      Flash.show("info", "Location sharing has expired")
+      Flash.show("info", translate("messages.location_sharing_has_expired"))
 
       document.dispatchEvent(
         new CustomEvent("location-sharing:expired", {
@@ -130,7 +131,7 @@ export default class extends Controller {
     const msRemaining = expiresAt.getTime() - Date.now()
 
     if (msRemaining <= 0) {
-      this.expirationInfoTarget.textContent = "Expired"
+      this.expirationInfoTarget.textContent = translate("common.expired")
       this.expirationInfoTarget.classList.remove("hidden")
       return
     }
@@ -142,10 +143,15 @@ export default class extends Controller {
 
     const timeText =
       hoursLeft > 0
-        ? `${hoursLeft}h ${minutesLeft}m remaining`
-        : `${minutesLeft}m remaining`
+        ? translate("sharing.hours_minutes_remaining", {
+            hours: hoursLeft,
+            minutes: minutesLeft,
+          })
+        : translate("sharing.minutes_remaining", { minutes: minutesLeft })
 
-    this.expirationInfoTarget.textContent = `Expires in ${timeText}`
+    this.expirationInfoTarget.textContent = translate("sharing.expires_in", {
+      time: timeText,
+    })
     this.expirationInfoTarget.classList.remove("hidden")
   }
 }

--- a/app/javascript/controllers/map_panel_controller.js
+++ b/app/javascript/controllers/map_panel_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 
 // Module-level flag so the document-level keyboard shortcuts and tab-change
 // mirror listeners are only bound once, even when multiple map-panel
@@ -15,13 +16,13 @@ export default class extends Controller {
   static targets = ["tabButton", "tabContent", "title"]
 
   // Tab title mappings
-  static titles = {
-    search: "Search",
-    layers: "Map Layers",
-    "timeline-feed": "Timeline",
-    tools: "Tools",
-    links: "Links",
-    settings: "Settings",
+  static titleKeys = {
+    search: "map_panel.search",
+    layers: "map_panel.layers",
+    "timeline-feed": "map_panel.timeline",
+    tools: "map_panel.tools",
+    links: "map_panel.links",
+    settings: "map_panel.settings",
   }
 
   connect() {
@@ -272,7 +273,8 @@ export default class extends Controller {
 
     // Update title
     if (this.hasTitleTarget) {
-      this.titleTarget.textContent = this.constructor.titles[tabName] || tabName
+      const titleKey = this.constructor.titleKeys[tabName]
+      this.titleTarget.textContent = titleKey ? translate(titleKey) : tabName
     }
 
     // Toggle Timeline expansion on panel + container

--- a/app/javascript/controllers/map_preview_controller.js
+++ b/app/javascript/controllers/map_preview_controller.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import L from "leaflet"
 import BaseController from "./base_controller"
 import Flash from "./flash_controller"
@@ -53,7 +54,10 @@ export default class extends BaseController {
       }).addTo(this.map)
     } catch (e) {
       console.error("Invalid tile URL:", e)
-      Flash.show("error", "Invalid tile URL. Reverting to OpenStreetMap.")
+      Flash.show(
+        "error",
+        translate("messages.invalid_tile_url_reverting_to_openstreetmap"),
+      )
 
       // Reset input to default OSM URL
       this.urlInputTarget.value = this.DEFAULT_TILE_URL

--- a/app/javascript/controllers/map_settings_dirty_controller.js
+++ b/app/javascript/controllers/map_settings_dirty_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 
 // Tracks unsaved edits in the map settings sections whose fields only
 // persist on "Apply Settings" (live-saving controls are simply not inside
@@ -62,8 +63,12 @@ export default class extends Controller {
       const changed = this.changedFields(section)
       badge.classList.toggle("hidden", changed.length === 0)
       if (changed.length > 0) {
-        badge.textContent = `${changed.length} unsaved`
-        badge.dataset.tip = `Changed: ${changed.join(", ")}`
+        badge.textContent = translate("settings.unsaved_count", {
+          count: changed.length,
+        })
+        badge.dataset.tip = translate("settings.changed_fields", {
+          fields: changed.join(", "),
+        })
       }
     })
   }

--- a/app/javascript/controllers/map_theme_editor_controller.js
+++ b/app/javascript/controllers/map_theme_editor_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import { SettingsManager } from "maps_maplibre/utils/settings_manager"
 import { extendTokens, loadThemeTokens } from "poster_studio/data/theme_loader"
 import Flash from "./flash_controller"
@@ -62,7 +63,10 @@ export default class extends Controller {
       if (this.hasBlockTarget) this.blockTarget.open = true
       this.scheduleSave()
     } catch (error) {
-      Flash.show("error", `Failed to load theme preset: ${error.message}`)
+      Flash.show(
+        "error",
+        translate("poster.theme_preset_failed", { error: error.message }),
+      )
     }
   }
 

--- a/app/javascript/controllers/maps/immich_enrich_controller.js
+++ b/app/javascript/controllers/maps/immich_enrich_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import maplibregl from "maplibre-gl"
 import Flash from "../flash_controller"
 
@@ -94,7 +95,7 @@ export default class extends Controller {
     const tolerance = (parseInt(this.toleranceTarget.value, 10) || 30) * 60
 
     if (!startDate || !endDate) {
-      Flash.show("error", "Please select a date range")
+      Flash.show("error", translate("messages.please_select_a_date_range"))
       return
     }
 
@@ -103,7 +104,7 @@ export default class extends Controller {
 
     this.scanning = true
     if (this.hasScanButtonTarget) this.scanButtonTarget.disabled = true
-    this.showLoading("Scanning Immich photos...")
+    this.showLoading(translate("immich.scanning"))
     this.removeMarkers()
 
     try {
@@ -129,7 +130,7 @@ export default class extends Controller {
       this.renderResults(data)
     } catch (error) {
       console.error("[Immich Enrich] Scan failed:", error)
-      Flash.show("error", "Failed to scan photos")
+      Flash.show("error", translate("messages.failed_to_scan_photos"))
       this.showScanForm()
     } finally {
       setTimeout(() => {
@@ -171,8 +172,8 @@ export default class extends Controller {
       this.resultsSummaryTarget.innerHTML = `
         <div class="text-center py-3">
           <div class="text-base-content/40 text-2xl mb-1">📷</div>
-          <div class="text-sm font-medium">${data.total_without_geodata} photos without GPS</div>
-          <div class="text-xs text-base-content/50">No matches found within tolerance</div>
+          <div class="text-sm font-medium">${translate("immich.photos_without_gps", { count: data.total_without_geodata })}</div>
+          <div class="text-xs text-base-content/50">${translate("immich.no_matches")}</div>
         </div>
       `
       this.matchListTarget.innerHTML = ""
@@ -181,7 +182,13 @@ export default class extends Controller {
       return
     }
 
-    this.resultsSummaryTarget.textContent = `${data.total_matched} of ${data.total_without_geodata} matched`
+    this.resultsSummaryTarget.textContent = translate(
+      "immich.matched_summary",
+      {
+        matched: data.total_matched,
+        total: data.total_without_geodata,
+      },
+    )
     this.matchListTarget.innerHTML = ""
 
     for (const [index, match] of this.matches.entries()) {
@@ -234,7 +241,7 @@ export default class extends Controller {
       </div>
       <a href="${immichPhotoUrl}" target="_blank" rel="noopener noreferrer"
          class="btn btn-ghost btn-xs btn-square flex-shrink-0 opacity-40 hover:opacity-100"
-         title="Open in Immich"
+         title="${translate("immich.open_in_immich")}"
          onclick="event.stopPropagation()">
         ${EXTERNAL_LINK_SVG}
       </a>
@@ -342,7 +349,9 @@ export default class extends Controller {
 
   updateEnrichButton() {
     const count = this.selectedCount()
-    this.enrichButtonTarget.textContent = `Enrich ${count} photo${count !== 1 ? "s" : ""}`
+    this.enrichButtonTarget.textContent = translate("immich.enrich_photos", {
+      count,
+    })
     this.enrichButtonTarget.disabled = count === 0
   }
 
@@ -386,11 +395,11 @@ export default class extends Controller {
     if (assets.length === 0) return
 
     const confirmed = window.confirm(
-      `Write GPS coordinates to ${assets.length} photo${assets.length !== 1 ? "s" : ""} in Immich? This will update their location metadata.`,
+      translate("immich.confirm_enrich", { count: assets.length }),
     )
     if (!confirmed) return
 
-    this.showLoading(`Enriching ${assets.length} photos...`)
+    this.showLoading(translate("immich.enriching", { count: assets.length }))
 
     try {
       const response = await fetch("/api/v1/immich/enrich", {
@@ -409,15 +418,18 @@ export default class extends Controller {
 
       const message =
         data.failed > 0
-          ? `Enriched ${data.enriched} photos. ${data.failed} failed.`
-          : `Successfully enriched ${data.enriched} photos!`
+          ? translate("immich.partially_enriched", {
+              enriched: data.enriched,
+              failed: data.failed,
+            })
+          : translate("immich.enriched", { count: data.enriched })
 
       Flash.show(data.failed > 0 ? "warning" : "notice", message)
       this.removeMarkers()
       this.showScanForm()
     } catch (error) {
       console.error("[Immich Enrich] Enrich failed:", error)
-      Flash.show("error", "Failed to enrich photos")
+      Flash.show("error", translate("messages.failed_to_enrich_photos"))
       this.showResults()
     }
   }
@@ -495,7 +507,10 @@ export default class extends Controller {
     const el = document.createElement("div")
     el.className = "immich-enrich-marker"
     this.applyMarkerStyle(el, match, selected, true)
-    el.title = `${match.filename} (${this.formatTimeDelta(match.time_delta_seconds)} delta)`
+    el.title = translate("immich.marker_title", {
+      filename: match.filename,
+      delta: this.formatTimeDelta(match.time_delta_seconds),
+    })
     return el
   }
 
@@ -591,7 +606,7 @@ export default class extends Controller {
 
   formatDatetime(isoString) {
     const d = new Date(isoString)
-    return d.toLocaleString("en-US", {
+    return d.toLocaleString(document.documentElement.lang || undefined, {
       year: "numeric",
       month: "short",
       day: "numeric",
@@ -601,9 +616,10 @@ export default class extends Controller {
   }
 
   formatTimeDelta(seconds) {
-    if (seconds < 60) return `${seconds}s`
+    if (seconds < 60)
+      return translate("immich.seconds_short", { count: seconds })
     const minutes = Math.round(seconds / 60)
-    return `${minutes}m`
+    return translate("immich.minutes_short", { count: minutes })
   }
 
   confidenceColor(timeDelta) {

--- a/app/javascript/controllers/maps/maplibre/area_selection_manager.js
+++ b/app/javascript/controllers/maps/maplibre/area_selection_manager.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { Toast } from "maps_maplibre/components/toast"
 import { VisitCard } from "maps_maplibre/components/visit_card"
 import { SelectedPointsLayer } from "maps_maplibre/layers/selected_points_layer"
@@ -65,7 +66,9 @@ export class AreaSelectionManager {
         "click->maps--maplibre#cancelAreaSelection"
     }
 
-    Toast.info("Draw a rectangle on the map to select points")
+    Toast.info(
+      translate("messages.draw_a_rectangle_on_the_map_to_select_points"),
+    )
   }
 
   /**
@@ -73,7 +76,7 @@ export class AreaSelectionManager {
    */
   async handleAreaSelected(bounds) {
     try {
-      Toast.info("Fetching data in selected area...")
+      Toast.info(translate("messages.fetching_data_in_selected_area"))
 
       const [points, visits] = await Promise.all([
         this.api.fetchPointsInArea({
@@ -103,7 +106,7 @@ export class AreaSelectionManager {
       )
 
       if (points.length === 0 && visits.length === 0) {
-        Toast.info("No data found in selected area")
+        Toast.info(translate("messages.no_data_found_in_selected_area"))
         this.cancelAreaSelection()
         return
       }
@@ -127,7 +130,10 @@ export class AreaSelectionManager {
 
       // Update delete button text with count
       if (this.controller.hasDeleteButtonTextTarget) {
-        this.controller.deleteButtonTextTarget.textContent = `Delete ${points.length} Point${points.length === 1 ? "" : "s"}`
+        this.controller.deleteButtonTextTarget.textContent = translate(
+          "selection.delete_points",
+          { count: points.length },
+        )
       }
 
       // Track anomaly point IDs separately so the user can opt to delete
@@ -141,7 +147,10 @@ export class AreaSelectionManager {
         if (anomalyCount > 0) {
           btn.classList.remove("hidden")
           if (this.controller.hasDeleteAnomaliesButtonTextTarget) {
-            this.controller.deleteAnomaliesButtonTextTarget.textContent = `Delete ${anomalyCount} Anomaly Point${anomalyCount === 1 ? "" : "s"}`
+            this.controller.deleteAnomaliesButtonTextTarget.textContent =
+              translate("selection.delete_anomaly_points", {
+                count: anomalyCount,
+              })
           }
         } else {
           btn.classList.add("hidden")
@@ -153,14 +162,18 @@ export class AreaSelectionManager {
 
       const messages = []
       if (points.length > 0)
-        messages.push(`${points.length} point${points.length === 1 ? "" : "s"}`)
+        messages.push(translate("selection.points", { count: points.length }))
       if (visits.length > 0)
-        messages.push(`${visits.length} visit${visits.length === 1 ? "" : "s"}`)
+        messages.push(translate("selection.visits", { count: visits.length }))
 
-      Toast.success(`Selected ${messages.join(" and ")}`)
+      Toast.success(
+        translate("selection.selected", {
+          items: messages.join(` ${translate("common.and")} `),
+        }),
+      )
     } catch (error) {
       console.error("[Maps V2] Failed to fetch data in area:", error)
-      Toast.error("Failed to fetch data in selected area")
+      Toast.error(translate("messages.failed_to_fetch_data_in_selected_area"))
       this.cancelAreaSelection()
     }
   }
@@ -185,7 +198,7 @@ export class AreaSelectionManager {
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
-          <h3 class="text-sm font-bold">Visits in Area (${visits.length})</h3>
+          <h3 class="text-sm font-bold">${translate("selection.visits_in_area", { count: visits.length })}</h3>
         </div>
         ${cardsHTML}
       </div>
@@ -269,26 +282,26 @@ export class AreaSelectionManager {
               <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
-              <span>${selectedCount} visit${selectedCount === 1 ? "" : "s"} selected</span>
+              <span>${translate("visits.selected", { count: selectedCount })}</span>
             </div>
             <div class="grid grid-cols-3 gap-1.5">
               <button class="btn btn-xs btn-outline normal-case" data-bulk-merge>
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
                 </svg>
-                Merge
+                ${translate("visits.merge")}
               </button>
               <button class="btn btn-xs btn-primary normal-case" data-bulk-confirm>
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                 </svg>
-                Confirm
+                ${translate("common.confirm")}
               </button>
               <button class="btn btn-xs btn-outline btn-error normal-case" data-bulk-delete>
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>
-                Delete
+                ${translate("common.delete")}
               </button>
             </div>
           </div>
@@ -316,11 +329,11 @@ export class AreaSelectionManager {
   async confirmVisit(visitId) {
     try {
       await this.api.updateVisitStatus(visitId, "confirmed")
-      Toast.success("Visit confirmed")
+      Toast.success(translate("messages.visit_confirmed"))
       await this.refreshSelectedVisits()
     } catch (error) {
       console.error("[Maps V2] Failed to confirm visit:", error)
-      Toast.error("Failed to confirm visit")
+      Toast.error(translate("messages.failed_to_confirm_visit"))
     }
   }
 
@@ -328,15 +341,15 @@ export class AreaSelectionManager {
    * Delete a single visit
    */
   async deleteVisit(visitId) {
-    if (!window.confirm("Delete this visit? Your location points stay.")) {
+    if (!window.confirm(translate("visits.confirm_delete_keep_points"))) {
       return
     }
     try {
       await this.api.deleteVisit(visitId)
-      Toast.success("Visit deleted")
+      Toast.success(translate("messages.visit_deleted"))
       await this.refreshSelectedVisits()
     } catch (_error) {
-      Toast.error("Failed to delete visit")
+      Toast.error(translate("messages.failed_to_delete_visit"))
     }
   }
 
@@ -347,24 +360,26 @@ export class AreaSelectionManager {
     const visitIds = Array.from(this.selectedVisitIds)
 
     if (visitIds.length < 2) {
-      Toast.error("Select at least 2 visits to merge")
+      Toast.error(translate("messages.select_at_least_2_visits_to_merge"))
       return
     }
 
-    if (!confirm(`Merge ${visitIds.length} visits into one?`)) {
+    if (
+      !confirm(translate("visits.confirm_merge", { count: visitIds.length }))
+    ) {
       return
     }
 
     try {
-      Toast.info("Merging visits...")
+      Toast.info(translate("messages.merging_visits"))
       const mergedVisit = await this.api.mergeVisits(visitIds)
-      Toast.success("Visits merged successfully")
+      Toast.success(translate("messages.visits_merged_successfully"))
 
       this.selectedVisitIds.clear()
       this.replaceVisitsWithMerged(visitIds, mergedVisit)
       this.updateBulkActions()
     } catch (_error) {
-      Toast.error("Failed to merge visits")
+      Toast.error(translate("messages.failed_to_merge_visits"))
     }
   }
 
@@ -375,14 +390,16 @@ export class AreaSelectionManager {
     const visitIds = Array.from(this.selectedVisitIds)
 
     try {
-      Toast.info("Confirming visits...")
+      Toast.info(translate("messages.confirming_visits"))
       await this.api.bulkUpdateVisits(visitIds, "confirmed")
-      Toast.success(`Confirmed ${visitIds.length} visits`)
+      Toast.success(
+        translate("visits.confirmed_count", { count: visitIds.length }),
+      )
 
       this.selectedVisitIds.clear()
       await this.refreshSelectedVisits()
     } catch (_error) {
-      Toast.error("Failed to confirm visits")
+      Toast.error(translate("messages.failed_to_confirm_visits"))
     }
   }
 
@@ -394,24 +411,26 @@ export class AreaSelectionManager {
 
     if (
       !window.confirm(
-        `Delete ${visitIds.length} visit${visitIds.length === 1 ? "" : "s"}? Your location points stay.`,
+        translate("visits.confirm_delete_count_keep_points", {
+          count: visitIds.length,
+        }),
       )
     ) {
       return
     }
 
     try {
-      Toast.info("Deleting visits...")
+      Toast.info(translate("messages.deleting_visits"))
       await this.api.bulkDestroyVisits(visitIds)
       Toast.success(
-        `Deleted ${visitIds.length} visit${visitIds.length === 1 ? "" : "s"}`,
+        translate("visits.deleted_count", { count: visitIds.length }),
       )
 
       this.selectedVisitIds.clear()
       await this.refreshSelectedVisits()
     } catch (error) {
       console.error("[Maps V2] Failed to delete visits:", error)
-      Toast.error("Failed to delete visits")
+      Toast.error(translate("messages.failed_to_delete_visits"))
     }
   }
 
@@ -467,7 +486,9 @@ export class AreaSelectionManager {
 
     const header = container.querySelector("h3")
     if (header) {
-      header.textContent = `Visits in Area (${this.selectedVisits.length})`
+      header.textContent = translate("selection.visits_in_area", {
+        count: this.selectedVisits.length,
+      })
     }
 
     this.attachVisitCardListeners()
@@ -550,7 +571,7 @@ export class AreaSelectionManager {
       this.controller.selectionActionsTarget.classList.add("hidden")
     }
 
-    Toast.info("Selection cancelled")
+    Toast.info(translate("messages.selection_cancelled"))
   }
 
   async refreshAnomaliesIfEnabled() {
@@ -572,12 +593,14 @@ export class AreaSelectionManager {
 
     const ids = this.selectedAnomalyIds
     if (!ids.length) {
-      Toast.error("No anomaly points in selection")
+      Toast.error(translate("messages.no_anomaly_points_in_selection"))
       return
     }
 
     const confirmed = confirm(
-      `Are you sure you want to delete ${ids.length} anomaly point${ids.length === 1 ? "" : "s"}? This action cannot be undone.`,
+      translate("selection.confirm_delete_anomaly_points", {
+        count: ids.length,
+      }),
     )
     if (!confirmed) return
 
@@ -588,11 +611,11 @@ export class AreaSelectionManager {
     if (btn) btn.disabled = true
 
     try {
-      Toast.info("Deleting anomaly points...")
+      Toast.info(translate("messages.deleting_anomaly_points"))
       const result = await this.api.bulkDeletePoints(ids)
 
       Toast.success(
-        `Deleted ${result.count} anomaly point${result.count === 1 ? "" : "s"}`,
+        translate("selection.anomaly_points_deleted", { count: result.count }),
       )
 
       this.cancelAreaSelection()
@@ -609,24 +632,25 @@ export class AreaSelectionManager {
           "[Maps V2] Map refresh failed after anomaly delete:",
           reloadError,
         )
-        Toast.error(
-          "Map didn't refresh. Reload the page to see updated points.",
-        )
+        Toast.error(translate("selection.map_refresh_failed"))
       }
     } catch (error) {
       console.error("[Maps V2] Failed to delete anomaly points:", error)
       const body = error?.body
       if (error?.status === 403 && body?.upgrade_url) {
         Toast.error(
-          `${body.error || "Write API requires Pro"} — ${body.upgrade_url}`,
+          `${body.error || translate("selection.write_api_requires_pro")} — ${body.upgrade_url}`,
         )
       } else if (error?.status === 422 && body?.limit) {
         Toast.error(
-          `Too many points (${body.requested}). Please draw a smaller area; max ${body.limit} per delete.`,
+          translate("selection.too_many_points", {
+            requested: body.requested,
+            limit: body.limit,
+          }),
         )
       } else {
         Toast.error(
-          error?.message || "Failed to delete points. Please try again.",
+          error?.message || translate("selection.delete_points_failed"),
         )
       }
     } finally {
@@ -645,12 +669,12 @@ export class AreaSelectionManager {
     const pointIds = this.selectedPointsLayer.getSelectedPointIds()
 
     if (pointIds.length === 0) {
-      Toast.error("No points selected")
+      Toast.error(translate("messages.no_points_selected"))
       return
     }
 
     const confirmed = confirm(
-      `Are you sure you want to delete ${pointCount} point${pointCount === 1 ? "" : "s"}? This action cannot be undone.`,
+      translate("selection.confirm_delete_points", { count: pointCount }),
     )
 
     if (!confirmed) return
@@ -662,11 +686,11 @@ export class AreaSelectionManager {
     if (deleteButton) deleteButton.disabled = true
 
     try {
-      Toast.info("Deleting points...")
+      Toast.info(translate("messages.deleting_points"))
       const result = await this.api.bulkDeletePoints(pointIds)
 
       Toast.success(
-        `Deleted ${result.count} point${result.count === 1 ? "" : "s"}`,
+        translate("selection.points_deleted", { count: result.count }),
       )
 
       this.cancelAreaSelection()
@@ -680,24 +704,25 @@ export class AreaSelectionManager {
         await this.refreshAnomaliesIfEnabled()
       } catch (reloadError) {
         console.error("[Maps V2] Map refresh failed after delete:", reloadError)
-        Toast.error(
-          "Map didn't refresh. Reload the page to see updated points.",
-        )
+        Toast.error(translate("selection.map_refresh_failed"))
       }
     } catch (error) {
       console.error("[Maps V2] Failed to delete points:", error)
       const body = error?.body
       if (error?.status === 403 && body?.upgrade_url) {
         Toast.error(
-          `${body.error || "Write API requires Pro"} — ${body.upgrade_url}`,
+          `${body.error || translate("selection.write_api_requires_pro")} — ${body.upgrade_url}`,
         )
       } else if (error?.status === 422 && body?.limit) {
         Toast.error(
-          `Too many points selected (${body.requested}). Please draw a smaller area; max ${body.limit} per delete.`,
+          translate("selection.too_many_selected_points", {
+            requested: body.requested,
+            limit: body.limit,
+          }),
         )
       } else {
         Toast.error(
-          error?.message || "Failed to delete points. Please try again.",
+          error?.message || translate("selection.delete_points_failed"),
         )
       }
     } finally {

--- a/app/javascript/controllers/maps/maplibre/event_handlers.js
+++ b/app/javascript/controllers/maps/maplibre/event_handlers.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import maplibregl from "maplibre-gl"
 import {
   formatDistance,
@@ -67,13 +68,13 @@ export class EventHandlers {
             handler: "handleDelete",
             id: pointId,
             entityType: "point",
-            label: "Delete",
+            label: translate("messages.delete"),
           },
         ]
       : []
 
     this.controller.showInfo(
-      "Location Point",
+      translate("map_info.location_point"),
       this._buildPointInfoContent(feature.properties, feature.geometry),
       actions,
     )
@@ -88,7 +89,7 @@ export class EventHandlers {
     if (!anomaliesLayer) return
 
     const content = anomaliesLayer.buildPopupContent(feature.properties)
-    this.controller.showInfo("Anomaly Point", content)
+    this.controller.showInfo(translate("messages.anomaly_point"), content)
   }
 
   /**
@@ -107,7 +108,7 @@ export class EventHandlers {
     const feature = e.features[0]
     container.innerHTML = `
       <div class="mt-3 pt-3 border-t border-base-300">
-        <div class="text-sm font-semibold mb-1">Selected Point</div>
+        <div class="text-sm font-semibold mb-1">${translate("map_info.selected_point")}</div>
         ${this._buildPointInfoContent(feature.properties, feature.geometry)}
       </div>
     `
@@ -135,11 +136,11 @@ export class EventHandlers {
     return `
       <div class="space-y-2">
         ${addressFrame}
-        ${coordStr ? `<div><span class="font-semibold">Coordinates:</span> ${coordStr}</div>` : ""}
-        <div><span class="font-semibold">Time:</span> ${formatTimestamp(properties.timestamp, this.controller.timezoneValue)}</div>
-        ${properties.battery ? `<div><span class="font-semibold">Battery:</span> ${properties.battery}%</div>` : ""}
-        ${properties.altitude ? `<div><span class="font-semibold">Altitude:</span> ${Math.round(properties.altitude)}m</div>` : ""}
-        ${properties.velocity ? `<div><span class="font-semibold">Speed:</span> ${formatSpeed(properties.velocity * 3.6, distanceUnit)}</div>` : ""}
+        ${coordStr ? `<div><span class="font-semibold">${translate("map_info.coordinates")}:</span> ${coordStr}</div>` : ""}
+        <div><span class="font-semibold">${translate("map_info.time")}:</span> ${formatTimestamp(properties.timestamp, this.controller.timezoneValue)}</div>
+        ${properties.battery ? `<div><span class="font-semibold">${translate("map_info.battery")}:</span> ${properties.battery}%</div>` : ""}
+        ${properties.altitude ? `<div><span class="font-semibold">${translate("map_info.altitude")}:</span> ${Math.round(properties.altitude)}m</div>` : ""}
+        ${properties.velocity ? `<div><span class="font-semibold">${translate("map_info.speed")}:</span> ${formatSpeed(properties.velocity * 3.6, distanceUnit)}</div>` : ""}
       </div>
     `
   }
@@ -172,12 +173,12 @@ export class EventHandlers {
 
     const content = `
       <div class="space-y-2">
-        ${properties.photo_url ? `<img src="${escapeHtml(properties.photo_url)}" alt="Photo" class="w-full rounded-lg mb-2" />` : ""}
-        ${properties.taken_at ? `<div><span class="font-semibold">Taken:</span> ${formatTimestamp(properties.taken_at, this.controller.timezoneValue)}</div>` : ""}
+        ${properties.photo_url ? `<img src="${escapeHtml(properties.photo_url)}" alt="${translate("map_info.photo")}" class="w-full rounded-lg mb-2" />` : ""}
+        ${properties.taken_at ? `<div><span class="font-semibold">${translate("map_info.taken")}:</span> ${formatTimestamp(properties.taken_at, this.controller.timezoneValue)}</div>` : ""}
       </div>
     `
 
-    this.controller.showInfo("Photo", content)
+    this.controller.showInfo(translate("map_info.photo"), content)
   }
 
   /**
@@ -193,7 +194,7 @@ export class EventHandlers {
         ${properties.description ? `<div>${escapeHtml(properties.description)}</div>` : ""}
         ${
           properties.nameLocked
-            ? `<div class="text-xs opacity-70" data-testid="place-name-lock">🔒 You named this place, so automatic naming won't change it. Rename it to "Suggested place" to hand it back.</div>`
+            ? `<div class="text-xs opacity-70" data-testid="place-name-lock">${translate("map_info.place_name_locked")}</div>`
             : ""
         }
       </div>
@@ -206,13 +207,13 @@ export class EventHandlers {
             handler: "handleEdit",
             id: properties.id,
             entityType: "place",
-            label: "Edit",
+            label: translate("messages.edit"),
           },
         ]
       : []
 
     this.controller.showInfo(
-      escapeHtml(properties.name) || "Place",
+      escapeHtml(properties.name) || translate("map_info.place"),
       content,
       actions,
     )
@@ -233,8 +234,8 @@ export class EventHandlers {
   _renderAreaInfo(properties) {
     const content = `
       <div class="space-y-2">
-        ${properties.radius ? `<div><span class="font-semibold">Radius:</span> ${Math.round(properties.radius)}m</div>` : ""}
-        ${properties.latitude && properties.longitude ? `<div><span class="font-semibold">Center:</span> ${properties.latitude.toFixed(6)}, ${properties.longitude.toFixed(6)}</div>` : ""}
+        ${properties.radius ? `<div><span class="font-semibold">${translate("map_info.radius")}:</span> ${Math.round(properties.radius)}m</div>` : ""}
+        ${properties.latitude && properties.longitude ? `<div><span class="font-semibold">${translate("map_info.center")}:</span> ${properties.latitude.toFixed(6)}, ${properties.longitude.toFixed(6)}</div>` : ""}
       </div>
     `
 
@@ -245,20 +246,20 @@ export class EventHandlers {
             handler: "openAreaEditModal",
             id: properties.id,
             entityType: "area",
-            label: "Edit",
+            label: translate("messages.edit"),
           },
           {
             type: "button",
             handler: "handleDelete",
             id: properties.id,
             entityType: "area",
-            label: "Delete",
+            label: translate("messages.delete"),
           },
         ]
       : []
 
     this.controller.showInfo(
-      escapeHtml(properties.name) || "Area",
+      escapeHtml(properties.name) || translate("map_info.area"),
       content,
       actions,
     )
@@ -772,7 +773,10 @@ export class EventHandlers {
       trackDistanceKm,
     )
 
-    this.controller.showInfo(`Track #${properties.id}`, content)
+    this.controller.showInfo(
+      translate("map_info.track_number", { id: properties.id }),
+      content,
+    )
 
     // Set up the show points toggle handler (uses event delegation)
     this._setupTrackPointsToggle()
@@ -796,9 +800,9 @@ export class EventHandlers {
                  id="track-points-toggle"
                  class="toggle toggle-sm toggle-success"
                  data-track-id="${properties.id}" />
-          <span class="label-text font-medium">Show Points</span>
+          <span class="label-text font-medium">${translate("map_info.show_points")}</span>
         </label>
-        <p class="text-xs text-base-content/60 ml-10">Enable to view and drag points to edit track</p>
+        <p class="text-xs text-base-content/60 ml-10">${translate("map_info.show_points_help")}</p>
       </div>
     `
 
@@ -814,19 +818,19 @@ export class EventHandlers {
           <svg id="track-replay-pause-icon" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 hidden" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd" />
           </svg>
-          <span id="track-replay-label">Replay</span>
+          <span id="track-replay-label">${translate("replay.replay")}</span>
         </button>
       </div>
     `
 
     return `
       <div class="space-y-2">
-        <div><span class="font-semibold">Start:</span> ${formatTimestamp(properties.start_at, this.controller.timezoneValue)}</div>
-        <div><span class="font-semibold">End:</span> ${formatTimestamp(properties.end_at, this.controller.timezoneValue)}</div>
-        <div><span class="font-semibold">Duration:</span> ${minutesToDaysHoursMinutes(durationMinutes)}</div>
-        <div><span class="font-semibold">Distance:</span> ${formatDistance(trackDistanceKm, distanceUnit)}</div>
-        <div><span class="font-semibold">Avg Speed:</span> ${formatSpeed(properties.avg_speed || 0, distanceUnit)}</div>
-        ${properties.dominant_mode ? `<div><span class="font-semibold">Mode:</span> ${escapeHtml(properties.dominant_mode_emoji)} ${escapeHtml(properties.dominant_mode)}</div>` : ""}
+        <div><span class="font-semibold">${translate("map_info.start")}:</span> ${formatTimestamp(properties.start_at, this.controller.timezoneValue)}</div>
+        <div><span class="font-semibold">${translate("map_info.end")}:</span> ${formatTimestamp(properties.end_at, this.controller.timezoneValue)}</div>
+        <div><span class="font-semibold">${translate("map_info.duration")}:</span> ${minutesToDaysHoursMinutes(durationMinutes)}</div>
+        <div><span class="font-semibold">${translate("map_info.distance")}:</span> ${formatDistance(trackDistanceKm, distanceUnit)}</div>
+        <div><span class="font-semibold">${translate("map_info.average_speed")}:</span> ${formatSpeed(properties.avg_speed || 0, distanceUnit)}</div>
+        ${properties.dominant_mode ? `<div><span class="font-semibold">${translate("map_info.mode")}:</span> ${escapeHtml(properties.dominant_mode_emoji)} ${translate(`transportation_modes.${properties.dominant_mode}`)}</div>` : ""}
         ${showPointsToggle}
         <div id="track-point-info-container"></div>
         ${replayButton}

--- a/app/javascript/controllers/maps/maplibre/map_data_manager.js
+++ b/app/javascript/controllers/maps/maplibre/map_data_manager.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import maplibregl from "maplibre-gl"
 import { Toast } from "maps_maplibre/components/toast"
 import { UpgradeBanner } from "maps_maplibre/components/upgrade_banner"
@@ -157,7 +158,9 @@ export class MapDataManager {
       if (showLoading) {
         this.controller.hideProgress()
       }
-      Toast.error("Failed to load location data. Please try again.")
+      Toast.error(
+        translate("messages.failed_to_load_location_data_please_try_again"),
+      )
       throw error
     } finally {
       const duration = performanceMonitor.measure("load-map-data")
@@ -513,7 +516,9 @@ export class MapDataManager {
 
     if (startDate < twelveMonthsAgo) {
       UpgradeBanner.show({
-        message: "Your Lite plan includes the last 12 months of data.",
+        message: translate(
+          "messages.your_lite_plan_includes_the_last_12_months_of_data",
+        ),
         upgradeUrl: this.controller.upgradeUrlValue,
         utmContent: "data_retention",
       })

--- a/app/javascript/controllers/maps/maplibre/map_initializer.js
+++ b/app/javascript/controllers/maps/maplibre/map_initializer.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import maplibregl from "maplibre-gl"
 import { Toast } from "maps_maplibre/components/toast"
 import { styleDocumentFailed } from "maps_maplibre/utils/basemap_url"
@@ -59,9 +60,7 @@ export class MapInitializer {
         settled = true
         map.off("style.load", onStyleLoad)
         map.off("error", onError)
-        Toast.error(
-          "Custom map style could not be loaded; reverting to the default style.",
-        )
+        Toast.error(translate("settings.custom_style_load_failed"))
         const fallbackStyle = await getMapStyle(mapStyle, {
           hiddenTileCategories,
           disabledPoiGroups,

--- a/app/javascript/controllers/maps/maplibre/places_manager.js
+++ b/app/javascript/controllers/maps/maplibre/places_manager.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { Toast } from "maps_maplibre/components/toast"
 import { SettingsManager } from "maps_maplibre/utils/settings_manager"
 
@@ -249,7 +250,7 @@ export class PlacesManager {
    */
   startCreatePlace() {
     this.controller.map.getCanvas().style.cursor = "crosshair"
-    Toast.info("Click on the map to place a place")
+    Toast.info(translate("messages.click_on_the_map_to_place_a_place"))
 
     this.handleCreatePlaceClick = (e) => {
       const { lng, lat } = e.lngLat

--- a/app/javascript/controllers/maps/maplibre/routes_manager.js
+++ b/app/javascript/controllers/maps/maplibre/routes_manager.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { Toast } from "maps_maplibre/components/toast"
 import { pointsToGeoJSON } from "maps_maplibre/utils/geojson_transformers"
 import { gatedToggle } from "maps_maplibre/utils/layer_gate"
@@ -110,25 +111,25 @@ export class RoutesManager {
       <input type="checkbox" id="speed-color-editor-toggle" class="modal-toggle" />
       <div class="modal" role="dialog" data-speed-color-editor-target="modal">
         <div class="modal-box max-w-2xl">
-          <h3 class="text-lg font-bold mb-4">Edit Speed Color Gradient</h3>
+          <h3 class="text-lg font-bold mb-4">${translate("speed_gradient.title")}</h3>
 
           <div class="space-y-4">
             <!-- Gradient Preview -->
             <div class="form-control">
               <label class="label">
-                <span class="label-text font-medium">Preview</span>
+                <span class="label-text font-medium">${translate("speed_gradient.preview")}</span>
               </label>
               <div class="h-12 rounded-lg border-2 border-base-300"
                    data-speed-color-editor-target="preview"></div>
               <label class="label">
-                <span class="label-text-alt">This gradient will be applied to routes based on speed</span>
+                <span class="label-text-alt">${translate("speed_gradient.help")}</span>
               </label>
             </div>
 
             <!-- Color Stops List -->
             <div class="form-control">
               <label class="label">
-                <span class="label-text font-medium">Color Stops</span>
+                <span class="label-text font-medium">${translate("speed_gradient.color_stops")}</span>
               </label>
               <div class="space-y-2" data-speed-color-editor-target="stopsList"></div>
             </div>
@@ -140,7 +141,7 @@ export class RoutesManager {
               <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
               </svg>
-              Add Color Stop
+              ${translate("speed_gradient.add_stop")}
             </button>
           </div>
 
@@ -148,17 +149,17 @@ export class RoutesManager {
             <button type="button"
                     class="btn btn-ghost"
                     data-action="click->speed-color-editor#resetToDefault">
-              Reset to Default
+              ${translate("common.reset_to_default")}
             </button>
             <button type="button"
                     class="btn"
                     data-action="click->speed-color-editor#close">
-              Cancel
+              ${translate("common.cancel")}
             </button>
             <button type="button"
                     class="btn btn-primary"
                     data-action="click->speed-color-editor#save">
-              Save
+              ${translate("common.save")}
             </button>
           </div>
         </div>
@@ -188,7 +189,7 @@ export class RoutesManager {
    * Reload routes layer
    */
   async reloadRoutes() {
-    this.controller.showLoading("Reloading routes...")
+    this.controller.showLoading(translate("messages.reloading_routes"))
 
     try {
       // In simplified mode the points layer holds a thinned subset, so
@@ -240,7 +241,7 @@ export class RoutesManager {
       if (routesLayer) routesLayer.update(routesGeoJSON)
     } catch (error) {
       console.error("Failed to reload routes:", error)
-      Toast.error("Failed to reload routes")
+      Toast.error(translate("messages.failed_to_reload_routes"))
     } finally {
       this.controller.hideLoading()
     }
@@ -420,7 +421,7 @@ export class RoutesManager {
       }
     } catch (error) {
       console.error("Failed to toggle scratch layer:", error)
-      Toast.error("Failed to load scratch layer")
+      Toast.error(translate("messages.failed_to_load_scratch_layer"))
     }
   }
 
@@ -480,7 +481,7 @@ export class RoutesManager {
       }
     } catch (error) {
       console.error("Failed to toggle photos layer:", error)
-      Toast.error("Failed to load photos")
+      Toast.error(translate("messages.failed_to_load_photos"))
     }
   }
 
@@ -521,7 +522,7 @@ export class RoutesManager {
       }
     } catch (error) {
       console.error("Failed to toggle areas layer:", error)
-      Toast.error("Failed to load areas")
+      Toast.error(translate("messages.failed_to_load_areas"))
     }
   }
 
@@ -573,7 +574,7 @@ export class RoutesManager {
       }
     } catch (error) {
       console.error("Failed to toggle tracks layer:", error)
-      Toast.error("Failed to load tracks")
+      Toast.error(translate("messages.failed_to_load_tracks"))
     }
   }
 
@@ -612,7 +613,7 @@ export class RoutesManager {
       this.controller.mapDataManager?.applyFlightMask()
     } catch (error) {
       console.error("Failed to toggle flights layer:", error)
-      Toast.error("Failed to load flights")
+      Toast.error(translate("messages.failed_to_load_flights"))
     }
   }
 
@@ -681,7 +682,7 @@ export class RoutesManager {
         counts: { anomalies: 0 },
         isComplete: true,
       })
-      Toast.error("Failed to load anomalies")
+      Toast.error(translate("messages.failed_to_load_anomalies"))
     }
   }
 

--- a/app/javascript/controllers/maps/maplibre/settings_manager.js
+++ b/app/javascript/controllers/maps/maplibre/settings_manager.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { Toast } from "maps_maplibre/components/toast"
 import { UpgradeBanner } from "maps_maplibre/components/upgrade_banner"
 import {
@@ -540,8 +541,9 @@ export class SettingsController {
 
     if (controller.hasTransportationDirtyMessageTarget) {
       if (this.transportationSettingsDirty) {
-        controller.transportationDirtyMessageTarget.textContent =
-          "You have unsaved changes. Click Apply to save and recalculate."
+        controller.transportationDirtyMessageTarget.textContent = translate(
+          "settings.unsaved_transportation_changes",
+        )
         controller.transportationDirtyMessageTarget.classList.add(
           "text-warning",
         )
@@ -549,8 +551,9 @@ export class SettingsController {
           "text-base-content/60",
         )
       } else {
-        controller.transportationDirtyMessageTarget.textContent =
-          "Make changes to enable the Apply button"
+        controller.transportationDirtyMessageTarget.textContent = translate(
+          "settings.make_changes_to_apply",
+        )
         controller.transportationDirtyMessageTarget.classList.remove(
           "text-warning",
         )
@@ -577,9 +580,7 @@ export class SettingsController {
 
     // Show confirmation dialog
     const confirmed = confirm(
-      "Applying these changes will recalculate transportation modes for ALL your tracks.\n\n" +
-        "This process may take some time depending on how many tracks you have, and settings will be locked until it completes.\n\n" +
-        "Do you want to continue?",
+      translate("settings.confirm_transportation_recalculation"),
     )
 
     if (!confirmed) return
@@ -696,7 +697,11 @@ export class SettingsController {
 
     // Check result and update UI
     if (result && result.status === "locked") {
-      Toast.error("Cannot update: recalculation is already in progress")
+      Toast.error(
+        translate(
+          "messages.cannot_update_recalculation_is_already_in_progress",
+        ),
+      )
       // Immediately lock the UI
       this.setTransportationSettingsLocked(true)
       // Also start polling for status updates
@@ -705,16 +710,14 @@ export class SettingsController {
     }
 
     if (result?.recalculation_triggered) {
-      Toast.info(
-        "Settings saved. Recalculating transportation modes for all tracks...",
-      )
+      Toast.info(translate("settings.transportation_recalculation_started"))
       this.resetTransportationDirtyState()
       // Immediately lock the UI since recalculation started
       this.setTransportationSettingsLocked(true)
       // Start polling for status updates
       this.startRecalculationPolling()
     } else {
-      Toast.success("Transportation settings saved")
+      Toast.success(translate("messages.transportation_settings_saved"))
       this.resetTransportationDirtyState()
     }
   }
@@ -797,7 +800,14 @@ export class SettingsController {
         spinner.className = "loading loading-spinner loading-xs"
 
         const text = document.createElement("span")
-        text.textContent = `Recalculating transportation modes... (${processedFormatted}/${totalFormatted} tracks, ${progress}%)`
+        text.textContent = translate(
+          "settings.transportation_recalculation_progress",
+          {
+            processed: processedFormatted,
+            total: totalFormatted,
+            progress,
+          },
+        )
 
         container.appendChild(spinner)
         container.appendChild(text)
@@ -806,7 +816,9 @@ export class SettingsController {
         alertEl.classList.add("alert-warning")
       } else if (isCompleted) {
         const text = document.createElement("span")
-        text.textContent = "Transportation mode recalculation completed!"
+        text.textContent = translate(
+          "settings.transportation_recalculation_completed",
+        )
 
         alertEl.appendChild(text)
         alertEl.classList.remove("hidden", "alert-warning", "alert-error")
@@ -817,7 +829,12 @@ export class SettingsController {
         this.resetTransportationDirtyState()
       } else if (isFailed) {
         const text = document.createElement("span")
-        text.textContent = `Recalculation failed: ${status.error_message || "Unknown error"}`
+        text.textContent = translate(
+          "settings.transportation_recalculation_failed",
+          {
+            error: status.error_message || translate("common.unknown_error"),
+          },
+        )
 
         alertEl.appendChild(text)
         alertEl.classList.remove("hidden", "alert-warning", "alert-success")
@@ -1171,9 +1188,7 @@ export class SettingsController {
       settled = true
       this.map.off("style.load", onLoad)
       this.map.off("error", onError)
-      Toast.error(
-        "Custom map style could not be loaded; reverting to the default style.",
-      )
+      Toast.error(translate("settings.custom_style_load_failed"))
       const fallback = await getMapStyle(styleName, this.mapStyleOptions())
       this.swapStyle(fallback)
     }
@@ -1207,7 +1222,7 @@ export class SettingsController {
    * Reset settings to defaults
    */
   resetSettings() {
-    if (confirm("Reset all settings to defaults? This will reload the page.")) {
+    if (confirm(translate("settings.confirm_reset"))) {
       SettingsManager.resetToDefaults()
       window.location.reload()
     }
@@ -1225,7 +1240,7 @@ export class SettingsController {
       // Globe can't do a timed preview (requires reload), so just show upgrade prompt
       toggle.checked = false
       UpgradeBanner.show({
-        message: "Globe View is a Pro feature.",
+        message: translate("messages.globe_view_is_a_pro_feature"),
         upgradeUrl: this.controller.upgradeUrlValue,
         utmContent: "globe_view",
       })
@@ -1234,12 +1249,12 @@ export class SettingsController {
 
     await SettingsManager.updateSetting("globeProjection", enabled)
 
-    Toast.info("Globe view will be applied after page reload")
+    Toast.info(
+      translate("messages.globe_view_will_be_applied_after_page_reload"),
+    )
 
     // Prompt user to reload
-    if (
-      confirm("Globe view requires a page reload to take effect. Reload now?")
-    ) {
+    if (confirm(translate("settings.confirm_globe_reload"))) {
       window.location.reload()
     }
   }
@@ -1398,8 +1413,8 @@ export class SettingsController {
       label.style.cursor = unavailable ? "not-allowed" : ""
       if (unavailable) {
         label.dataset.tip = foreignBasemap
-          ? "Not available with a custom raster or style basemap — these layers come from the built-in vector tiles"
-          : "Not available with the Custom map style — it draws no labels or points of interest"
+          ? translate("settings.layer_unavailable_foreign_basemap")
+          : translate("settings.layer_unavailable_custom_style")
       } else {
         delete label.dataset.tip
       }
@@ -1416,9 +1431,7 @@ export class SettingsController {
     const raw = event.target.value.trim()
 
     if (!SettingsManager.validVectorTilesUrl(raw)) {
-      Toast.error(
-        "Tile URL must include {z}, {x}, and {y} placeholders, or be a MapLibre style URL",
-      )
+      Toast.error(translate("settings.invalid_tile_url"))
       return
     }
 
@@ -1559,7 +1572,7 @@ export class SettingsController {
       new CustomEvent("map-settings:saved", { detail: { scope: "form" } }),
     )
 
-    Toast.success("Settings updated successfully")
+    Toast.success(translate("messages.settings_updated_successfully"))
   }
 
   /**
@@ -1600,7 +1613,7 @@ export class SettingsController {
       settings.pointsRenderingMode ||
       settings.speedColoredRoutes !== undefined
     ) {
-      Toast.info("Reloading map data with new settings...")
+      Toast.info(translate("messages.reloading_map_data_with_new_settings"))
       await this.controller.loadMapData()
     }
   }
@@ -1649,22 +1662,15 @@ export class SettingsController {
   }
 
   async reapplyAnomalyFilter() {
-    if (
-      !window.confirm(
-        "This is destructive and long-running.\n\n" +
-          "• All existing anomaly flags will be cleared and re-computed with your current settings.\n" +
-          "• Tracks, stats, and digests will be rebuilt afterwards.\n" +
-          "• Depending on how many points you have, this can take several minutes (or longer for years of history).\n" +
-          "• During the rebuild, tracks and stats on the map may temporarily look incomplete.\n\n" +
-          "Continue?",
-      )
-    ) {
+    if (!window.confirm(translate("settings.confirm_reapply_anomaly_filter"))) {
       return
     }
 
     const apiKey = this.controller.apiKeyValue
     if (!apiKey) {
-      Toast.error("API key not available; please reload the page.")
+      Toast.error(
+        translate("messages.api_key_not_available_please_reload_the_page"),
+      )
       return
     }
 
@@ -1681,31 +1687,25 @@ export class SettingsController {
         throw new Error(`Request failed: ${response.status}`)
       }
 
-      Toast.success(
-        "Re-evaluation queued. The map will update once the job finishes.",
-      )
+      Toast.success(translate("settings.re_evaluation_queued"))
     } catch (error) {
       console.error("[Settings] reapplyAnomalyFilter failed:", error)
-      Toast.error("Could not queue re-evaluation. Please try again.")
+      Toast.error(
+        translate("messages.could_not_queue_re_evaluation_please_try_again"),
+      )
     }
   }
 
   async recalculateUserData() {
-    if (
-      !window.confirm(
-        "This is long-running and rebuilds derived data.\n\n" +
-          "• Tracks, stats, and digests will be regenerated from scratch using your current points and settings.\n" +
-          "• Existing tracks/stats are replaced — anything you tweaked manually on a track will be overwritten.\n" +
-          "• Depending on your history this can take several minutes; you'll get a notification when it's done.\n\n" +
-          "Continue?",
-      )
-    ) {
+    if (!window.confirm(translate("settings.confirm_recalculate_user_data"))) {
       return
     }
 
     const apiKey = this.controller.apiKeyValue
     if (!apiKey) {
-      Toast.error("API key not available; please reload the page.")
+      Toast.error(
+        translate("messages.api_key_not_available_please_reload_the_page"),
+      )
       return
     }
 
@@ -1722,12 +1722,12 @@ export class SettingsController {
         throw new Error(`Request failed: ${response.status}`)
       }
 
-      Toast.success(
-        "Recalculation queued. You'll get a notification when it finishes.",
-      )
+      Toast.success(translate("settings.recalculation_queued"))
     } catch (error) {
       console.error("[Settings] recalculateUserData failed:", error)
-      Toast.error("Could not queue recalculation. Please try again.")
+      Toast.error(
+        translate("messages.could_not_queue_recalculation_please_try_again"),
+      )
     }
   }
 }

--- a/app/javascript/controllers/maps/maplibre/visits_manager.js
+++ b/app/javascript/controllers/maps/maplibre/visits_manager.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { Toast } from "maps_maplibre/components/toast"
 import { SettingsManager } from "maps_maplibre/utils/settings_manager"
 
@@ -335,7 +336,7 @@ export class VisitsManager {
     this.disarmCreateVisit()
 
     this.controller.map.getCanvas().style.cursor = "crosshair"
-    Toast.info("Click on the map to place a visit (Esc to cancel)")
+    Toast.info(translate("messages.click_on_the_map_to_place_a_visit_esc_to"))
 
     this.handleCreateVisitClick = (e) => {
       const { lng, lat } = e.lngLat
@@ -378,7 +379,7 @@ export class VisitsManager {
     )
 
     if (!modalElement) {
-      Toast.error("Visit creation modal not available")
+      Toast.error(translate("messages.visit_creation_modal_not_available"))
       return
     }
 
@@ -391,7 +392,7 @@ export class VisitsManager {
     if (controller) {
       controller.open(lat, lng, this.controller)
     } else {
-      Toast.error("Visit creation controller not available")
+      Toast.error(translate("messages.visit_creation_controller_not_available"))
     }
   }
 

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import { Toast } from "maps_maplibre/components/toast"
 import { ReplayPanel } from "maps_maplibre/managers/replay_panel"
 import { ApiClient } from "maps_maplibre/services/api_client"
@@ -539,7 +540,7 @@ export default class extends Controller {
       this.progressBadgeTarget.classList.add("visible")
     }
     if (this.hasProgressBadgeTextTarget) {
-      this.progressBadgeTextTarget.textContent = "Loading..."
+      this.progressBadgeTextTarget.textContent = translate("common.loading")
     }
   }
 
@@ -608,7 +609,7 @@ export default class extends Controller {
     this._lastSourceCount = sourceCount
 
     this.progressBadgeTextTarget.textContent =
-      parts.length > 0 ? parts.join(" \u00B7 ") : "Loading..."
+      parts.length > 0 ? parts.join(" \u00B7 ") : translate("common.loading")
 
     if (isComplete) {
       if (this.hasProgressBadgeTarget) {
@@ -1339,7 +1340,7 @@ export default class extends Controller {
     if (drawerController) {
       drawerController.startDrawing(this.map)
     } else {
-      Toast.error("Area drawer controller not available")
+      Toast.error(translate("messages.area_drawer_controller_not_available"))
     }
   }
 
@@ -1388,9 +1389,9 @@ export default class extends Controller {
       // in place so the side panel matches the map.
       this.eventHandlers?.refreshActiveAreaInfo(areas)
 
-      Toast.success("Area created successfully!")
+      Toast.success(translate("messages.area_created_successfully"))
     } catch (_error) {
-      Toast.error("Failed to reload areas")
+      Toast.error(translate("messages.failed_to_reload_areas"))
     }
   }
 
@@ -1471,7 +1472,7 @@ export default class extends Controller {
 
       if (!response.ok) {
         if (response.status === 403) {
-          Toast.info("Family feature not available")
+          Toast.info(translate("messages.family_feature_not_available"))
           this.updateLoadingCounts({
             counts: { family: 0 },
             isComplete: true,
@@ -1500,13 +1501,15 @@ export default class extends Controller {
       // Render family members list
       this.renderFamilyMembersList(locations)
 
-      Toast.success(`Loaded ${locations.length} family member(s)`)
+      Toast.success(
+        translate("family.loaded_members", { count: locations.length }),
+      )
 
       // Load history polylines
       this.loadFamilyHistory()
     } catch (error) {
       console.error("[Maps V2] Failed to load family members:", error)
-      Toast.error("Failed to load family members")
+      Toast.error(translate("messages.failed_to_load_family_members"))
     }
   }
 
@@ -1570,12 +1573,18 @@ export default class extends Controller {
           (Date.now() - sharingDate.getTime()) / (1000 * 60 * 60 * 24),
         ),
       )
-      const formattedDate = sharingDate.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-      })
+      const formattedDate = sharingDate.toLocaleDateString(
+        document.documentElement.lang || undefined,
+        {
+          month: "short",
+          day: "numeric",
+        },
+      )
 
-      infoEl.textContent = `Sharing since ${formattedDate} (${daysSharing} day${daysSharing !== 1 ? "s" : ""} of history)`
+      infoEl.textContent = translate("family.sharing_since", {
+        date: formattedDate,
+        count: daysSharing,
+      })
     }
   }
 
@@ -1585,8 +1594,7 @@ export default class extends Controller {
     const container = this.familyMembersContainerTarget
 
     if (locations.length === 0) {
-      container.innerHTML =
-        '<p class="text-xs text-base-content/60">No family members sharing location</p>'
+      container.innerHTML = `<p class="text-xs text-base-content/60">${translate("family.none_sharing")}</p>`
       return
     }
 
@@ -1594,13 +1602,16 @@ export default class extends Controller {
       ...locations.map((location) => {
         const emailInitial = location.email?.charAt(0)?.toUpperCase() || "?"
         const color = this.getFamilyMemberColor(location.user_id)
-        const lastSeen = new Date(location.updated_at).toLocaleString("en-US", {
-          timeZone: this.timezoneValue || "UTC",
-          month: "short",
-          day: "numeric",
-          hour: "numeric",
-          minute: "2-digit",
-        })
+        const lastSeen = new Date(location.updated_at).toLocaleString(
+          document.documentElement.lang || undefined,
+          {
+            timeZone: this.timezoneValue || "UTC",
+            month: "short",
+            day: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+          },
+        )
 
         const row = document.createElement("div")
         row.className =
@@ -1629,7 +1640,7 @@ export default class extends Controller {
 
         const emailDiv = document.createElement("div")
         emailDiv.className = "text-sm font-medium truncate"
-        emailDiv.textContent = location.email || "Unknown"
+        emailDiv.textContent = location.email || translate("common.unknown")
 
         const timeDiv = document.createElement("div")
         timeDiv.className = "text-xs text-base-content/60"
@@ -1670,7 +1681,7 @@ export default class extends Controller {
     const familyLayer = this.layerManager.getLayer("family")
     if (familyLayer) {
       familyLayer.centerOnMember(parseInt(memberId, 10))
-      Toast.success("Centered on family member")
+      Toast.success(translate("messages.centered_on_family_member"))
     }
   }
 
@@ -1695,7 +1706,7 @@ export default class extends Controller {
             // For button actions (modals, etc.), create a button with data-action
             // Use error styling for delete buttons
             const buttonClass =
-              action.label === "Delete"
+              action.handler === "handleDelete"
                 ? "btn btn-sm btn-error"
                 : "btn btn-sm btn-primary"
             return `<button class="${buttonClass}" data-action="click->maps--maplibre#${action.handler}" data-id="${action.id}" data-entity-type="${action.entityType}">${action.label}</button>`
@@ -1759,7 +1770,7 @@ export default class extends Controller {
     const div = document.createElement("div")
     div.appendChild(fragment)
 
-    this.showInfo("Route Information", div.innerHTML)
+    this.showInfo(translate("map_info.route_information"), div.innerHTML)
   }
 
   closeInfo() {
@@ -1843,7 +1854,7 @@ export default class extends Controller {
       })
       document.dispatchEvent(event)
     } catch (_error) {
-      Toast.error("Failed to load visit details")
+      Toast.error(translate("messages.failed_to_load_visit_details"))
     }
   }
 
@@ -1871,7 +1882,7 @@ export default class extends Controller {
         new CustomEvent("area:edit", { detail: { area }, bubbles: true }),
       )
     } catch (_error) {
-      Toast.error("Failed to load area details")
+      Toast.error(translate("messages.failed_to_load_area_details"))
     }
   }
 
@@ -1881,9 +1892,7 @@ export default class extends Controller {
    * full reload.
    */
   async deletePoint(pointId) {
-    const confirmed = confirm(
-      "Delete this point?\n\nThis action cannot be undone.",
-    )
+    const confirmed = confirm(translate("map.confirm_delete_point_permanently"))
     if (!confirmed) return
 
     const numericId = Number(pointId)
@@ -1924,7 +1933,7 @@ export default class extends Controller {
     try {
       await this.api.deletePoint(pointId)
       this.closeInfo()
-      Toast.success("Point deleted successfully")
+      Toast.success(translate("messages.point_deleted_successfully"))
     } catch (_error) {
       // The point still exists server-side, so restore it in the cache even
       // when the layer reconcile below is skipped.
@@ -1956,7 +1965,7 @@ export default class extends Controller {
         pointsLayer.data = currentData
         this.routesManager.reloadRoutes().catch((error) => console.error(error))
       }
-      Toast.error("Failed to delete point")
+      Toast.error(translate("messages.failed_to_delete_point"))
     }
   }
 
@@ -1970,12 +1979,12 @@ export default class extends Controller {
 
       // Show delete confirmation
       const confirmed = confirm(
-        `Delete area "${area.name}"?\n\nThis action cannot be undone.`,
+        translate("areas.confirm_delete_named", { name: area.name }),
       )
 
       if (!confirmed) return
 
-      Toast.info("Deleting area...")
+      Toast.info(translate("messages.deleting_area"))
 
       // Delete the area
       await this.api.deleteArea(areaId)
@@ -1992,9 +2001,9 @@ export default class extends Controller {
       // Close info display
       this.closeInfo()
 
-      Toast.success("Area deleted successfully")
+      Toast.success(translate("messages.area_deleted_successfully"))
     } catch (_error) {
-      Toast.error("Failed to delete area")
+      Toast.error(translate("messages.failed_to_delete_area"))
     }
   }
 
@@ -2024,7 +2033,7 @@ export default class extends Controller {
       })
       document.dispatchEvent(event)
     } catch (_error) {
-      Toast.error("Failed to load place details")
+      Toast.error(translate("messages.failed_to_load_place_details"))
     }
   }
 
@@ -2175,11 +2184,11 @@ export default class extends Controller {
     if (playing) {
       playIcon.classList.add("hidden")
       pauseIcon.classList.remove("hidden")
-      label.textContent = "Pause"
+      label.textContent = translate("replay.pause")
     } else {
       playIcon.classList.remove("hidden")
       pauseIcon.classList.add("hidden")
-      label.textContent = "Replay"
+      label.textContent = translate("replay.replay")
     }
   }
 

--- a/app/javascript/controllers/maps/maplibre_realtime_controller.js
+++ b/app/javascript/controllers/maps/maplibre_realtime_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import { createMapChannel } from "maps_maplibre/channels/map_channel"
 import { Toast } from "maps_maplibre/components/toast"
 import { SettingsManager } from "maps_maplibre/utils/settings_manager"
@@ -84,8 +85,8 @@ export default class extends Controller {
     SettingsManager.updateSetting("liveMapEnabled", this.liveModeEnabled)
 
     const message = this.liveModeEnabled
-      ? "Live mode enabled"
-      : "Live mode disabled"
+      ? translate("live_map.enabled")
+      : translate("live_map.disabled")
     Toast.info(message)
   }
 
@@ -119,7 +120,7 @@ export default class extends Controller {
     this.connectedChannels.add(channelName)
 
     if (this.connectedChannels.size === 1) {
-      Toast.success("Connected to real-time updates")
+      Toast.success(translate("messages.connected_to_real_time_updates"))
       this.updateConnectionIndicator(true)
     }
   }
@@ -131,7 +132,7 @@ export default class extends Controller {
     this.connectedChannels.delete(channelName)
 
     if (this.connectedChannels.size === 0) {
-      Toast.warning("Disconnected from real-time updates")
+      Toast.warning(translate("messages.disconnected_from_real_time_updates"))
       this.updateConnectionIndicator(false)
     }
   }
@@ -238,7 +239,7 @@ export default class extends Controller {
 
     this.zoomToPoint(parseFloat(lon), parseFloat(lat))
 
-    Toast.info("New location recorded")
+    Toast.info(translate("messages.new_location_recorded"))
   }
 
   /**

--- a/app/javascript/controllers/maps_controller.js
+++ b/app/javascript/controllers/maps_controller.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import L from "leaflet"
 import "leaflet.heat"
 import "leaflet.control.layers.tree"
@@ -185,7 +186,11 @@ export default class extends BaseController {
         }
 
         const unit = this.distanceUnit === "km" ? "km" : "mi"
-        div.innerHTML = `${distance} ${unit} | ${pointsNumber} points`
+        div.innerHTML = translate("map.stats_summary", {
+          distance,
+          unit,
+          count: pointsNumber,
+        })
         applyThemeToControl(div, this.userTheme, {
           padding: "0 5px",
           marginRight: "5px",
@@ -356,7 +361,9 @@ export default class extends BaseController {
 
     if (startDate < twelveMonthsAgo) {
       UpgradeBanner.show({
-        message: "Your Lite plan includes the last 12 months of data.",
+        message: translate(
+          "messages.your_lite_plan_includes_the_last_12_months_of_data",
+        ),
         upgradeUrl: this.element.dataset.upgrade_url,
         utmContent: "data_retention",
       })
@@ -554,7 +561,7 @@ export default class extends BaseController {
   createTreeLayerControl(additionalLayers = {}) {
     // Build base maps tree structure
     const baseMapsTree = {
-      label: "Map Styles",
+      label: translate("messages.map_styles"),
       children: [],
     }
 
@@ -585,7 +592,7 @@ export default class extends BaseController {
 
     const placesChildren = [
       {
-        label: "Untagged",
+        label: translate("messages.untagged"),
         layer: untaggedLayer,
       },
     ]
@@ -612,11 +619,11 @@ export default class extends BaseController {
     // Build visits subtree
     const visitsChildren = [
       {
-        label: "Suggested",
+        label: translate("messages.suggested"),
         layer: this.visitsManager?.getVisitCirclesLayer() || L.layerGroup(),
       },
       {
-        label: "Confirmed",
+        label: translate("messages.confirmed"),
         layer:
           this.visitsManager?.getConfirmedVisitCirclesLayer() || L.layerGroup(),
       },
@@ -624,48 +631,48 @@ export default class extends BaseController {
 
     // Build the overlays tree structure
     const overlaysTree = {
-      label: "Layers",
+      label: translate("messages.layers"),
       selectAllCheckbox: false,
       children: [
         {
-          label: "Points",
+          label: translate("messages.points"),
           layer: this.markersLayer,
         },
         {
-          label: "Routes",
+          label: translate("messages.routes"),
           layer: this.polylinesLayer,
         },
         {
-          label: "Tracks",
+          label: translate("messages.tracks"),
           layer: this.tracksLayer,
         },
         {
-          label: "Heatmap",
+          label: translate("messages.heatmap"),
           layer: this.heatmapLayer,
         },
         {
-          label: "Fog of War",
+          label: translate("messages.fog_of_war"),
           layer: this.fogOverlay,
         },
         {
-          label: "Scratch map",
+          label: translate("messages.scratch_map"),
           layer: this.scratchLayerManager?.getLayer() || L.layerGroup(),
         },
         {
-          label: "Areas",
+          label: translate("messages.areas"),
           layer: this.areasLayer,
         },
         {
-          label: "Photos",
+          label: translate("messages.photos"),
           layer: this.photoMarkers,
         },
         {
-          label: "Visits",
+          label: translate("messages.visits"),
           selectAllCheckbox: true,
           children: visitsChildren,
         },
         {
-          label: "Places",
+          label: translate("messages.places"),
           selectAllCheckbox: true,
           children: placesChildren,
         },
@@ -675,7 +682,7 @@ export default class extends BaseController {
     // Add Family Members layer if available
     if (additionalLayers["Family Members"]) {
       overlaysTree.children.push({
-        label: "Family Members",
+        label: translate("messages.family_members"),
         layer: additionalLayers["Family Members"],
       })
     }
@@ -700,7 +707,7 @@ export default class extends BaseController {
           event.preventDefault()
           const pointId = event.target.getAttribute("data-id")
 
-          if (confirm("Are you sure you want to delete this point?")) {
+          if (confirm(translate("map.confirm_delete_point"))) {
             this.deletePoint(pointId, this.apiKey)
           }
         }
@@ -874,7 +881,9 @@ export default class extends BaseController {
         if (data.status === "success") {
           Flash.show(
             "notice",
-            `Preferred map layer updated to: ${selectedLayerName}`,
+            translate("map.preferred_layer_updated", {
+              layer: selectedLayerName,
+            }),
           )
         } else {
           Flash.show("error", data.message)
@@ -953,13 +962,18 @@ export default class extends BaseController {
           console.error("Failed to save enabled layers:", data.message)
           Flash.show(
             "error",
-            `Failed to save layer preferences: ${data.message}`,
+            translate("map.layer_preferences_failed", {
+              error: data.message,
+            }),
           )
         }
       })
       .catch((error) => {
         console.error("Error saving enabled layers:", error)
-        Flash.show("error", "Error saving layer preferences")
+        Flash.show(
+          "error",
+          translate("messages.error_saving_layer_preferences"),
+        )
       })
   }
 
@@ -1037,11 +1051,11 @@ export default class extends BaseController {
         }, 100)
 
         // Show success message
-        Flash.show("notice", "Point deleted successfully")
+        Flash.show("notice", translate("messages.point_deleted_successfully"))
       })
       .catch((error) => {
         console.error("There was a problem with the delete request:", error)
-        Flash.show("error", "Failed to delete point")
+        Flash.show("error", translate("messages.failed_to_delete_point"))
       })
   }
 
@@ -1138,7 +1152,7 @@ export default class extends BaseController {
         )
         button.innerHTML =
           '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-cog-icon lucide-cog"><path d="M11 10.27 7 3.34"/><path d="m11 13.73-4 6.93"/><path d="M12 22v-2"/><path d="M12 2v2"/><path d="M14 12h8"/><path d="m17 20.66-1-1.73"/><path d="m17 3.34-1 1.73"/><path d="M2 12h2"/><path d="m20.66 17-1.73-1"/><path d="m20.66 7-1.73 1"/><path d="m3.34 17 1.73-1"/><path d="m3.34 7 1.73 1"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="12" r="8"/></svg>' // Gear icon
-        button.setAttribute("data-tip", "Settings")
+        button.setAttribute("data-tip", translate("common.settings"))
 
         // Style the button with theme-aware styling
         applyThemeToButton(button, this.userTheme)
@@ -1179,7 +1193,7 @@ export default class extends BaseController {
           "map-info-toggle-button tooltip tooltip-right",
           container,
         )
-        button.setAttribute("data-tip", "Toggle footer visibility")
+        button.setAttribute("data-tip", translate("map_controls.toggle_footer"))
 
         // Lucide info icon
         button.innerHTML = `
@@ -1300,7 +1314,7 @@ export default class extends BaseController {
         <form id="settings-form" class="space-y-3">
           <div class="form-control">
             <label class="label py-1">
-              <span class="label-text text-xs">Route Opacity, %</span>
+              <span class="label-text text-xs">${translate("legacy_settings.route_opacity")}</span>
             </label>
             <div class="join join-horizontal w-full">
               <input type="number" class="input input-bordered input-sm join-item flex-1" id="route-opacity" name="route_opacity" min="10" max="100" step="10" value="${Math.round(this.routeOpacity * 100)}">
@@ -1310,7 +1324,7 @@ export default class extends BaseController {
 
           <div class="form-control">
             <label class="label py-1">
-              <span class="label-text text-xs">Fog of War radius</span>
+              <span class="label-text text-xs">${translate("legacy_settings.fog_radius")}</span>
             </label>
             <div class="join join-horizontal w-full">
               <input type="number" class="input input-bordered input-sm join-item flex-1" id="fog_of_war_meters" name="fog_of_war_meters" min="5" max="200" step="1" value="${this.clearFogRadius}">
@@ -1320,7 +1334,7 @@ export default class extends BaseController {
 
           <div class="form-control">
             <label class="label py-1">
-              <span class="label-text text-xs">Fog of War threshold</span>
+              <span class="label-text text-xs">${translate("legacy_settings.fog_threshold")}</span>
             </label>
             <div class="join join-horizontal w-full">
               <input type="number" class="input input-bordered input-sm join-item flex-1" id="fog_of_war_threshold" name="fog_of_war_threshold" step="1" value="${this.userSettings.fog_of_war_threshold}">
@@ -1330,7 +1344,7 @@ export default class extends BaseController {
 
           <div class="form-control">
             <label class="label py-1">
-              <span class="label-text text-xs">Meters between routes</span>
+              <span class="label-text text-xs">${translate("legacy_settings.meters_between_routes")}</span>
             </label>
             <div class="join join-horizontal w-full">
               <input type="number" class="input input-bordered input-sm join-item flex-1" id="meters_between_routes" name="meters_between_routes" step="1" value="${this.userSettings.meters_between_routes}">
@@ -1340,7 +1354,7 @@ export default class extends BaseController {
 
           <div class="form-control">
             <label class="label py-1">
-              <span class="label-text text-xs">Minutes between routes</span>
+              <span class="label-text text-xs">${translate("legacy_settings.minutes_between_routes")}</span>
             </label>
             <div class="join join-horizontal w-full">
               <input type="number" class="input input-bordered input-sm join-item flex-1" id="minutes_between_routes" name="minutes_between_routes" step="1" value="${this.userSettings.minutes_between_routes}">
@@ -1350,7 +1364,7 @@ export default class extends BaseController {
 
           <div class="form-control">
             <label class="label py-1">
-              <span class="label-text text-xs">Time threshold minutes</span>
+              <span class="label-text text-xs">${translate("legacy_settings.time_threshold")}</span>
             </label>
             <div class="join join-horizontal w-full">
               <input type="number" class="input input-bordered input-sm join-item flex-1" id="time_threshold_minutes" name="time_threshold_minutes" step="1" value="${this.userSettings.time_threshold_minutes}">
@@ -1360,7 +1374,7 @@ export default class extends BaseController {
 
           <div class="form-control">
             <label class="label py-1">
-              <span class="label-text text-xs">Merge threshold minutes</span>
+              <span class="label-text text-xs">${translate("legacy_settings.merge_threshold")}</span>
             </label>
             <div class="join join-horizontal w-full">
               <input type="number" class="input input-bordered input-sm join-item flex-1" id="merge_threshold_minutes" name="merge_threshold_minutes" step="1" value="${this.userSettings.merge_threshold_minutes}">
@@ -1370,24 +1384,24 @@ export default class extends BaseController {
 
           <div class="form-control">
             <label class="label py-1">
-              <span class="label-text text-xs">Points rendering mode</span>
+              <span class="label-text text-xs">${translate("legacy_settings.points_rendering_mode")}</span>
               <label for="points_rendering_mode_info" class="btn btn-xs btn-ghost cursor-pointer">?</label>
             </label>
             <div class="flex flex-col gap-2">
               <label class="label cursor-pointer justify-start gap-2 py-1">
                 <input type="radio" id="raw" name="points_rendering_mode" class="radio radio-sm" value="raw" ${this.pointsRenderingModeChecked("raw")} />
-                <span class="label-text text-xs">Raw</span>
+                <span class="label-text text-xs">${translate("legacy_settings.raw")}</span>
               </label>
               <label class="label cursor-pointer justify-start gap-2 py-1">
                 <input type="radio" id="simplified" name="points_rendering_mode" class="radio radio-sm" value="simplified" ${this.pointsRenderingModeChecked("simplified")} />
-                <span class="label-text text-xs">Simplified</span>
+                <span class="label-text text-xs">${translate("legacy_settings.simplified")}</span>
               </label>
             </div>
           </div>
 
           <div class="form-control">
             <label class="label cursor-pointer py-1">
-              <span class="label-text text-xs">Live Map</span>
+              <span class="label-text text-xs">${translate("legacy_settings.live_map")}</span>
               <div class="flex items-center gap-1">
                 <label for="live_map_enabled_info" class="btn btn-xs btn-ghost cursor-pointer">?</label>
                 <input type="checkbox" id="live_map_enabled" name="live_map_enabled" class="checkbox checkbox-sm" ${this.liveMapEnabledChecked(true)} />
@@ -1397,7 +1411,7 @@ export default class extends BaseController {
 
           <div class="form-control">
             <label class="label cursor-pointer py-1">
-              <span class="label-text text-xs">Speed-colored routes</span>
+              <span class="label-text text-xs">${translate("legacy_settings.speed_colored_routes")}</span>
               <div class="flex items-center gap-1">
                 <label for="speed_colored_routes_info" class="btn btn-xs btn-ghost cursor-pointer">?</label>
                 <input type="checkbox" id="speed_colored_routes" name="speed_colored_routes" class="checkbox checkbox-sm" ${this.speedColoredRoutesChecked()} />
@@ -1407,18 +1421,18 @@ export default class extends BaseController {
 
           <div class="form-control">
             <label class="label py-1">
-              <span class="label-text text-xs">Speed color scale</span>
+              <span class="label-text text-xs">${translate("legacy_settings.speed_color_scale")}</span>
             </label>
             <div class="join join-horizontal w-full">
               <input type="text" class="input input-bordered input-sm join-item flex-1" id="speed_color_scale" name="speed_color_scale" value="${this.speedColorScale}">
               <label for="speed_color_scale_info" class="btn btn-sm btn-ghost join-item cursor-pointer">?</label>
             </div>
-            <button type="button" id="edit-gradient-btn" class="btn btn-sm mt-2 w-full">Edit Colors</button>
+            <button type="button" id="edit-gradient-btn" class="btn btn-sm mt-2 w-full">${translate("legacy_settings.edit_colors")}</button>
           </div>
 
           <div class="divider my-2"></div>
 
-          <button type="submit" class="btn btn-sm btn-primary w-full">Update</button>
+          <button type="submit" class="btn btn-sm btn-primary w-full">${translate("common.update")}</button>
         </form>
       `
 
@@ -1523,7 +1537,7 @@ export default class extends BaseController {
       })
       .catch((error) => {
         console.error("Settings update error:", error)
-        Flash.show("error", "Failed to update settings")
+        Flash.show("error", translate("messages.failed_to_update_settings"))
       })
   }
 
@@ -1531,8 +1545,7 @@ export default class extends BaseController {
     // Show loading indicator
     const loadingDiv = document.createElement("div")
     loadingDiv.className = "map-loading-overlay"
-    loadingDiv.innerHTML =
-      '<div class="loading loading-lg">Updating map...</div>'
+    loadingDiv.innerHTML = `<div class="loading loading-lg">${translate("map.updating")}</div>`
     document.body.appendChild(loadingDiv)
 
     try {
@@ -1727,15 +1740,15 @@ export default class extends BaseController {
         const savedPreference = localStorage.getItem("mapRouteMode") || "routes"
 
         container.innerHTML = `
-          <div style="margin-bottom: 4px; font-weight: bold; text-align: center;">Display</div>
+          <div style="margin-bottom: 4px; font-weight: bold; text-align: center;">${translate("map.display")}</div>
           <div>
             <label style="display: block; margin-bottom: 4px; cursor: pointer;">
               <input type="radio" name="route-mode" value="routes" ${savedPreference === "routes" ? "checked" : ""} style="margin-right: 4px;">
-              Routes
+              ${translate("map_info.routes")}
             </label>
             <label style="display: block; cursor: pointer;">
               <input type="radio" name="route-mode" value="tracks" ${savedPreference === "tracks" ? "checked" : ""} style="margin-right: 4px;">
-              Tracks
+              ${translate("map_info.tracks")}
             </label>
           </div>
         `
@@ -2179,14 +2192,14 @@ export default class extends BaseController {
                 ${
                   currentYear
                     ? `<option value="${currentYear}" selected>${currentYear}</option>`
-                    : "<option disabled selected>Loading years...</option>"
+                    : `<option disabled selected>${translate("calendar_panel.loading_years")}</option>`
                 }
               </select>
               <a href="${this.getWholeYearLink()}"
                  id="whole-year-link"
                  class="btn btn-default"
                  style="color: rgb(116 128 255) !important;">
-                Whole year
+                ${translate("calendar_panel.whole_year")}
               </a>
             </div>
 
@@ -2229,10 +2242,10 @@ export default class extends BaseController {
       // Add container for visited cities
       div.innerHTML += `
         <div id="visited-cities-container" class="mt-4">
-          <h3 class="text-lg font-bold mb-2">Visited cities</h3>
+          <h3 class="text-lg font-bold mb-2">${translate("calendar_panel.visited_cities")}</h3>
           <div id="visited-cities-list" class="space-y-2"
                style="max-height: 300px; overflow-y: auto; overflow-x: auto; padding-right: 10px;">
-            <p class="text-gray-500">Loading visited places...</p>
+            <p class="text-gray-500">${translate("calendar_panel.loading_visited_places")}</p>
           </div>
         </div>
       `
@@ -2281,8 +2294,7 @@ export default class extends BaseController {
       const yearSelect = document.getElementById("year-select")
 
       if (!Array.isArray(yearsData) || yearsData.length === 0) {
-        yearSelect.innerHTML =
-          "<option disabled selected>No data available</option>"
+        yearSelect.innerHTML = `<option disabled selected>${translate("calendar_panel.no_data")}</option>`
         return
       }
 
@@ -2307,7 +2319,7 @@ export default class extends BaseController {
         .join("")
 
       yearSelect.innerHTML = `
-        <option disabled>Select year</option>
+        <option disabled>${translate("calendar_panel.select_year")}</option>
         ${options}
       `
 
@@ -2326,7 +2338,10 @@ export default class extends BaseController {
           if (!monthLink) return
 
           // Update the content to show the month name instead of loading dots
-          monthLink.innerHTML = month
+          monthLink.innerHTML = new Intl.DateTimeFormat(
+            document.documentElement.lang || undefined,
+            { month: "short" },
+          ).format(new Date(2020, index, 1))
 
           // Check if this month falls within the selected date range
           const isSelected =
@@ -2403,8 +2418,7 @@ export default class extends BaseController {
       }
     } catch (error) {
       const yearSelect = document.getElementById("year-select")
-      yearSelect.innerHTML =
-        "<option disabled selected>Error loading years</option>"
+      yearSelect.innerHTML = `<option disabled selected>${translate("calendar_panel.years_error")}</option>`
       console.error("Error fetching tracked months:", error)
     }
   }
@@ -2471,8 +2485,7 @@ export default class extends BaseController {
       console.error("Error fetching visited cities:", error)
       const container = document.getElementById("visited-cities-list")
       if (container) {
-        container.innerHTML =
-          '<p class="text-red-500">Error loading visited places</p>'
+        container.innerHTML = `<p class="text-red-500">${translate("calendar_panel.visited_places_error")}</p>`
       }
     }
   }
@@ -2482,8 +2495,7 @@ export default class extends BaseController {
     if (!container) return
 
     if (!citiesData || citiesData.length === 0) {
-      container.innerHTML =
-        '<p class="text-gray-500">No places visited during this period</p>'
+      container.innerHTML = `<p class="text-gray-500">${translate("calendar_panel.no_places_visited")}</p>`
       return
     }
 
@@ -2500,7 +2512,7 @@ export default class extends BaseController {
             <li class="text-sm whitespace-nowrap">
               ${city.city}
               <span class="text-gray-500">
-                (${new Date(city.timestamp * 1000).toLocaleDateString("en-US", { timeZone: timezone })})
+                (${new Date(city.timestamp * 1000).toLocaleDateString(document.documentElement.lang || undefined, { timeZone: timezone })})
               </span>
             </li>
           `,
@@ -2543,7 +2555,7 @@ export default class extends BaseController {
     })
 
     const title = document.createElement("h2")
-    title.textContent = "Edit Speed Color Scale"
+    title.textContent = translate("map.edit_speed_color_scale")
     content.appendChild(title)
 
     const gradientContainer = document.createElement("div")
@@ -2581,7 +2593,10 @@ export default class extends BaseController {
         if (gradientContainer.childElementCount > 1) {
           gradientContainer.removeChild(row)
         } else {
-          Flash.show("error", "At least one gradient stop is required.")
+          Flash.show(
+            "error",
+            translate("messages.at_least_one_gradient_stop_is_required"),
+          )
         }
       })
 
@@ -2605,7 +2620,7 @@ export default class extends BaseController {
     content.appendChild(gradientContainer)
 
     const addRowBtn = document.createElement("button")
-    addRowBtn.textContent = "Add Row"
+    addRowBtn.textContent = translate("common.add_row")
     addRowBtn.style.marginTop = "10px"
     addRowBtn.addEventListener("click", () => {
       const newRow = createRow({ speed: 0, color: "#000000" })
@@ -2620,13 +2635,13 @@ export default class extends BaseController {
     btnContainer.style.marginTop = "15px"
 
     const cancelBtn = document.createElement("button")
-    cancelBtn.textContent = "Cancel"
+    cancelBtn.textContent = translate("common.cancel")
     cancelBtn.addEventListener("click", () => {
       document.body.removeChild(modal)
     })
 
     const saveBtn = document.createElement("button")
-    saveBtn.textContent = "Save"
+    saveBtn.textContent = translate("common.save")
     saveBtn.addEventListener("click", () => {
       const newStops = []
       gradientContainer.querySelectorAll("div").forEach((row) => {
@@ -2730,7 +2745,7 @@ export default class extends BaseController {
       this.placesManager.disableCreationMode()
       if (button) {
         setCreatePlaceButtonInactive(button, this.userTheme)
-        button.setAttribute("data-tip", "Create a place")
+        button.setAttribute("data-tip", translate("map_controls.create_place"))
       }
     } else {
       // Enable creation mode
@@ -2739,7 +2754,7 @@ export default class extends BaseController {
         setCreatePlaceButtonActive(button)
         button.setAttribute(
           "data-tip",
-          "Click map to place marker (click to cancel)",
+          translate("map_controls.place_marker_mode"),
         )
       }
     }
@@ -2757,7 +2772,7 @@ export default class extends BaseController {
       const button = document.getElementById("create-place-btn")
       if (button) {
         setCreatePlaceButtonInactive(button, this.userTheme)
-        button.setAttribute("data-tip", "Create a place")
+        button.setAttribute("data-tip", translate("map_controls.create_place"))
       }
     }
   }

--- a/app/javascript/controllers/onboarding_modal_controller.js
+++ b/app/javascript/controllers/onboarding_modal_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import Flash from "./flash_controller"
 
 export default class extends Controller {
@@ -109,7 +110,10 @@ export default class extends Controller {
       .catch((error) => {
         console.error("Failed to load demo data:", error)
         this.hideDemoLoading()
-        Flash.show("error", "Failed to load demo data. Please try again.")
+        Flash.show(
+          "error",
+          translate("messages.failed_to_load_demo_data_please_try_again"),
+        )
       })
   }
 
@@ -124,8 +128,8 @@ export default class extends Controller {
         <div class="flex items-center gap-3">
           <span class="loading loading-spinner loading-md text-accent"></span>
           <div>
-            <h4 class="text-lg font-semibold">Creating your demo data…</h4>
-            <p class="text-sm opacity-70">Seeding a month of Berlin tracking plus a Prague weekend trip. Takes about a second.</p>
+            <h4 class="text-lg font-semibold">${translate("demo.creating")}</h4>
+            <p class="text-sm opacity-70">${translate("demo.creating_help")}</p>
           </div>
         </div>
       </div>
@@ -158,7 +162,7 @@ export default class extends Controller {
     if (this.hasDemoDataValue && this.hasDemoButtonTarget) {
       this.demoButtonTarget.classList.add("opacity-50", "pointer-events-none")
       const label = this.demoButtonTarget.querySelector("h4")
-      if (label) label.textContent = "Demo data already loaded"
+      if (label) label.textContent = translate("demo.already_loaded")
     }
   }
 

--- a/app/javascript/controllers/place_creation_controller.js
+++ b/app/javascript/controllers/place_creation_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 
 export default class extends Controller {
   static targets = [
@@ -64,9 +65,9 @@ export default class extends Controller {
     this.removeMethodOverride()
 
     if (this.hasModalTitleTarget)
-      this.modalTitleTarget.textContent = "Create New Place"
+      this.modalTitleTarget.textContent = translate("places.create_new")
     if (this.hasSubmitButtonTarget)
-      this.submitButtonTarget.value = "Create Place"
+      this.submitButtonTarget.value = translate("places.create")
 
     this.modalTarget.classList.add("modal-open")
     this.nameInputTarget.focus()
@@ -90,9 +91,9 @@ export default class extends Controller {
     this.addMethodOverride("patch")
 
     if (this.hasModalTitleTarget)
-      this.modalTitleTarget.textContent = "Edit Place"
+      this.modalTitleTarget.textContent = translate("places.edit")
     if (this.hasSubmitButtonTarget)
-      this.submitButtonTarget.value = "Update Place"
+      this.submitButtonTarget.value = translate("places.update")
 
     // Check appropriate tag checkboxes
     const tagCheckboxes = this.formTarget.querySelectorAll(
@@ -119,8 +120,7 @@ export default class extends Controller {
 
     // Reset nearby frame
     if (this.hasNearbyFrameTarget) {
-      this.nearbyFrameTarget.innerHTML =
-        '<p class="text-sm text-gray-500">Open modal to load nearby suggestions</p>'
+      this.nearbyFrameTarget.innerHTML = `<p class="text-sm text-gray-500">${translate("places.open_for_suggestions")}</p>`
     }
 
     document.dispatchEvent(new CustomEvent("place:create:cancelled"))

--- a/app/javascript/controllers/poster_studio_editor_controller.js
+++ b/app/javascript/controllers/poster_studio_editor_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import {
   DEFAULT_FONT_KEY,
   ensurePosterFont,
@@ -168,7 +169,10 @@ export default class extends Controller {
       this.updateSummary()
       this.syncOrderAvailability()
     } catch (error) {
-      Flash.show("error", `Poster studio failed to open: ${error.message}`)
+      Flash.show(
+        "error",
+        translate("poster.open_failed", { error: error.message }),
+      )
       this.close()
     }
   }
@@ -288,7 +292,10 @@ export default class extends Controller {
       this.scheduleRestyle()
       this.updateSummary()
     } catch (error) {
-      Flash.show("error", `Failed to load theme: ${error.message}`)
+      Flash.show(
+        "error",
+        translate("poster.theme_load_failed", { error: error.message }),
+      )
     }
   }
 
@@ -318,11 +325,11 @@ export default class extends Controller {
     select.innerHTML = ""
     LAYOUT_CATEGORIES.forEach((category) => {
       const group = document.createElement("optgroup")
-      group.label = category.name
+      group.label = translate(`poster.categories.${category.id}`)
       category.layouts.forEach((layout) => {
         const option = document.createElement("option")
         option.value = layout.id
-        option.textContent = layout.name
+        option.textContent = translate(`poster.layouts.${layout.id}`)
         group.appendChild(option)
       })
       select.appendChild(group)
@@ -344,7 +351,7 @@ export default class extends Controller {
       button.dataset.action = "poster-studio-editor#pickPrintSize"
 
       const name = document.createElement("span")
-      name.textContent = layout.name
+      name.textContent = translate(`poster.layouts.${layout.id}`)
       const price = document.createElement("span")
       price.className = "opacity-70"
       price.textContent = PRINT_PRODUCTS[id].priceLabel
@@ -498,7 +505,7 @@ export default class extends Controller {
     const subtitleWasAuto =
       this.subtitleInputTarget.value === this.dateRangeLabel()
     this.setLoadBusy(true)
-    this.setStatus("Loading tracks for the new range…")
+    this.setStatus(translate("poster.loading_tracks"))
     try {
       await this.provider.applyDates(start, end)
 
@@ -517,7 +524,9 @@ export default class extends Controller {
     if (!this.hasLoadButtonTarget) return
     this.loadButtonTarget.disabled = value
     this.loadSpinnerTarget.classList.toggle("hidden", !value)
-    this.loadLabelTarget.textContent = value ? "Loading…" : "Load"
+    this.loadLabelTarget.textContent = translate(
+      value ? "poster.loading" : "poster.load",
+    )
   }
 
   presetRange(event) {
@@ -572,7 +581,12 @@ export default class extends Controller {
       const layout = this.layout
       const dpi = Number.parseInt(this.dpiTarget.value, 10)
       const geometry = resolveLayoutGeometry(layout, dpi)
-      this.setStatus(`Rendering ${geometry.width} × ${geometry.height}px…`)
+      this.setStatus(
+        translate("poster.rendering", {
+          width: geometry.width,
+          height: geometry.height,
+        }),
+      )
 
       const mapBounds = this.previewMap.getBounds()
       const { blob, extension } = await exportPoster({
@@ -598,11 +612,16 @@ export default class extends Controller {
       )
       this.setStatus(
         geometry.steppedDown
-          ? `Saved at ${geometry.effectiveDpi} dpi (device GL limit)`
-          : "Saved",
+          ? translate("poster.saved_at_dpi", {
+              dpi: geometry.effectiveDpi,
+            })
+          : translate("poster.saved"),
       )
     } catch (error) {
-      Flash.show("error", `Poster export failed: ${error.message}`)
+      Flash.show(
+        "error",
+        translate("poster.export_failed", { error: error.message }),
+      )
       this.setStatus("")
     } finally {
       this.setBusy(false)
@@ -635,7 +654,10 @@ export default class extends Controller {
   }
 
   showOrderDialog(product) {
-    this.orderSummaryTarget.textContent = `${this.layout.name} poster — ${product.priceLabel}`
+    this.orderSummaryTarget.textContent = translate("poster.order_summary", {
+      layout: translate(`poster.layouts.${this.layout.id}`),
+      price: product.priceLabel,
+    })
     this.orderErrorTarget.classList.add("hidden")
     this.resetOrderSteps()
     this.showOrderView("dialog")
@@ -777,7 +799,7 @@ export default class extends Controller {
     // neutral placeholder so an untitled poster never reads "MY POSTER".
     const title = this.titleInputTarget.value.trim()
     this.saveTitleTarget.value = title
-    this.saveNameTarget.value = title || "Untitled poster"
+    this.saveNameTarget.value = title || translate("poster.untitled")
     this.saveThemeTarget.value = this.themeBase || "blueprint"
     this.saveLatTarget.value = center.lat
     this.saveLonTarget.value = center.lng
@@ -789,7 +811,7 @@ export default class extends Controller {
     this.saveOpacityTarget.value = this.trackOpacityTarget.value
     this.saveWidthTarget.value = this.trackWidthTarget.value
     this.saveFormTarget.requestSubmit()
-    this.setStatus("Queued — rendering server-side into Recent posters…")
+    this.setStatus(translate("poster.queued"))
   }
 
   framedDistance() {
@@ -816,17 +838,13 @@ export default class extends Controller {
     const coords = collectCoords(this.trackGeojson)
     let reason = null
     if (coords.length === 0) {
-      reason =
-        "No location data in this date range — pick a range with tracks in the date bar above."
+      reason = translate("poster.no_location_data")
     } else if (!this.frameCoversTrack(coords)) {
-      reason =
-        "No tracks inside the frame — move or zoom the map over your route to save to the gallery."
+      reason = translate("poster.no_tracks_in_frame")
     }
     const message =
       reason ||
-      (this.frameIsClamped()
-        ? "This view is wider than the largest poster area — the saved poster will be more zoomed in than the preview."
-        : null)
+      (this.frameIsClamped() ? translate("poster.frame_too_wide") : null)
     this.saveButtonTarget.disabled = Boolean(reason)
     this.saveNoticeTarget.textContent = message || ""
     this.saveNoticeTarget.classList.toggle("hidden", !message)
@@ -844,7 +862,7 @@ export default class extends Controller {
     const dpi = Number.parseInt(this.dpiTarget.value, 10)
     const geometry = resolveLayoutGeometry(layout, dpi)
     const lines = [
-      `${layout.name} — ${layout.dimensionsLabel}`,
+      `${translate(`poster.layouts.${layout.id}`)} — ${layout.dimensionsLabel}`,
       `Theme: ${this.themeName || "—"}`,
       `Export: ${geometry.width} × ${geometry.height}px${
         layout.kind === "paper" ? ` @ ${geometry.effectiveDpi} dpi` : ""

--- a/app/javascript/controllers/public_stat_map_controller.js
+++ b/app/javascript/controllers/public_stat_map_controller.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import L from "leaflet"
 import { createAllMapLayers } from "../maps/layers"
 import BaseController from "./base_controller"
@@ -274,51 +275,61 @@ export default class extends BaseController {
   buildPopupContent(props) {
     const timezone = this.timezoneValue || "UTC"
     const startDate = props.earliest_point
-      ? new Date(props.earliest_point).toLocaleDateString("en-US", {
-          timeZone: timezone,
-        })
-      : "N/A"
+      ? new Date(props.earliest_point).toLocaleDateString(
+          document.documentElement.lang || undefined,
+          { timeZone: timezone },
+        )
+      : translate("common.not_available")
     const endDate = props.latest_point
-      ? new Date(props.latest_point).toLocaleDateString("en-US", {
-          timeZone: timezone,
-        })
-      : "N/A"
+      ? new Date(props.latest_point).toLocaleDateString(
+          document.documentElement.lang || undefined,
+          {
+            timeZone: timezone,
+          },
+        )
+      : translate("common.not_available")
     const startTime = props.earliest_point
-      ? new Date(props.earliest_point).toLocaleTimeString("en-US", {
-          timeZone: timezone,
-        })
+      ? new Date(props.earliest_point).toLocaleTimeString(
+          document.documentElement.lang || undefined,
+          {
+            timeZone: timezone,
+          },
+        )
       : ""
     const endTime = props.latest_point
-      ? new Date(props.latest_point).toLocaleTimeString("en-US", {
-          timeZone: timezone,
-        })
+      ? new Date(props.latest_point).toLocaleTimeString(
+          document.documentElement.lang || undefined,
+          {
+            timeZone: timezone,
+          },
+        )
       : ""
 
     return `
       <div style="font-size: 12px; line-height: 1.6; max-width: 300px;">
-        <strong style="color: #3388ff;">📍 Location Data</strong><br>
+        <strong style="color: #3388ff;">📍 ${translate("map_info.location_data")}</strong><br>
         <div style="margin: 4px 0;">
-          <strong>Points:</strong> ${props.point_count || 0}
+          <strong>${translate("map_info.points")}:</strong> ${props.point_count || 0}
         </div>
         ${
           props.h3_index
             ? `
         <div style="margin: 4px 0;">
-          <strong>H3 Index:</strong><br>
+          <strong>${translate("map_info.h3_index")}:</strong><br>
           <code style="font-size: 10px; background: #f5f5f5; padding: 2px;">${props.h3_index}</code>
         </div>
         `
             : ""
         }
         <div style="margin: 4px 0;">
-          <strong>Time Range:</strong><br>
+          <strong>${translate("map_info.time_range")}:</strong><br>
           <small>${startDate} ${startTime}<br>→ ${endDate} ${endTime}</small>
         </div>
         ${
           props.center
             ? `
         <div style="margin: 4px 0;">
-          <strong>Center:</strong><br>
+          <strong>${translate("map_info.center")}:</strong><br>
           <small>${props.center[0].toFixed(6)}, ${props.center[1].toFixed(6)}</small>
         </div>
         `

--- a/app/javascript/controllers/shared_live_map_controller.js
+++ b/app/javascript/controllers/shared_live_map_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import { createConsumer } from "@rails/actioncable"
+import { translate } from "i18n"
 import maplibregl from "maplibre-gl"
 import { RecentPointLayer } from "maps_maplibre/layers/recent_point_layer"
 import { getMapStyle } from "maps_maplibre/utils/style_manager"
@@ -67,7 +68,7 @@ export default class extends Controller {
     if (!res.ok) return
     const points = await res.json()
     if (!points.length) {
-      this.setStatus("Location unknown — waiting for an update…")
+      this.setStatus(translate("live_share.location_unknown"))
       return
     }
     const [lon, lat, ts] = points[0]
@@ -90,13 +91,13 @@ export default class extends Controller {
 
   handleMessage(data) {
     if (data.revoked) {
-      this.setStatus("This live share has ended.")
+      this.setStatus(translate("live_share.ended"))
       this.hideMarker()
       if (this.subscription) this.subscription.unsubscribe()
       return
     }
     if (data.masked) {
-      this.setStatus("Location hidden.")
+      this.setStatus(translate("live_share.location_hidden"))
       this.hideMarker()
       return
     }
@@ -251,12 +252,18 @@ export default class extends Controller {
   renderLastSeen() {
     if (!this.hasLastSeenTarget || this.lastSeenTs == null) return
     const seenAt = new Date(this.lastSeenTs * 1000)
-    this.lastSeenTarget.textContent = `Last seen: ${seenAt.toLocaleString()} (${this.relativeTime(this.lastSeenTs)})`
+    this.lastSeenTarget.textContent = translate("live_share.last_seen", {
+      date: seenAt.toLocaleString(document.documentElement.lang || undefined),
+      relative: this.relativeTime(this.lastSeenTs),
+    })
   }
 
   relativeTime(ts) {
     const diff = Math.floor(Date.now() / 1000) - Number(ts)
-    const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "always" })
+    const rtf = new Intl.RelativeTimeFormat(
+      document.documentElement.lang || undefined,
+      { numeric: "always" },
+    )
     if (diff < 60) return rtf.format(-diff, "second")
     if (diff < 3600) return rtf.format(-Math.floor(diff / 60), "minute")
     if (diff < 86400) return rtf.format(-Math.floor(diff / 3600), "hour")

--- a/app/javascript/controllers/sharing_modal_controller.js
+++ b/app/javascript/controllers/sharing_modal_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 
 export default class extends Controller {
   static targets = [
@@ -38,7 +39,7 @@ export default class extends Controller {
 
       const button = this.sharingLinkTarget.nextElementSibling
       const originalText = button.innerHTML
-      button.innerHTML = "Link Copied!"
+      button.innerHTML = translate("sharing.link_copied")
       button.classList.add("btn-outline", "btn-success")
 
       setTimeout(() => {

--- a/app/javascript/controllers/speed_color_editor_controller.js
+++ b/app/javascript/controllers/speed_color_editor_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 
 /**
  * Speed Color Editor Controller
@@ -43,7 +44,7 @@ export default class extends Controller {
       <div class="flex items-center gap-3 p-3 bg-base-200 rounded-lg" data-index="${index}">
         <div class="flex-1">
           <label class="label">
-            <span class="label-text text-sm">Speed (km/h)</span>
+            <span class="label-text text-sm">${translate("speed_gradient.speed")}</span>
           </label>
           <input type="number"
                  class="input input-bordered input-sm w-full"
@@ -56,7 +57,7 @@ export default class extends Controller {
 
         <div class="flex-1">
           <label class="label">
-            <span class="label-text text-sm">Color</span>
+            <span class="label-text text-sm">${translate("speed_gradient.color")}</span>
           </label>
           <div class="flex gap-2 items-center">
             <input type="color"

--- a/app/javascript/controllers/stat_page_controller.js
+++ b/app/javascript/controllers/stat_page_controller.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import L from "leaflet"
 import "leaflet.heat"
 import { createAllMapLayers } from "../maps/layers"
@@ -72,7 +73,7 @@ export default class extends BaseController {
       this.loadMonthData()
     } catch (error) {
       console.error("Error initializing map:", error)
-      this.showError("Failed to initialize map")
+      this.showError(translate("stats.map_initialization_failed"))
     }
   }
 
@@ -95,7 +96,7 @@ export default class extends BaseController {
       }
     } catch (error) {
       console.error("Error loading month data:", error)
-      this.showError("Failed to load location data")
+      this.showError(translate("stats.location_data_load_failed"))
     } finally {
       this.showLoading(false)
     }
@@ -270,14 +271,16 @@ export default class extends BaseController {
   showNoData() {
     if (this.hasLoadingTarget) {
       const dateLabel = new Date(this.year, this.month - 1).toLocaleDateString(
-        "en-US",
+        document.documentElement.lang || undefined,
         { month: "long", year: "numeric" },
       )
       const container = document.createElement("div")
       container.className = "alert alert-info"
       container.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>`
       const span = document.createElement("span")
-      span.textContent = `No location data available for ${dateLabel}`
+      span.textContent = translate("stats.no_location_data", {
+        date: dateLabel,
+      })
       container.appendChild(span)
       this.loadingTarget.replaceChildren(container)
       this.loadingTarget.style.display = "flex"

--- a/app/javascript/controllers/timeline_feed_controller.js
+++ b/app/javascript/controllers/timeline_feed_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 
 /**
  * Timeline Feed Controller (Unified Timeline)
@@ -877,22 +878,31 @@ export default class extends Controller {
     const countEl = this.activeSelectionCount()
     if (countEl) {
       countEl.textContent = overCap
-        ? `${n} selected (max ${max})`
-        : `${n} selected`
+        ? translate("timeline.selected_with_max", { count: n, max })
+        : translate("timeline.selected", { count: n })
     }
     const mergeBtn = this.activeMergeButton()
     if (mergeBtn) {
       mergeBtn.disabled = n < 2 || overCap
-      mergeBtn.textContent = n >= 2 ? `Merge ${n}` : "Merge"
+      mergeBtn.textContent =
+        n >= 2
+          ? translate("timeline.merge_count", { count: n })
+          : translate("visits.merge")
     }
-    for (const [getter, label] of [
-      [this.activeConfirmButton.bind(this), "Confirm"],
-      [this.activeDeleteButton.bind(this), "Delete"],
+    for (const [getter, key] of [
+      [this.activeConfirmButton.bind(this), "common.confirm"],
+      [this.activeDeleteButton.bind(this), "common.delete"],
     ]) {
       const btn = getter()
       if (!btn) continue
       btn.disabled = n < 1 || overCap
-      btn.textContent = n >= 1 ? `${label} ${n}` : label
+      btn.textContent =
+        n >= 1
+          ? translate("timeline.action_count", {
+              action: translate(key),
+              count: n,
+            })
+          : translate(key)
     }
   }
 

--- a/app/javascript/controllers/trip_maplibre_controller.js
+++ b/app/javascript/controllers/trip_maplibre_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import { MapInitializer } from "controllers/maps/maplibre/map_initializer"
+import { translate } from "i18n"
 import maplibregl from "maplibre-gl"
 import { DayRoutesLayer } from "maps_maplibre/layers/day_routes_layer"
 import { FlightsLayer } from "maps_maplibre/layers/flights_layer"
@@ -365,14 +366,16 @@ export default class extends Controller {
         d.removeAttribute("open")
       }
       if (this.hasExpandAllBtnTarget) {
-        this.expandAllBtnTarget.textContent = "Show all days"
+        this.expandAllBtnTarget.textContent = translate("trip.show_all_days")
       }
     } else {
       for (const d of allDetails) {
         d.setAttribute("open", "")
       }
       if (this.hasExpandAllBtnTarget) {
-        this.expandAllBtnTarget.textContent = "Collapse all days"
+        this.expandAllBtnTarget.textContent = translate(
+          "trip.collapse_all_days",
+        )
       }
     }
 
@@ -524,7 +527,10 @@ export default class extends Controller {
         this.flightsGeoJSON = null
         this.flightsActive = false
         this._setButtonActive(this.flightsToggleBtnTarget, false)
-        Flash.show("error", "Could not load flights. Please try again.")
+        Flash.show(
+          "error",
+          translate("messages.could_not_load_flights_please_try_again"),
+        )
         return
       }
     }
@@ -535,7 +541,7 @@ export default class extends Controller {
       this.flightsGeoJSON = null
       this.flightsActive = false
       this._setButtonActive(this.flightsToggleBtnTarget, false)
-      Flash.show("notice", "No flights found for this trip.")
+      Flash.show("notice", translate("messages.no_flights_found_for_this_trip"))
       return
     }
 

--- a/app/javascript/controllers/upload_controller.js
+++ b/app/javascript/controllers/upload_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import { DirectUpload } from "@rails/activestorage"
+import { translate } from "i18n"
 import { shouldZip, zipSingleFile } from "services/zip_file"
 import Flash from "./flash_controller"
 
@@ -52,7 +53,10 @@ export default class extends Controller {
     this.inputTarget.disabled = true
     if (!this.hasUploadedFiles()) {
       event.preventDefault()
-      Flash.show("error", "Please select and upload files first")
+      Flash.show(
+        "error",
+        translate("messages.please_select_and_upload_files_first"),
+      )
     }
   }
 
@@ -73,8 +77,8 @@ export default class extends Controller {
     Flash.show(
       "notice",
       willCompress
-        ? `Preparing ${filesToUpload.length} file(s) for upload...`
-        : `Uploading ${filesToUpload.length} file(s), please wait...`,
+        ? translate("upload.preparing", { count: filesToUpload.length })
+        : translate("upload.uploading", { count: filesToUpload.length }),
     )
 
     const prepared = await this.prepareForUpload(filesToUpload)
@@ -98,7 +102,10 @@ export default class extends Controller {
         if (error) {
           Flash.show(
             "error",
-            `Error uploading ${file.name}: ${error.message || "Unknown error"}`,
+            translate("upload.error", {
+              name: file.name,
+              error: error.message || translate("common.unknown_error"),
+            }),
           )
         } else {
           this.fileProgress[index] = file.size
@@ -127,7 +134,7 @@ export default class extends Controller {
         )
         Flash.show(
           "warning",
-          `Could not compress ${original.name}, uploading as-is.`,
+          translate("upload.compression_failed", { name: original.name }),
         )
         result.push(original)
       }
@@ -142,7 +149,7 @@ export default class extends Controller {
       const accepted = ACCEPTED_EXTENSIONS.map((e) => `.${e}`).join(", ")
       Flash.show(
         "error",
-        `Unsupported file type: ${names}. Supported formats: ${accepted}.`,
+        translate("upload.unsupported_type", { names, accepted }),
       )
       this.inputTarget.value = ""
       return false
@@ -155,7 +162,7 @@ export default class extends Controller {
     ) {
       Flash.show(
         "error",
-        `Import limit reached. Trial users can only create up to ${this.maxImportsValue} imports.`,
+        translate("upload.import_limit", { count: this.maxImportsValue }),
       )
       this.inputTarget.value = ""
       return false
@@ -167,7 +174,10 @@ export default class extends Controller {
         !VALID_ZIP_TYPES.includes(file.type) &&
         !file.name.toLowerCase().endsWith(".zip")
       ) {
-        Flash.show("error", "Please select a valid ZIP file.")
+        Flash.show(
+          "error",
+          translate("messages.please_select_a_valid_zip_file"),
+        )
         this.inputTarget.value = ""
         return false
       }
@@ -176,10 +186,7 @@ export default class extends Controller {
     if (this.userTrialValue) {
       const oversized = files.filter((f) => f.size > MAX_FILE_SIZE)
       if (oversized.length > 0) {
-        Flash.show(
-          "error",
-          `File size limit exceeded. Trial users can only upload files up to 10MB.`,
-        )
+        Flash.show("error", translate("upload.file_size_limit"))
         this.inputTarget.value = ""
         return false
       }
@@ -195,7 +202,7 @@ export default class extends Controller {
     wrapper.className = "w-full mt-4 mb-4"
     wrapper.innerHTML = `
       <div class="text-sm font-medium text-base-content mb-2 flex justify-between items-center">
-        <span>Upload Progress</span>
+        <span>${translate("upload.progress")}</span>
         <span class="text-xs text-base-content/70 progress-percentage">0%</span>
       </div>
       <progress data-upload-target="progress" class="progress progress-primary w-full h-3" value="0" max="100"></progress>
@@ -211,15 +218,9 @@ export default class extends Controller {
     this.submitTarget.classList.toggle("cursor-not-allowed", count === 0)
 
     if (count === 0) {
-      Flash.show(
-        "error",
-        "No files were successfully uploaded. Please try again.",
-      )
+      Flash.show("error", translate("upload.none_uploaded"))
     } else {
-      Flash.show(
-        "notice",
-        `${count} file(s) uploaded successfully. Ready to submit.`,
-      )
+      Flash.show("notice", translate("upload.complete", { count }))
       this.markProgressComplete()
     }
     this.isUploading = false

--- a/app/javascript/controllers/visit_creation_v2_controller.js
+++ b/app/javascript/controllers/visit_creation_v2_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
+import { translate } from "i18n"
 import { Toast } from "maps_maplibre/components/toast"
 
 /**
@@ -46,10 +47,10 @@ export default class extends Controller {
 
     // Set modal title and button for creation
     if (this.hasModalTitleTarget) {
-      this.modalTitleTarget.textContent = "Create New Visit"
+      this.modalTitleTarget.textContent = translate("visits.create_new")
     }
     if (this.hasSubmitButtonTarget) {
-      this.submitButtonTarget.textContent = "Create Visit"
+      this.submitButtonTarget.textContent = translate("visits.create")
     }
 
     // Set default times
@@ -77,10 +78,10 @@ export default class extends Controller {
 
     // Set modal title and button for editing
     if (this.hasModalTitleTarget) {
-      this.modalTitleTarget.textContent = "Edit Visit"
+      this.modalTitleTarget.textContent = translate("visits.edit")
     }
     if (this.hasSubmitButtonTarget) {
-      this.submitButtonTarget.textContent = "Update Visit"
+      this.submitButtonTarget.textContent = translate("visits.update")
     }
 
     // Fill form with visit data

--- a/app/javascript/i18n.js
+++ b/app/javascript/i18n.js
@@ -1,0 +1,24 @@
+let translations
+
+function loadTranslations() {
+  if (typeof document === "undefined") return {}
+  const element = document.getElementById("i18n-translations")
+  if (!element) return {}
+
+  try {
+    return JSON.parse(element.textContent)
+  } catch (_error) {
+    return {}
+  }
+}
+
+export function translate(key, values = {}) {
+  translations ||= loadTranslations()
+  let value = key.split(".").reduce((current, part) => current?.[part], translations)
+  if (value && typeof value === "object" && values.count !== undefined) {
+    value = value[Number(values.count) === 1 ? "one" : "other"]
+  }
+  if (typeof value !== "string") return key
+
+  return value.replace(/%\{([^}]+)\}/g, (_match, name) => values[name] ?? `%{${name}}`)
+}

--- a/app/javascript/maps/areas.js
+++ b/app/javascript/maps/areas.js
@@ -1,4 +1,5 @@
 import Flash from "controllers/flash_controller"
+import { translate } from "i18n"
 
 // Add custom CSS for popup styling
 const addPopupStyles = () => {
@@ -97,14 +98,14 @@ export function handleAreaCreated(areasLayer, layer, apiKey) {
   const formHtml = `
     <div class="card w-96 bg-base-100 border border-base-300 shadow-xl">
       <div class="card-body">
-        <h2 class="card-title text-gray-500">New Area</h2>
+        <h2 class="card-title text-gray-500">${translate("areas.new")}</h2>
         <form id="circle-form" class="space-y-4">
           <div class="form-control">
             <input type="text"
                    id="circle-name"
                    name="area[name]"
                    class="input input-bordered input-primary w-full bg-base-200 text-base-content placeholder-base-content/70 border-base-300 focus:border-primary focus:bg-base-100"
-                   placeholder="Enter area name"
+                   placeholder="${translate("areas.enter_name")}"
                    autofocus
                    required>
           </div>
@@ -115,9 +116,9 @@ export function handleAreaCreated(areasLayer, layer, apiKey) {
             <button type="button"
                     class="btn btn-outline btn-neutral text-base-content border-base-300 hover:bg-base-200"
                     onclick="this.closest('.leaflet-popup').querySelector('.leaflet-popup-close-button').click()">
-              Cancel
+              ${translate("common.cancel")}
             </button>
-            <button type="button" id="save-area-btn" class="btn btn-primary">Save Area</button>
+            <button type="button" id="save-area-btn" class="btn btn-primary">${translate("areas.save")}</button>
           </div>
         </form>
       </div>
@@ -207,14 +208,14 @@ export function saveArea(formData, areasLayer, layer, apiKey) {
         <div class="card-body">
           <h3 class="card-title text-base-content text-lg">${data.name}</h3>
           <div class="space-y-2 text-base-content/80">
-            <p><span class="font-medium text-base-content">Radius:</span> ${Math.round(data.radius)} meters</p>
+            <p><span class="font-medium text-base-content">${translate("map_info.radius")}:</span> ${translate("map_info.meters", { count: Math.round(data.radius) })}</p>
           </div>
           <div class="card-actions justify-end mt-4">
             <button class="btn btn-sm btn-error delete-area" data-id="${data.id}">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
               </svg>
-              Delete
+              ${translate("common.delete")}
             </button>
           </div>
         </div>
@@ -262,7 +263,7 @@ export function deleteArea(id, areasLayer, layer, apiKey) {
     .then((_data) => {
       areasLayer.removeLayer(layer) // Remove the layer from the areas layer group
 
-      Flash.show("notice", `Area was successfully deleted!`)
+      Flash.show("notice", translate("areas.deleted"))
     })
     .catch((error) => {
       console.error("There was a problem with the delete request:", error)
@@ -322,22 +323,22 @@ export function fetchAndDrawAreas(areasLayer, apiKey) {
               <div class="space-y-3">
                 <div class="stats stats-vertical shadow bg-base-200">
                   <div class="stat py-2">
-                    <div class="stat-title text-base-content/70 text-sm">Radius</div>
-                    <div class="stat-value text-base-content text-lg">${Math.round(radius)} meters</div>
+                    <div class="stat-title text-base-content/70 text-sm">${translate("map_info.radius")}</div>
+                    <div class="stat-value text-base-content text-lg">${translate("map_info.meters", { count: Math.round(radius) })}</div>
                   </div>
                   <div class="stat py-2">
-                    <div class="stat-title text-base-content/70 text-sm">Center</div>
+                    <div class="stat-title text-base-content/70 text-sm">${translate("map_info.center")}</div>
                     <div class="stat-value text-base-content text-sm">[${lat.toFixed(4)}, ${lng.toFixed(4)}]</div>
                   </div>
                 </div>
               </div>
               <div class="card-actions justify-between items-center mt-6">
-                <div class="badge badge-primary badge-outline">Area ${area.id}</div>
+                <div class="badge badge-primary badge-outline">${translate("map_info.area_number", { id: area.id })}</div>
                 <button class="btn btn-error btn-sm delete-area" data-id="${area.id}">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                   </svg>
-                  Delete
+                  ${translate("common.delete")}
                 </button>
               </div>
             </div>
@@ -360,7 +361,7 @@ export function fetchAndDrawAreas(areasLayer, apiKey) {
               deleteButton.addEventListener("click", (e) => {
                 e.preventDefault()
                 e.stopPropagation()
-                if (confirm("Are you sure you want to delete this area?")) {
+                if (confirm(translate("areas.confirm_delete"))) {
                   deleteArea(area.id, areasLayer, circle, apiKey)
                 }
               })

--- a/app/javascript/maps/helpers.js
+++ b/app/javascript/maps/helpers.js
@@ -1,4 +1,5 @@
 // javascript/maps/helpers.js
+import { translate } from "i18n"
 export function formatDistance(distance, unit = "km") {
   let smallUnit, bigUnit
 
@@ -39,15 +40,15 @@ export function minutesToDaysHoursMinutes(minutes) {
   let result = ""
 
   if (days > 0) {
-    result += `${days}d `
+    result += `${translate("time.days_short", { count: days })} `
   }
 
   if (hours > 0) {
-    result += `${hours}h `
+    result += `${translate("time.hours_short", { count: hours })} `
   }
 
   if (minutes > 0) {
-    result += `${minutes}min`
+    result += translate("time.minutes_short", { count: minutes })
   }
 
   return result
@@ -71,12 +72,12 @@ export function formatDate(timestamp, timezone) {
     }
   } else {
     // Invalid input
-    return "Invalid Date"
+    return translate("time.invalid_date")
   }
 
   // Check if date is valid
   if (Number.isNaN(date.getTime())) {
-    return "Invalid Date"
+    return translate("time.invalid_date")
   }
 
   let locale
@@ -85,7 +86,7 @@ export function formatDate(timestamp, timezone) {
   } else if (navigator.language) {
     locale = navigator.language
   } else {
-    locale = "en-GB"
+    locale = document.documentElement.lang || undefined
   }
   return date.toLocaleString(locale, { timeZone: timezone })
 }

--- a/app/javascript/maps/location_search.js
+++ b/app/javascript/maps/location_search.js
@@ -1,4 +1,6 @@
 // Location search functionality for the map
+
+import { translate } from "i18n"
 import { applyThemeToButton } from "./theme_utils"
 
 class LocationSearch {
@@ -45,7 +47,7 @@ class LocationSearch {
         button.style.display = "flex"
         button.style.alignItems = "center"
         button.style.justifyContent = "center"
-        button.title = "Search locations"
+        button.title = translate("search.locations")
         button.id = "location-search-toggle"
         return button
       },
@@ -93,7 +95,7 @@ class LocationSearch {
       <div class="flex items-center space-x-2">
         <input
           type="text"
-          placeholder="Search locations..."
+          placeholder="${translate("search.locations_placeholder")}"
           class="flex-1 px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
           id="location-search-input"
         />
@@ -107,13 +109,13 @@ class LocationSearch {
 
       <!-- Suggestions dropdown -->
       <div id="location-search-suggestions-panel" class="hidden mt-2 border-t border-gray-200">
-        <div class="bg-gray-50 px-3 py-2 border-b text-xs font-medium text-gray-700">Suggestions</div>
+        <div class="bg-gray-50 px-3 py-2 border-b text-xs font-medium text-gray-700">${translate("search.suggestions")}</div>
         <div id="location-search-suggestions" class="max-h-48 overflow-y-auto border border-gray-200 rounded-b"></div>
       </div>
 
       <!-- Results dropdown -->
       <div id="location-search-results-panel" class="hidden mt-2 border-t border-gray-200">
-        <div class="bg-gray-50 px-3 py-2 border-b text-xs font-medium text-gray-700">Results</div>
+        <div class="bg-gray-50 px-3 py-2 border-b text-xs font-medium text-gray-700">${translate("search.results")}</div>
         <div id="location-search-results" class="border border-gray-200 rounded-b"></div>
       </div>
     `
@@ -337,7 +339,7 @@ class LocationSearch {
     this.resultsContainer.innerHTML = `
       <div class="p-8 text-center">
         <div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
-        <div class="text-sm text-gray-600 mt-3">Searching for "${this.escapeHtml(this.currentSearchQuery)}"...</div>
+        <div class="text-sm text-gray-600 mt-3">${translate("search.searching_for", { query: this.escapeHtml(this.currentSearchQuery) })}</div>
       </div>
     `
   }
@@ -350,7 +352,7 @@ class LocationSearch {
     this.resultsContainer.innerHTML = `
       <div class="p-8 text-center">
         <div class="text-4xl mb-3">⚠️</div>
-        <div class="text-sm font-medium text-red-600 mb-2">Search Failed</div>
+        <div class="text-sm font-medium text-red-600 mb-2">${translate("search.failed")}</div>
         <div class="text-xs text-gray-500">${this.escapeHtml(message)}</div>
       </div>
     `
@@ -365,8 +367,8 @@ class LocationSearch {
       this.resultsContainer.innerHTML = `
         <div class="p-6 text-center text-gray-500">
           <div class="text-3xl mb-3">📍</div>
-          <div class="text-sm font-medium">No visits found</div>
-          <div class="text-xs mt-1">No visits found for "${this.escapeHtml(this.currentSearchQuery)}"</div>
+          <div class="text-sm font-medium">${translate("visits.none_found")}</div>
+          <div class="text-xs mt-1">${translate("visits.none_found_for", { query: this.escapeHtml(this.currentSearchQuery) })}</div>
         </div>
       `
       return
@@ -377,8 +379,8 @@ class LocationSearch {
 
     let resultsHtml = `
       <div class="p-4 border-b bg-gray-50">
-        <div class="text-sm font-medium text-gray-700">Found ${data.total_locations} location(s)</div>
-        <div class="text-xs text-gray-500 mt-1">for "${this.escapeHtml(this.currentSearchQuery)}"</div>
+        <div class="text-sm font-medium text-gray-700">${translate("search.locations_found", { count: data.total_locations })}</div>
+        <div class="text-xs text-gray-500 mt-1">${translate("search.for_query", { query: this.escapeHtml(this.currentSearchQuery) })}</div>
       </div>
     `
 
@@ -404,9 +406,9 @@ class LocationSearch {
           <div class="font-medium text-sm">${this.escapeHtml(location.place_name)}</div>
           <div class="text-xs text-gray-600 mt-1">${this.escapeHtml(location.address || "")}</div>
           <div class="flex justify-between items-center mt-3">
-            <div class="text-xs text-blue-600">${location.total_visits} visit(s)</div>
+            <div class="text-xs text-blue-600">${translate("selection.visits", { count: location.total_visits })}</div>
             <div class="text-xs text-gray-500">
-              first ${this.formatDateShort(firstVisit.date)}, last ${this.formatDateShort(lastVisit.date)}
+              ${translate("search.first_last", { first: this.formatDateShort(firstVisit.date), last: this.formatDateShort(lastVisit.date) })}
             </div>
           </div>
         </div>
@@ -420,7 +422,7 @@ class LocationSearch {
               <div class="year-toggle p-3 hover:bg-gray-100 cursor-pointer border-b border-gray-200 flex justify-between items-center"
                    data-location-index="${index}" data-year="${year}">
                 <span class="text-sm font-medium text-gray-700">${year}</span>
-                <span class="text-xs text-blue-600">${yearVisits.length} visits</span>
+                <span class="text-xs text-blue-600">${translate("selection.visits", { count: yearVisits.length })}</span>
                 <span class="year-arrow text-gray-400 transition-transform">▶</span>
               </div>
               <div class="year-visits hidden" id="year-${index}-${year}">
@@ -474,7 +476,7 @@ class LocationSearch {
 
   formatDateShort(dateString) {
     const date = new Date(dateString)
-    return date.toLocaleDateString("en-GB", {
+    return date.toLocaleDateString(document.documentElement.lang || undefined, {
       day: "2-digit",
       month: "2-digit",
       year: "numeric",
@@ -599,18 +601,18 @@ class LocationSearch {
         <div class="font-semibold text-green-600">${this.escapeHtml(location.place_name)}</div>
         <div class="text-gray-600 mt-1">${this.escapeHtml(location.address || "")}</div>
         <div class="mt-2">
-          <div class="text-xs text-gray-500">Visit Details:</div>
+          <div class="text-xs text-gray-500">${translate("visits.details")}:</div>
           <div class="text-sm">${this.formatDateTime(visit.date)}</div>
-          <div class="text-xs text-gray-500">Duration: ${visit.duration_estimate}</div>
+          <div class="text-xs text-gray-500">${translate("map_info.duration")}: ${visit.duration_estimate}</div>
         </div>
         <div class="mt-3 pt-2 border-t border-gray-200 flex gap-2">
           <button data-action="create-visit"
                   class="text-xs bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 flex-1">
-            Create Visit
+            ${translate("visits.create")}
           </button>
           <button data-action="close-popup"
                   class="text-xs text-blue-600 hover:text-blue-800 px-2">
-            Close
+            ${translate("common.close")}
           </button>
         </div>
       </div>
@@ -828,7 +830,7 @@ class LocationSearch {
     this.suggestionsContainer.innerHTML = `
       <div class="p-6 text-center">
         <div class="text-2xl animate-bounce">⏳</div>
-        <div class="text-sm text-gray-500 mt-2">Finding suggestions...</div>
+        <div class="text-sm text-gray-500 mt-2">${translate("search.finding_suggestions")}</div>
       </div>
     `
   }
@@ -931,7 +933,7 @@ class LocationSearch {
     this.resultsContainer.innerHTML = `
       <div class="p-8 text-center">
         <div class="text-3xl animate-bounce">⏳</div>
-        <div class="text-sm text-gray-600 mt-3">Searching visits to</div>
+        <div class="text-sm text-gray-600 mt-3">${translate("search.searching_visits_to")}</div>
         <div class="text-sm font-medium text-gray-800">${this.escapeHtml(locationName)}</div>
       </div>
     `
@@ -967,7 +969,7 @@ class LocationSearch {
       this.displaySearchResults(data)
     } catch (error) {
       console.error("Coordinate search error:", error)
-      this.showError("Failed to search locations. Please try again.")
+      this.showError(translate("search.locations_failed"))
     }
   }
 
@@ -1040,24 +1042,24 @@ class LocationSearch {
     // Create form HTML
     const formHTML = `
       <div class="visit-form" style="min-width: 280px;">
-        <h3 style="margin-top: 0; margin-bottom: 15px; font-size: 16px; color: #333;">Add New Visit</h3>
+        <h3 style="margin-top: 0; margin-bottom: 15px; font-size: 16px; color: #333;">${translate("visits.add_new")}</h3>
 
         <form id="basic-add-visit-form" style="display: flex; flex-direction: column; gap: 10px;">
           <div>
-            <label for="basic-visit-name" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 14px;">Name:</label>
+            <label for="basic-visit-name" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 14px;">${translate("common.name")}:</label>
             <input type="text" id="basic-visit-name" name="name" required value="${this.escapeHtml(placeName)}"
                    style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 14px;"
-                   placeholder="Enter visit name">
+                   placeholder="${translate("visits.enter_name")}">
           </div>
 
           <div>
-            <label for="basic-visit-start" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 14px;">Start Time:</label>
+            <label for="basic-visit-start" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 14px;">${translate("visits.start_time")}:</label>
             <input type="datetime-local" id="basic-visit-start" name="started_at" required value="${startTime}"
                    max="9999-12-31T23:59" style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 14px;">
           </div>
 
           <div>
-            <label for="basic-visit-end" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 14px;">End Time:</label>
+            <label for="basic-visit-end" style="display: block; margin-bottom: 5px; font-weight: bold; font-size: 14px;">${translate("visits.end_time")}:</label>
             <input type="datetime-local" id="basic-visit-end" name="ended_at" required value="${endTime}"
                    max="9999-12-31T23:59" style="width: 100%; padding: 8px; border: 1px solid #ccc; border-radius: 4px; font-size: 14px;">
           </div>
@@ -1067,10 +1069,10 @@ class LocationSearch {
 
           <div style="display: flex; gap: 10px; margin-top: 15px;">
             <button type="submit" style="flex: 1; background: #28a745; color: white; border: none; padding: 10px; border-radius: 4px; cursor: pointer; font-weight: bold;">
-              Create Visit
+              ${translate("visits.create")}
             </button>
             <button type="button" id="basic-cancel-visit" style="flex: 1; background: #dc3545; color: white; border: none; padding: 10px; border-radius: 4px; cursor: pointer; font-weight: bold;">
-              Cancel
+              ${translate("common.cancel")}
             </button>
           </div>
         </form>
@@ -1136,7 +1138,7 @@ class LocationSearch {
     const endTime = new Date(visitData.visit.ended_at)
 
     if (endTime <= startTime) {
-      alert("End time must be after start time")
+      alert(translate("visits.end_after_start"))
       return
     }
 
@@ -1144,7 +1146,7 @@ class LocationSearch {
     const submitButton = form.querySelector('button[type="submit"]')
     const originalText = submitButton.textContent
     submitButton.disabled = true
-    submitButton.textContent = "Creating..."
+    submitButton.textContent = translate("common.creating")
 
     try {
       const response = await fetch(`/api/v1/visits`, {
@@ -1160,19 +1162,19 @@ class LocationSearch {
       const data = await response.json()
 
       if (response.ok) {
-        alert(`Visit "${visitData.visit.name}" created successfully!`)
+        alert(translate("visits.created", { name: visitData.visit.name }))
         this.map.closePopup(popup)
 
         // Try to refresh visits layer if available
         this.refreshVisitsIfAvailable()
       } else {
         const errorMessage =
-          data.error || data.message || "Failed to create visit"
+          data.error || data.message || translate("visits.create_failed")
         alert(errorMessage)
       }
     } catch (error) {
       console.error("Error creating visit:", error)
-      alert("Network error: Failed to create visit")
+      alert(translate("visits.network_create_error"))
     } finally {
       // Re-enable form
       submitButton.disabled = false

--- a/app/javascript/maps/location_search.js
+++ b/app/javascript/maps/location_search.js
@@ -476,7 +476,7 @@ class LocationSearch {
 
   formatDateShort(dateString) {
     const date = new Date(dateString)
-    return date.toLocaleDateString(document.documentElement.lang || undefined, {
+    return date.toLocaleDateString("en-GB", {
       day: "2-digit",
       month: "2-digit",
       year: "numeric",

--- a/app/javascript/maps/map_controls.js
+++ b/app/javascript/maps/map_controls.js
@@ -1,5 +1,7 @@
 // Map control buttons and utilities
 // This file contains all button controls that are positioned on the top-right corner of the map
+
+import { translate } from "i18n"
 import L from "leaflet"
 import { applyThemeToButton } from "./theme_utils"
 
@@ -73,7 +75,7 @@ export function createTogglePanelControl(onClickCallback, userTheme = "dark") {
       return createStandardButton(
         "toggle-panel-button",
         svgIcon,
-        "Toggle Panel",
+        translate("map_controls.toggle_panel"),
         userTheme,
         onClickCallback,
       )
@@ -97,7 +99,7 @@ export function createVisitsDrawerControl(onClickCallback, userTheme = "dark") {
       return createStandardButton(
         "leaflet-control-button drawer-button",
         svgIcon,
-        "Toggle Visits Drawer",
+        translate("map_controls.toggle_visits_drawer"),
         userTheme,
         onClickCallback,
       )
@@ -124,7 +126,7 @@ export function createAreaSelectionControl(
       const button = createStandardButton(
         "leaflet-bar leaflet-control leaflet-control-custom",
         svgIcon,
-        "Select Area",
+        translate("map_controls.select_area"),
         userTheme,
         onClickCallback,
       )
@@ -150,7 +152,7 @@ export function createAddVisitControl(onClickCallback, userTheme = "dark") {
       return createStandardButton(
         "leaflet-control-button add-visit-button",
         svgIcon,
-        "Add a visit",
+        translate("map_controls.add_visit"),
         userTheme,
         onClickCallback,
       )
@@ -174,7 +176,7 @@ export function createCreatePlaceControl(onClickCallback, userTheme = "dark") {
       const button = createStandardButton(
         "leaflet-control-button create-place-button",
         svgIcon,
-        "Create a place",
+        translate("map_controls.create_place"),
         userTheme,
         onClickCallback,
       )

--- a/app/javascript/maps/marker_factory.js
+++ b/app/javascript/maps/marker_factory.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { createPopupContent } from "./popups"
 
 const MARKER_DATA_INDICES = {
@@ -284,7 +285,7 @@ function addDragHandlers(marker, apiKey, userSettings) {
           e.target.options.originalLat,
           e.target.options.originalLng,
         ])
-        alert("Failed to update point position. Please try again.")
+        alert(translate("map.failed_to_update_point_position"))
       })
   })
 }

--- a/app/javascript/maps/photos.js
+++ b/app/javascript/maps/photos.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 // javascript/maps/photos.js
 
 import Flash from "controllers/flash_controller"
@@ -90,7 +91,7 @@ export async function fetchAndDisplayPhotos(
     console.log("Photos loading completed successfully")
   } catch (error) {
     console.error("Error fetching photos:", error)
-    Flash.show("error", "Failed to fetch photos")
+    Flash.show("error", translate("messages.failed_to_fetch_photos"))
 
     if (retryCount < MAX_RETRIES) {
       console.log(
@@ -103,7 +104,10 @@ export async function fetchAndDisplayPhotos(
         )
       }, RETRY_DELAY)
     } else {
-      Flash.show("error", "Failed to fetch photos after multiple attempts")
+      Flash.show(
+        "error",
+        translate("messages.failed_to_fetch_photos_after_multiple_attempts"),
+      )
     }
   } finally {
     map.removeControl(loadingControl)
@@ -186,10 +190,10 @@ export function createPhotoMarker(photo, userSettings, photoMarkers, apiKey) {
             alt="${photo.originalFileName}">
       </a>
       <h3 class="font-bold">${photo.originalFileName}</h3>
-      <p>Taken: ${formatDate(photo.localDateTime, userSettings.timezone)}</p>
-      <p>Location: ${photo.city}, ${photo.state}, ${photo.country}</p>
-      <p>Source: <a href="${source_url}" target="_blank">${photo.source}</a></p>
-      ${photo.type === "VIDEO" ? "🎥 Video" : "📷 Photo"}
+      <p>${translate("map_info.taken")}: ${formatDate(photo.localDateTime, userSettings.timezone)}</p>
+      <p>${translate("map_info.location")}: ${photo.city}, ${photo.state}, ${photo.country}</p>
+      <p>${translate("map_info.source")}: <a href="${source_url}" target="_blank">${photo.source}</a></p>
+      ${photo.type === "VIDEO" ? `🎥 ${translate("map_info.video")}` : `📷 ${translate("map_info.photo")}`}
     </div>
   `
   marker.bindPopup(popupContent)

--- a/app/javascript/maps/places.js
+++ b/app/javascript/maps/places.js
@@ -2,6 +2,7 @@
 // Handles displaying user places with tag icons and colors on the map
 
 import Flash from "controllers/flash_controller"
+import { translate } from "i18n"
 import L from "leaflet"
 
 export class PlacesManager {
@@ -35,7 +36,7 @@ export class PlacesManager {
       const { place } = event.detail
 
       // Show success message
-      Flash.show("success", `Place "${place.name}" created successfully!`)
+      Flash.show("success", translate("places.created", { name: place.name }))
 
       // Add the place to our local array
       this.places.push(place)
@@ -76,7 +77,7 @@ export class PlacesManager {
       const { place } = event.detail
 
       // Show success message
-      Flash.show("success", `Place "${place.name}" updated successfully!`)
+      Flash.show("success", translate("places.updated", { name: place.name }))
 
       // Update the place in our local array
       const index = this.places.findIndex((p) => p.id === place.id)
@@ -343,7 +344,7 @@ export class PlacesManager {
   }
 
   async deletePlace(placeId) {
-    if (!confirm("Are you sure you want to delete this place?")) return
+    if (!confirm(translate("places.confirm_delete"))) return
 
     try {
       const response = await fetch(`/api/v1/places/${placeId}`, {
@@ -376,17 +377,17 @@ export class PlacesManager {
       // Remove from places array
       this.places = this.places.filter((p) => p.id !== parseInt(placeId, 10))
 
-      Flash.show("success", "Place deleted successfully")
+      Flash.show("success", translate("messages.place_deleted_successfully"))
     } catch (error) {
       console.error("Error deleting place:", error)
-      Flash.show("error", "Failed to delete place")
+      Flash.show("error", translate("messages.failed_to_delete_place"))
     }
   }
 
   enableCreationMode() {
     this.creationMode = true
     this.map.getContainer().style.cursor = "crosshair"
-    this.showNotification("Click on the map to add a place", "info")
+    this.showNotification(translate("places.click_map_to_add"), "info")
   }
 
   disableCreationMode() {

--- a/app/javascript/maps/places_control.js
+++ b/app/javascript/maps/places_control.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import L from "leaflet"
 import { applyThemeToPanel } from "./theme_utils"
 
@@ -35,7 +36,7 @@ export function createPlacesControl(placesManager, tags, userTheme = "dark") {
         container,
       )
       this.button.href = "#"
-      this.button.title = "Places Layer"
+      this.button.title = translate("map.places_layer")
       this.button.innerHTML = "📍"
       this.button.style.fontSize = "20px"
       this.button.style.width = "34px"
@@ -78,7 +79,7 @@ export function createPlacesControl(placesManager, tags, userTheme = "dark") {
     buildPanelContent: function () {
       const html = `
         <div style="margin-bottom: 10px; font-weight: bold; font-size: 14px; border-bottom: 1px solid rgba(128,128,128,0.3); padding-bottom: 8px;">
-          📍 Places Layer
+          📍 ${translate("map.places_layer")}
         </div>
 
         <!-- All Places Toggle -->
@@ -90,7 +91,7 @@ export function createPlacesControl(placesManager, tags, userTheme = "dark") {
                  data-filter="all"
                  style="margin-right: 8px; cursor: pointer;"
                  ${this.placesEnabled ? "checked" : ""}>
-          <span style="font-weight: bold;">Show All Places</span>
+          <span style="font-weight: bold;">${translate("places.show_all")}</span>
         </label>
 
         <!-- Untagged Places Toggle -->
@@ -102,7 +103,7 @@ export function createPlacesControl(placesManager, tags, userTheme = "dark") {
                  data-filter="untagged"
                  style="margin-right: 8px; cursor: pointer;"
                  ${this.showUntagged ? "checked" : ""}>
-          <span>Untagged Places</span>
+          <span>${translate("places.untagged")}</span>
         </label>
 
         ${
@@ -110,7 +111,7 @@ export function createPlacesControl(placesManager, tags, userTheme = "dark") {
             ? `
           <div style="border-top: 1px solid rgba(128,128,128,0.3); padding-top: 8px; margin-top: 8px;">
             <div style="font-size: 12px; font-weight: bold; margin-bottom: 6px; opacity: 0.7;">
-              FILTER BY TAG
+              ${translate("places.filter_by_tag")}
             </div>
             <div style="max-height: 250px; overflow-y: auto; margin-right: -5px; padding-right: 5px;">
               ${this.tags
@@ -137,7 +138,7 @@ export function createPlacesControl(placesManager, tags, userTheme = "dark") {
             </div>
           </div>
         `
-            : '<div style="font-size: 12px; opacity: 0.6; padding: 8px; text-align: center;">No tags created yet</div>'
+            : `<div style="font-size: 12px; opacity: 0.6; padding: 8px; text-align: center;">${translate("places.no_tags")}</div>`
         }
       `
 

--- a/app/javascript/maps/polylines.js
+++ b/app/javascript/maps/polylines.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import {
   formatDate,
   formatDistance,
@@ -245,11 +246,11 @@ export function addHighlightOnHover(
       endMarker.addTo(map)
 
       const popupContent = `
-            <strong>Start:</strong> ${firstTimestamp}<br>
-            <strong>End:</strong> ${lastTimestamp}<br>
-            <strong>Duration:</strong> ${timeOnRoute}<br>
-            <strong>Total Distance:</strong> ${formatDistance(totalDistance, distanceUnit)}<br>
-            <strong>Current Speed:</strong> ${formatSpeed(speed, distanceUnit)}
+            <strong>${translate("map_info.start")}:</strong> ${firstTimestamp}<br>
+            <strong>${translate("map_info.end")}:</strong> ${lastTimestamp}<br>
+            <strong>${translate("map_info.duration")}:</strong> ${timeOnRoute}<br>
+            <strong>${translate("map_info.total_distance")}:</strong> ${formatDistance(totalDistance, distanceUnit)}<br>
+            <strong>${translate("map_info.current_speed")}:</strong> ${formatSpeed(speed, distanceUnit)}
         `
 
       if (hoverPopup) {
@@ -344,11 +345,11 @@ export function addHighlightOnHover(
     endMarker.addTo(map)
 
     const popupContent = `
-      <strong>Start:</strong> ${firstTimestamp}<br>
-      <strong>End:</strong> ${lastTimestamp}<br>
-      <strong>Duration:</strong> ${timeOnRoute}<br>
-      <strong>Total Distance:</strong> ${formatDistance(totalDistance, distanceUnit)}<br>
-      <strong>Current Speed:</strong> ${formatSpeed(clickedLayer.options.speed || 0, distanceUnit)}
+      <strong>${translate("map_info.start")}:</strong> ${firstTimestamp}<br>
+      <strong>${translate("map_info.end")}:</strong> ${lastTimestamp}<br>
+      <strong>${translate("map_info.duration")}:</strong> ${timeOnRoute}<br>
+      <strong>${translate("map_info.total_distance")}:</strong> ${formatDistance(totalDistance, distanceUnit)}<br>
+      <strong>${translate("map_info.current_speed")}:</strong> ${formatSpeed(clickedLayer.options.speed || 0, distanceUnit)}
     `
 
     if (hoverPopup) {

--- a/app/javascript/maps/popups.js
+++ b/app/javascript/maps/popups.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { formatDate } from "./helpers"
 
 export function createPopupContent(marker, timezone, distanceUnit) {
@@ -22,13 +23,13 @@ export function createPopupContent(marker, timezone, distanceUnit) {
   altitude = Math.round(altitude)
 
   return `
-    <strong>Timestamp:</strong> ${formatDate(marker[4], timezone)}<br>
-    <strong>Latitude:</strong> ${marker[0]}<br>
-    <strong>Longitude:</strong> ${marker[1]}<br>
-    <strong>Altitude:</strong> ${altitude}${altitudeUnit}<br>
-    <strong>Speed:</strong> ${speed}${speedUnit}<br>
-    <strong>Battery:</strong> ${marker[2]}%<br>
-    <strong>Id:</strong> ${marker[6]}<br>
-    <a href="#" data-id="${marker[6]}" class="delete-point">[Delete]</a>
+    <strong>${translate("map_info.timestamp")}:</strong> ${formatDate(marker[4], timezone)}<br>
+    <strong>${translate("map_info.latitude")}:</strong> ${marker[0]}<br>
+    <strong>${translate("map_info.longitude")}:</strong> ${marker[1]}<br>
+    <strong>${translate("map_info.altitude")}:</strong> ${altitude}${altitudeUnit}<br>
+    <strong>${translate("map_info.speed")}:</strong> ${speed}${speedUnit}<br>
+    <strong>${translate("map_info.battery")}:</strong> ${marker[2]}%<br>
+    <strong>${translate("map_info.id")}:</strong> ${marker[6]}<br>
+    <a href="#" data-id="${marker[6]}" class="delete-point">[${translate("common.delete")}]</a>
   `
 }

--- a/app/javascript/maps/visits.js
+++ b/app/javascript/maps/visits.js
@@ -1,4 +1,5 @@
 import Flash from "controllers/flash_controller"
+import { translate } from "i18n"
 import L from "leaflet"
 import { createPolylinesLayer } from "./polylines"
 
@@ -98,10 +99,7 @@ export class VisitsManager {
       this.map.dragging.disable()
       this.map.on("mousedown", this.onMouseDown, this)
 
-      Flash.show(
-        "info",
-        "Selection mode enabled. Click and drag to select an area.",
-      )
+      Flash.show("info", translate("selection.enabled"))
     }
   }
 
@@ -187,7 +185,7 @@ export class VisitsManager {
     // Reset drawer title
     const drawerTitle = document.querySelector("#visits-drawer .drawer h2")
     if (drawerTitle) {
-      drawerTitle.textContent = "Recent Visits"
+      drawerTitle.textContent = translate("visits.recent")
     }
   }
 
@@ -241,7 +239,10 @@ export class VisitsManager {
       }, 0)
     } catch (error) {
       console.error("Error fetching visits in selection:", error)
-      Flash.show("error", "Failed to load visits in selected area")
+      Flash.show(
+        "error",
+        translate("messages.failed_to_load_visits_in_selected_area"),
+      )
     }
   }
 
@@ -427,15 +428,14 @@ export class VisitsManager {
     const cancelButton = document.createElement("button")
     cancelButton.id = "cancel-selection-button"
     cancelButton.className = "btn btn-sm btn-warning w-full"
-    cancelButton.textContent = "Cancel Selection"
+    cancelButton.textContent = translate("visits.cancel_selection")
     cancelButton.onclick = () => this.clearSelection()
 
     // Delete all selected points button
     const deleteButton = document.createElement("button")
     deleteButton.id = "delete-selection-button"
     deleteButton.className = "btn btn-sm btn-error w-full"
-    deleteButton.innerHTML =
-      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline mr-1"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>Delete Points'
+    deleteButton.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="inline mr-1"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>${translate("selection.delete_points_label")}`
     deleteButton.onclick = () => this.deleteSelectedPoints()
 
     // Add count badge if we have selected points
@@ -458,15 +458,13 @@ export class VisitsManager {
    */
   async deleteSelectedPoints() {
     if (!this.selectedPoints || this.selectedPoints.length === 0) {
-      Flash.show("warning", "No points selected")
+      Flash.show("warning", translate("messages.no_points_selected"))
       return
     }
 
     const pointCount = this.selectedPoints.length
     const confirmed = confirm(
-      `⚠️ WARNING: This will permanently delete ${pointCount} point${pointCount > 1 ? "s" : ""} from your location history.\n\n` +
-        `This action cannot be undone!\n\n` +
-        `Are you sure you want to continue?`,
+      translate("selection.confirm_delete_points", { count: pointCount }),
     )
 
     if (!confirmed) return
@@ -485,7 +483,7 @@ export class VisitsManager {
       console.log("Point IDs to delete:", pointIds)
 
       if (pointIds.length === 0) {
-        Flash.show("error", "No valid point IDs found")
+        Flash.show("error", translate("messages.no_valid_point_ids_found"))
         return
       }
 
@@ -513,10 +511,7 @@ export class VisitsManager {
 
       // Check if any points were actually deleted
       if (result.count === 0) {
-        Flash.show(
-          "warning",
-          "No points were deleted. They may have already been removed.",
-        )
+        Flash.show("warning", translate("selection.no_points_deleted"))
         this.clearSelection()
         return
       }
@@ -524,7 +519,7 @@ export class VisitsManager {
       // Show success message
       Flash.show(
         "notice",
-        `Successfully deleted ${result.count} point${result.count > 1 ? "s" : ""}`,
+        translate("selection.points_deleted", { count: result.count }),
       )
 
       // Remove deleted points from the map
@@ -562,7 +557,10 @@ export class VisitsManager {
       this.clearSelection()
     } catch (error) {
       console.error("Error deleting points:", error)
-      Flash.show("error", "Failed to delete points. Please try again.")
+      Flash.show(
+        "error",
+        translate("messages.failed_to_delete_points_please_try_again"),
+      )
     }
   }
 
@@ -658,8 +656,8 @@ export class VisitsManager {
       if (container) {
         container.innerHTML = `
           <div class="text-gray-500 text-center p-4">
-            <p class="mb-2">No visits data loaded</p>
-            <p class="text-sm">Enable "Suggested Visits" or "Confirmed Visits" layers from the map controls to view visits.</p>
+            <p class="mb-2">${translate("visits.no_data_loaded")}</p>
+            <p class="text-sm">${translate("visits.enable_layers_help")}</p>
           </div>
         `
       }
@@ -682,12 +680,12 @@ export class VisitsManager {
 
     drawer.innerHTML = `
       <div class="p-3 my-2 drawer flex flex-col items-center relative">
-        <button id="close-visits-drawer" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" title="Close panel">
+        <button id="close-visits-drawer" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" title="${translate("common.close_panel")}">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-x-icon lucide-circle-x"><circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg>
         </button>
-        <h2 class="text-xl font-bold mb-4 text-accent-content w-full text-center">Recent Visits</h2>
+        <h2 class="text-xl font-bold mb-4 text-accent-content w-full text-center">${translate("visits.recent")}</h2>
         <div id="visits-list" class="space-y-2 w-full">
-          <p class="text-gray-500">Loading visits...</p>
+          <p class="text-gray-500">${translate("visits.loading")}</p>
         </div>
       </div>
     `
@@ -798,7 +796,7 @@ export class VisitsManager {
       console.error("Error fetching visits:", error)
       const container = document.getElementById("visits-list")
       if (container) {
-        container.innerHTML = '<p class="text-red-500">Error loading visits</p>'
+        container.innerHTML = `<p class="text-red-500">${translate("visits.loading_error")}</p>`
       }
     }
   }
@@ -902,13 +900,15 @@ export class VisitsManager {
         : 0
       const drawerTitle = document.querySelector("#visits-drawer .drawer h2")
       if (drawerTitle) {
-        drawerTitle.textContent = `${visitsCount} visits found`
+        drawerTitle.textContent = translate("visits.found", {
+          count: visitsCount,
+        })
       }
     } else {
       // Reset title to default when not in selection mode
       const drawerTitle = document.querySelector("#visits-drawer .drawer h2")
       if (drawerTitle) {
-        drawerTitle.textContent = "Recent Visits"
+        drawerTitle.textContent = translate("visits.recent")
       }
     }
 
@@ -923,8 +923,7 @@ export class VisitsManager {
     }
 
     if (!visits || visits.length === 0) {
-      const noVisitsHtml =
-        '<p class="text-gray-500">No visits found in selected timeframe</p>'
+      const noVisitsHtml = `<p class="text-gray-500">${translate("visits.none_in_timeframe")}</p>`
       container.innerHTML = dateGroupsHtml + noVisitsHtml
       return
     }
@@ -1189,7 +1188,7 @@ export class VisitsManager {
         // Merge button
         const mergeButton = document.createElement("button")
         mergeButton.className = "btn btn-xs btn-primary"
-        mergeButton.textContent = "Merge"
+        mergeButton.textContent = translate("visits.merge")
         mergeButton.addEventListener("click", () => {
           this.mergeVisits(Array.from(checkedBoxes).map((cb) => cb.dataset.id))
         })
@@ -1197,7 +1196,7 @@ export class VisitsManager {
         // Confirm button
         const confirmButton = document.createElement("button")
         confirmButton.className = "btn btn-xs btn-success"
-        confirmButton.textContent = "Confirm"
+        confirmButton.textContent = translate("common.confirm")
         confirmButton.addEventListener("click", () => {
           this.bulkUpdateVisitStatus(
             Array.from(checkedBoxes).map((cb) => cb.dataset.id),
@@ -1208,7 +1207,7 @@ export class VisitsManager {
         // Decline button
         const declineButton = document.createElement("button")
         declineButton.className = "btn btn-xs btn-error"
-        declineButton.textContent = "Decline"
+        declineButton.textContent = translate("common.decline")
         declineButton.addEventListener("click", () => {
           this.bulkUpdateVisitStatus(
             Array.from(checkedBoxes).map((cb) => cb.dataset.id),
@@ -1224,12 +1223,14 @@ export class VisitsManager {
         // Add selection count text
         const selectionText = document.createElement("div")
         selectionText.className = "text-sm text-center mt-1 text-gray-500"
-        selectionText.textContent = `${checkedBoxes.length} visits selected`
+        selectionText.textContent = translate("visits.selected", {
+          count: checkedBoxes.length,
+        })
 
         // Add cancel selection button
         const cancelButton = document.createElement("button")
         cancelButton.className = "btn btn-xs btn-neutral w-full mt-2"
-        cancelButton.textContent = "Cancel Selection"
+        cancelButton.textContent = translate("visits.cancel_selection")
         cancelButton.addEventListener("click", () => {
           // Uncheck all checkboxes
           checkedBoxes.forEach((checkbox) => {
@@ -1265,7 +1266,10 @@ export class VisitsManager {
    */
   async mergeVisits(visitIds) {
     if (!visitIds || visitIds.length < 2) {
-      Flash.show("error", "At least 2 visits must be selected for merging")
+      Flash.show(
+        "error",
+        translate("messages.at_least_2_visits_must_be_selected_for_merging"),
+      )
       return
     }
 
@@ -1285,13 +1289,13 @@ export class VisitsManager {
         throw new Error("Failed to merge visits")
       }
 
-      Flash.show("notice", "Visits merged successfully")
+      Flash.show("notice", translate("messages.visits_merged_successfully"))
 
       // Refresh the visits list
       this.fetchAndDisplayVisits()
     } catch (error) {
       console.error("Error merging visits:", error)
-      Flash.show("error", "Failed to merge visits")
+      Flash.show("error", translate("messages.failed_to_merge_visits"))
     }
   }
 
@@ -1302,7 +1306,7 @@ export class VisitsManager {
    */
   async bulkUpdateVisitStatus(visitIds, status) {
     if (!visitIds || visitIds.length === 0) {
-      Flash.show("error", "No visits selected")
+      Flash.show("error", translate("messages.no_visits_selected"))
       return
     }
 
@@ -1325,14 +1329,22 @@ export class VisitsManager {
 
       Flash.show(
         "notice",
-        `${visitIds.length} visits ${status === "confirmed" ? "confirmed" : "declined"} successfully`,
+        translate("visits.bulk_status_updated", {
+          count: visitIds.length,
+          status: translate(`visit_statuses.${status}`),
+        }),
       )
 
       // Refresh the visits list
       this.fetchAndDisplayVisits()
     } catch (error) {
       console.error(`Error ${status}ing visits:`, error)
-      Flash.show("error", `Failed to ${status} visits`)
+      Flash.show(
+        "error",
+        translate("visits.bulk_status_failed", {
+          status: translate(`visit_statuses.${status}`),
+        }),
+      )
     }
   }
 
@@ -1396,10 +1408,13 @@ export class VisitsManager {
 
           // Refresh visits list
           this.fetchAndDisplayVisits()
-          Flash.show("notice", "Visit confirmed successfully")
+          Flash.show(
+            "notice",
+            translate("messages.visit_confirmed_successfully"),
+          )
         } catch (error) {
           console.error("Error confirming visit:", error)
-          Flash.show("error", "Failed to confirm visit")
+          Flash.show("error", translate("messages.failed_to_confirm_visit"))
         }
       })
 
@@ -1426,10 +1441,13 @@ export class VisitsManager {
 
           // Refresh visits list
           this.fetchAndDisplayVisits()
-          Flash.show("notice", "Visit declined successfully")
+          Flash.show(
+            "notice",
+            translate("messages.visit_declined_successfully"),
+          )
         } catch (error) {
           console.error("Error declining visit:", error)
-          Flash.show("error", "Failed to decline visit")
+          Flash.show("error", translate("messages.failed_to_decline_visit"))
         }
       })
     })
@@ -1613,25 +1631,25 @@ export class VisitsManager {
           <h3 class="text-base font-semibold mb-3">${dateTimeDisplay.trim()}</h3>
 
           <div class="space-y-1 mb-4 text-sm">
-            <div>Duration: ${durationText}</div>
-            <div class="${statusColorClass} font-semibold">Status: ${visit.status.charAt(0).toUpperCase() + visit.status.slice(1)}</div>
+            <div>${translate("map_info.duration")}: ${durationText}</div>
+            <div class="${statusColorClass} font-semibold">${translate("map_info.status")}: ${translate(`visit_statuses.${visit.status}`)}</div>
             <div class="text-xs opacity-60 font-mono">${visit.place.latitude}, ${visit.place.longitude}</div>
           </div>
 
           <form class="visit-name-form space-y-3" data-visit-id="${visit.id}">
             <div class="form-control">
               <label class="label">
-                <span class="label-text font-medium">Visit Name:</span>
+                <span class="label-text font-medium">${translate("visits.name")}:</span>
               </label>
               <input type="text"
                      class="input input-bordered w-full"
                      value="${defaultName}"
-                     placeholder="Enter visit name">
+                     placeholder="${translate("visits.enter_name")}">
             </div>
 
             <div class="form-control">
               <label class="label">
-                <span class="label-text font-medium">Location:</span>
+                <span class="label-text font-medium">${translate("map_info.location")}:</span>
               </label>
               <select class="select select-bordered w-full" name="place">
                 ${
@@ -1647,7 +1665,7 @@ export class VisitsManager {
                         .join("")
                     : `
                   <option value="${visit.place.id}" selected>
-                    ${visit.place.name || "Current Location"}
+                    ${visit.place.name || translate("visits.current_location")}
                   </option>
                 `
                 }
@@ -1656,16 +1674,16 @@ export class VisitsManager {
 
             <div class="grid grid-cols-3 gap-2">
               <button type="submit" class="btn btn-primary btn-sm">
-                Save
+                ${translate("common.save")}
               </button>
               ${
                 visit.status !== "confirmed"
                   ? `
                 <button type="button" class="btn btn-success btn-sm confirm-visit" data-id="${visit.id}">
-                  Confirm
+                  ${translate("common.confirm")}
                 </button>
                 <button type="button" class="btn btn-error btn-sm decline-visit" data-id="${visit.id}">
-                  Decline
+                  ${translate("common.decline")}
                 </button>
               `
                   : '<div class="col-span-2"></div>'
@@ -1673,7 +1691,7 @@ export class VisitsManager {
             </div>
 
             <button type="button" class="btn btn-outline btn-error btn-sm w-full delete-visit" data-id="${visit.id}">
-              Delete Visit
+              ${translate("visits.delete")}
             </button>
           </form>
         </div>
@@ -1702,7 +1720,7 @@ export class VisitsManager {
       this.addPopupFormEventListeners(visit)
     } catch (error) {
       console.error("Error fetching possible places:", error)
-      Flash.show("error", "Failed to load possible places")
+      Flash.show("error", translate("messages.failed_to_load_possible_places"))
     }
   }
 
@@ -1725,7 +1743,10 @@ export class VisitsManager {
 
         // Validate that we have a valid place_id
         if (!selectedPlaceId || selectedPlaceId === "") {
-          Flash.show("error", "Please select a valid location")
+          Flash.show(
+            "error",
+            translate("messages.please_select_a_valid_location"),
+          )
           return
         }
 
@@ -1791,10 +1812,10 @@ export class VisitsManager {
           // Close the popup
           this.map.closePopup(this.currentPopup)
           this.currentPopup = null
-          Flash.show("notice", "Visit updated successfully")
+          Flash.show("notice", translate("messages.visit_updated_successfully"))
         } catch (error) {
           console.error("Error updating visit:", error)
-          Flash.show("error", "Failed to update visit")
+          Flash.show("error", translate("messages.failed_to_update_visit"))
         }
       })
 
@@ -1846,10 +1867,20 @@ export class VisitsManager {
       }
 
       this.fetchAndDisplayVisits()
-      Flash.show("notice", `Visit ${status}d successfully`)
+      Flash.show(
+        "notice",
+        translate("visits.status_updated", {
+          status: translate(`visit_statuses.${status}`),
+        }),
+      )
     } catch (error) {
       console.error(`Error ${status}ing visit:`, error)
-      Flash.show("error", `Failed to ${status} visit`)
+      Flash.show(
+        "error",
+        translate("visits.status_failed", {
+          status: translate(`visit_statuses.${status}`),
+        }),
+      )
     }
   }
 
@@ -1864,7 +1895,7 @@ export class VisitsManager {
 
     // Show confirmation dialog
     const confirmDelete = confirm(
-      "Are you sure you want to delete this visit? This action cannot be undone.",
+      translate("visits.confirm_delete_permanently"),
     )
 
     if (!confirmDelete) {
@@ -1888,15 +1919,16 @@ export class VisitsManager {
 
         // Refresh the visits list
         this.fetchAndDisplayVisits()
-        Flash.show("notice", "Visit deleted successfully")
+        Flash.show("notice", translate("messages.visit_deleted_successfully"))
       } else {
         const errorData = await response.json()
-        const errorMessage = errorData.error || "Failed to delete visit"
+        const errorMessage =
+          errorData.error || translate("messages.failed_to_delete_visit")
         Flash.show("error", errorMessage)
       }
     } catch (error) {
       console.error("Error deleting visit:", error)
-      Flash.show("error", "Failed to delete visit")
+      Flash.show("error", translate("messages.failed_to_delete_visit"))
     }
   }
 

--- a/app/javascript/maps_maplibre/components/photo_popup.js
+++ b/app/javascript/maps_maplibre/components/photo_popup.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { escapeHtml, formatTimestamp } from "../utils/geojson_transformers"
 
 function escapeAttr(value) {
@@ -26,10 +27,16 @@ export class PhotoPopupFactory {
       source,
     } = properties
 
-    const takenDate = taken_at ? formatTimestamp(taken_at, timezone) : "Unknown"
+    const takenDate = taken_at
+      ? formatTimestamp(taken_at, timezone)
+      : translate("common.unknown")
     const location =
-      [city, state, country].filter(Boolean).join(", ") || "Unknown location"
-    const mediaType = type === "VIDEO" ? "🎥 Video" : "📷 Photo"
+      [city, state, country].filter(Boolean).join(", ") ||
+      translate("search.unknown_location")
+    const mediaType =
+      type === "VIDEO"
+        ? `🎥 ${translate("map_info.video")}`
+        : `📷 ${translate("map_info.photo")}`
 
     return `
       <div class="photo-popup">
@@ -40,9 +47,9 @@ export class PhotoPopupFactory {
         </div>
         <div class="photo-info">
           <div class="filename">${escapeHtml(filename)}</div>
-          <div class="timestamp">Taken: ${escapeHtml(takenDate)}</div>
-          <div class="location">Location: ${escapeHtml(location)}</div>
-          <div class="source">Source: ${escapeHtml(source)}</div>
+          <div class="timestamp">${translate("map_info.taken")}: ${escapeHtml(takenDate)}</div>
+          <div class="location">${translate("map_info.location")}: ${escapeHtml(location)}</div>
+          <div class="source">${translate("map_info.source")}: ${escapeHtml(source)}</div>
           <div class="media-type">${mediaType}</div>
         </div>
       </div>

--- a/app/javascript/maps_maplibre/components/upgrade_banner.js
+++ b/app/javascript/maps_maplibre/components/upgrade_banner.js
@@ -1,3 +1,5 @@
+import { translate } from "i18n"
+
 /**
  * Persistent, dismissible map overlay banner for upgrade prompts.
  * Singleton: only one banner is visible at a time.
@@ -47,11 +49,11 @@ export class UpgradeBanner {
     cta.href = url
     cta.target = "_blank"
     cta.rel = "noopener noreferrer"
-    cta.textContent = "Upgrade to Pro"
+    cta.textContent = translate("common.upgrade_to_pro")
 
     const dismissBtn = document.createElement("button")
     dismissBtn.className = "map-upgrade-banner-dismiss"
-    dismissBtn.setAttribute("aria-label", "Dismiss")
+    dismissBtn.setAttribute("aria-label", translate("common.dismiss"))
     dismissBtn.textContent = "\u2715"
     dismissBtn.addEventListener("click", () => UpgradeBanner.dismiss())
 

--- a/app/javascript/maps_maplibre/components/visit_card.js
+++ b/app/javascript/maps_maplibre/components/visit_card.js
@@ -1,3 +1,5 @@
+import { translate } from "i18n"
+
 /**
  * Visit card component for rendering individual visit cards in the side panel
  */
@@ -17,15 +19,16 @@ export class VisitCard {
     // Format date and time
     const startDate = new Date(visit.started_at)
     const endDate = new Date(visit.ended_at)
-    const dateStr = startDate.toLocaleDateString("en-US", {
+    const locale = document.documentElement.lang || undefined
+    const dateStr = startDate.toLocaleDateString(locale, {
       month: "short",
       day: "numeric",
       year: "numeric",
     })
-    const timeRange = `${startDate.toLocaleTimeString("en-US", {
+    const timeRange = `${startDate.toLocaleTimeString(locale, {
       hour: "2-digit",
       minute: "2-digit",
-    })} - ${endDate.toLocaleTimeString("en-US", {
+    })} - ${endDate.toLocaleTimeString(locale, {
       hour: "2-digit",
       minute: "2-digit",
     })}`
@@ -33,7 +36,10 @@ export class VisitCard {
     // Format duration (duration is in minutes from the backend)
     const hours = Math.floor(visit.duration / 60)
     const minutes = visit.duration % 60
-    const durationStr = hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`
+    const durationStr =
+      hours > 0
+        ? translate("map_info.duration_hours_minutes", { hours, minutes })
+        : translate("map_info.duration_minutes", { minutes })
 
     // Border style based on status
     const borderClass = isSuggested ? "border-dashed" : ""
@@ -59,7 +65,7 @@ export class VisitCard {
         <div class="card-body p-3">
           <!-- Visit Name -->
           <h3 class="card-title text-sm font-semibold mb-2">
-            ${visit.name || visit.place?.name || "Unnamed Visit"}
+            ${visit.name || visit.place?.name || translate("visits.unnamed")}
           </h3>
 
           <!-- Date and Time -->
@@ -93,13 +99,13 @@ export class VisitCard {
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                 </svg>
-                Delete
+                ${translate("common.delete")}
               </button>
               <button class="btn btn-xs btn-primary" data-visit-confirm="${visit.id}">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                 </svg>
-                Confirm
+                ${translate("common.confirm")}
               </button>
             </div>
           `
@@ -112,7 +118,7 @@ export class VisitCard {
               ? `
             <div class="mt-2">
               <span class="badge badge-xs ${isConfirmed ? "badge-success" : "badge-error"}">
-                ${visit.status}
+                ${translate(`visit_statuses.${visit.status}`)}
               </span>
             </div>
           `
@@ -134,26 +140,26 @@ export class VisitCard {
     return `
       <div class="bulk-actions-panel sticky bottom-0 bg-base-100 border-t border-base-300 p-4 mt-4 space-y-2">
         <div class="text-sm font-medium mb-3">
-          ${selectedCount} visit${selectedCount === 1 ? "" : "s"} selected
+          ${translate("visits.selected", { count: selectedCount })}
         </div>
         <div class="grid grid-cols-3 gap-2">
           <button class="btn btn-sm btn-outline" data-bulk-merge>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
             </svg>
-            Merge
+            ${translate("visits.merge")}
           </button>
           <button class="btn btn-sm btn-primary" data-bulk-confirm>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
             </svg>
-            Confirm
+            ${translate("common.confirm")}
           </button>
           <button class="btn btn-sm btn-outline btn-error" data-bulk-delete>
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
-            Delete
+            ${translate("common.delete")}
           </button>
         </div>
       </div>

--- a/app/javascript/maps_maplibre/components/visit_place_search.js
+++ b/app/javascript/maps_maplibre/components/visit_place_search.js
@@ -1,3 +1,5 @@
+import { translate } from "i18n"
+
 const DEBOUNCE_MS = 250
 const DEFAULT_RADIUS_KM = 1.0
 const MOVE_THRESHOLD_M = 100
@@ -88,7 +90,7 @@ export class VisitPlaceSearch {
 
     this.list.innerHTML = rows.length
       ? rows.join("")
-      : `<li class="px-3 py-2 text-xs text-base-content/60">No places found</li>`
+      : `<li class="px-3 py-2 text-xs text-base-content/60">${translate("places.none_found")}</li>`
 
     this.bindRows(places, areas, query)
   }
@@ -112,7 +114,9 @@ export class VisitPlaceSearch {
     try {
       if (distance > MOVE_THRESHOLD_M) {
         const move = window.confirm(
-          `This place is ~${Math.round(distance)} m from the visit. Move the visit here?`,
+          translate("places.confirm_move_visit", {
+            distance: Math.round(distance),
+          }),
         )
         if (!move) {
           return
@@ -204,7 +208,7 @@ export class VisitPlaceSearch {
   shellHtml() {
     return `
       <div class="visit-search-panel mt-2 border-t border-base-300 pt-2">
-        <input type="text" data-search-input placeholder="Search for a place…"
+        <input type="text" data-search-input placeholder="${translate("places.search_placeholder")}"
                maxlength="200"
                class="input input-bordered input-xs w-full mb-2"
                onclick="event.stopPropagation()">
@@ -233,7 +237,7 @@ export class VisitPlaceSearch {
       this.distanceMeters(area.latitude, area.longitude),
     )
     return `<li class="w-full"><a data-select-area="${idx}" onclick="event.stopPropagation()" class="${this.rowClass()}">
-      <span class="block truncate"><span class="badge badge-xs badge-secondary mr-1">Area</span>${this.escape(area.name)}</span>
+      <span class="block truncate"><span class="badge badge-xs badge-secondary mr-1">${translate("map_info.area")}</span>${this.escape(area.name)}</span>
       ${dist ? `<span class="block text-xs opacity-60 truncate">${this.escape(dist)}</span>` : ""}</a></li>`
   }
 
@@ -252,17 +256,17 @@ export class VisitPlaceSearch {
 
   createRow(query) {
     return `<li class="w-full"><a data-create-place onclick="event.stopPropagation()" class="${this.rowClass()} truncate">
-      + Create "<span class="font-medium">${this.escape(query)}</span>" here</a></li>`
+      ${translate("places.create_here", { name: `<span class="font-medium">${this.escape(query)}</span>` })}</a></li>`
   }
 
   renderLoading() {
     if (this.list)
-      this.list.innerHTML = `<li class="px-3 py-2 text-xs text-base-content/60">Searching…</li>`
+      this.list.innerHTML = `<li class="px-3 py-2 text-xs text-base-content/60">${translate("search.searching")}</li>`
   }
 
   renderError() {
     if (this.list)
-      this.list.innerHTML = `<li class="px-3 py-2 text-xs text-error">Search unavailable</li>`
+      this.list.innerHTML = `<li class="px-3 py-2 text-xs text-error">${translate("search.unavailable")}</li>`
   }
 
   escape(str) {

--- a/app/javascript/maps_maplibre/layers/anomalies_layer.js
+++ b/app/javascript/maps_maplibre/layers/anomalies_layer.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { escapeHtml } from "../utils/geojson_transformers"
 import { BaseLayer } from "./base_layer"
 
@@ -94,9 +95,9 @@ export class AnomaliesLayer extends BaseLayer {
   static anomalyReason(properties) {
     const accuracy = properties.accuracy
     if (accuracy != null && accuracy > 100) {
-      return `Filtered: low accuracy (${accuracy}m, threshold 100m)`
+      return translate("anomalies.low_accuracy", { accuracy, threshold: 100 })
     }
-    return "Filtered: impossible speed between neighboring points"
+    return translate("anomalies.impossible_speed")
   }
 
   /**
@@ -140,8 +141,8 @@ export class AnomaliesLayer extends BaseLayer {
     const reason = AnomaliesLayer.anomalyReason(properties)
 
     return `<div class="text-sm space-y-1">
-      <div><strong>Time:</strong> ${escapeHtml(ts)}</div>
-      <div><strong>Reason:</strong> ${escapeHtml(reason)}</div>
+      <div><strong>${translate("map_info.time")}:</strong> ${escapeHtml(ts)}</div>
+      <div><strong>${translate("map_info.reason")}:</strong> ${escapeHtml(reason)}</div>
     </div>`
   }
 

--- a/app/javascript/maps_maplibre/layers/day_routes_layer.js
+++ b/app/javascript/maps_maplibre/layers/day_routes_layer.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import maplibregl from "maplibre-gl"
 import { maskLines } from "../utils/flight_mask"
 import { RouteSegmenter } from "../utils/route_segmenter"
@@ -272,10 +273,18 @@ export class DayRoutesLayer {
           const endCoord = coords[coords.length - 1]
 
           this.hoverMarkers.push(
-            this.createCircleMarker(startCoord, "#22c55e", "Start"),
+            this.createCircleMarker(
+              startCoord,
+              "#22c55e",
+              translate("map_info.start"),
+            ),
           )
           this.hoverMarkers.push(
-            this.createCircleMarker(endCoord, "#ef4444", "End"),
+            this.createCircleMarker(
+              endCoord,
+              "#ef4444",
+              translate("map_info.end"),
+            ),
           )
         }
       }

--- a/app/javascript/maps_maplibre/layers/family_layer.js
+++ b/app/javascript/maps_maplibre/layers/family_layer.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import maplibregl from "maplibre-gl"
 import { escapeHtml } from "../utils/geojson_transformers"
 import { BaseLayer } from "./base_layer"
@@ -83,13 +84,13 @@ export class FamilyLayer extends BaseLayer {
           minute: "2-digit",
           hour12: false,
         })
-      : "Unknown"
+      : translate("common.unknown")
 
-    const name = props.name || "Family member"
+    const name = props.name || translate("family.member")
     const html = `
       <div style="min-width:160px">
         <div style="font-weight:600;margin-bottom:4px">${escapeHtml(name)}</div>
-        <div style="font-size:12px;opacity:0.8">Last seen: ${escapeHtml(lastSeen)}</div>
+        <div style="font-size:12px;opacity:0.8">${translate("live_share.last_seen_short")}: ${escapeHtml(lastSeen)}</div>
       </div>
     `
 
@@ -343,7 +344,7 @@ export class FamilyLayer extends BaseLayer {
       },
       properties: {
         id: location.user_id,
-        name: location.email || "Unknown",
+        name: location.email || translate("common.unknown"),
         email: location.email,
         color: location.color || this.getMemberColor(location.user_id),
         lastUpdate: Date.now(),

--- a/app/javascript/maps_maplibre/layers/hexagon_layer.js
+++ b/app/javascript/maps_maplibre/layers/hexagon_layer.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import maplibregl from "maplibre-gl"
 import { Toast } from "../components/toast"
 import { resolutionForZoom } from "../utils/h3_resolution"
@@ -99,7 +100,7 @@ export class HexagonLayer extends BaseLayer {
     const count = feature.properties.count
     this.popup
       .setLngLat(e.lngLat)
-      .setHTML(`<strong>${count.toLocaleString()}</strong> points`)
+      .setHTML(translate("hexagons.points", { count: count.toLocaleString() }))
       .addTo(this.map)
   }
 
@@ -240,9 +241,7 @@ export class HexagonLayer extends BaseLayer {
       if (generation !== this._loadGeneration) return
       if (result.length >= 100_000 && !this._quotaWarned) {
         this._quotaWarned = true
-        Toast.warning(
-          "Showing the first 100,000 points in this range — narrow the date range for denser detail.",
-        )
+        Toast.warning(translate("hexagons.limit_warning"))
       }
       this.controller?.updateLoadingCounts?.({
         counts: { hexagons: result.length },
@@ -254,7 +253,7 @@ export class HexagonLayer extends BaseLayer {
       console.error("HexagonLayer load failed:", error)
       this.controller?.hideLoading?.()
       if (error.name !== "AbortError" && error.message !== "Load cancelled") {
-        Toast.error(`Couldn't load hexagons: ${error.message}`)
+        Toast.error(translate("hexagons.load_failed", { error: error.message }))
       }
       throw error
     }
@@ -313,7 +312,7 @@ export class HexagonLayer extends BaseLayer {
       console.error("HexagonLayer resumeLoad failed:", error)
       this.controller?.hideLoading?.()
       if (error.name !== "AbortError" && error.message !== "Load cancelled") {
-        Toast.error(`Couldn't load hexagons: ${error.message}`)
+        Toast.error(translate("hexagons.load_failed", { error: error.message }))
       }
       throw error
     }

--- a/app/javascript/maps_maplibre/layers/photos_layer.js
+++ b/app/javascript/maps_maplibre/layers/photos_layer.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import maplibregl from "maplibre-gl"
 import { formatTimestamp } from "../utils/geojson_transformers"
 import { getCurrentTheme, getThemeColors } from "../utils/popup_theme"
@@ -541,10 +542,14 @@ export class PhotosLayer extends BaseLayer {
 
     const takenDate = taken_at
       ? formatTimestamp(taken_at, this.timezone)
-      : "Unknown"
+      : translate("common.unknown")
     const location =
-      [city, state, country].filter(Boolean).join(", ") || "Unknown location"
-    const mediaType = type === "VIDEO" ? "🎥 Video" : "📷 Photo"
+      [city, state, country].filter(Boolean).join(", ") ||
+      translate("search.unknown_location")
+    const mediaType =
+      type === "VIDEO"
+        ? `🎥 ${translate("map_info.video")}`
+        : `📷 ${translate("map_info.photo")}`
 
     // Get theme colors
     const theme = getCurrentTheme()
@@ -556,7 +561,7 @@ export class PhotosLayer extends BaseLayer {
         <div style="width: 100%; border-radius: 8px; overflow: hidden; margin-bottom: 12px; background: ${colors.backgroundAlt};">
           <img
             src="${thumbnail_url}"
-            alt="${filename || "Photo"}"
+            alt="${filename || translate("map_info.photo")}"
             style="width: 100%; height: auto; max-height: 350px; object-fit: contain; display: block;"
             loading="lazy"
           />
@@ -565,8 +570,8 @@ export class PhotosLayer extends BaseLayer {
           ${filename ? `<div style="font-weight: 600; color: ${colors.textPrimary}; margin-bottom: 6px; word-wrap: break-word;">${filename}</div>` : ""}
           <div style="color: ${colors.textMuted}; font-size: 12px; margin-bottom: 6px;">📅 ${takenDate}</div>
           <div style="color: ${colors.textMuted}; font-size: 12px; margin-bottom: 6px;">📍 ${location}</div>
-          <div style="color: ${colors.textMuted}; font-size: 12px; margin-bottom: 6px;">Coordinates: ${lat.toFixed(6)}, ${lng.toFixed(6)}</div>
-          ${source ? `<div style="color: ${colors.textSecondary}; font-size: 11px; margin-bottom: 6px;">Source: ${source}</div>` : ""}
+          <div style="color: ${colors.textMuted}; font-size: 12px; margin-bottom: 6px;">${translate("map_info.coordinates")}: ${lat.toFixed(6)}, ${lng.toFixed(6)}</div>
+          ${source ? `<div style="color: ${colors.textSecondary}; font-size: 11px; margin-bottom: 6px;">${translate("map_info.source")}: ${source}</div>` : ""}
           <div style="font-size: 14px; margin-top: 8px; color: ${colors.textPrimary};">${mediaType}</div>
         </div>
       </div>

--- a/app/javascript/maps_maplibre/layers/points_layer.js
+++ b/app/javascript/maps_maplibre/layers/points_layer.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { Toast } from "maps_maplibre/components/toast"
 import { getMarkerStrokeColor } from "../utils/marker_theme"
 import { BaseLayer } from "./base_layer"
@@ -209,7 +210,9 @@ export class PointsLayer extends BaseLayer {
           source.setData(data)
         }
       }
-      Toast.error("Failed to update point position. Please try again.")
+      Toast.error(
+        translate("messages.failed_to_update_point_position_please_try_again"),
+      )
     }
 
     this.draggedFeature = null

--- a/app/javascript/maps_maplibre/layers/track_points_layer.js
+++ b/app/javascript/maps_maplibre/layers/track_points_layer.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { Toast } from "maps_maplibre/components/toast"
 import { BaseLayer } from "./base_layer"
 
@@ -82,7 +83,7 @@ export class TrackPointsLayer extends BaseLayer {
       )
     } catch (error) {
       console.error("[TrackPointsLayer] Failed to load track points:", error)
-      Toast.error("Failed to load track points")
+      Toast.error(translate("messages.failed_to_load_track_points"))
       throw error
     }
   }
@@ -221,7 +222,9 @@ export class TrackPointsLayer extends BaseLayer {
     // Update the point on the backend
     try {
       await this.updatePointPosition(pointId, coords.lat, coords.lng)
-      Toast.success("Point updated. Track will be recalculated.")
+      Toast.success(
+        translate("messages.point_updated_track_will_be_recalculated"),
+      )
     } catch (error) {
       console.error("Failed to update point:", error)
       // Revert the point position on error
@@ -234,7 +237,9 @@ export class TrackPointsLayer extends BaseLayer {
           source.setData(data)
         }
       }
-      Toast.error("Failed to update point position. Please try again.")
+      Toast.error(
+        translate("messages.failed_to_update_point_position_please_try_again"),
+      )
     }
 
     this.draggedFeature = null

--- a/app/javascript/maps_maplibre/managers/replay_manager.js
+++ b/app/javascript/maps_maplibre/managers/replay_manager.js
@@ -1,3 +1,5 @@
+import { translate } from "i18n"
+
 /**
  * ReplayManager - Core business logic for replay feature
  * Manages point data grouping by day, indexing by minute, and navigation state
@@ -197,12 +199,12 @@ export class ReplayManager {
    */
   getCurrentDayDisplay() {
     const day = this.getCurrentDay()
-    if (!day) return "No data"
+    if (!day) return translate("replay.no_data")
 
     const [year, month, dayNum] = day.split("-").map(Number)
     const date = new Date(year, month - 1, dayNum)
 
-    return date.toLocaleDateString("en-US", {
+    return date.toLocaleDateString(document.documentElement.lang || undefined, {
       year: "numeric",
       month: "long",
       day: "numeric",

--- a/app/javascript/maps_maplibre/managers/replay_panel.js
+++ b/app/javascript/maps_maplibre/managers/replay_panel.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 import { ReplayPhotoStack } from "maps_maplibre/components/replay_photo_stack"
 import { ReplayMarkerLayer } from "maps_maplibre/layers/replay_marker_layer"
 import { ReplayPhotoLayer } from "maps_maplibre/layers/replay_photo_layer"
@@ -367,7 +368,9 @@ export class ReplayPanel {
     if (this.c.hasReplayDataIndicatorTarget) {
       if (showNoData) {
         this.c.replayDataIndicatorTarget.classList.remove("hidden")
-        this.c.replayDataIndicatorTarget.textContent = "No data at this time"
+        this.c.replayDataIndicatorTarget.textContent = translate(
+          "replay.no_data_at_this_time",
+        )
       } else {
         this.c.replayDataIndicatorTarget.classList.add("hidden")
       }
@@ -387,7 +390,12 @@ export class ReplayPanel {
     if (velocity !== null && velocity !== undefined && velocity !== "") {
       const speedMs = parseFloat(velocity)
       if (!Number.isNaN(speedMs) && speedMs > 0) {
-        this.c.replaySpeedDisplayTarget.textContent = `${Math.round(speedMs * 3.6)} km/h`
+        this.c.replaySpeedDisplayTarget.textContent = translate(
+          "replay.speed",
+          {
+            speed: Math.round(speedMs * 3.6),
+          },
+        )
         return
       }
     }
@@ -398,7 +406,10 @@ export class ReplayPanel {
     if (!this.c.hasReplayDayCountTarget || !this.replayManager) return
     const dayCount = this.replayManager.getDayCount()
     const currentIndex = this.replayManager.currentDayIndex + 1
-    this.c.replayDayCountTarget.textContent = `Day ${currentIndex} of ${dayCount}`
+    this.c.replayDayCountTarget.textContent = translate("replay.day_count", {
+      current: currentIndex,
+      total: dayCount,
+    })
   }
 
   renderDensity() {
@@ -426,7 +437,10 @@ export class ReplayPanel {
       this.c.replayCycleControlsTarget.classList.remove("hidden")
       if (this.c.hasReplayPointCounterTarget) {
         const currentIndex = (this.replayManager.cycleIndex % count) + 1
-        this.c.replayPointCounterTarget.textContent = `Point ${currentIndex} of ${count}`
+        this.c.replayPointCounterTarget.textContent = translate(
+          "replay.point_count",
+          { current: currentIndex, total: count },
+        )
       }
     } else {
       this.c.replayCycleControlsTarget.classList.add("hidden")

--- a/app/javascript/maps_maplibre/utils/layer_gate.js
+++ b/app/javascript/maps_maplibre/utils/layer_gate.js
@@ -6,6 +6,8 @@
  * layer, it shows for PREVIEW_SECONDS then auto-hides with an upgrade
  * prompt.
  */
+
+import { translate } from "i18n"
 import { Toast } from "maps_maplibre/components/toast"
 import { UpgradeBanner } from "maps_maplibre/components/upgrade_banner"
 
@@ -62,7 +64,10 @@ async function startPreview({ layerName, toggle, showFn, hideFn, upgradeUrl }) {
   cancelPreview(layerName)
 
   const toast = Toast.info(
-    `Previewing ${layerName} for ${PREVIEW_SECONDS} seconds.`,
+    translate("layer_preview.started", {
+      layer: layerName,
+      seconds: PREVIEW_SECONDS,
+    }),
     0,
   )
 
@@ -70,7 +75,10 @@ async function startPreview({ layerName, toggle, showFn, hideFn, upgradeUrl }) {
   const countdownInterval = setInterval(() => {
     remaining -= 5
     if (remaining > 0 && toast?.parentNode) {
-      toast.textContent = `Previewing ${layerName} — ${remaining}s remaining.`
+      toast.textContent = translate("layer_preview.remaining", {
+        layer: layerName,
+        seconds: remaining,
+      })
     }
   }, 5000)
 
@@ -93,7 +101,7 @@ async function startPreview({ layerName, toggle, showFn, hideFn, upgradeUrl }) {
     delete activeTimers[`${layerName}_countdown`]
 
     UpgradeBanner.show({
-      message: `${layerName} preview ended.`,
+      message: translate("layer_preview.ended", { layer: layerName }),
       upgradeUrl,
       utmContent: `layer_preview_${layerName.toLowerCase().replace(/ /g, "_")}`,
     })

--- a/app/javascript/maps_maplibre/utils/search_manager.js
+++ b/app/javascript/maps_maplibre/utils/search_manager.js
@@ -3,6 +3,7 @@
  * Manages location search functionality for Maps V2
  */
 
+import { translate } from "i18n"
 import { LocationSearchService } from "../services/location_search_service.js"
 
 export class SearchManager {
@@ -98,7 +99,7 @@ export class SearchManager {
         this.displayResults(suggestions)
       } catch (error) {
         if (renderId !== this._activeRenderId) return
-        this.showError("Failed to fetch suggestions")
+        this.showError(translate("search.suggestions_failed"))
         console.error("SearchManager: Search error:", error)
       }
     }, this.debounceDelay)
@@ -138,7 +139,7 @@ export class SearchManager {
 
     const name = document.createElement("div")
     name.className = "font-medium text-sm"
-    name.textContent = suggestion.name || "Unknown location"
+    name.textContent = suggestion.name || translate("search.unknown_location")
 
     if (suggestion.address) {
       const address = document.createElement("div")
@@ -200,7 +201,7 @@ export class SearchManager {
     } catch (error) {
       if (renderId !== this._activeRenderId) return
       console.error("SearchManager: Failed to fetch visits:", error)
-      this.showError("Failed to load visits for this location")
+      this.showError(translate("search.visits_load_failed"))
     }
 
     // Dispatch custom event for other components
@@ -263,7 +264,7 @@ export class SearchManager {
     this.resultsContainer.innerHTML = `
       <div class="p-3 text-sm text-base-content/60 flex items-center gap-2">
         <span class="loading loading-spinner loading-sm"></span>
-        Searching...
+        ${translate("search.searching")}
       </div>
     `
     this.resultsContainer.classList.remove("hidden")
@@ -275,7 +276,7 @@ export class SearchManager {
   showNoResults() {
     this.resultsContainer.innerHTML = `
       <div class="p-3 text-sm text-base-content/60">
-        No locations found
+        ${translate("search.no_locations")}
       </div>
     `
     this.resultsContainer.classList.remove("hidden")
@@ -303,7 +304,7 @@ export class SearchManager {
       <div class="p-4 text-sm text-base-content/60">
         <div class="flex items-center gap-2 mb-2">
           <span class="loading loading-spinner loading-sm"></span>
-          <span class="font-medium">Searching for visits...</span>
+          <span class="font-medium">${translate("search.searching_for_visits")}</span>
         </div>
         <div class="text-xs">${this.escapeHtml(locationName)}</div>
       </div>
@@ -324,8 +325,8 @@ export class SearchManager {
       this.resultsContainer.innerHTML = `
         <div class="p-6 text-center text-base-content/60">
           <div class="text-3xl mb-3">📍</div>
-          <div class="text-sm font-medium">No visits found</div>
-          <div class="text-xs mt-1">No visits found for "${this.escapeHtml(location.name)}"</div>
+          <div class="text-sm font-medium">${translate("visits.none_found")}</div>
+          <div class="text-xs mt-1">${translate("visits.none_found_for", { query: this.escapeHtml(location.name) })}</div>
         </div>
       `
       this.resultsContainer.classList.remove("hidden")
@@ -335,8 +336,8 @@ export class SearchManager {
     // Display visits grouped by location
     let html = `
       <div class="p-4 border-b bg-base-200">
-        <div class="text-sm font-medium">Found ${visitsData.total_locations} location(s)</div>
-        <div class="text-xs text-base-content/60 mt-1">for "${this.escapeHtml(location.name)}"</div>
+        <div class="text-sm font-medium">${translate("search.locations_found", { count: visitsData.total_locations })}</div>
+        <div class="text-xs text-base-content/60 mt-1">${translate("search.for_query", { query: this.escapeHtml(location.name) })}</div>
       </div>
     `
 
@@ -373,7 +374,10 @@ export class SearchManager {
     const displayName =
       location.place_name ||
       location.address ||
-      `Location (${location.coordinates?.[0]?.toFixed(4)}, ${location.coordinates?.[1]?.toFixed(4)})`
+      translate("map_info.location_coordinates", {
+        latitude: location.coordinates?.[0]?.toFixed(4),
+        longitude: location.coordinates?.[1]?.toFixed(4),
+      })
 
     return `
       <div class="location-result border-b" data-location-index="${index}">
@@ -385,9 +389,9 @@ export class SearchManager {
               : ""
           }
           <div class="flex justify-between items-center mt-3">
-            <div class="text-xs text-primary">${location.total_visits} visit(s)</div>
+            <div class="text-xs text-primary">${translate("selection.visits", { count: location.total_visits })}</div>
             <div class="text-xs text-base-content/60">
-              first ${this.formatDateShort(firstVisit.date)}, last ${this.formatDateShort(lastVisit.date)}
+              ${translate("search.first_last", { first: this.formatDateShort(firstVisit.date), last: this.formatDateShort(lastVisit.date) })}
             </div>
           </div>
         </div>
@@ -402,7 +406,7 @@ export class SearchManager {
                    data-location-index="${index}" data-year="${year}">
                 <span class="text-sm font-medium">${year}</span>
                 <div class="flex items-center gap-2">
-                  <span class="text-xs text-primary">${yearVisits.length} visits</span>
+                  <span class="text-xs text-primary">${translate("selection.visits", { count: yearVisits.length })}</span>
                   <span class="year-arrow text-base-content/40 transition-transform">▶</span>
                 </div>
               </div>
@@ -414,7 +418,7 @@ export class SearchManager {
                        data-location-index="${index}" data-visit-index="${visits.indexOf(visit)}">
                     <div class="flex justify-between items-start">
                       <div>📍 ${this.formatDateTime(visit.date)}</div>
-                      <div class="text-xs text-base-content/60">${visit.duration_estimate || "N/A"}</div>
+                      <div class="text-xs text-base-content/60">${visit.duration_estimate || translate("common.not_available")}</div>
                     </div>
                   </div>
                 `,
@@ -509,7 +513,9 @@ export class SearchManager {
     const startTime = visitDetails.start_time || visit.date
     const endTime = visitDetails.end_time || visit.date
     const placeName =
-      location.place_name || location.address || "Unnamed Location"
+      location.place_name ||
+      location.address ||
+      translate("search.unnamed_location")
 
     // Open create visit modal
     this.openCreateVisitModal({
@@ -541,12 +547,12 @@ export class SearchManager {
       <input type="checkbox" id="${modalId}-toggle" class="modal-toggle" checked />
       <div class="modal" role="dialog">
         <div class="modal-box">
-          <h3 class="text-lg font-bold mb-4">Create Visit</h3>
+          <h3 class="text-lg font-bold mb-4">${translate("visits.create")}</h3>
 
           <form id="${modalId}-form">
             <div class="form-control mb-4">
               <label class="label">
-                <span class="label-text">Name</span>
+                <span class="label-text">${translate("common.name")}</span>
               </label>
               <input type="text" name="name" class="input input-bordered w-full"
                      value="${this.escapeHtml(visitData.name)}" required />
@@ -554,7 +560,7 @@ export class SearchManager {
 
             <div class="form-control mb-4">
               <label class="label">
-                <span class="label-text">Start Time</span>
+                <span class="label-text">${translate("visits.start_time")}</span>
               </label>
               <input type="datetime-local" name="started_at" class="input input-bordered w-full"
                      max="9999-12-31T23:59" value="${this.formatDateTimeForInput(visitData.started_at)}" required />
@@ -562,7 +568,7 @@ export class SearchManager {
 
             <div class="form-control mb-4">
               <label class="label">
-                <span class="label-text">End Time</span>
+                <span class="label-text">${translate("visits.end_time")}</span>
               </label>
               <input type="datetime-local" name="ended_at" class="input input-bordered w-full"
                      max="9999-12-31T23:59" value="${this.formatDateTimeForInput(visitData.ended_at)}" required />
@@ -572,9 +578,9 @@ export class SearchManager {
             <input type="hidden" name="longitude" value="${visitData.longitude}" />
 
             <div class="modal-action">
-              <button type="button" class="btn" data-action="close">Cancel</button>
+              <button type="button" class="btn" data-action="close">${translate("common.cancel")}</button>
               <button type="submit" class="btn btn-primary">
-                <span class="submit-text">Create Visit</span>
+                <span class="submit-text">${translate("visits.create")}</span>
                 <span class="loading loading-spinner loading-sm hidden"></span>
               </button>
             </div>
@@ -646,7 +652,7 @@ export class SearchManager {
       setTimeout(() => modal.remove(), 300)
 
       // Show success notification
-      this.showSuccessNotification("Visit created successfully!")
+      this.showSuccessNotification(translate("visits.created_without_name"))
 
       // Dispatch custom event for other components to react
       document.dispatchEvent(
@@ -659,7 +665,9 @@ export class SearchManager {
       )
     } catch (error) {
       console.error("Failed to create visit:", error)
-      this.showError(`Failed to create visit: ${error.message}`)
+      this.showError(
+        translate("visits.create_failed_with_error", { error: error.message }),
+      )
 
       // Re-enable submit button
       submitBtn.disabled = false
@@ -709,7 +717,7 @@ export class SearchManager {
    */
   formatDateShort(dateString) {
     const date = new Date(dateString)
-    return date.toLocaleDateString("en-US", {
+    return date.toLocaleDateString(document.documentElement.lang || undefined, {
       month: "short",
       day: "numeric",
       year: "numeric",
@@ -723,7 +731,7 @@ export class SearchManager {
    */
   formatDateTime(dateString) {
     const date = new Date(dateString)
-    return date.toLocaleString("en-US", {
+    return date.toLocaleString(document.documentElement.lang || undefined, {
       month: "short",
       day: "numeric",
       year: "numeric",

--- a/app/javascript/maps_maplibre/utils/style_manager.js
+++ b/app/javascript/maps_maplibre/utils/style_manager.js
@@ -1,3 +1,4 @@
+import { translate } from "i18n"
 /**
  * Style Manager for MapLibre GL styles
  * Loads and configures local map styles with dynamic tile source
@@ -163,7 +164,7 @@ export const TILE_LAYER_CATEGORIES = {
  */
 export const POI_GROUPS = {
   food_drink: {
-    label: "Food & Drink",
+    label: translate("messages.food_drink"),
     kinds: [
       "restaurant",
       "fast_food",
@@ -176,7 +177,7 @@ export const POI_GROUPS = {
     ],
   },
   shopping: {
-    label: "Shopping",
+    label: translate("messages.shopping"),
     kinds: [
       "supermarket",
       "convenience",
@@ -197,7 +198,7 @@ export const POI_GROUPS = {
     ],
   },
   transport: {
-    label: "Transport",
+    label: translate("messages.transport"),
     kinds: [
       "aerodrome",
       "station",
@@ -213,11 +214,11 @@ export const POI_GROUPS = {
     ],
   },
   cycling: {
-    label: "Cycling",
+    label: translate("messages.cycling"),
     kinds: ["bicycle_parking", "bicycle_rental", "bicycle_repair_station"],
   },
   nature_leisure: {
-    label: "Nature & Leisure",
+    label: translate("messages.nature_leisure"),
     kinds: [
       "park",
       "forest",
@@ -238,7 +239,7 @@ export const POI_GROUPS = {
     ],
   },
   tourism: {
-    label: "Tourism & Culture",
+    label: translate("messages.tourism_culture"),
     kinds: [
       "attraction",
       "museum",
@@ -255,7 +256,7 @@ export const POI_GROUPS = {
     ],
   },
   services: {
-    label: "Services & Civic",
+    label: translate("messages.services_civic"),
     kinds: [
       "post_office",
       "post_box",
@@ -277,7 +278,7 @@ export const POI_GROUPS = {
     ],
   },
   urban_amenities: {
-    label: "Urban Amenities",
+    label: translate("messages.urban_amenities"),
     kinds: [
       "bench",
       "toilets",
@@ -451,11 +452,11 @@ export function getAvailableStyles() {
  */
 export function getStyleDisplayName(styleName) {
   const displayNames = {
-    dark: "Dark",
-    light: "Light",
-    white: "White",
-    black: "Black",
-    grayscale: "Grayscale",
+    dark: translate("map_styles.dark"),
+    light: translate("map_styles.light"),
+    white: translate("map_styles.white"),
+    black: translate("map_styles.black"),
+    grayscale: translate("map_styles.grayscale"),
   }
   return (
     displayNames[styleName] ||

--- a/app/javascript/poster_studio/data/layouts.js
+++ b/app/javascript/poster_studio/data/layouts.js
@@ -9,54 +9,50 @@ import {
 export const LAYOUT_CATEGORIES = [
   {
     id: "print",
-    name: "Print",
     layouts: [
-      paper("print-a5", "A5 Portrait", "A5"),
-      paper("print-a4", "A4 Portrait", "A4"),
-      paper("print-a3", "A3 Portrait", "A3"),
-      paper("print-a2", "A2 Portrait", "A2"),
-      paper("print-a1", "A1 Portrait", "A1"),
-      paper("print-a0", "A0 Portrait", "A0"),
-      paper("print-30x40", "30 × 40 cm", "P30X40"),
-      paper("print-50x70", "50 × 70 cm", "P50X70"),
-      paper("print-70x100", "70 × 100 cm", "P70X100"),
-      paper("print-letter", "Letter (US)", "LETTER"),
-      paper("print-a4-landscape", "A4 Landscape", "A4", true),
-      paper("print-a3-landscape", "A3 Landscape", "A3", true),
+      paper("print-a5", "A5"),
+      paper("print-a4", "A4"),
+      paper("print-a3", "A3"),
+      paper("print-a2", "A2"),
+      paper("print-a1", "A1"),
+      paper("print-a0", "A0"),
+      paper("print-30x40", "P30X40"),
+      paper("print-50x70", "P50X70"),
+      paper("print-70x100", "P70X100"),
+      paper("print-letter", "LETTER"),
+      paper("print-a4-landscape", "A4", true),
+      paper("print-a3-landscape", "A3", true),
     ],
   },
   {
     id: "social",
-    name: "Social",
     layouts: [
-      pixels("social-ig-square", "Instagram Square", 1080, 1080),
-      pixels("social-ig-portrait", "Instagram Portrait", 1080, 1350),
-      pixels("social-story", "Story (9:16)", 1080, 1920),
-      pixels("social-x-header", "X Header", 1500, 500),
-      pixels("social-youtube-thumb", "YouTube Thumbnail", 1280, 720),
+      pixels("social-ig-square", 1080, 1080),
+      pixels("social-ig-portrait", 1080, 1350),
+      pixels("social-story", 1080, 1920),
+      pixels("social-x-header", 1500, 500),
+      pixels("social-youtube-thumb", 1280, 720),
     ],
   },
   {
     id: "wallpaper",
-    name: "Wallpaper",
     layouts: [
-      pixels("wallpaper-fhd", "Desktop Full HD", 1920, 1080),
-      pixels("wallpaper-4k", "Desktop 4K", 3840, 2160),
-      pixels("wallpaper-ultrawide", "Desktop Ultrawide", 3440, 1440),
-      pixels("wallpaper-phone", "Phone", 1179, 2556),
-      pixels("wallpaper-tablet", "Tablet", 2064, 2752),
+      pixels("wallpaper-fhd", 1920, 1080),
+      pixels("wallpaper-4k", 3840, 2160),
+      pixels("wallpaper-ultrawide", 3440, 1440),
+      pixels("wallpaper-phone", 1179, 2556),
+      pixels("wallpaper-tablet", 2064, 2752),
     ],
   },
 ]
 
 export const DEFAULT_LAYOUT_ID = "print-a3"
 
-function paper(id, name, paperKey, landscape = false) {
+function paper(id, paperKey, landscape = false) {
   const size = PAPER_SIZES[paperKey]
   const [wmm, hmm] = landscape ? [size.hmm, size.wmm] : [size.wmm, size.hmm]
   return {
     id,
-    name,
     kind: "paper",
     paperKey,
     landscape,
@@ -65,10 +61,9 @@ function paper(id, name, paperKey, landscape = false) {
   }
 }
 
-function pixels(id, name, width, height) {
+function pixels(id, width, height) {
   return {
     id,
-    name,
     kind: "pixels",
     width,
     height,

--- a/app/javascript/poster_studio/ui/order_client.js
+++ b/app/javascript/poster_studio/ui/order_client.js
@@ -1,12 +1,12 @@
-const ERROR_MESSAGES = {
-  wrong_size: "The exported PDF doesn't match the selected format — try again.",
-  too_large:
-    "The exported PDF is too large (50 MB max). Lower the DPI cap or zoom out.",
-  unknown_sku: "This format is not orderable right now.",
-  payment_unavailable:
-    "Payment is temporarily unavailable — try again in a minute.",
-  not_pdf: "The export didn't produce a valid PDF — try again.",
-  unreadable: "The exported PDF couldn't be read — try again.",
+import { translate } from "i18n"
+
+const ERROR_KEYS = {
+  wrong_size: "poster.order_errors.wrong_size",
+  too_large: "poster.order_errors.too_large",
+  unknown_sku: "poster.order_errors.unknown_sku",
+  payment_unavailable: "poster.order_errors.payment_unavailable",
+  not_pdf: "poster.order_errors.not_pdf",
+  unreadable: "poster.order_errors.unreadable",
 }
 
 export async function submitPrintOrder({
@@ -28,7 +28,7 @@ export async function submitPrintOrder({
   const { status, body } = await postForm(url, form, onProgress)
   if (status < 200 || status >= 300) {
     throw new Error(
-      ERROR_MESSAGES[body.error] || "Order upload failed — try again.",
+      translate(ERROR_KEYS[body.error] || "poster.order_errors.generic"),
     )
   }
   return { token: body.token, checkoutUrl: body.checkout_url }
@@ -50,9 +50,7 @@ function postForm(url, form, onProgress) {
       resolve({ status: xhr.status, body: xhr.response || {} }),
     )
     xhr.addEventListener("error", () =>
-      reject(
-        new Error("Could not reach the order service — check your connection."),
-      ),
+      reject(new Error(translate("poster.order_errors.connection"))),
     )
     xhr.send(form)
   })

--- a/app/jobs/air_trail/import_flights_job.rb
+++ b/app/jobs/air_trail/import_flights_job.rb
@@ -20,9 +20,11 @@ module AirTrail
     def notify_sync_failed(user, error)
       Notifications::Create.new(
         user: user,
-        title: 'AirTrail sync failed',
-        content: "Your AirTrail flight sync failed with error: #{error.message}. " \
-                 'Check your AirTrail settings and try again.',
+        title: I18n.t('jobs.air_trail.import_flights_job.airtrail_sync_failed'),
+        content: I18n.t(
+          'jobs.air_trail.import_flights_job.your_airtrail_flight_sync_failed_with_error_message_check_your',
+          message: error.message
+        ),
         kind: :error
       ).call
     end

--- a/app/jobs/data_migrations/recalculate_anomalies_user_job.rb
+++ b/app/jobs/data_migrations/recalculate_anomalies_user_job.rb
@@ -133,10 +133,10 @@ class DataMigrations::RecalculateAnomaliesUserJob < ApplicationJob
     Notifications::Create.new(
       user: user,
       kind: :info,
-      title: 'GPS noise re-check finished',
-      content: 'Your points were re-checked against the noise rules introduced in this release, and your ' \
-               'tracks, stats and digests were rebuilt from the result. Some points may appear or disappear ' \
-               'on the map. No points were deleted.'
+      title: I18n.t('jobs.data_migrations.recalculate_anomalies_user_job.gps_noise_re_check_finished'),
+      content: I18n.t(
+        'jobs.data_migrations.recalculate_anomalies_user_job.rules_recheck_finished'
+      )
     ).call
   end
 

--- a/app/jobs/lite/archival_warning_job.rb
+++ b/app/jobs/lite/archival_warning_job.rb
@@ -46,9 +46,8 @@ class Lite::ArchivalWarningJob < ApplicationJob
     Notification.create!(
       user: user,
       kind: :warning,
-      title: 'Your oldest data will archive in 30 days',
-      content: 'Your oldest month of location data will be archived soon. ' \
-               'Upgrade to Pro to keep your full history searchable.'
+      title: I18n.t('jobs.lite.archival_warning_job.your_oldest_data_will_archive_in_30_days'),
+      content: I18n.t('jobs.lite.archival_warning_job.your_oldest_month_of_location_data_will_be_archived_soon')
     )
   end
 
@@ -60,10 +59,8 @@ class Lite::ArchivalWarningJob < ApplicationJob
     Notification.create!(
       user: user,
       kind: :warning,
-      title: 'Data has been archived',
-      content: '1 month of location data has been archived. ' \
-               'Your archived data can be exported at any time. ' \
-               'Upgrade to Pro to make it visible and interactive in-app again.'
+      title: I18n.t('jobs.lite.archival_warning_job.data_has_been_archived'),
+      content: I18n.t('jobs.lite.archival_warning_job.month_of_location_data_has_been_archived_your_archived')
     )
   end
 

--- a/app/jobs/stale_jobs_recovery_job.rb
+++ b/app/jobs/stale_jobs_recovery_job.rb
@@ -16,13 +16,15 @@ class StaleJobsRecoveryJob < ApplicationJob
 
   def recover_stale_exports
     Export.processing.where(processing_started_at: ...EXPORT_TIMEOUT.ago).find_each do |export|
-      export.update!(status: :failed, error_message: 'Export timed out after being stuck in processing')
+      error_message = I18n.t('jobs.stale_jobs_recovery_job.export_timed_out_after_being_stuck_in_processing')
+      export.update!(status: :failed, error_message: error_message)
 
       Notifications::Create.new(
         user: export.user,
         kind: :error,
-        title: 'Export failed',
-        content: "Export \"#{export.name}\" was stuck in processing and has been marked as failed."
+        title: I18n.t('jobs.stale_jobs_recovery_job.export_failed'),
+        content: I18n.t('jobs.stale_jobs_recovery_job.export_name_was_stuck_in_processing_and_has_been_marked',
+                        name: export.name)
       ).call
     rescue StandardError => e
       Rails.logger.error("Failed to recover stale export #{export.id}: #{e.message}")
@@ -31,13 +33,15 @@ class StaleJobsRecoveryJob < ApplicationJob
 
   def recover_stale_imports
     Import.processing.where(processing_started_at: ...IMPORT_TIMEOUT.ago).find_each do |import|
-      import.update!(status: :failed, error_message: 'Import timed out after being stuck in processing')
+      error_message = I18n.t('jobs.stale_jobs_recovery_job.import_timed_out_after_being_stuck_in_processing')
+      import.update!(status: :failed, error_message: error_message)
 
       Notifications::Create.new(
         user: import.user,
         kind: :error,
-        title: 'Import failed',
-        content: "Import \"#{import.name}\" was stuck in processing and has been marked as failed."
+        title: I18n.t('jobs.stale_jobs_recovery_job.import_failed'),
+        content: I18n.t('jobs.stale_jobs_recovery_job.import_name_was_stuck_in_processing_and_has_been_marked',
+                        name: import.name)
       ).call
     rescue StandardError => e
       Rails.logger.error("Failed to recover stale import #{import.id}: #{e.message}")

--- a/app/jobs/stats/calculating_job.rb
+++ b/app/jobs/stats/calculating_job.rb
@@ -17,8 +17,9 @@ class Stats::CalculatingJob < ApplicationJob
     Notifications::Create.new(
       user:,
       kind: :error,
-      title: 'Stats update failed',
-      content: "#{error.message}, stacktrace: #{error.backtrace.join("\n")}"
+      title: I18n.t('jobs.stats.calculating_job.stats_update_failed'),
+      content: I18n.t('jobs.stats.calculating_job.message_stacktrace_n', message: error.message,
+                      backtrace: error.backtrace.join("\n"))
     ).call
   end
 end

--- a/app/jobs/users/digests/monthly/calculating_job.rb
+++ b/app/jobs/users/digests/monthly/calculating_job.rb
@@ -24,8 +24,9 @@ class Users::Digests::Monthly::CalculatingJob < ApplicationJob
     Notifications::Create.new(
       user:,
       kind: :error,
-      title: 'Monthly Digest calculation failed',
-      content: "#{error.message}, stacktrace: #{backtrace}"
+      title: I18n.t('jobs.users.digests.monthly.calculating_job.monthly_digest_calculation_failed'),
+      content: I18n.t('jobs.users.digests.monthly.calculating_job.message_stacktrace_backtrace',
+                      message: error.message, backtrace: backtrace)
     ).call
   rescue ActiveRecord::RecordNotFound
     nil

--- a/app/jobs/users/digests/yearly/calculating_job.rb
+++ b/app/jobs/users/digests/yearly/calculating_job.rb
@@ -30,8 +30,10 @@ class Users::Digests::Yearly::CalculatingJob < ApplicationJob
     Notifications::Create.new(
       user:,
       kind: :error,
-      title: "#{period_label} calculation failed",
-      content: "#{error.message}, stacktrace: #{backtrace}"
+      title: I18n.t('jobs.users.digests.yearly.calculating_job.period_label_calculation_failed',
+                    period_label: period_label),
+      content: I18n.t('jobs.users.digests.yearly.calculating_job.message_stacktrace_backtrace', message: error.message,
+backtrace: backtrace)
     ).call
   rescue ActiveRecord::RecordNotFound
     nil

--- a/app/jobs/users/import_data_job.rb
+++ b/app/jobs/users/import_data_job.rb
@@ -65,8 +65,9 @@ class Users::ImportDataJob < ApplicationJob
   def create_import_failed_notification(user, error)
     ::Notifications::Create.new(
       user: user,
-      title: 'Data import failed',
-      content: "Your data import failed with error: #{error.message}. Please check the archive format and try again.",
+      title: I18n.t('jobs.users.import_data_job.data_import_failed'),
+      content: I18n.t('jobs.users.import_data_job.your_data_import_failed_with_error_message_please_check_the',
+                      message: error.message),
       kind: :error
     ).call
   end

--- a/app/jobs/users/recalculate_data_job.rb
+++ b/app/jobs/users/recalculate_data_job.rb
@@ -17,9 +17,10 @@ class Users::RecalculateDataJob < ApplicationJob
     notify = options.is_a?(Hash) ? options.symbolize_keys.fetch(:notify, true) : true
     user = User.find_by(id: user_id) if notify
     if user
+      content = I18n.t('jobs.users.recalculate_data_job.another_recalculation_is_already_running_please_try_again_in_a')
       Notifications::Create.new(
-        user: user, kind: :warning, title: 'Data recalculation busy',
-        content: 'Another recalculation is already running. Please try again in a few minutes.'
+        user: user, kind: :warning, title: I18n.t('jobs.users.recalculate_data_job.data_recalculation_busy'),
+        content: content
       ).call
     end
   end
@@ -102,8 +103,9 @@ class Users::RecalculateDataJob < ApplicationJob
     Notifications::Create.new(
       user: user,
       kind: :info,
-      title: 'Data recalculation completed',
-      content: "Stats, tracks, and digests have been recalculated for #{year_label}."
+      title: I18n.t('jobs.users.recalculate_data_job.data_recalculation_completed'),
+      content: I18n.t('jobs.users.recalculate_data_job.stats_tracks_and_digests_have_been_recalculated_for_year_label',
+                      year_label: year_label)
     ).call
   end
 
@@ -111,8 +113,9 @@ class Users::RecalculateDataJob < ApplicationJob
     Notifications::Create.new(
       user: user,
       kind: :error,
-      title: 'Data recalculation failed',
-      content: "#{error.message}, stacktrace: #{error.backtrace.first(10).join("\n")}"
+      title: I18n.t('jobs.users.recalculate_data_job.data_recalculation_failed'),
+      content: I18n.t('jobs.users.recalculate_data_job.message_stacktrace_n', message: error.message,
+                      backtrace: error.backtrace.first(10).join("\n"))
     ).call
   rescue ActiveRecord::RecordNotFound
     nil

--- a/app/jobs/visits/full_history_redetect_job.rb
+++ b/app/jobs/visits/full_history_redetect_job.rb
@@ -31,8 +31,8 @@ class Visits::FullHistoryRedetectJob < ApplicationJob
     user_for_notify = defined?(user) ? user : User.find_by(id: user_id)
     if user_for_notify
       notify!(
-        user_for_notify, kind: :warning, title: 'Visit re-detection busy',
-        content: 'Another re-detection is already running. Try again in a few minutes.'
+        user_for_notify, kind: :warning, title: I18n.t('jobs.visits.full_history_redetect_job.visit_re_detection_busy'),
+        content: I18n.t('jobs.visits.full_history_redetect_job.another_re_detection_is_already_running_try_again_in_a')
       )
     end
   rescue StandardError => e
@@ -55,8 +55,8 @@ class Visits::FullHistoryRedetectJob < ApplicationJob
     max_ts = user.points.maximum(:timestamp)
 
     if min_ts.nil?
-      notify!(user, kind: :info, title: 'Visit re-detection',
-                    content: 'No points to re-detect.')
+      notify!(user, kind: :info, title: I18n.t('jobs.visits.full_history_redetect_job.visit_re_detection'),
+                    content: I18n.t('jobs.visits.full_history_redetect_job.no_points_to_re_detect'))
       return
     end
 
@@ -99,13 +99,26 @@ class Visits::FullHistoryRedetectJob < ApplicationJob
     )
 
     if months_failed.empty?
-      notify!(user, kind: :info, title: 'Visit re-detection complete',
-                    content: "#{visits_created} visits across #{months.size} months.")
+      content = I18n.t(
+        'jobs.visits.full_history_redetect_job.visits_created_visits_across_size_months',
+        visits_created: visits_created,
+        size: months.size
+      )
+      notify!(user, kind: :info,
+                    title: I18n.t('jobs.visits.full_history_redetect_job.visit_re_detection_complete'),
+                    content: content)
     else
       ok_months = months.size - months_failed.size
-      notify!(user, kind: :warning, title: 'Visit re-detection partially complete',
-                    content: "#{visits_created} visits across #{ok_months} of #{months.size} months. " \
-                             "#{months_failed.size} month(s) failed; re-run after the cooldown to retry.")
+      content = I18n.t(
+        'jobs.visits.full_history_redetect_job.visits_created_visits_across_ok_months_of_size_months_size',
+        visits_created: visits_created,
+        ok_months: ok_months,
+        size: months.size,
+        failed_count: months_failed.size
+      )
+      notify!(user, kind: :warning,
+                    title: I18n.t('jobs.visits.full_history_redetect_job.visit_re_detection_partially_complete'),
+                    content: content)
     end
   end
 
@@ -141,7 +154,8 @@ class Visits::FullHistoryRedetectJob < ApplicationJob
   end
 
   def notify_failure(user, error)
-    notify!(user, kind: :error, title: 'Visit re-detection failed', content: error.message)
+    notify!(user, kind: :error, title: I18n.t('jobs.visits.full_history_redetect_job.visit_re_detection_failed'),
+content: error.message)
   end
 
   def notify!(user, kind:, title:, content:)

--- a/app/mailers/family_mailer.rb
+++ b/app/mailers/family_mailer.rb
@@ -9,7 +9,7 @@ class FamilyMailer < ApplicationMailer
 
     mail(
       to: @invitation.email,
-      subject: "🎉 You've been invited to join #{@family.name} on Dawarich!"
+      subject: I18n.t('mailers.family.invitation.subject', family: @family.name)
     )
   end
 
@@ -21,7 +21,7 @@ class FamilyMailer < ApplicationMailer
 
     mail(
       to: @target_user.email,
-      subject: "📍 #{@requester.email} is requesting your location on Dawarich"
+      subject: I18n.t('mailers.family.location_request.subject', requester: @requester.email)
     )
   end
 
@@ -31,7 +31,7 @@ class FamilyMailer < ApplicationMailer
 
     mail(
       to: @family.owner.email,
-      subject: "👪 #{@user.name} has joined your family #{@family.name} on Dawarich!"
+      subject: I18n.t('mailers.family.member_joined.subject', user: @user.name, family: @family.name)
     )
   end
 end

--- a/app/mailers/users/digests_mailer.rb
+++ b/app/mailers/users/digests_mailer.rb
@@ -18,7 +18,7 @@ class Users::DigestsMailer < ApplicationMailer
 
     mail(
       to: @user.email,
-      subject: "Your #{@digest.year} Year in Review - Dawarich"
+      subject: I18n.t('mailers.users.digests.year_end.subject', year: @digest.year)
     )
   end
 
@@ -37,7 +37,11 @@ class Users::DigestsMailer < ApplicationMailer
 
     mail(
       to: @user.email,
-      subject: "Your #{Date::MONTHNAMES[@digest.month]} #{@digest.year} in review — Dawarich"
+      subject: I18n.t(
+        'mailers.users.digests.monthly.subject',
+        month: I18n.l(Date.new(@digest.year, @digest.month), format: :month_name),
+        year: @digest.year
+      )
     )
   end
 

--- a/app/mailers/users_mailer.rb
+++ b/app/mailers/users_mailer.rb
@@ -5,14 +5,14 @@ class UsersMailer < ApplicationMailer
     # Sent after user signs up
     @user = params[:user]
 
-    mail(to: @user.email, subject: 'Welcome to Dawarich!')
+    mail(to: @user.email, subject: I18n.t('mailers.users.welcome.subject'))
   end
 
   def explore_features
     # Sent 2 days after user signs up
     @user = params[:user]
 
-    mail(to: @user.email, subject: 'Explore Dawarich features!')
+    mail(to: @user.email, subject: I18n.t('mailers.users.explore_features.subject'))
   end
 
   def archival_approaching
@@ -20,7 +20,7 @@ class UsersMailer < ApplicationMailer
     @upgrade_url = "#{MANAGER_URL}/auth/dawarich?token=#{@user.generate_subscription_token}" \
                    '&utm_source=email&utm_medium=email&utm_campaign=archival_approaching&utm_content=upgrade'
 
-    mail(to: @user.email, subject: 'Keep your full history — upgrade to Pro')
+    mail(to: @user.email, subject: I18n.t('mailers.users.archival_approaching.subject'))
   end
 
   # Sent by Auth::FindOrCreateOauthUser when a mobile OAuth signup
@@ -32,20 +32,23 @@ class UsersMailer < ApplicationMailer
     @provider_label = params[:provider_label]
     @link_url = params[:link_url]
 
-    mail(to: @user.email, subject: "Confirm linking #{@provider_label} to your Dawarich account")
+    mail(
+      to: @user.email,
+      subject: I18n.t('mailers.users.oauth_account_link.subject', provider: @provider_label)
+    )
   end
 
   def account_destroy_confirmation
     @user = params[:user]
     @link_url = params[:link_url]
 
-    mail(to: @user.email, subject: 'Confirm Dawarich account deletion')
+    mail(to: @user.email, subject: I18n.t('mailers.users.account_destroy_confirmation.subject'))
   end
 
   def otp_account_locked
     @user = params[:user]
 
-    mail(to: @user.email, subject: 'Dawarich account temporarily locked')
+    mail(to: @user.email, subject: I18n.t('mailers.users.otp_account_locked.subject'))
   end
 
   def trial_expired; end

--- a/app/models/family/location_request.rb
+++ b/app/models/family/location_request.rb
@@ -24,7 +24,7 @@ class Family::LocationRequest < ApplicationRecord
   def requester_cannot_be_target
     return unless requester_id.present? && requester_id == target_user_id
 
-    errors.add(:requester_id, 'cannot request your own location')
+    errors.add(:requester_id, I18n.t('models.family.location_request.cannot_request_your_own_location'))
   end
 
   def set_defaults

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -144,7 +144,7 @@ class Import < ApplicationRecord
 
     return unless file.blob.byte_size > 11.megabytes
 
-    errors.add(:file, 'is too large. Trial users can only upload files up to 10MB.')
+    errors.add(:file, I18n.t('models.import.is_too_large_trial_users_can_only_upload_files_up'))
   end
 
   def import_count_within_limit
@@ -153,7 +153,7 @@ class Import < ApplicationRecord
     existing_imports_count = user.imports.where(demo: false).count
     return unless existing_imports_count >= 5
 
-    errors.add(:base, 'Trial users can only create up to 5 imports. Please subscribe to import more files.')
+    errors.add(:base, I18n.t('models.import.trial_users_can_only_create_up_to_5_imports_please'))
   end
 
   def recalculate_stats

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -69,7 +69,7 @@ class Note < ApplicationRecord
                 .where('CAST(noted_at AS date) = ?', noted_at.utc.to_date)
     scope = scope.where.not(id: id) if persisted?
 
-    errors.add(:date, 'has already been taken') if scope.exists?
+    errors.add(:date, I18n.t('models.note.has_already_been_taken')) if scope.exists?
   end
 
   def date_within_attachable_range
@@ -78,7 +78,7 @@ class Note < ApplicationRecord
     return if attachable.started_at.blank? || attachable.ended_at.blank?
     return unless date < attachable.started_at.to_date || date > attachable.ended_at.to_date
 
-    errors.add(:date, 'must be within the trip date range')
+    errors.add(:date, I18n.t('models.note.must_be_within_the_trip_date_range'))
   end
 
   def attachable_belongs_to_user
@@ -86,6 +86,6 @@ class Note < ApplicationRecord
     return unless attachable.respond_to?(:user_id)
     return if attachable.user_id == user_id
 
-    errors.add(:attachable, 'must belong to the same user')
+    errors.add(:attachable, I18n.t('models.note.must_belong_to_the_same_user'))
   end
 end

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -16,7 +16,7 @@ class Point < ApplicationRecord
   validates :timestamp, :lonlat, presence: true
   validates :lonlat, uniqueness: {
     scope: %i[timestamp user_id],
-    message: 'already has a point at this location and time for this user',
+    message: ->(*) { I18n.t('models.point.already_has_a_point_at_this_location_and_time_for') },
     index: true
   }
 

--- a/app/models/points/raw_data_archive.rb
+++ b/app/models/points/raw_data_archive.rb
@@ -67,7 +67,7 @@ module Points
 
       return unless metadata['expected_count'].blank? || metadata['actual_count'].blank?
 
-      errors.add(:metadata, 'must contain expected_count and actual_count')
+      errors.add(:metadata, I18n.t('models.points.raw_data_archive.must_contain_expected_count_and_actual_count'))
     end
 
     def remove_attached_file

--- a/app/models/shared_link.rb
+++ b/app/models/shared_link.rb
@@ -67,9 +67,9 @@ class SharedLink < ApplicationRecord
   def resource_id_matches_type
     needs_id = RESOURCE_TYPES_REQUIRING_ID.include?(resource_type)
     if needs_id && resource_id.blank?
-      errors.add(:resource_id, 'is required for this resource type')
+      errors.add(:resource_id, I18n.t('models.shared_link.is_required_for_this_resource_type'))
     elsif !needs_id && resource_id.present?
-      errors.add(:resource_id, 'must be blank for this resource type')
+      errors.add(:resource_id, I18n.t('models.shared_link.must_be_blank_for_this_resource_type'))
     end
   end
 
@@ -77,7 +77,7 @@ class SharedLink < ApplicationRecord
     return if expires_at.blank?
     return unless new_record? || will_save_change_to_expires_at?
 
-    errors.add(:expires_at, 'must be in the future') if expires_at <= Time.current
+    errors.add(:expires_at, I18n.t('models.shared_link.must_be_in_the_future')) if expires_at <= Time.current
   end
 
   def timeline_dates_present_and_ordered
@@ -87,7 +87,7 @@ class SharedLink < ApplicationRecord
     end_date   = settings['end_date'].presence
 
     if start_date.blank? || end_date.blank?
-      errors.add(:settings, 'must include start_date and end_date for timeline shares')
+      errors.add(:settings, I18n.t('models.shared_link.must_include_start_date_and_end_date_for_timeline_shares'))
       return
     end
 
@@ -95,11 +95,14 @@ class SharedLink < ApplicationRecord
     parsed_end   = safe_parse_date(end_date)
 
     if parsed_start.nil? || parsed_end.nil?
-      errors.add(:settings, 'start_date and end_date must be parseable as dates')
+      errors.add(:settings, I18n.t('models.shared_link.start_date_and_end_date_must_be_parseable_as_dates'))
       return
     end
 
-    errors.add(:settings, 'end_date must be on or after start_date') if parsed_end < parsed_start
+    return unless parsed_end < parsed_start
+
+    errors.add(:settings,
+               I18n.t('models.shared_link.end_date_must_be_on_or_after_start_date'))
   end
 
   def safe_parse_date(value)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -31,6 +31,6 @@ class Tag < ApplicationRecord
     return if icon.blank?
     return unless icon.match?(/\A[a-zA-Z]+\z/)
 
-    errors.add(:icon, 'must be an emoji or symbol, not a letter')
+    errors.add(:icon, I18n.t('models.tag.must_be_an_emoji_or_symbol_not_a_letter'))
   end
 end

--- a/app/models/track_segment.rb
+++ b/app/models/track_segment.rb
@@ -31,6 +31,9 @@ class TrackSegment < ApplicationRecord
   def end_index_greater_than_or_equal_to_start_index
     return if end_index.nil? || start_index.nil?
 
-    errors.add(:end_index, 'must be greater than or equal to start_index') if end_index < start_index
+    return unless end_index < start_index
+
+    errors.add(:end_index,
+               I18n.t('models.track_segment.must_be_greater_than_or_equal_to_start_index'))
   end
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -88,6 +88,6 @@ class Trip < ApplicationRecord
     return if started_at.blank? || ended_at.blank?
     return unless started_at >= ended_at
 
-    errors.add(:ended_at, 'must be after start date')
+    errors.add(:ended_at, I18n.t('models.trip.must_be_after_start_date'))
   end
 end

--- a/app/models/users/digest.rb
+++ b/app/models/users/digest.rb
@@ -208,7 +208,7 @@ class Users::Digest < ApplicationRecord
   def month_name
     return nil unless month
 
-    Date::MONTHNAMES[month]
+    I18n.l(Date.new(year, month), format: :month_name)
   end
 
   def untracked_days
@@ -223,10 +223,10 @@ class Users::Digest < ApplicationRecord
   def distance_comparison_text
     if distance_km >= MOON_DISTANCE_KM
       percentage = ((distance_km / MOON_DISTANCE_KM) * 100).round(1)
-      "That's #{percentage}% of the distance to the Moon!"
+      I18n.t('helpers.users.digests.moon_distance', percentage:)
     else
       percentage = ((distance_km / EARTH_CIRCUMFERENCE_KM) * 100).round(1)
-      "That's #{percentage}% of Earth's circumference!"
+      I18n.t('helpers.users.digests.earth_circumference', percentage:)
     end
   end
 

--- a/app/services/air_trail/connection_tester.rb
+++ b/app/services/air_trail/connection_tester.rb
@@ -9,13 +9,20 @@ module AirTrail
     end
 
     def call
-      return { success: false, error: 'AirTrail URL is missing' } if @url.blank?
-      return { success: false, error: 'AirTrail API key is missing' } if @api_key.blank?
+      if @url.blank?
+        return { success: false,
+error: I18n.t('services.air_trail.connection_tester.airtrail_url_is_missing') }
+      end
+      if @api_key.blank?
+        return { success: false,
+error: I18n.t('services.air_trail.connection_tester.airtrail_api_key_is_missing') }
+      end
 
       AirTrail::Client.new(@url, @api_key, skip_ssl_verification: @skip_ssl_verification).flights
-      { success: true, message: 'AirTrail connection verified' }
+      { success: true, message: I18n.t('services.air_trail.connection_tester.airtrail_connection_verified') }
     rescue AirTrail::Client::Error => e
-      { success: false, error: "AirTrail connection failed: #{e.message}" }
+      { success: false,
+error: I18n.t('services.air_trail.connection_tester.airtrail_connection_failed_message', message: e.message) }
     end
   end
 end

--- a/app/services/concerns/url_validatable.rb
+++ b/app/services/concerns/url_validatable.rb
@@ -60,22 +60,26 @@ module UrlValidatable
     return if url.blank?
 
     uri = URI.parse(url)
-    raise BlockedUrlError, "Invalid URL scheme: #{uri.scheme}" unless %w[http https].include?(uri.scheme)
-    raise BlockedUrlError, 'URL must include a host' if uri.host.blank?
+    unless %w[http https].include?(uri.scheme)
+      raise BlockedUrlError, I18n.t('services.concerns.url_validatable.invalid_scheme', scheme: uri.scheme)
+    end
+    raise BlockedUrlError, I18n.t('services.concerns.url_validatable.host_required') if uri.host.blank?
 
     # Cloud refuses URLs that embed credentials. Self-hosters legitimately
     # use http://user:pass@host — homelab Immich behind nginx basic-auth
     # is a real config we don't want to break.
     if uri.userinfo.present? && !DawarichSettings.self_hosted?
-      raise BlockedUrlError, 'URL must not embed credentials (user:pass@host)'
+      raise BlockedUrlError, I18n.t('services.concerns.url_validatable.embedded_credentials')
     end
 
     ip = IPAddr.new(Resolv.getaddress(uri.host))
-    raise BlockedUrlError, 'URL resolves to a blocked address' if blocked_ranges.any? { |range| range.include?(ip) }
+    if blocked_ranges.any? { |range| range.include?(ip) }
+      raise BlockedUrlError, I18n.t('services.concerns.url_validatable.blocked_address')
+    end
   rescue URI::InvalidURIError
-    raise BlockedUrlError, 'Invalid URL format'
+    raise BlockedUrlError, I18n.t('services.concerns.url_validatable.invalid_format')
   rescue Resolv::ResolvError
-    raise BlockedUrlError, "Could not resolve hostname: #{uri.host}"
+    raise BlockedUrlError, I18n.t('services.concerns.url_validatable.unresolvable_host', host: uri.host)
   end
 
   def blocked_ranges

--- a/app/services/csv/detector.rb
+++ b/app/services/csv/detector.rb
@@ -89,8 +89,7 @@ module Csv
       return if missing.empty?
 
       raise DetectionError,
-            'Could not detect required columns: latitude, longitude, timestamp. ' \
-            'Found headers must include recognized aliases for all three.'
+            I18n.t('services.csv.detector.required_columns_missing')
     end
 
     def parse_data_rows(lines, delimiter)

--- a/app/services/exports/create.rb
+++ b/app/services/exports/create.rb
@@ -45,7 +45,7 @@ class Exports::Create
     case file_format.to_sym
     when :json then Exports::PointGeojsonSerializer.new(time_framed_points).call
     when :gpx  then Exports::PointGpxSerializer.new(time_framed_points, export.name).call
-    else raise ArgumentError, "Unsupported file format: #{file_format}"
+    else raise ArgumentError, I18n.t('services.exports.create.unsupported_file_format', format: file_format)
     end
   end
 
@@ -53,8 +53,8 @@ class Exports::Create
     Notifications::Create.new(
       user:,
       kind: :info,
-      title: 'Export finished',
-      content: "Export \"#{export.name}\" successfully finished."
+      title: I18n.t('services.exports.create.export_finished'),
+      content: I18n.t('services.exports.create.export_name_successfully_finished', name: export.name)
     ).call
   end
 
@@ -62,8 +62,9 @@ class Exports::Create
     Notifications::Create.new(
       user:,
       kind: :error,
-      title: 'Export failed',
-      content: "Export \"#{export.name}\" failed: #{error.message}, stacktrace: #{error.backtrace.join("\n")}"
+      title: I18n.t('services.exports.create.export_failed'),
+      content: I18n.t('services.exports.create.export_name_failed_message_stacktrace_n', name: export.name,
+                      message: error.message, backtrace: error.backtrace.join("\n"))
     ).call
   end
 

--- a/app/services/families/accept_invitation.rb
+++ b/app/services/families/accept_invitation.rb
@@ -14,7 +14,9 @@ module Families
       return false unless can_accept?
 
       if user.in_family?
-        @error_message = 'You must leave your current family before joining a new one.'
+        @error_message = I18n.t(
+          'services.families.accept_invitation.you_must_leave_your_current_family_before_joining_a_new'
+        )
 
         return false
       end
@@ -48,7 +50,7 @@ module Families
     def validate_invitation
       return true if invitation.can_be_accepted?
 
-      @error_message = 'This invitation is no longer valid or has expired.'
+      @error_message = I18n.t('services.families.accept_invitation.this_invitation_is_no_longer_valid_or_has_expired')
 
       false
     end
@@ -56,7 +58,7 @@ module Families
     def validate_email_match
       return true if invitation.email == user.email
 
-      @error_message = 'This invitation is not for your email address.'
+      @error_message = I18n.t('services.families.accept_invitation.this_invitation_is_not_for_your_email_address')
 
       false
     end
@@ -64,7 +66,7 @@ module Families
     def validate_family_plan
       return true if DawarichSettings.family_feature_available_for?(invitation.family.owner)
 
-      @error_message = "This family's plan is no longer active."
+      @error_message = I18n.t('services.families.accept_invitation.this_family_s_plan_is_no_longer_active')
 
       false
     end
@@ -72,7 +74,9 @@ module Families
     def validate_family_capacity
       return true unless invitation.family.full?
 
-      @error_message = 'This family has reached the maximum number of members.'
+      @error_message = I18n.t(
+        'services.families.accept_invitation.this_family_has_reached_the_maximum_number_of_members'
+      )
 
       false
     end
@@ -98,8 +102,9 @@ module Families
       Notification.create!(
         user: user,
         kind: :info,
-        title: 'Welcome to Family!',
-        content: "You've joined the family '#{invitation.family.name}'"
+        title: I18n.t('services.families.accept_invitation.welcome_to_family'),
+        content: I18n.t('services.families.accept_invitation.you_ve_joined_the_family_name',
+                        name: invitation.family.name)
       )
     end
 
@@ -107,8 +112,8 @@ module Families
       Notification.create!(
         user: invitation.family.creator,
         kind: :info,
-        title: 'New Family Member!',
-        content: "#{user.email} has joined your family"
+        title: I18n.t('services.families.accept_invitation.new_family_member'),
+        content: I18n.t('services.families.accept_invitation.email_has_joined_your_family', email: user.email)
       )
     rescue StandardError => e
       ExceptionReporter.call(e, "Unexpected error in Families::AcceptInvitation: #{e.message}")
@@ -119,14 +124,16 @@ module Families
         if error.record&.errors&.any?
           error.record.errors.full_messages.first
         else
-          "Failed to join family: #{error.message}"
+          I18n.t('services.families.accept_invitation.failed_to_join', message: error.message)
         end
     end
 
     def handle_generic_error(error)
       ExceptionReporter.call(error, "Unexpected error in Families::AcceptInvitation: #{error.message}")
 
-      @error_message = 'An unexpected error occurred while joining the family. Please try again'
+      @error_message = I18n.t(
+        'services.families.accept_invitation.an_unexpected_error_occurred_while_joining_the_family_please_try'
+      )
     end
   end
 end

--- a/app/services/families/create.rb
+++ b/app/services/families/create.rb
@@ -6,10 +6,12 @@ module Families
 
     attr_reader :user, :name, :family, :error_message
 
-    validates :name, presence: { message: 'Family name is required' }
+    validates :name, presence: {
+      message: ->(*) { I18n.t('services.families.create.family_name_is_required') }
+    }
     validates :name, length: {
       maximum: 50,
-      message: 'Family name must be 50 characters or less'
+      message: ->(*) { I18n.t('services.families.create.family_name_must_be_50_characters_or_less') }
     }
 
     def initialize(user:, name:)
@@ -48,12 +50,12 @@ module Families
 
     def validate_user_eligibility
       if user.in_family?
-        @error_message = 'You must leave your current family before creating a new one'
+        @error_message = I18n.t('services.families.create.you_must_leave_your_current_family_before_creating_a_new')
         return false
       end
 
       if user.created_family.present?
-        @error_message = 'You have already created a family. Each user can only create one family'
+        @error_message = I18n.t('services.families.create.you_have_already_created_a_family_each_user_can_only')
         return false
       end
 
@@ -64,7 +66,7 @@ module Families
       return true if can_create_family?
 
       # Only reachable on cloud — self-hosted short-circuits in can_create_family?
-      @error_message = 'Family feature requires an active subscription'
+      @error_message = I18n.t('services.families.create.family_feature_requires_an_active_subscription')
 
       false
     end
@@ -91,8 +93,8 @@ module Families
       Notification.create!(
         user: user,
         kind: :info,
-        title: 'Family Created',
-        content: "You've successfully created the family '#{family.name}'"
+        title: I18n.t('services.families.create.family_created'),
+        content: I18n.t('services.families.create.you_ve_successfully_created_the_family_name', name: family.name)
       )
     rescue StandardError => e
       # Don't fail the entire operation if notification fails
@@ -104,17 +106,19 @@ module Families
         if family&.errors&.any?
           family.errors.full_messages.first
         else
-          "Failed to create family: #{error.message}"
+          I18n.t('services.families.create.failed_to_create_family', message: error.message)
         end
     end
 
     def handle_uniqueness_error(_error)
-      @error_message = 'A family with this name already exists for your account'
+      @error_message = I18n.t('services.families.create.a_family_with_this_name_already_exists_for_your_account')
     end
 
     def handle_generic_error(error)
       ExceptionReporter.call(error, "Unexpected error in Families::Create: #{error.message}")
-      @error_message = 'An unexpected error occurred while creating the family. Please try again'
+      @error_message = I18n.t(
+        'services.families.create.an_unexpected_error_occurred_while_creating_the_family_please_try'
+      )
     end
   end
 end

--- a/app/services/families/create_location_request.rb
+++ b/app/services/families/create_location_request.rb
@@ -24,7 +24,9 @@ class Families::CreateLocationRequest
     Result.new(success?: false, payload: { message: e.message }, status: :unprocessable_content)
   rescue StandardError => e
     ExceptionReporter.call(e, "Error in Families::CreateLocationRequest: #{e.message}")
-    Result.new(success?: false, payload: { message: 'An error occurred' }, status: :internal_server_error)
+    message = I18n.t('services.families.create_location_request.an_error_occurred')
+    Result.new(success?: false,
+               payload: { message: message }, status: :internal_server_error)
   end
 
   private
@@ -54,7 +56,7 @@ class Families::CreateLocationRequest
   def create_notification!(request)
     safe_email = ERB::Util.html_escape(requester.email)
     link = ActionController::Base.helpers.link_to(
-      'View Request',
+      I18n.t('services.families.create_location_request.view_request'),
       Rails.application.routes.url_helpers.family_location_request_path(request),
       class: 'link link-primary'
     )
@@ -62,8 +64,9 @@ class Families::CreateLocationRequest
     Notification.create!(
       user: target_user,
       kind: :info,
-      title: 'Location Request',
-      content: "#{safe_email} is requesting your location. #{link}"
+      title: I18n.t('services.families.create_location_request.location_request'),
+      content: I18n.t('services.families.create_location_request.safe_email_is_requesting_your_location_link',
+                      email: safe_email, link: link)
     )
   rescue StandardError => e
     ExceptionReporter.call(e, "Failed to create notification for location request: #{e.message}")
@@ -74,16 +77,22 @@ class Families::CreateLocationRequest
   end
 
   def not_in_same_family_error
-    Result.new(success?: false, payload: { message: 'Users must be in the same family' }, status: :forbidden)
+    message = I18n.t('services.families.create_location_request.users_must_be_in_the_same_family')
+    Result.new(success?: false,
+               payload: { message: message }, status: :forbidden)
   end
 
   def already_sharing_error
-    Result.new(success?: false, payload: { message: 'Target user is already sharing their location' },
+    message = I18n.t('services.families.create_location_request.target_user_is_already_sharing_their_location')
+    Result.new(success?: false, payload: { message: message },
                status: :unprocessable_content)
   end
 
   def cooldown_error
-    Result.new(success?: false, payload: { message: 'Request cooldown active. Please wait before requesting again.' },
+    message = I18n.t(
+      'services.families.create_location_request.request_cooldown_active_please_wait_before_requesting_again'
+    )
+    Result.new(success?: false, payload: { message: message },
                status: :too_many_requests)
   end
 end

--- a/app/services/families/invite.rb
+++ b/app/services/families/invite.rb
@@ -40,7 +40,7 @@ module Families
       return errors.full_messages.first if errors.any?
       return @custom_error_message if @custom_error_message
 
-      'Failed to send invitation'
+      I18n.t('services.families.invite.failed_to_send_invitation')
     end
 
     private
@@ -48,11 +48,15 @@ module Families
     def invite_sendable?
       unless invited_by.family_owner?
         return add_error_and_false(:invited_by,
-                                   'You must be a family owner to send invitations')
+                                   I18n.t('services.families.invite.owner_required'))
       end
-      return add_error_and_false(:family, 'Family is full') if family.full?
-      return add_error_and_false(:email, 'User is already in a family') if user_already_in_family?
-      return add_error_and_false(:email, 'Invitation already sent to this email') if pending_invitation_exists?
+      return add_error_and_false(:family, I18n.t('services.families.invite.family_full')) if family.full?
+      if user_already_in_family?
+        return add_error_and_false(:email, I18n.t('services.families.invite.user_already_in_family'))
+      end
+      if pending_invitation_exists?
+        return add_error_and_false(:email, I18n.t('services.families.invite.invitation_already_sent'))
+      end
 
       true
     end
@@ -85,18 +89,15 @@ module Families
     end
 
     def send_notification
-      content = if DawarichSettings.self_hosted?
-                  "Family invitation sent to #{email} if SMTP is configured properly. " \
-                    "If you're not using SMTP, copy the invitation link from the family page " \
-                    'and share it manually.'
-                else
-                  "Family invitation sent to #{email}"
-                end
+      content = I18n.t(
+        DawarichSettings.self_hosted? ? 'services.families.invite.sent_self_hosted' : 'services.families.invite.sent',
+        email:
+      )
 
       Notification.create!(
         user: invited_by,
         kind: :info,
-        title: 'Invitation Sent',
+        title: I18n.t('services.families.invite.invitation_sent'),
         content: content
       )
     rescue StandardError => e
@@ -108,13 +109,13 @@ module Families
       @custom_error_message = if invitation&.errors&.any?
                                 invitation.errors.full_messages.first
                               else
-                                "Failed to create invitation: #{error.message}"
+                                I18n.t('services.families.invite.failed_to_create', message: error.message)
                               end
     end
 
     def handle_email_error(error)
       Rails.logger.error "Email delivery failed for family invitation: #{error.message}"
-      @custom_error_message = 'Failed to send invitation email. Please try again later'
+      @custom_error_message = I18n.t('services.families.invite.failed_to_send_invitation_email_please_try_again_later')
 
       # Clean up the invitation if email fails
       invitation&.destroy
@@ -122,7 +123,9 @@ module Families
 
     def handle_generic_error(error)
       ExceptionReporter.call(error, "Unexpected error in Families::Invite: #{error.message}")
-      @custom_error_message = 'An unexpected error occurred while sending the invitation. Please try again'
+      @custom_error_message = I18n.t(
+        'services.families.invite.an_unexpected_error_occurred_while_sending_the_invitation_please_try'
+      )
     end
   end
 end

--- a/app/services/families/memberships/destroy.rb
+++ b/app/services/families/memberships/destroy.rb
@@ -45,7 +45,7 @@ module Families
       def validate_in_family
         return true if member_to_remove.in_family?
 
-        @error_message = 'User is not currently in a family.'
+        @error_message = I18n.t('services.families.memberships.destroy.user_is_not_currently_in_a_family')
         false
       end
 
@@ -66,28 +66,32 @@ module Families
       def validate_owner_can_leave
         return true unless member_to_remove.family_owner?
 
-        @error_message = 'Family owners cannot remove their own membership. To leave the family, delete it instead.'
+        @error_message = I18n.t(
+          'services.families.memberships.destroy.family_owners_cannot_remove_their_own_membership_to_leave_the'
+        )
         false
       end
 
       def validate_remover_is_owner
         return true if user.family_owner?
 
-        @error_message = 'Only family owners can remove other members.'
+        @error_message = I18n.t('services.families.memberships.destroy.only_family_owners_can_remove_other_members')
         false
       end
 
       def validate_same_family
         return true if user.family == member_to_remove.family
 
-        @error_message = 'Cannot remove members from a different family.'
+        @error_message = I18n.t('services.families.memberships.destroy.cannot_remove_members_from_a_different_family')
         false
       end
 
       def validate_not_removing_owner
         return true unless member_to_remove.family_owner?
 
-        @error_message = 'Cannot remove the family owner. The owner must delete the family or leave on their own.'
+        @error_message = I18n.t(
+          'services.families.memberships.destroy.cannot_remove_the_family_owner_the_owner_must_delete_the'
+        )
         false
       end
 
@@ -107,8 +111,9 @@ module Families
         Notification.create!(
           user: member_to_remove,
           kind: :info,
-          title: 'Left Family',
-          content: "You've left the family \"#{@family_name}\""
+          title: I18n.t('services.families.memberships.destroy.left_family'),
+          content: I18n.t('services.families.memberships.destroy.you_ve_left_the_family_family_name',
+                          family_name: @family_name)
         )
 
         return unless @family_owner&.persisted?
@@ -116,8 +121,9 @@ module Families
         Notification.create!(
           user: @family_owner,
           kind: :info,
-          title: 'Family Member Left',
-          content: "#{member_to_remove.email} has left the family \"#{@family_name}\""
+          title: I18n.t('services.families.memberships.destroy.family_member_left'),
+          content: I18n.t('services.families.memberships.destroy.email_has_left_the_family_family_name',
+                          email: member_to_remove.email, family_name: @family_name)
         )
       end
 
@@ -125,8 +131,9 @@ module Families
         Notification.create!(
           user: member_to_remove,
           kind: :info,
-          title: 'Removed from Family',
-          content: "You have been removed from the family \"#{@family_name}\" by #{user.email}"
+          title: I18n.t('services.families.memberships.destroy.removed_from_family'),
+          content: I18n.t('services.families.memberships.destroy.you_have_been_removed_from_the_family_family_name_by',
+                          family_name: @family_name, email: user.email)
         )
 
         return unless user != member_to_remove
@@ -134,8 +141,9 @@ module Families
         Notification.create!(
           user: user,
           kind: :info,
-          title: 'Member Removed',
-          content: "#{member_to_remove.email} has been removed from the family \"#{@family_name}\""
+          title: I18n.t('services.families.memberships.destroy.member_removed'),
+          content: I18n.t('services.families.memberships.destroy.email_has_been_removed_from_the_family_family_name',
+                          email: member_to_remove.email, family_name: @family_name)
         )
       end
 
@@ -144,13 +152,15 @@ module Families
           if error.record&.errors&.any?
             error.record.errors.full_messages.first
           else
-            "Failed to leave family: #{error.message}"
+            I18n.t('services.families.memberships.destroy.failed_to_leave', message: error.message)
           end
       end
 
       def handle_generic_error(error)
         ExceptionReporter.call(error, "Unexpected error in Families::Memberships::Destroy: #{error.message}")
-        @error_message = 'An unexpected error occurred while removing the membership. Please try again'
+        @error_message = I18n.t(
+          'services.families.memberships.destroy.an_unexpected_error_occurred_while_removing_the_membership_please_try'
+        )
       end
     end
   end

--- a/app/services/families/update_location_sharing.rb
+++ b/app/services/families/update_location_sharing.rb
@@ -15,11 +15,11 @@ class Families::UpdateLocationSharing
   def call
     return success_result if update_location_sharing
 
-    failure_result('Failed to update location sharing setting', :unprocessable_content)
+    failure_result(I18n.t('services.families.update_location_sharing.update_failed'), :unprocessable_content)
   rescue StandardError => e
     ExceptionReporter.call(e, "Error in Families::UpdateLocationSharing: #{e.message}")
 
-    failure_result('An error occurred while updating location sharing', :internal_server_error)
+    failure_result(I18n.t('services.families.update_location_sharing.unexpected_error'), :internal_server_error)
   end
 
   private
@@ -49,7 +49,7 @@ class Families::UpdateLocationSharing
 
     if enabled? && user.family_sharing_expires_at.present?
       payload[:expires_at] = user.family_sharing_expires_at.iso8601
-      payload[:expires_at_formatted] = user.family_sharing_expires_at.strftime('%b %d at %I:%M %p')
+      payload[:expires_at_formatted] = I18n.l(user.family_sharing_expires_at, format: :short_with_time)
     end
 
     Result.new(success?: true, payload: payload, status: :ok)
@@ -60,19 +60,19 @@ class Families::UpdateLocationSharing
   end
 
   def build_sharing_message
-    return 'Location sharing disabled' unless enabled?
+    return I18n.t('services.families.update_location_sharing.disabled') unless enabled?
 
     case duration_param
-    when '1h' then 'Location sharing enabled for 1 hour'
-    when '6h' then 'Location sharing enabled for 6 hours'
-    when '12h' then 'Location sharing enabled for 12 hours'
-    when '24h' then 'Location sharing enabled for 24 hours'
-    when 'permanent', nil then 'Location sharing enabled'
+    when '1h' then I18n.t('services.families.update_location_sharing.enabled_for_hours', count: 1)
+    when '6h' then I18n.t('services.families.update_location_sharing.enabled_for_hours', count: 6)
+    when '12h' then I18n.t('services.families.update_location_sharing.enabled_for_hours', count: 12)
+    when '24h' then I18n.t('services.families.update_location_sharing.enabled_for_hours', count: 24)
+    when 'permanent', nil then I18n.t('services.families.update_location_sharing.enabled')
     else
       if duration_param.to_i.positive?
-        "Location sharing enabled for #{duration_param.to_i} hours"
+        I18n.t('services.families.update_location_sharing.enabled_for_hours', count: duration_param.to_i)
       else
-        'Location sharing enabled'
+        I18n.t('services.families.update_location_sharing.enabled')
       end
     end
   end

--- a/app/services/fit/importer.rb
+++ b/app/services/fit/importer.rb
@@ -24,12 +24,13 @@ class Fit::Importer
     begin
       activity = Fit4Ruby.read(path)
     rescue StandardError => e
-      import.update!(status: :failed, error_message: "FIT parsing error: #{e.message}")
+      import.update!(status: :failed,
+                     error_message: I18n.t('services.fit.importer.fit_parsing_error_message', message: e.message))
       return
     end
 
     unless activity
-      import.update!(status: :failed, error_message: 'No activities found in FIT file')
+      import.update!(status: :failed, error_message: I18n.t('services.fit.importer.no_activities_found_in_fit_file'))
       return
     end
 

--- a/app/services/google_maps/semantic_history_importer.rb
+++ b/app/services/google_maps/semantic_history_importer.rb
@@ -37,7 +37,7 @@ class GoogleMaps::SemanticHistoryImporter
     )
     # rubocop:enable Rails/SkipsModelValidations
   rescue StandardError => e
-    create_notification("Failed to process location batch: #{e.message}")
+    create_notification(I18n.t('services.google_maps.semantic_history_importer.batch_failed', message: e.message))
   end
 
   def prepare_point_data(point_data)
@@ -58,7 +58,7 @@ class GoogleMaps::SemanticHistoryImporter
   def create_notification(message)
     Notification.create!(
       user_id: user_id,
-      title: 'Google Maps Timeline Import Error',
+      title: I18n.t('services.google_maps.semantic_history_importer.google_maps_timeline_import_error'),
       content: message,
       kind: :error
     )

--- a/app/services/gpx/track_importer.rb
+++ b/app/services/gpx/track_importer.rb
@@ -158,7 +158,7 @@ class Gpx::TrackImporter
     end
 
     def error(message)
-      raise Nokogiri::XML::SyntaxError, "GPX parse error: #{message}"
+      raise Nokogiri::XML::SyntaxError, I18n.t('services.gpx.track_importer.parse_error', message:)
     end
 
     def end_element_namespace(name, _prefix = nil, _uri = nil)

--- a/app/services/immich/connection_tester.rb
+++ b/app/services/immich/connection_tester.rb
@@ -12,22 +12,33 @@ class Immich::ConnectionTester
   end
 
   def call
-    return { success: false, error: 'Immich URL is missing' } if url.blank?
-    return { success: false, error: 'Immich API key is missing' } if api_key.blank?
+    return { success: false, error: I18n.t('services.immich.connection_tester.immich_url_is_missing') } if url.blank?
+    if api_key.blank?
+      return { success: false,
+error: I18n.t('services.immich.connection_tester.immich_api_key_is_missing') }
+    end
 
     test_connection
   rescue HTTParty::Error, Net::OpenTimeout, Net::ReadTimeout, JSON::ParserError => e
-    { success: false, error: "Immich connection failed: #{e.message}" }
+    { success: false,
+error: I18n.t('services.immich.connection_tester.immich_connection_failed_message', message: e.message) }
   end
 
   private
 
   def test_connection
     response = search_metadata
-    return { success: false, error: "Immich connection failed: #{response.code}" } unless response.success?
+    unless response.success?
+      return { success: false,
+error: I18n.t('services.immich.connection_tester.immich_connection_failed_code',
+              code: response.code) }
+    end
 
     asset_id = extract_asset_id(response.body)
-    return { success: true, message: 'Immich connection verified' } if asset_id.blank?
+    if asset_id.blank?
+      return { success: true,
+message: I18n.t('services.immich.connection_tester.immich_connection_verified') }
+    end
 
     test_thumbnail_access(asset_id)
   end
@@ -64,13 +75,18 @@ class Immich::ConnectionTester
                                  })
     )
 
-    return { success: true, message: 'Immich connection verified' } if response.success?
-
-    if missing_asset_view_permission?(response)
-      return { success: false, error: 'Immich API key missing permission: asset.view' }
+    if response.success?
+      return { success: true,
+message: I18n.t('services.immich.connection_tester.immich_connection_verified') }
     end
 
-    { success: false, error: "Immich thumbnail check failed: #{response.code}" }
+    if missing_asset_view_permission?(response)
+      return { success: false,
+error: I18n.t('services.immich.connection_tester.immich_api_key_missing_permission_asset_view') }
+    end
+
+    { success: false,
+error: I18n.t('services.immich.connection_tester.immich_thumbnail_check_failed_code', code: response.code) }
   end
 
   def extract_asset_id(body)

--- a/app/services/immich/enrich_photos.rb
+++ b/app/services/immich/enrich_photos.rb
@@ -11,8 +11,10 @@ class Immich::EnrichPhotos
   end
 
   def call
-    return error_result('Immich URL is missing') if user.safe_settings.immich_url.blank?
-    return error_result('Immich API key is missing') if user.safe_settings.immich_api_key.blank?
+    return error_result(I18n.t('services.immich.configuration.url_missing')) if user.safe_settings.immich_url.blank?
+    if user.safe_settings.immich_api_key.blank?
+      return error_result(I18n.t('services.immich.configuration.api_key_missing'))
+    end
     return { enriched: 0, failed: 0, errors: [] } if assets.empty?
 
     enriched = 0
@@ -50,7 +52,8 @@ class Immich::EnrichPhotos
     if response.success?
       { success: true }
     else
-      { success: false, error: "HTTP #{response.code}: #{response.message}" }
+      { success: false,
+error: I18n.t('services.immich.enrich_photos.http_code_message', code: response.code, message: response.message) }
     end
   rescue HTTParty::Error, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNREFUSED => e
     { success: false, error: e.message }

--- a/app/services/immich/enrich_scan.rb
+++ b/app/services/immich/enrich_scan.rb
@@ -13,8 +13,10 @@ class Immich::EnrichScan
   end
 
   def call
-    return error_result('Immich URL is missing') if user.safe_settings.immich_url.blank?
-    return error_result('Immich API key is missing') if user.safe_settings.immich_api_key.blank?
+    return error_result(I18n.t('services.immich.configuration.url_missing')) if user.safe_settings.immich_url.blank?
+    if user.safe_settings.immich_api_key.blank?
+      return error_result(I18n.t('services.immich.configuration.api_key_missing'))
+    end
 
     immich_data = fetch_immich_photos
     return error_result(immich_data[:error]) if immich_data[:error]
@@ -33,7 +35,7 @@ class Immich::EnrichScan
 
   def fetch_immich_photos
     photos = Immich::RequestPhotos.new(user, start_date: start_date || '1970-01-01', end_date:).call
-    return { error: 'Failed to fetch photos from Immich' } if photos.nil?
+    return { error: I18n.t('services.immich.enrich_scan.failed_to_fetch_photos_from_immich') } if photos.nil?
 
     { photos: photos }
   end

--- a/app/services/immich/import_geodata.rb
+++ b/app/services/immich/import_geodata.rb
@@ -73,9 +73,9 @@ class Immich::ImportGeodata
     Notifications::Create.new(
       user:,
       kind: :info,
-      title: 'Import was not created',
-      content: "Import with the same name (#{import_name}) already exists. " \
-               'If you want to proceed, delete the existing import and try again.'
+      title: I18n.t('services.immich.import_geodata.import_was_not_created'),
+      content: I18n.t('services.immich.import_geodata.import_with_the_same_name_import_name_already_exists_if',
+                      import_name: import_name)
     ).call
   end
 

--- a/app/services/immich/request_photos.rb
+++ b/app/services/immich/request_photos.rb
@@ -14,8 +14,8 @@ class Immich::RequestPhotos
   end
 
   def call
-    raise ArgumentError, 'Immich API key is missing' if immich_api_key.blank?
-    raise ArgumentError, 'Immich URL is missing'     if user.safe_settings.immich_url.blank?
+    raise ArgumentError, I18n.t('services.immich.configuration.api_key_missing') if immich_api_key.blank?
+    raise ArgumentError, I18n.t('services.immich.configuration.url_missing') if user.safe_settings.immich_url.blank?
 
     data = retrieve_immich_data
     return nil if data.nil?

--- a/app/services/immich/response_analyzer.rb
+++ b/app/services/immich/response_analyzer.rb
@@ -17,8 +17,8 @@ class Immich::ResponseAnalyzer
   end
 
   def error_message
-    return 'Immich API key missing permission: asset.view' if permission_error?
+    return I18n.t('services.immich.response_analyzer.permission_missing') if permission_error?
 
-    'Failed to fetch thumbnail'
+    I18n.t('services.immich.response_analyzer.thumbnail_failed')
   end
 end

--- a/app/services/immich/response_validator.rb
+++ b/app/services/immich/response_validator.rb
@@ -3,12 +3,16 @@
 module Immich
   class ResponseValidator
     def self.validate_and_parse(response, logger: Rails.logger)
-      return { success: false, error: "Request failed: #{response.code}" } unless response.success?
+      unless response.success?
+        return { success: false,
+error: I18n.t('services.immich.response_validator.request_failed_code', code: response.code) }
+      end
 
       unless json_content_type?(response)
         content_type = response.headers['content-type'] || response.headers['Content-Type'] || 'unknown'
         logger.error("Immich returned non-JSON response: #{response.code} #{truncate_body(response.body)}")
-        return { success: false, error: "Expected JSON, got #{content_type}" }
+        return { success: false,
+error: I18n.t('services.immich.response_validator.expected_json_got_content_type', content_type: content_type) }
       end
 
       parsed = JSON.parse(response.body)
@@ -16,18 +20,18 @@ module Immich
     rescue JSON::ParserError => e
       logger.error("Immich JSON parse error: #{e.message}")
       logger.error("Response body: #{truncate_body(response.body)}")
-      { success: false, error: 'Invalid JSON response' }
+      { success: false, error: I18n.t('services.immich.response_validator.invalid_json_response') }
     end
 
     def self.validate_and_parse_body(body_string, logger: Rails.logger)
-      return { success: false, error: 'Invalid JSON' } if body_string.nil?
+      return { success: false, error: I18n.t('services.immich.response_validator.invalid_json') } if body_string.nil?
 
       parsed = JSON.parse(body_string)
       { success: true, data: parsed }
     rescue JSON::ParserError, TypeError => e
       logger.error("JSON parse error: #{e.message}")
       logger.error("Body: #{truncate_body(body_string)}")
-      { success: false, error: 'Invalid JSON' }
+      { success: false, error: I18n.t('services.immich.response_validator.invalid_json') }
     end
 
     private_class_method def self.json_content_type?(response)

--- a/app/services/imports/bulk_insertable.rb
+++ b/app/services/imports/bulk_insertable.rb
@@ -53,7 +53,7 @@ module Imports
     def create_import_error_notification(message)
       Notification.create!(
         user_id: import.user_id,
-        title: "#{importer_name} Import Error",
+        title: I18n.t('services.imports.bulk_insertable.importer_name_import_error', importer_name: importer_name),
         content: message,
         kind: :error
       )

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -77,10 +77,9 @@ class Imports::Create
     Notifications::Create.new(
       user:,
       kind: :warning,
-      title: 'Import post-processing incomplete',
-      content: "Your import \"#{import.name}\" finished and all points were saved, but the " \
-               "#{step.tr('_', ' ')} step failed. Statistics, tracks or visit suggestions " \
-               'may be missing or outdated. You can trigger a recalculation from Settings.'
+      title: I18n.t('services.imports.create.import_post_processing_incomplete'),
+      content: I18n.t('services.imports.create.your_import_name_finished_and_all_points_were_saved_but',
+                      name: import.name, step: step.tr('_', ' '))
     ).call
   rescue StandardError => e
     ExceptionReporter.call(e, 'Failed to create post-import failure notification')
@@ -93,7 +92,7 @@ class Imports::Create
   end
 
   def importer(source)
-    raise ArgumentError, 'Import source cannot be nil' if source.nil?
+    raise ArgumentError, I18n.t('services.imports.create.source_missing') if source.nil?
 
     case source.to_s
     when 'google_semantic_history'      then GoogleMaps::SemanticHistoryImporter
@@ -110,9 +109,9 @@ class Imports::Create
     when 'fit'                          then Fit::Importer
     when 'polarsteps'                   then Polarsteps::Importer
     when 'zip'
-      raise ArgumentError, 'Could not classify zip contents -- file may be corrupted'
+      raise ArgumentError, I18n.t('services.imports.create.zip_unclassified')
     else
-      raise ArgumentError, "Unsupported source: #{source}"
+      raise ArgumentError, I18n.t('services.imports.create.unsupported_source', source:)
     end
   end
 
@@ -127,17 +126,15 @@ class Imports::Create
     if import.doubles.to_i.positive?
       Notification.create!(
         user_id: import.user_id,
-        title: 'Import completed with no new points',
-        content: "Your file #{import.name} contained #{import.raw_points} points, all of which " \
-                 'already exist in your timeline at the same coordinates and timestamps. ' \
-                 'Nothing was imported. If this was unexpected, delete the existing points ' \
-                 'for that date range and re-import.',
+        title: I18n.t('services.imports.create.import_completed_with_no_new_points'),
+        content: I18n.t('services.imports.create.your_file_name_contained_raw_points_points_all_of_which',
+                        name: import.name, raw_points: import.raw_points),
         kind: :info
       )
     else
       Notification.create!(
         user_id: import.user_id,
-        title: 'Import completed with no points',
+        title: I18n.t('services.imports.create.import_completed_with_no_points'),
         content: zero_points_content(import),
         kind: :warning
       )
@@ -210,7 +207,7 @@ class Imports::Create
     Notifications::Create.new(
       user:,
       kind: :error,
-      title: 'Import failed',
+      title: I18n.t('services.imports.create.import_failed'),
       content: message
     ).call
   end

--- a/app/services/imports/source_detector.rb
+++ b/app/services/imports/source_detector.rb
@@ -382,47 +382,37 @@ class Imports::SourceDetector
   def unsupported_reason
     content = read_for_raw_detection.to_s
 
-    return 'The uploaded file is empty (0 bytes).' if content.empty?
+    return I18n.t('services.imports.source_detector.empty_file') if content.empty?
 
     binary_reason = unsupported_binary_reason(content)
     return binary_reason if binary_reason
 
     stripped = content.strip
-    return 'The uploaded file contains no data (empty JSON object or array).' if EMPTY_JSON_BODIES.include?(stripped)
+    return I18n.t('services.imports.source_detector.empty_json') if EMPTY_JSON_BODIES.include?(stripped)
 
     if content.include?('You have encrypted Timeline backups')
-      'Your Google Timeline data is encrypted. Open the Google Maps app, ' \
-        'turn off Timeline encryption in your settings, then re-export your data.'
+      I18n.t('services.imports.source_detector.encrypted_timeline')
     elsif content.lstrip.start_with?('<!DOCTYPE html', '<!doctype html', '<html', '<HTML')
-      'This is an HTML page (likely "archive_browser.html" from your Google Takeout), ' \
-        'not the data file. Open the Takeout archive and look for the .json or .kml inside.'
+      I18n.t('services.imports.source_detector.html_page')
     elsif content.include?('"timelineEdits"')
-      'Google Timeline Edits format is not yet supported. Please upload Records.json ' \
-        'or the files inside the Timeline/ folder of your Google Takeout instead.'
+      I18n.t('services.imports.source_detector.timeline_edits')
     elsif content.include?('"deviceSettings"') ||
           (content.include?('"gaiaId"') && content.include?('"hasReportedLocations"'))
-      'This file contains your Google Maps settings, not location data. ' \
-        'Look for "Records.json" or files inside "Timeline/" in your Google Takeout.'
+      I18n.t('services.imports.source_detector.google_settings')
     elsif content.include?('"placeUrl"') && content.include?('"selectedChoice"')
-      'This is a Google Maps place-feedback file (Maps Q&A answers like "Was this place open?"), ' \
-        'not your location history. Look for "Records.json" or files inside "Timeline/" in your Google Takeout.'
+      I18n.t('services.imports.source_detector.place_feedback')
     elsif google_my_activity?(content)
-      'This is a Google "My Activity" log (search and Maps activity), not your location history. ' \
-        'Look for "Records.json" or files inside "Timeline/" in your Google Takeout.'
+      I18n.t('services.imports.source_detector.my_activity')
     elsif google_saved_places?(content)
-      'This is a Google saved-places / geocodes file, not your location history. ' \
-        'Look for "Records.json" or files inside "Timeline/" in your Google Takeout.'
+      I18n.t('services.imports.source_detector.saved_places')
     elsif amazon_order?(content)
-      'This is an Amazon order export, not location data. ' \
-        'Dawarich imports location history from Google Takeout, OwnTracks, GPX, and similar sources.'
+      I18n.t('services.imports.source_detector.amazon_order')
     elsif snapchat_export?(content)
-      'This appears to be a Snapchat data export, not location data. ' \
-        'Dawarich imports location history from Google Takeout, OwnTracks, GPX, and similar sources.'
+      I18n.t('services.imports.source_detector.snapchat_export')
     elsif looks_like_json_fragment?(content)
-      'The uploaded file appears to be a truncated or corrupted fragment of a JSON file ' \
-        '(it does not start with "{" or "["). Please re-export and upload the original complete file.'
+      I18n.t('services.imports.source_detector.json_fragment')
     else
-      'Unable to detect file format'
+      I18n.t('services.imports.source_detector.unknown_format')
     end
   end
 
@@ -436,25 +426,23 @@ class Imports::SourceDetector
     head_bytes = content.bytes
 
     if head4 == '%PDF'
-      'PDF files are not supported. Open the PDF and find your actual location data file.'
+      I18n.t('services.imports.source_detector.pdf')
     elsif head4.start_with?('Rar!')
-      'RAR archives are not supported. Please extract the archive and upload the data files inside.'
+      I18n.t('services.imports.source_detector.rar')
     elsif head8 == 'bplist00'
-      'Apple binary plist (.plist) files are not supported.'
+      I18n.t('services.imports.source_detector.apple_plist')
     elsif head_bytes[0, 2] == [0x1F, 0x8B]
-      'Gzip-compressed files (.gz) are not auto-decompressed. Please decompress the file and re-upload the contents.'
+      I18n.t('services.imports.source_detector.gzip')
     elsif head_bytes[0, 8] == [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]
-      'Microsoft Office documents (Word/Excel) are not supported. Please upload your location data file.'
+      I18n.t('services.imports.source_detector.office_document')
     elsif heic_file?(content)
-      'HEIC image files are not supported. Photos do not contain a location history; ' \
-        'connect your photo library via the Immich or PhotoPrism integration to import photo locations.'
+      I18n.t('services.imports.source_detector.heic')
     elsif head_bytes[0, 3] == [0xFF, 0xD8, 0xFF]
-      'JPEG image files are not supported. Photos do not contain a location history; ' \
-        'connect your photo library via the Immich or PhotoPrism integration to import photo locations.'
+      I18n.t('services.imports.source_detector.jpeg')
     elsif head8 == "\x89PNG\r\n\x1A\n".b
-      'PNG image files are not supported. Please upload your location data file (.json, .gpx, .kml, etc).'
+      I18n.t('services.imports.source_detector.png')
     elsif ds_store?(head_bytes)
-      'This is a macOS Finder metadata file (.DS_Store), not a data file. Please upload your actual location export.'
+      I18n.t('services.imports.source_detector.ds_store')
     end
   end
 

--- a/app/services/imports/watcher.rb
+++ b/app/services/imports/watcher.rb
@@ -75,7 +75,7 @@ class Imports::Watcher
     when 'geojson' then :geojson
     when 'kml', 'kmz' then :kml
     when 'zip' then nil
-    else raise UnsupportedSourceError, 'Unsupported source '
+    else raise UnsupportedSourceError, I18n.t('services.imports.watcher.unsupported_source_without_name')
     end
   end
 
@@ -93,7 +93,7 @@ class Imports::Watcher
     when nil
       'application/octet-stream' # fallback MIME type for nil source
     else
-      raise UnsupportedSourceError, "Unsupported source: #{source}"
+      raise UnsupportedSourceError, I18n.t('services.imports.watcher.unsupported_source', source:)
     end
   end
 end

--- a/app/services/insights/travel_insight_generator.rb
+++ b/app/services/insights/travel_insight_generator.rb
@@ -4,14 +4,7 @@ module Insights
   # Generates human-readable travel insights from time-of-day,
   # day-of-week, and seasonality data.
   class TravelInsightGenerator
-    TIME_LABELS = {
-      'morning' => 'in the morning (6am-12pm)',
-      'afternoon' => 'in the afternoon (12pm-6pm)',
-      'evening' => 'in the evening (6pm-12am)',
-      'night' => 'at night (12am-6am)'
-    }.freeze
-
-    DAYS = %w[Monday Tuesday Wednesday Thursday Friday Saturday Sunday].freeze
+    DAYS = %w[monday tuesday wednesday thursday friday saturday sunday].freeze
 
     MINIMUM_PERCENTAGE_THRESHOLD = 30
 
@@ -31,10 +24,15 @@ module Insights
       insights.compact!
       return nil if insights.empty?
 
-      base_insight = "#{insights.join('. ')}."
+      base_insight = I18n.t('services.insights.travel_insight_generator.sentence', insights: insights.join('. '))
       suggestion = generate_suggestion
 
-      suggestion ? "#{base_insight} #{suggestion}" : base_insight
+      if suggestion
+        I18n.t('services.insights.travel_insight_generator.with_suggestion', insight: base_insight,
+      suggestion:)
+      else
+        base_insight
+      end
     end
 
     private
@@ -47,7 +45,8 @@ module Insights
       peak_time = time_of_day.max_by { |_, v| v.to_i }
       return nil unless peak_time && peak_time[1].to_i > MINIMUM_PERCENTAGE_THRESHOLD
 
-      "You travel most #{TIME_LABELS[peak_time[0]]}"
+      period = I18n.t("services.insights.travel_insight_generator.time_periods.#{peak_time[0]}")
+      I18n.t('services.insights.travel_insight_generator.peak_time', period:)
     end
 
     def day_of_week_insight
@@ -61,9 +60,10 @@ module Insights
 
       if weekend_avg > weekday_avg * 1.3
         peak_day_idx = day_of_week.each_with_index.max_by { |v, _| v }[1]
-        "#{DAYS[peak_day_idx]}s are your most active travel day"
+        day = I18n.t("services.insights.travel_insight_generator.days.#{DAYS[peak_day_idx]}")
+        I18n.t('services.insights.travel_insight_generator.active_day', day:)
       elsif weekday_avg > weekend_avg * 1.3
-        'You travel more on weekdays than weekends'
+        I18n.t('services.insights.travel_insight_generator.weekday_preference')
       end
     end
 
@@ -73,7 +73,8 @@ module Insights
       peak_season = seasonality.max_by { |_, v| v.to_i }
       return nil unless peak_season && peak_season[1].to_i > MINIMUM_PERCENTAGE_THRESHOLD
 
-      "#{peak_season[0].capitalize} is your peak travel season"
+      season = I18n.t("services.insights.travel_insight_generator.seasons.#{peak_season[0]}")
+      I18n.t('services.insights.travel_insight_generator.peak_season', season:)
     end
 
     def generate_suggestion
@@ -92,9 +93,9 @@ module Insights
 
       case peak_time
       when 'morning'
-        'Early starts seem to work well for you!'
+        I18n.t('services.insights.travel_insight_generator.early_start_suggestion')
       when 'evening'
-        'Consider a sunset drive for your next adventure.'
+        I18n.t('services.insights.travel_insight_generator.sunset_suggestion')
       end
     end
 
@@ -106,7 +107,7 @@ module Insights
       weekend_avg = weekend_total / 2
       weekday_avg = weekday_total / 5
 
-      'Your weekends are made for exploring!' if weekend_avg > weekday_avg * 1.5
+      I18n.t('services.insights.travel_insight_generator.weekend_suggestion') if weekend_avg > weekday_avg * 1.5
     end
   end
 end

--- a/app/services/maps/bounds_calculator.rb
+++ b/app/services/maps/bounds_calculator.rb
@@ -28,8 +28,8 @@ module Maps
     private
 
     def validate_inputs!
-      raise NoUserFoundError, 'No user found' unless @user
-      raise NoDateRangeError, 'No date range specified' unless @start_date && @end_date
+      raise NoUserFoundError, I18n.t('services.maps.bounds_calculator.no_user') unless @user
+      raise NoDateRangeError, I18n.t('services.maps.bounds_calculator.no_date_range') unless @start_date && @end_date
     end
 
     def execute_bounds_query(start_timestamp, end_timestamp)
@@ -63,7 +63,7 @@ module Maps
     def build_no_data_response
       {
         success: false,
-        error: 'No data found for the specified date range',
+        error: I18n.t('services.maps.bounds_calculator.no_data_found_for_the_specified_date_range'),
         point_count: 0
       }
     end
@@ -75,7 +75,7 @@ module Maps
           param.to_i
         else
           parsed_time = Time.zone.parse(param)
-          raise ArgumentError, "Invalid date format: #{param}" if parsed_time.nil?
+          raise ArgumentError, I18n.t('services.maps.bounds_calculator.invalid_date', value: param) if parsed_time.nil?
 
           parsed_time.to_i
         end
@@ -86,7 +86,7 @@ module Maps
       end
     rescue ArgumentError => e
       Rails.logger.error "Invalid date format: #{param} - #{e.message}"
-      raise ArgumentError, "Invalid date format: #{param}"
+      raise ArgumentError, I18n.t('services.maps.bounds_calculator.invalid_date', value: param)
     end
   end
 end

--- a/app/services/photoprism/connection_tester.rb
+++ b/app/services/photoprism/connection_tester.rb
@@ -12,12 +12,19 @@ class Photoprism::ConnectionTester
   end
 
   def call
-    return { success: false, error: 'Photoprism URL is missing' } if url.blank?
-    return { success: false, error: 'Photoprism API key is missing' } if api_key.blank?
+    if url.blank?
+      return { success: false,
+error: I18n.t('services.photoprism.connection_tester.photoprism_url_is_missing') }
+    end
+    if api_key.blank?
+      return { success: false,
+error: I18n.t('services.photoprism.connection_tester.photoprism_api_key_is_missing') }
+    end
 
     test_connection
   rescue HTTParty::Error, Net::OpenTimeout, Net::ReadTimeout, JSON::ParserError => e
-    { success: false, error: "Photoprism connection failed: #{e.message}" }
+    { success: false,
+error: I18n.t('services.photoprism.connection_tester.photoprism_connection_failed_message', message: e.message) }
   end
 
   private
@@ -38,8 +45,12 @@ class Photoprism::ConnectionTester
       )
     )
 
-    return { success: true, message: 'Photoprism connection verified' } if response.success?
+    if response.success?
+      return { success: true,
+message: I18n.t('services.photoprism.connection_tester.photoprism_connection_verified') }
+    end
 
-    { success: false, error: "Photoprism connection failed: #{response.code}" }
+    { success: false,
+error: I18n.t('services.photoprism.connection_tester.photoprism_connection_failed_code', code: response.code) }
   end
 end

--- a/app/services/photoprism/import_geodata.rb
+++ b/app/services/photoprism/import_geodata.rb
@@ -78,9 +78,9 @@ class Photoprism::ImportGeodata
     Notifications::Create.new(
       user:,
       kind: :info,
-      title: 'Import was not created',
-      content: "Import with the same name (#{import_name}) already exists. " \
-               'If you want to proceed, delete the existing import and try again.'
+      title: I18n.t('services.photoprism.import_geodata.import_was_not_created'),
+      content: I18n.t('services.photoprism.import_geodata.import_with_the_same_name_import_name_already_exists_if',
+                      import_name: import_name)
     ).call
   end
 

--- a/app/services/photoprism/request_photos.rb
+++ b/app/services/photoprism/request_photos.rb
@@ -18,8 +18,11 @@ class Photoprism::RequestPhotos
   end
 
   def call
-    raise ArgumentError, 'Photoprism URL is missing' if user.safe_settings.photoprism_url.blank?
-    raise ArgumentError, 'Photoprism API key is missing' if photoprism_api_key.blank?
+    if user.safe_settings.photoprism_url.blank?
+      raise ArgumentError,
+            I18n.t('services.photoprism.configuration.url_missing')
+    end
+    raise ArgumentError, I18n.t('services.photoprism.configuration.api_key_missing') if photoprism_api_key.blank?
 
     data = retrieve_photoprism_data
 

--- a/app/services/photoprism/response_validator.rb
+++ b/app/services/photoprism/response_validator.rb
@@ -3,12 +3,17 @@
 module Photoprism
   class ResponseValidator
     def self.validate_and_parse(response, logger: Rails.logger)
-      return { success: false, error: "Request failed: #{response.code}" } unless response.success?
+      unless response.success?
+        return { success: false,
+error: I18n.t('services.photoprism.response_validator.request_failed_code',
+              code: response.code) }
+      end
 
       unless json_content_type?(response)
         content_type = response.headers['content-type'] || response.headers['Content-Type'] || 'unknown'
         logger.error("Photoprism returned non-JSON response: #{response.code} #{truncate_body(response.body)}")
-        return { success: false, error: "Expected JSON, got #{content_type}" }
+        return { success: false,
+error: I18n.t('services.photoprism.response_validator.expected_json_got_content_type', content_type: content_type) }
       end
 
       parsed = JSON.parse(response.body)
@@ -16,7 +21,7 @@ module Photoprism
     rescue JSON::ParserError => e
       logger.error("Photoprism JSON parse error: #{e.message}")
       logger.error("Response body: #{truncate_body(response.body)}")
-      { success: false, error: 'Invalid JSON response' }
+      { success: false, error: I18n.t('services.photoprism.response_validator.invalid_json_response') }
     end
 
     private_class_method def self.json_content_type?(response)

--- a/app/services/points/raw_data/verifier.rb
+++ b/app/services/points/raw_data/verifier.rb
@@ -102,7 +102,10 @@ module Points
       end
 
       def download_and_verify_content(archive)
-        return { success: false, error: 'File not attached' } unless archive.file.attached?
+        unless archive.file.attached?
+          return { success: false,
+error: I18n.t('services.points.raw_data.verifier.file_not_attached') }
+        end
 
         begin
           raw_content = archive.file.blob.download
@@ -110,21 +113,29 @@ module Points
           # Only I/O errors get the download_failed label — it exempts the
           # archive from the verified_at unset, so decrypt/integrity errors
           # must never be classified here.
-          return { success: false, error: "File download failed: #{e.message}" }
+          return { success: false,
+error: I18n.t('services.points.raw_data.verifier.file_download_failed_message', message: e.message) }
         end
 
-        return { success: false, error: 'File is empty' } if raw_content.bytesize.zero?
+        if raw_content.bytesize.zero?
+          return { success: false,
+error: I18n.t('services.points.raw_data.verifier.file_is_empty') }
+        end
 
         verify_content_integrity(raw_content, archive)
       rescue StandardError => e
-        { success: false, error: "Decryption failed: #{e.message}" }
+        { success: false,
+error: I18n.t('services.points.raw_data.verifier.decryption_failed_message', message: e.message) }
       end
 
       def verify_content_integrity(raw_content, archive)
         stored_checksum = archive.metadata&.dig('content_checksum')
         if stored_checksum.present?
           actual_checksum = Digest::SHA256.hexdigest(raw_content)
-          return { success: false, error: 'Content checksum mismatch' } if actual_checksum != stored_checksum
+          if actual_checksum != stored_checksum
+            return { success: false,
+error: I18n.t('services.points.raw_data.verifier.content_checksum_mismatch') }
+          end
         end
 
         compressed_content = Encryption.decrypt_if_needed(raw_content, archive)
@@ -138,16 +149,21 @@ module Points
         if point_ids.count != archive.point_count
           return {
             success: false,
-            error: "Point count mismatch: expected #{archive.point_count}, found #{point_ids.count}"
+            error: I18n.t('services.points.raw_data.verifier.point_count_mismatch_expected_point_count_found_count',
+                          point_count: archive.point_count, count: point_ids.count)
           }
         end
 
         id_checksum = calculate_checksum(point_ids)
-        return { success: false, error: 'Point IDs checksum mismatch' } if id_checksum != archive.point_ids_checksum
+        if id_checksum != archive.point_ids_checksum
+          return { success: false,
+error: I18n.t('services.points.raw_data.verifier.point_ids_checksum_mismatch') }
+        end
 
         { success: true, point_ids: point_ids, sampled_data: parse_result[:sampled_data] }
       rescue StandardError => e
-        { success: false, error: "Decompression/parsing failed: #{e.message}" }
+        { success: false,
+error: I18n.t('services.points.raw_data.verifier.decompression_parsing_failed_message', message: e.message) }
       end
 
       def verify_existing_points(archive, point_ids, sampled_data)
@@ -233,8 +249,11 @@ module Points
         if mismatches.any?
           return {
             success: false,
-            error: "Raw data mismatch detected in #{mismatches.count} point(s). " \
-                   "First mismatch: Point #{mismatches.first[:point_id]}"
+            error: I18n.t(
+              'services.points.raw_data.verifier.raw_data_mismatch_detected_in_count_point_s_first_mismatch',
+              count: mismatches.count,
+              point_id: mismatches.first[:point_id]
+            )
           }
         end
 

--- a/app/services/posters/generate.rb
+++ b/app/services/posters/generate.rb
@@ -19,18 +19,15 @@ module Posters
       @poster.update!(status: :processing)
 
       track = build_track
-      return fail_with('No location data found for the selected period.') if track.nil?
+      return fail_with(I18n.t('services.posters.generate.no_location_data')) if track.nil?
 
-      unless track_intersects_area?(track)
-        return fail_with('Your track does not pass through the selected map area. ' \
-                         'Recenter the map or adjust the dates.')
-      end
+      return fail_with(I18n.t('services.posters.generate.track_outside_area')) unless track_intersects_area?(track)
 
       render_natively(track)
       @poster.update!(status: :completed)
     rescue StandardError => e
       ExceptionReporter.call(e, "Poster render failed for poster #{@poster.id}")
-      fail_with('Poster generation failed. Please try again later.')
+      fail_with(I18n.t('services.posters.generate.failed'))
     end
 
     private

--- a/app/services/settings/update.rb
+++ b/app/services/settings/update.rb
@@ -24,19 +24,23 @@ class Settings::Update
 
       validate_integration_url!(updated_settings[key])
     rescue UrlValidatable::BlockedUrlError => e
-      return { success: false, notices: [], alerts: ["#{key.humanize} is not allowed: #{e.message}"] }
+      return {
+        success: false,
+        notices: [],
+        alerts: [I18n.t('services.settings.update.not_allowed', setting: key.humanize, message: e.message)]
+      }
     end
 
     unless user.update(settings: updated_settings)
-      return { success: false, notices: [], alerts: ['Settings could not be updated'] }
+      return { success: false, notices: [], alerts: [I18n.t('services.settings.update.failed')] }
     end
 
-    notices = ['Settings updated']
+    notices = [I18n.t('services.settings.update.updated')]
     alerts = []
 
     if refresh_photos_cache
       Photos::CacheCleaner.new(user).call
-      notices << 'Photo cache refreshed'
+      notices << I18n.t('services.settings.update.photo_cache_refreshed')
     end
 
     test_immich_connection(updated_settings, notices, alerts) if immich_changed

--- a/app/services/stats/calculate_month.rb
+++ b/app/services/stats/calculate_month.rb
@@ -84,8 +84,9 @@ class Stats::CalculateMonth
     Notifications::Create.new(
       user:,
       kind: :error,
-      title: 'Stats update failed',
-      content: "#{error.message}, stacktrace: #{error.backtrace.join("\n")}"
+      title: I18n.t('services.stats.calculate_month.stats_update_failed'),
+      content: I18n.t('services.stats.calculate_month.message_stacktrace_n', message: error.message,
+                      backtrace: error.backtrace.join("\n"))
     ).call
   end
 

--- a/app/services/users/destroy.rb
+++ b/app/services/users/destroy.rb
@@ -25,7 +25,7 @@ class Users::Destroy
       if created_family
         member_count = Family::Membership.where(family_id: created_family.id).count
         if member_count > 1
-          error_message = 'Cannot delete user who owns a family with other members'
+          error_message = I18n.t('services.users.destroy.cannot_delete_user_who_owns_a_family_with_other_members')
           Rails.logger.warn "#{error_message}: user_id=#{user_id}"
           user.errors.add(:base, error_message)
           raise ActiveRecord::RecordInvalid, user

--- a/app/services/users/export_data.rb
+++ b/app/services/users/export_data.rb
@@ -445,9 +445,9 @@ class Users::ExportData
 
     ::Notifications::Create.new(
       user: user,
-      title: 'Export completed',
-      content: "Your data export has been processed successfully (#{summary}). " \
-               'You can download it from the exports page.',
+      title: I18n.t('services.users.export_data.export_completed'),
+      content: I18n.t('services.users.export_data.your_data_export_has_been_processed_successfully_summary_you_can',
+                      summary: summary),
       kind: :info
     ).call
   end

--- a/app/services/users/import_data.rb
+++ b/app/services/users/import_data.rb
@@ -194,7 +194,7 @@ class Users::ImportData
     elsif File.exist?(data_json_path)
       1 # Legacy format
     else
-      raise UnsupportedFormatError, 'Unknown export format: neither manifest.json nor data.json found'
+      raise UnsupportedFormatError, I18n.t('services.users.import_data.unknown_export_format')
     end
   end
 
@@ -205,7 +205,7 @@ class Users::ImportData
     when 2
       Users::ImportData::V2Handler.new(user, @import_directory, @import_stats)
     else
-      raise StandardError, "Unsupported export format version: #{format_version}"
+      raise StandardError, I18n.t('services.users.import_data.unsupported_format_version', version: format_version)
     end
   end
 
@@ -235,8 +235,8 @@ class Users::ImportData
 
     ::Notifications::Create.new(
       user: user,
-      title: 'Data import completed',
-      content: "Your data has been imported successfully (#{summary}).",
+      title: I18n.t('services.users.import_data.data_import_completed'),
+      content: I18n.t('services.users.import_data.your_data_has_been_imported_successfully_summary', summary: summary),
       kind: :info
     ).call
   end
@@ -244,8 +244,9 @@ class Users::ImportData
   def create_failure_notification(error)
     ::Notifications::Create.new(
       user: user,
-      title: 'Data import failed',
-      content: "Your data import failed with error: #{error.message}. Please check the archive format and try again.",
+      title: I18n.t('services.users.import_data.data_import_failed'),
+      content: I18n.t('services.users.import_data.your_data_import_failed_with_error_message_please_check_the',
+                      message: error.message),
       kind: :error
     ).call
   end

--- a/app/services/users/import_data/v1_handler.rb
+++ b/app/services/users/import_data/v1_handler.rb
@@ -39,7 +39,7 @@ class Users::ImportData::V1Handler
     Rails.logger.info "Processing v1 format archive for user: #{user.email}"
 
     json_path = import_directory.join('data.json')
-    raise StandardError, 'Data file not found in archive: data.json' unless File.exist?(json_path)
+    raise StandardError, I18n.t('services.users.import_data.v1_handler.data_file_missing') unless File.exist?(json_path)
 
     initialize_stream_state
 
@@ -52,9 +52,9 @@ class Users::ImportData::V1Handler
 
     finalize_stream_processing
   rescue Oj::ParseError => e
-    raise StandardError, "Invalid JSON format in data file: #{e.message}"
+    raise StandardError, I18n.t('services.users.import_data.v1_handler.invalid_json', message: e.message)
   rescue IOError => e
-    raise StandardError, "Failed to read JSON data: #{e.message}"
+    raise StandardError, I18n.t('services.users.import_data.v1_handler.read_failed', message: e.message)
   end
 
   attr_reader :expected_counts

--- a/app/services/users/import_data/v2_handler.rb
+++ b/app/services/users/import_data/v2_handler.rb
@@ -79,7 +79,10 @@ class Users::ImportData::V2Handler
 
   def load_manifest
     manifest_path = import_directory.join('manifest.json')
-    raise StandardError, 'Manifest file not found in archive: manifest.json' unless File.exist?(manifest_path)
+    unless File.exist?(manifest_path)
+      raise StandardError,
+            I18n.t('services.users.import_data.v2_handler.manifest_missing')
+    end
 
     @manifest = JSON.parse(File.read(manifest_path))
     Rails.logger.info "Loaded manifest: format_version=#{@manifest['format_version']}, " \

--- a/app/services/users/transportation_thresholds_updater.rb
+++ b/app/services/users/transportation_thresholds_updater.rb
@@ -46,7 +46,7 @@ module Users
     def invalid_allowlist_result
       Result.new(
         success?: false,
-        error: 'Enable at least one transportation mode',
+        error: I18n.t('services.users.transportation_thresholds_updater.enable_at_least_one_transportation_mode'),
         recalculation_triggered?: false
       )
     end
@@ -112,7 +112,9 @@ module Users
     def locked_result
       Result.new(
         success?: false,
-        error: 'Transportation mode recalculation is in progress. Please wait until it completes.',
+        error: I18n.t(
+          'services.users.transportation_thresholds_updater.recalculation_in_progress'
+        ),
         recalculation_triggered?: false
       )
     end

--- a/app/services/visits/bulk_destroy.rb
+++ b/app/services/visits/bulk_destroy.rb
@@ -23,10 +23,10 @@ module Visits
     private
 
     def validate
-      return errors << 'No visits selected' if visit_ids.blank?
+      return errors << I18n.t('services.visits.bulk_destroy.none_selected') if visit_ids.blank?
       return if visit_ids.length <= MAX_VISIT_IDS
 
-      errors << "Too many visits selected (max #{MAX_VISIT_IDS})"
+      errors << I18n.t('services.visits.bulk_destroy.too_many_selected', max: MAX_VISIT_IDS)
     end
 
     def destroy_visits
@@ -34,7 +34,7 @@ module Visits
       ids = visits.pluck(:id)
 
       if ids.empty?
-        errors << 'No matching visits found'
+        errors << I18n.t('services.visits.bulk_destroy.none_found')
         return false
       end
 
@@ -56,7 +56,7 @@ module Visits
       Rails.logger.warn(
         "Visits::BulkDestroy failed user_id=#{user.id} count=#{ids&.length} error=#{e.class}: #{e.message}"
       )
-      errors << 'Database error: please try again.'
+      errors << I18n.t('services.visits.bulk_destroy.database_error')
       false
     end
 

--- a/app/services/visits/bulk_update.rb
+++ b/app/services/visits/bulk_update.rb
@@ -22,20 +22,20 @@ module Visits
 
     def validate
       if visit_ids.blank?
-        errors << 'No visits selected'
+        errors << I18n.t('services.visits.bulk_update.none_selected')
         return
       end
 
       return if Visit.statuses.keys.include?(status)
 
-      errors << 'Invalid status'
+      errors << I18n.t('services.visits.bulk_update.invalid_status')
     end
 
     def update_visits
       visits = user.visits.where(id: visit_ids)
 
       if visits.empty?
-        errors << 'No matching visits found'
+        errors << I18n.t('services.visits.bulk_update.none_found')
         return false
       end
 

--- a/app/services/visits/merge_service.rb
+++ b/app/services/visits/merge_service.rb
@@ -11,7 +11,7 @@ module Visits
     end
 
     def call
-      return add_error('At least 2 visits must be selected for merging') if visits.length < 2
+      return add_error(I18n.t('services.visits.merge_service.minimum_visits')) if visits.length < 2
 
       merge_visits
     end

--- a/app/services/visits/suggest.rb
+++ b/app/services/visits/suggest.rb
@@ -48,7 +48,7 @@ class Visits::Suggest
     user.notifications.create!(
       kind: :error,
       title: ERROR_TITLE,
-      content: "Error suggesting visits: #{error.message}"
+      content: I18n.t('services.visits.suggest.error_suggesting_visits_message', message: error.message)
     )
   end
 
@@ -68,7 +68,7 @@ class Visits::Suggest
 
     user.notifications.create!(
       kind: :info,
-      title: 'New visits suggested',
+      title: I18n.t('services.visits.suggest.new_visits_suggested'),
       content:
     )
   end

--- a/app/views/auth/account_links/challenge.html.erb
+++ b/app/views/auth/account_links/challenge.html.erb
@@ -1,15 +1,13 @@
-<% content_for :title, "Confirm account linking" %>
+<% content_for :title, t('.confirm_account_linking') %>
 
 <div class="min-h-content w-full my-5">
   <div class="max-w-lg mx-auto">
     <div class="card bg-base-200 shadow-xl">
       <div class="card-body">
-        <h2 class="card-title">Link <%= @provider_label %> to your Dawarich account</h2>
+        <h2 class="card-title"><%= t('.link') %> <%= @provider_label %> <%= t('.to_your_dawarich_account') %></h2>
 
         <p class="text-sm text-base-content/70 mt-2">
-          We found an existing Dawarich account for <strong><%= @user_email %></strong>.
-          Enter your password to link your <%= @provider_label %> identity to that account
-          and sign in.
+          <%= t('.we_found_an_existing_dawarich_account_for') %> <strong><%= @user_email %></strong><%= t('.enter_your_password_to_link_your') %> <%= @provider_label %> <%= t('.identity_to_that_account_and_sign_in') %>
         </p>
 
         <% if flash[:alert].present? %>
@@ -21,26 +19,26 @@
         <%= form_with url: confirm_auth_account_link_path, method: :post, data: { turbo: false }, class: "space-y-4 mt-4" do |f| %>
           <div class="form-control">
             <%= f.label :password, class: 'label' do %>
-              <span class="label-text">Current password</span>
+              <span class="label-text"><%= t('.current_password') %></span>
             <% end %>
             <%= f.password_field :password, class: 'input input-bordered w-full', required: true, autocomplete: 'current-password', autofocus: true %>
           </div>
           <div class="form-control">
-            <%= f.submit "Link #{@provider_label} and sign in", class: 'btn btn-primary w-full' %>
+            <%= f.submit t('.link_provider_and_sign_in', provider: @provider_label), class: 'btn btn-primary w-full' %>
           </div>
         <% end %>
 
-        <div class="divider">or</div>
+        <div class="divider"><%= t('.or') %></div>
 
         <%= form_with url: email_fallback_auth_account_link_path, method: :post, data: { turbo: false } do %>
-          <%= submit_tag "Email me a confirmation link instead", class: 'btn btn-ghost w-full' %>
+          <%= submit_tag t('.email_me_a_confirmation_link_instead'), class: 'btn btn-ghost w-full' %>
         <% end %>
 
         <p class="text-xs text-base-content/50 mt-4">
-          Forgot your password?
-          <%= link_to 'Reset it', new_user_password_path, class: 'link' %>
-          or
-          <%= link_to 'go back to sign in', new_user_session_path, class: 'link' %>.
+          <%= t('.forgot_your_password') %>
+          <%= link_to t('.reset_it'), new_user_password_path, class: 'link' %>
+          <%= t('.or') %>
+          <%= link_to t('.go_back_to_sign_in'), new_user_session_path, class: 'link' %>.
         </p>
       </div>
     </div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,9 +1,9 @@
 <div class="hero min-h-content bg-base-200">
   <div class="hero-content flex-col lg:flex-row-reverse w-full my-10">
     <div class="text-center lg:text-left">
-      <h1 class="text-5xl font-bold text-base-content">Resend confirmation</h1>
+      <h1 class="text-5xl font-bold text-base-content"><%= t('.resend_confirmation') %></h1>
       <p class="py-6 text-base-content opacity-70">
-        Enter your email address and we'll resend the confirmation instructions.
+        <%= t('.enter_your_email_address_and_we_ll_resend_the_confirmation') %>
       </p>
     </div>
     <div class="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100 px-5 py-5">
@@ -12,7 +12,7 @@
 
         <div class="form-control">
           <%= f.label :email, class: 'label' do %>
-            <span class="label-text">Email</span>
+            <span class="label-text"><%= t('.email') %></span>
           <% end %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email",
               value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
@@ -20,7 +20,7 @@
         </div>
 
         <div class="form-control mt-6">
-          <%= f.submit "Resend confirmation instructions", class: 'btn btn-primary w-full' %>
+          <%= f.submit t('.resend_confirmation_instructions'), class: 'btn btn-primary w-full' %>
         </div>
       <% end %>
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= t('.welcome') %> <%= @email %>!</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t('.you_can_confirm_your_account_email_through_the_link_below') %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to t('.confirm_my_account'), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @email %>!</p>
+<p><%= t('.hello') %> <%= @email %>!</p>
 
 <% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+  <p><%= t('.we_re_contacting_you_to_notify_you_that_your_email') %> <%= @resource.unconfirmed_email %>.</p>
 <% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+  <p><%= t('.we_re_contacting_you_to_notify_you_that_your_email_2') %> <%= @resource.email %>.</p>
 <% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,3 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.hello') %> <%= @resource.email %>!</p>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+<p><%= t('.we_re_contacting_you_to_notify_you_that_your_password') %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.hello') %> <%= @resource.email %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('.someone_has_requested_a_link_to_change_your_password_you') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('.change_my_password'), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t('.if_you_didn_t_request_this_please_ignore_this_email') %></p>
+<p><%= t('.your_password_won_t_change_until_you_access_the_link') %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.hello') %> <%= @resource.email %>!</p>
 
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+<p><%= t('.your_account_has_been_locked_due_to_an_excessive_number') %></p>
 
-<p>Click the link below to unlock your account:</p>
+<p><%= t('.click_the_link_below_to_unlock_your_account') %></p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>
+<p><%= link_to t('.unlock_my_account'), unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,9 +1,9 @@
 <div class="hero min-h-content bg-base-200">
   <div class="hero-content flex-col lg:flex-row-reverse w-full my-10">
     <div class="text-center lg:text-left">
-      <h1 class="text-5xl font-bold text-base-content">Change your password</h1>
+      <h1 class="text-5xl font-bold text-base-content"><%= t('.change_your_password') %></h1>
       <p class="py-6 text-base-content opacity-70">
-        Enter your new password below.
+        <%= t('.enter_your_new_password_below') %>
       </p>
     </div>
     <div class="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100 px-5 py-5">
@@ -12,24 +12,24 @@
         <%= f.hidden_field :reset_password_token %>
 
         <div class="form-control">
-          <%= f.label :password, "New password", class: 'label' do %>
-            <span class="label-text">New password</span>
+          <%= f.label :password, t('.new_password'), class: 'label' do %>
+            <span class="label-text"><%= t('.new_password') %></span>
           <% end %>
           <% if @minimum_password_length %>
-            <em class="text-base-content opacity-60 text-sm">(<%= @minimum_password_length %> characters minimum)</em>
+            <em class="text-base-content opacity-60 text-sm">(<%= @minimum_password_length %> <%= t('.characters_minimum') %></em>
           <% end %>
           <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: 'input input-bordered w-full' %>
         </div>
 
         <div class="form-control">
           <%= f.label :password_confirmation, class: 'label' do %>
-            <span class="label-text">Confirm new password</span>
+            <span class="label-text"><%= t('.confirm_new_password') %></span>
           <% end %>
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input input-bordered w-full' %>
         </div>
 
         <div class="form-control mt-6">
-          <%= f.submit "Change my password", class: 'btn btn-primary w-full' %>
+          <%= f.submit t('.change_my_password'), class: 'btn btn-primary w-full' %>
         </div>
       <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,9 +1,9 @@
 <div class="hero min-h-content bg-base-200">
   <div class="hero-content flex-col lg:flex-row-reverse w-full my-10">
     <div class="text-center lg:text-left">
-      <h1 class="text-5xl font-bold text-base-content">Forgot your password?</h1>
+      <h1 class="text-5xl font-bold text-base-content"><%= t('.forgot_your_password') %></h1>
       <p class="py-6 text-base-content opacity-70">
-        Enter your email address and we'll send you instructions to reset your password.
+        <%= t('.enter_your_email_address_and_we_ll_send_you_instructions') %>
       </p>
     </div>
     <div class="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100 px-5 py-5">
@@ -12,13 +12,13 @@
 
         <div class="form-control">
           <%= f.label :email, class: 'label' do %>
-            <span class="label-text">Email</span>
+            <span class="label-text"><%= t('.email') %></span>
           <% end %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-bordered w-full' %>
         </div>
 
         <div class="form-control mt-6">
-          <%= f.submit "Send me reset password instructions", class: 'btn btn-primary w-full' %>
+          <%= f.submit t('.send_me_reset_password_instructions'), class: 'btn btn-primary w-full' %>
         </div>
       <% end %>
 

--- a/app/views/devise/registrations/_api_key.html.erb
+++ b/app/views/devise/registrations/_api_key.html.erb
@@ -1,14 +1,14 @@
 <div class="space-y-4">
   <div class="rounded-2xl bg-base-200/70 p-4 sm:p-5">
-    <p class="text-sm font-medium text-base-content/70">Current API key</p>
+    <p class="text-sm font-medium text-base-content/70"><%= t('.current_api_key') %></p>
     <div class="mt-2 rounded-xl bg-base-300/70 p-3">
       <code class="block break-all text-sm sm:text-base"><%= current_user.api_key %></code>
     </div>
-    <p class="mt-3 text-sm text-base-content/70">Docs: <%= link_to "API documentation", 'https://dawarich.app/docs/api/dawarich-api?utm_source=app&utm_medium=web&utm_campaign=api_docs', class: 'underline hover:no-underline' %></p>
+    <p class="mt-3 text-sm text-base-content/70"><%= t('.docs') %> <%= link_to t('.api_documentation'), 'https://dawarich.app/docs/api/dawarich-api?utm_source=app&utm_medium=web&utm_campaign=api_docs', class: 'underline hover:no-underline' %></p>
   </div>
 
   <div class="rounded-2xl border border-base-300/70 bg-base-200/40 p-4 text-center">
-    <p class="text-sm font-medium text-base-content/70">Scan with Dawarich app</p>
+    <p class="text-sm font-medium text-base-content/70"><%= t('.scan_with_dawarich_app') %></p>
     <div class="mt-4 mx-auto max-w-xs overflow-hidden rounded-2xl bg-white p-4 shadow-lg flex justify-center">
       <%= api_key_qr_code(current_user) %>
     </div>
@@ -16,24 +16,24 @@
 
   <div class="space-y-3">
     <div tabindex="0" class="collapse collapse-arrow rounded-2xl border border-base-300/70 bg-base-200/40">
-      <div class="collapse-title text-lg font-semibold">Usage examples</div>
+      <div class="collapse-title text-lg font-semibold"><%= t('.usage_examples') %></div>
       <div class="collapse-content space-y-4">
         <section class="rounded-2xl border border-base-300/70 bg-base-100/40 p-4">
-          <h4 class='text-lg font-bold'>Dawarich iOS or Android app</h4>
-          <p class="mt-2 text-sm text-base-content/70">Provide your instance URL:</p>
+          <h4 class='text-lg font-bold'><%= t('.dawarich_ios_or_android_app') %></h4>
+          <p class="mt-2 text-sm text-base-content/70"><%= t('.provide_your_instance_url') %></p>
           <code class="mt-2 block break-all rounded-xl bg-base-300/70 p-3 text-sm"><%= root_url %></code>
 
-          <p class="mt-3 text-sm text-base-content/70">And provide your API key:</p>
+          <p class="mt-3 text-sm text-base-content/70"><%= t('.and_provide_your_api_key') %></p>
           <code class="mt-2 block break-all rounded-xl bg-base-300/70 p-3 text-sm"><%= current_user.api_key %></code>
         </section>
 
         <section class="rounded-2xl border border-base-300/70 bg-base-100/40 p-4">
-          <h4 class='text-lg font-bold'>OwnTracks</h4>
+          <h4 class='text-lg font-bold'><%= t('.owntracks') %></h4>
           <code class="mt-2 block break-all rounded-xl bg-base-300/70 p-3 text-sm"><%= api_v1_owntracks_points_url(api_key: current_user.api_key) %></code>
         </section>
 
         <section class="rounded-2xl border border-base-300/70 bg-base-100/40 p-4">
-          <h4 class='text-lg font-bold'>Overland</h4>
+          <h4 class='text-lg font-bold'><%= t('.overland') %></h4>
           <code class="mt-2 block break-all rounded-xl bg-base-300/70 p-3 text-sm"><%= api_v1_overland_batches_url(api_key: current_user.api_key) %></code>
         </section>
       </div>
@@ -41,6 +41,6 @@
   </div>
 
   <div>
-    <%= link_to "Generate new API key", generate_api_key_path, data: { turbo_confirm: "Are you sure? This will invalidate the current API key.", turbo_method: :post }, class: 'btn btn-primary w-full sm:w-auto' %>
+    <%= link_to t('.generate_new_api_key'), generate_api_key_path, data: { turbo_confirm: t('.are_you_sure_this_will_invalidate_the_current_api_key'), turbo_method: :post }, class: 'btn btn-primary w-full sm:w-auto' %>
   </div>
 </div>

--- a/app/views/devise/registrations/_points_usage.html.erb
+++ b/app/views/devise/registrations/_points_usage.html.erb
@@ -1,6 +1,6 @@
 <div class="space-y-3">
   <p class='text-sm text-base-content/70'>
-    You have used <span class="font-medium text-base-content"><%= number_with_delimiter(current_user.points_count.to_i) %></span> points of <span class="font-medium text-base-content"><%= number_with_delimiter(DawarichSettings::BASIC_PAID_PLAN_LIMIT) %></span> available.
+    <%= t('.you_have_used') %> <span class="font-medium text-base-content"><%= number_with_delimiter(current_user.points_count.to_i) %></span> <%= t('.points_of') %> <span class="font-medium text-base-content"><%= number_with_delimiter(DawarichSettings::BASIC_PAID_PLAN_LIMIT) %></span> <%= t('.available') %>
   </p>
   <progress class="progress progress-primary h-5 w-full" value="<%= current_user.points_count.to_i %>" max="<%= DawarichSettings::BASIC_PAID_PLAN_LIMIT %>"></progress>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, 'Account' %>
+<% content_for :title, t('.account') %>
 
 <div class="w-full min-w-0 my-5">
   <div class="mx-auto w-full max-w-7xl space-y-6">
     <div>
-      <h1 class="text-3xl font-bold sm:text-4xl">Account settings</h1>
+      <h1 class="text-3xl font-bold sm:text-4xl"><%= t('.account_settings') %></h1>
     </div>
 
     <div class="grid gap-6 lg:grid-cols-[minmax(0,24rem)_minmax(0,1fr)] lg:items-start">
@@ -11,13 +11,13 @@
         <div class="card bg-base-100 shadow-xl">
           <div class="card-body gap-5 p-5 sm:p-6">
             <div>
-              <h2 class="card-title text-2xl">Profile</h2>
-              <p class="mt-1 text-sm text-base-content/70">Update your email address and password from one place.</p>
+              <h2 class="card-title text-2xl"><%= t('.profile') %></h2>
+              <p class="mt-1 text-sm text-base-content/70"><%= t('.update_your_email_address_and_password_from_one_place') %></p>
             </div>
 
             <% if current_user.oauth_user? %>
               <div class="rounded-xl border border-base-300 bg-base-200/50 px-4 py-3 text-sm font-medium">
-                Connected with <%= oauth_provider_display_name(current_user.provider) %>
+                <%= t('.connected_with') %> <%= oauth_provider_display_name(current_user.provider) %>
               </div>
             <% end %>
 
@@ -26,33 +26,33 @@
 
               <div class="form-control">
                 <%= f.label :email, class: 'label' do %>
-                  <span class="label-text">Email</span>
+                  <span class="label-text"><%= t('.email') %></span>
                 <% end %>
                 <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-bordered w-full' %>
               </div>
 
               <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
                 <div class="mt-4 rounded-xl border border-warning/40 bg-warning/10 px-4 py-3 text-sm">
-                  Currently waiting confirmation for: <span class="font-medium"><%= resource.unconfirmed_email %></span>
+                  <%= t('.currently_waiting_confirmation_for') %> <span class="font-medium"><%= resource.unconfirmed_email %></span>
                 </div>
               <% end %>
 
               <div class="form-control mt-5">
                 <%= f.label :password, class: 'label' do %>
-                  <span class="label-text">New password <span class="text-base-content/60">(leave blank to keep the current one)</span></span>
+                  <span class="label-text"><%= t('.new_password') %> <span class="text-base-content/60"><%= t('.leave_blank_to_keep_the_current_one') %></span></span>
                 <% end %>
                 <% if @minimum_password_length %>
-                  <em class='text-xs text-base-content/60'>(<%= @minimum_password_length %> characters minimum)</em>
+                  <em class='text-xs text-base-content/60'>(<%= @minimum_password_length %> <%= t('.characters_minimum') %></em>
                 <% end %>
                 <%= f.password_field :password, autocomplete: "new-password", class: 'input input-bordered w-full' %>
               </div>
 
               <div class="form-control mt-5">
                 <%= f.label :password_confirmation, class: 'label' do %>
-                  <span class="label-text">Password confirmation</span>
+                  <span class="label-text"><%= t('.password_confirmation') %></span>
                 <% end %>
                 <% if @minimum_password_length %>
-                  <em class='text-xs text-base-content/60'>(<%= @minimum_password_length %> characters minimum)</em>
+                  <em class='text-xs text-base-content/60'>(<%= @minimum_password_length %> <%= t('.characters_minimum') %></em>
                 <% end %>
                 <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input input-bordered w-full' %>
               </div>
@@ -60,15 +60,15 @@
               <% unless current_user.oauth_user? %>
                 <div class="form-control mt-5">
                   <%= f.label :current_password, class: 'label' do %>
-                    <span class="label-text">Current password</span>
+                    <span class="label-text"><%= t('.current_password') %></span>
                   <% end %>
-                  <i class='text-xs text-base-content/60'>(required to confirm your changes)</i>
+                  <i class='text-xs text-base-content/60'><%= t('.required_to_confirm_your_changes') %></i>
                   <%= f.password_field :current_password, autocomplete: "current-password", class: 'input input-bordered mt-2 w-full' %>
                 </div>
               <% end %>
 
               <div class="form-control mt-6">
-                <%= f.submit "Save changes", class: 'btn btn-primary w-full sm:w-auto' %>
+                <%= f.submit t('.save_changes'), class: 'btn btn-primary w-full sm:w-auto' %>
               </div>
             <% end %>
 
@@ -78,8 +78,8 @@
 
         <dialog id="import_modal" class="modal">
           <div class="modal-box">
-            <h3 class="mb-4 text-lg font-bold">Import your data</h3>
-            <p class="mb-4 text-sm text-base-content/70">Upload a ZIP file containing your exported Dawarich data to restore your points, trips, and settings.</p>
+            <h3 class="mb-4 text-lg font-bold"><%= t('.import_your_data') %></h3>
+            <p class="mb-4 text-sm text-base-content/70"><%= t('.upload_a_zip_file_containing_your_exported_dawarich_data_to') %></p>
 
             <%= form_with url: import_settings_users_path, method: :post, multipart: true, class: 'space-y-4', data: {
               turbo: false,
@@ -93,7 +93,7 @@
             } do |f| %>
               <div class="form-control">
                 <%= f.label :archive, class: 'label' do %>
-                  <span class="label-text">Select ZIP archive</span>
+                  <span class="label-text"><%= t('.select_zip_archive') %></span>
                 <% end %>
                 <%= f.file_field :archive,
                     accept: '.zip',
@@ -102,23 +102,23 @@
                     class: 'file-input file-input-bordered w-full',
                     data: { upload_target: "input" } %>
                 <div class="mt-2 text-sm text-base-content/60">
-                  File will be uploaded directly to storage. Please be patient during upload.
+                  <%= t('.file_will_be_uploaded_directly_to_storage_please_be_patient') %>
                 </div>
               </div>
 
               <div class="modal-action flex-col-reverse sm:flex-row">
-                <button type="button" class="btn w-full sm:w-auto" onclick="import_modal.close()">Cancel</button>
-                <%= f.submit "Import data",
+                <button type="button" class="btn w-full sm:w-auto" onclick="import_modal.close()"><%= t('.cancel') %></button>
+                <%= f.submit t('.import_data'),
                     class: 'btn btn-primary w-full sm:w-auto',
                     data: {
-                      disable_with: 'Importing...',
+                      disable_with: t('.importing'),
                       upload_target: "submit"
                     } %>
               </div>
             <% end %>
           </div>
           <form method="dialog" class="modal-backdrop">
-            <button>close</button>
+            <button><%= t('.close') %></button>
           </form>
         </dialog>
       </div>
@@ -129,13 +129,13 @@
             <% if current_user.trial? %>
               <div class="card bg-base-100 shadow-xl">
                 <div class="card-body p-5 sm:p-6">
-                  <h2 class="card-title text-xl">Trial status</h2>
-                  <p class="text-sm text-base-content/70">Your trial period ends at <span class="font-medium text-base-content"><%= human_datetime current_user.active_until, current_user.safe_settings.timezone %></span>.</p>
+                  <h2 class="card-title text-xl"><%= t('.trial_status') %></h2>
+                  <p class="text-sm text-base-content/70"><%= t('.your_trial_period_ends_at') %> <span class="font-medium text-base-content"><%= human_datetime current_user.active_until, current_user.safe_settings.timezone %></span>.</p>
                   <div class="mt-2">
                     <% if current_user.auto_converting_trial? %>
-                      <%= link_to 'Manage subscription', "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}", class: 'btn btn-primary btn-sm glass' %>
+                      <%= link_to t('.manage_subscription'), "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}", class: 'btn btn-primary btn-sm glass' %>
                     <% else %>
-                      <%= link_to 'Subscribe', "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}", class: 'btn btn-success btn-sm glass' %>
+                      <%= link_to t('.subscribe'), "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}", class: 'btn btn-success btn-sm glass' %>
                     <% end %>
                   </div>
                 </div>
@@ -145,7 +145,7 @@
             <% if !DawarichSettings.self_hosted? %>
               <div class="card bg-base-100 shadow-xl">
                 <div class="card-body p-5 sm:p-6">
-                  <h2 class="card-title text-xl">Plan usage</h2>
+                  <h2 class="card-title text-xl"><%= t('.plan_usage') %></h2>
                   <%= render 'devise/registrations/points_usage' %>
                 </div>
               </div>
@@ -157,19 +157,19 @@
               <div class="card-body p-5 sm:p-6">
                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
                   <div>
-                    <h2 class="card-title text-xl">Subscription</h2>
+                    <h2 class="card-title text-xl"><%= t('.subscription') %></h2>
                     <p class="text-sm text-base-content/70">
                       <% case %>
                       <% when current_user.pending_payment? %>
-                        Your signup isn't complete yet — finish setting up your subscription to start your trial.
+                        <%= t('.your_signup_isn_t_complete_yet_finish_setting_up_your') %>
                       <% when current_user.active? && current_user.active_until&.future? %>
-                        Change plan, update your payment method, or cancel your subscription on Manager.
+                        <%= t('.change_plan_update_your_payment_method_or_cancel_your_subscription') %>
                       <% else %>
-                        Manage your subscription, change plan, or update billing on Manager.
+                        <%= t('.manage_your_subscription_change_plan_or_update_billing_on_manager') %>
                       <% end %>
                     </p>
                   </div>
-                  <%= link_to 'Manage subscription',
+                  <%= link_to t('.manage_subscription'),
                               "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}",
                               class: 'btn btn-primary btn-sm whitespace-nowrap' %>
                 </div>
@@ -181,8 +181,8 @@
         <div class="card bg-base-100 shadow-xl">
           <div class="card-body p-5 sm:p-6">
             <div class="max-w-3xl">
-              <h2 class="card-title text-2xl">API access</h2>
-              <p class="mt-1 text-sm text-base-content/70">Use your API key for clients, imports, and external integrations.</p>
+              <h2 class="card-title text-2xl"><%= t('.api_access') %></h2>
+              <p class="mt-1 text-sm text-base-content/70"><%= t('.use_your_api_key_for_clients_imports_and_external_integrations') %></p>
             </div>
             <%= render 'devise/registrations/api_key' %>
           </div>
@@ -191,33 +191,33 @@
         <div class="card bg-base-100 shadow-xl">
           <div class="card-body gap-5 p-5 sm:p-6">
             <div>
-              <h2 class="card-title text-2xl">Data tools</h2>
-              <p class="mt-1 text-sm text-base-content/70">Export a backup or restore a previous archive.</p>
+              <h2 class="card-title text-2xl"><%= t('.data_tools') %></h2>
+              <p class="mt-1 text-sm text-base-content/70"><%= t('.export_a_backup_or_restore_a_previous_archive') %></p>
             </div>
 
             <div class='flex flex-col gap-3 sm:flex-row sm:flex-wrap'>
-              <%= link_to "Export my data", export_settings_users_path, class: 'btn btn-primary w-full sm:w-auto', data: {
-                  turbo_confirm: "Are you sure you want to export your data?",
+              <%= link_to t('.export_my_data'), export_settings_users_path, class: 'btn btn-primary w-full sm:w-auto', data: {
+                  turbo_confirm: t('.are_you_sure_you_want_to_export_your_data'),
                   turbo_method: :get
                 } %>
-              <button type="button" class='btn btn-outline w-full sm:w-auto' onclick="import_modal.showModal()">Import my data</button>
+              <button type="button" class='btn btn-outline w-full sm:w-auto' onclick="import_modal.showModal()"><%= t('.import_my_data') %></button>
             </div>
 
             <div class="rounded-2xl border border-error/30 bg-error/5 p-4">
-              <h3 class="text-lg font-semibold">Danger zone</h3>
-              <p class="mt-2 text-sm text-base-content/70">Deleting your account is permanent and removes all your data.</p>
+              <h3 class="text-lg font-semibold"><%= t('.danger_zone') %></h3>
+              <p class="mt-2 text-sm text-base-content/70"><%= t('.deleting_your_account_is_permanent_and_removes_all_your_data') %></p>
               <div class="mt-4">
-                <button type="button" class='btn btn-error btn-outline w-full sm:w-auto' onclick="delete_account_modal.showModal()">Cancel my account</button>
+                <button type="button" class='btn btn-error btn-outline w-full sm:w-auto' onclick="delete_account_modal.showModal()"><%= t('.cancel_my_account') %></button>
               </div>
             </div>
 
             <dialog id="delete_account_modal" class="modal" onclose="this.querySelector('.modal-box form')?.reset()">
               <div class="modal-box">
-                <h3 class="mb-4 text-lg font-bold">Delete your account</h3>
+                <h3 class="mb-4 text-lg font-bold"><%= t('.delete_your_account') %></h3>
                 <% if DawarichSettings.self_hosted? %>
-                  <p class="mb-4 text-sm text-base-content/70">This is permanent and removes all your data. This cannot be undone.</p>
+                  <p class="mb-4 text-sm text-base-content/70"><%= t('.this_is_permanent_and_removes_all_your_data_this_cannot') %></p>
                 <% else %>
-                  <p class="mb-4 text-sm text-base-content/70">This is permanent and removes all your data. This cannot be undone. We'll email you a link to confirm — your account is deleted only after you click it.</p>
+                  <p class="mb-4 text-sm text-base-content/70"><%= t('.this_is_permanent_and_removes_all_your_data_this_cannot_2') %></p>
                 <% end %>
 
                 <%= form_with url: registration_path(resource_name), method: :delete, class: 'space-y-4', data: { turbo: false } do %>
@@ -225,14 +225,14 @@
                     <% if current_user.oauth_user? %>
                       <div class="form-control">
                         <%= label_tag :confirm_email, class: 'label' do %>
-                          <span class="label-text">Type your email (<span class="font-medium"><%= current_user.email %></span>) to confirm</span>
+                          <span class="label-text"><%= t('.type_your_email') %><span class="font-medium"><%= current_user.email %></span><%= t('.to_confirm') %></span>
                         <% end %>
                         <%= text_field_tag :confirm_email, nil, autocomplete: "off", required: true, class: 'input input-bordered w-full' %>
                       </div>
                     <% else %>
                       <div class="form-control">
                         <%= label_tag :password, class: 'label' do %>
-                          <span class="label-text">Enter your current password to confirm</span>
+                          <span class="label-text"><%= t('.enter_your_current_password_to_confirm') %></span>
                         <% end %>
                         <%= password_field_tag :password, nil, autocomplete: "current-password", required: true, class: 'input input-bordered w-full' %>
                       </div>
@@ -240,13 +240,13 @@
                   <% end %>
 
                   <div class="modal-action flex-col-reverse sm:flex-row">
-                    <button type="button" class="btn w-full sm:w-auto" onclick="delete_account_modal.close()">Cancel</button>
-                    <%= submit_tag(DawarichSettings.self_hosted? ? 'Delete my account' : 'Email me the confirmation link', class: 'btn btn-error w-full sm:w-auto') %>
+                    <button type="button" class="btn w-full sm:w-auto" onclick="delete_account_modal.close()"><%= t('.cancel') %></button>
+                    <%= submit_tag(t(DawarichSettings.self_hosted? ? '.delete_my_account' : '.email_me_the_confirmation_link'), class: 'btn btn-error w-full sm:w-auto') %>
                   </div>
                 <% end %>
               </div>
               <form method="dialog" class="modal-backdrop">
-                <button>close</button>
+                <button><%= t('.close') %></button>
               </form>
             </dialog>
           </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,31 +2,30 @@
   <div class="hero-content flex-col lg:flex-row-reverse w-full my-10">
     <div class="text-center lg:text-left">
       <% if @invitation %>
-        <h1 class="text-5xl font-bold text-base-content">Join <%= @invitation.family.name %>!</h1>
+        <h1 class="text-5xl font-bold text-base-content"><%= t('.join') %> <%= @invitation.family.name %>!</h1>
         <p class="py-6 text-base-content opacity-70">
-          You've been invited by <strong><%= @invitation.invited_by.email %></strong> to join their family.
-          Create your account to accept the invitation and start sharing location data.
+          <%= t('.you_ve_been_invited_by') %> <strong><%= @invitation.invited_by.email %></strong> <%= t('.to_join_their_family_create_your_account_to_accept_the') %>
         </p>
         <div class="alert alert-info mb-4">
           <svg class="h-5 w-5 mr-2" fill="currentColor" viewBox="0 0 20 20">
             <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
           </svg>
           <span class="text-sm">
-            Your email (<%= @invitation.email %>) will be used for this account
+            <%= t('.your_email') %><%= @invitation.email %><%= t('.will_be_used_for_this_account') %>
           </span>
         </div>
       <% else %>
-        <h1 class="text-5xl font-bold text-base-content">Almost there!</h1>
+        <h1 class="text-5xl font-bold text-base-content"><%= t('.almost_there') %></h1>
       <% end %>
         <p class="py-6 text-base-content opacity-70">
-          Only a few steps left until you get control over your location data!
+          <%= t('.only_a_few_steps_left_until_you_get_control_over') %>
         </p>
         <ol>
-          <li class="mb-2">1. Create your account</li>
-          <li class="mb-2">2. Configure your mobile app</li>
-          <li class="mb-2">3. Start tracking your location data securely</li>
+          <li class="mb-2"><%= t('.create_your_account') %></li>
+          <li class="mb-2"><%= t('.configure_your_mobile_app') %></li>
+          <li class="mb-2"><%= t('.start_tracking_your_location_data_securely') %></li>
           <li class="mb-2">4. ...</li>
-          <li class="mb-2">5. You're beautiful!</li>
+          <li class="mb-2"><%= t('.you_re_beautiful') %></li>
         </ol>
 
     </div>
@@ -39,7 +38,7 @@
 
         <div class="form-control">
           <%= f.label :email, class: 'label' do %>
-            <span class="label-text">Email</span>
+            <span class="label-text"><%= t('.email') %></span>
           <% end %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email",
                 readonly: @invitation.present?,
@@ -48,20 +47,20 @@
 
         <div class="form-control">
           <%= f.label :password, class: 'label' do %>
-            <span class="label-text">Password</span>
+            <span class="label-text"><%= t('.password') %></span>
           <% end %>
           <% if @minimum_password_length %>
-            <em class="text-base-content opacity-60 text-sm">(<%= @minimum_password_length %> characters minimum)</em>
+            <em class="text-base-content opacity-60 text-sm">(<%= @minimum_password_length %> <%= t('.characters_minimum') %></em>
           <% end %><br />
           <%= f.password_field :password, autocomplete: "new-password", class: 'input input-bordered w-full' %>
         </div>
 
         <div class="form-control">
           <%= f.label :password_confirmation, class: 'label' do %>
-            <span class="label-text">Password Confirmation</span>
+            <span class="label-text"><%= t('.password_confirmation') %></span>
           <% end %>
           <% if @minimum_password_length %>
-            <em class="text-base-content opacity-60 text-sm">(<%= @minimum_password_length %> characters minimum)</em>
+            <em class="text-base-content opacity-60 text-sm">(<%= @minimum_password_length %> <%= t('.characters_minimum') %></em>
           <% end %><br />
           <%= f.password_field :password_confirmation, autocomplete: "new-password", class: 'input input-bordered w-full' %>
         </div>
@@ -70,12 +69,12 @@
           <% unless @invitation %>
             <div class="form-control">
               <%= label_tag 'user[signup_intent]', class: 'label' do %>
-                <span class="label-text">How do you plan to use Dawarich?</span>
+                <span class="label-text"><%= t('.how_do_you_plan_to_use_dawarich') %></span>
               <% end %>
               <%= select_tag 'user[signup_intent]',
                     options_for_select([
                       ["I want to use the cloud version", "cloud"],
-                      ["I'm self-hosting and exploring the demo", "self_hosted_demo"]
+                      [t('.i_m_self_hosting_and_exploring_the_demo'), "self_hosted_demo"]
                     ]),
                     class: 'select select-bordered w-full' %>
             </div>
@@ -85,7 +84,7 @@
         <% end %>
 
         <div class="form-control mt-6">
-          <%= f.submit (@invitation ? "Create Account & Join Family" : "Sign up"),
+          <%= f.submit (@invitation ? t('.create_account_join_family') : t('.sign_up')),
                 class: 'btn btn-primary' %>
         </div>
       <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,22 +2,21 @@
   <div class="hero-content flex-col lg:flex-row-reverse w-full my-10">
     <div class="text-center lg:text-left">
       <% if @invitation %>
-        <h1 class="text-5xl font-bold text-base-content">Sign in to join <%= @invitation.family.name %>!</h1>
+        <h1 class="text-5xl font-bold text-base-content"><%= t('.sign_in_to_join') %> <%= @invitation.family.name %>!</h1>
         <p class="py-6 text-base-content opacity-70">
-          You've been invited by <strong><%= @invitation.invited_by.email %></strong> to join their family.
-          Sign in to your account to accept the invitation.
+          <%= t('.you_ve_been_invited_by') %> <strong><%= @invitation.invited_by.email %></strong> <%= t('.to_join_their_family_sign_in_to_your_account_to') %>
         </p>
         <% if email_password_login_enabled? %>
           <div class="alert alert-info">
             <p class="text-sm">
-              Don't have an account yet?
-              <%= link_to "Create one here", new_user_registration_path(invitation_token: @invitation.token), class: "font-semibold underline" %>
+              <%= t('.don_t_have_an_account_yet') %>
+              <%= link_to t('.create_one_here'), new_user_registration_path(invitation_token: @invitation.token), class: "font-semibold underline" %>
             </p>
           </div>
         <% end %>
       <% else %>
-        <h1 class="text-5xl font-bold text-base-content">Login now</h1>
-        <p class="py-6 text-base-content opacity-70">and take control over your location data.</p>
+        <h1 class="text-5xl font-bold text-base-content"><%= t('.login_now') %></h1>
+        <p class="py-6 text-base-content opacity-70"><%= t('.and_take_control_over_your_location_data') %></p>
       <% end %>
     </div>
     <div class="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100 px-5 py-5">
@@ -31,26 +30,26 @@
 
           <div class="form-control">
             <%= f.label :email, class: 'label' do %>
-              <span class="label-text">Email</span>
+              <span class="label-text"><%= t('.email') %></span>
             <% end %>
             <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-bordered' %>
           </div>
           <div class="form-control">
             <%= f.label :password, class: 'label' do %>
-              <span class="label-text">Password</span>
+              <span class="label-text"><%= t('.password') %></span>
             <% end %>
             <%= f.password_field :password, autocomplete: "current-password", class: 'input input-bordered' %>
             <% if devise_mapping.rememberable? %>
               <div class="form-control">
                 <label class="label cursor-pointer">
-                  <span class="label-text">Remember me</span>
+                  <span class="label-text"><%= t('.remember_me') %></span>
                   <%= f.check_box :remember_me, class: 'checkbox checkbox-sm' %>
                 </label>
               </div>
             <% end %>
           </div>
           <div class="form-control mt-6">
-            <%= f.submit (@invitation ? "Sign in & Accept Invitation" : "Log in"), class: 'btn btn-primary' %>
+            <%= f.submit (@invitation ? t('.sign_in_accept_invitation') : "Log in"), class: 'btn btn-primary' %>
           </div>
         <% end %>
 
@@ -60,7 +59,7 @@
       <% else %>
         <%# OIDC-only mode: show OIDC login buttons prominently %>
         <div class="text-center mb-4">
-          <p class="text-base-content opacity-70 mb-4">Sign in using your organization's identity provider</p>
+          <p class="text-base-content opacity-70 mb-4"><%= t('.sign_in_using_your_organization_s_identity_provider') %></p>
         </div>
         <% if devise_mapping.omniauthable? %>
           <% visible_omniauth_providers.each do |provider| %>

--- a/app/views/devise/sessions/otp_challenge.html.erb
+++ b/app/views/devise/sessions/otp_challenge.html.erb
@@ -1,29 +1,29 @@
 <div class="hero min-h-content bg-base-200">
   <div class="hero-content flex-col lg:flex-row-reverse w-full my-10">
     <div class="text-center lg:text-left">
-      <h1 class="text-5xl font-bold text-base-content">Two-Factor Authentication</h1>
+      <h1 class="text-5xl font-bold text-base-content"><%= t('.two_factor_authentication') %></h1>
       <p class="py-6 text-base-content opacity-70">
-        Enter the 6-digit code from your authenticator app to continue.
+        <%= t('.enter_the_6_digit_code_from_your_authenticator_app_to') %>
       </p>
     </div>
     <div class="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100 px-5 py-5">
       <%= form_with url: user_otp_challenge_path, method: :post, class: 'form-body' do |f| %>
         <div class="form-control">
-          <%= f.label :otp_attempt, 'Authentication code', class: 'label' do %>
-            <span class="label-text">Authentication code</span>
+          <%= f.label :otp_attempt, t('.authentication_code'), class: 'label' do %>
+            <span class="label-text"><%= t('.authentication_code') %></span>
           <% end %>
           <%= f.text_field :otp_attempt, class: 'input input-bordered text-center text-2xl tracking-widest',
               maxlength: 32, inputmode: 'numeric', autocomplete: 'one-time-code',
               autofocus: true, required: true, placeholder: '000000' %>
-          <p class="text-xs text-base-content/50 mt-2">You can also use a backup code.</p>
+          <p class="text-xs text-base-content/50 mt-2"><%= t('.you_can_also_use_a_backup_code') %></p>
         </div>
         <div class="form-control mt-6">
-          <%= f.submit 'Verify', class: 'btn btn-primary' %>
+          <%= f.submit t('.verify'), class: 'btn btn-primary' %>
         </div>
       <% end %>
 
       <div class="text-center mt-4">
-        <%= link_to 'Back to login', new_user_session_path, class: 'link link-hover text-sm' %>
+        <%= link_to t('.back_to_login'), new_user_session_path, class: 'link link-hover text-sm' %>
       </div>
     </div>
   </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,31 +1,31 @@
 <div class="mt-5 space-y-2 text-sm">
   <% if !signed_in? %>
     <div>
-      <%= link_to "Log in", new_session_path(resource_name), class: 'link link-hover text-base-content/70' %>
+      <%= link_to t('.log_in'), new_session_path(resource_name), class: 'link link-hover text-base-content/70' %>
     </div>
   <% end %>
 
   <% if email_password_registration_enabled? && defined?(devise_mapping) && devise_mapping&.registerable? && controller_name != 'registrations' %>
     <div>
-      <%= link_to "Register", new_registration_path(resource_name), class: 'link link-hover text-base-content/70' %>
+      <%= link_to t('.register'), new_registration_path(resource_name), class: 'link link-hover text-base-content/70' %>
     </div>
   <% end %>
 
   <% if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
     <div>
-      <%= link_to "Forgot your password?", new_password_path(resource_name), class: 'link link-hover text-base-content/70' %>
+      <%= link_to t('.forgot_your_password'), new_password_path(resource_name), class: 'link link-hover text-base-content/70' %>
     </div>
   <% end %>
 
   <% if devise_mapping.confirmable? && controller_name != 'confirmations' %>
     <div>
-      <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: 'link link-hover text-base-content/70' %>
+      <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name), class: 'link link-hover text-base-content/70' %>
     </div>
   <% end %>
 
   <% if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
     <div>
-      <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: 'link link-hover text-base-content/70' %>
+      <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name), class: 'link link-hover text-base-content/70' %>
     </div>
   <% end %>
 

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,9 +1,9 @@
 <div class="hero min-h-content bg-base-200">
   <div class="hero-content flex-col lg:flex-row-reverse w-full my-10">
     <div class="text-center lg:text-left">
-      <h1 class="text-5xl font-bold text-base-content">Resend unlock instructions</h1>
+      <h1 class="text-5xl font-bold text-base-content"><%= t('.resend_unlock_instructions') %></h1>
       <p class="py-6 text-base-content opacity-70">
-        Enter your email address and we'll send you instructions to unlock your account.
+        <%= t('.enter_your_email_address_and_we_ll_send_you_instructions') %>
       </p>
     </div>
     <div class="card flex-shrink-0 w-full max-w-sm shadow-2xl bg-base-100 px-5 py-5">
@@ -12,13 +12,13 @@
 
         <div class="form-control">
           <%= f.label :email, class: 'label' do %>
-            <span class="label-text">Email</span>
+            <span class="label-text"><%= t('.email') %></span>
           <% end %>
           <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'input input-bordered w-full' %>
         </div>
 
         <div class="form-control mt-6">
-          <%= f.submit "Resend unlock instructions", class: 'btn btn-primary w-full' %>
+          <%= f.submit t('.resend_unlock_instructions'), class: 'btn btn-primary w-full' %>
         </div>
       <% end %>
 

--- a/app/views/exports/_table_row.html.erb
+++ b/app/views/exports/_table_row.html.erb
@@ -6,11 +6,11 @@
       </div>
       <div>
         <div class="font-medium"><%= export.name %></div>
-        <div class="text-xs text-base-content/50"><%= export.file_format&.upcase %> &middot; <%= export.file_type&.humanize %></div>
+        <div class="text-xs text-base-content/50"><%= export.file_format&.upcase %> <%= t('.middot') %> <%= t("enums.export.file_type.#{export.file_type}") %></div>
       </div>
     </div>
   </td>
-  <td class="px-4 py-3 text-sm tabular-nums"><%= number_to_human_size(export.file&.byte_size) || 'N/A' %></td>
+  <td class="px-4 py-3 text-sm tabular-nums"><%= number_to_human_size(export.file&.byte_size) || t('common.not_available') %></td>
   <td class="px-4 py-3">
     <%= status_badge(export) %>
   </td>
@@ -19,21 +19,21 @@
     <div class="flex items-center gap-1 justify-end">
       <% if export.completed? %>
         <% if export.file.present? %>
-          <div class="tooltip" data-tip="Download file">
+          <div class="tooltip" data-tip="<%= t('.download_file') %>">
             <%= link_to rails_blob_path(export.file, disposition: 'attachment'), class: "btn btn-ghost btn-xs", download: export.name do %>
               <%= icon 'arrow-big-down', class: 'w-4 h-4' %>
             <% end %>
           </div>
         <% elsif export.url.present? %>
-          <div class="tooltip" data-tip="Download file">
+          <div class="tooltip" data-tip="<%= t('.download_file') %>">
             <%= link_to export.url, class: "btn btn-ghost btn-xs", download: export.name do %>
               <%= icon 'arrow-big-down', class: 'w-4 h-4' %>
             <% end %>
           </div>
         <% end %>
       <% end %>
-      <div class="tooltip" data-tip="Delete export">
-        <%= link_to export, data: { turbo_confirm: "Are you sure?", turbo_method: :delete }, class: "btn btn-ghost btn-xs text-error hover:bg-error/10" do %>
+      <div class="tooltip" data-tip="<%= t('.delete_export') %>">
+        <%= link_to export, data: { turbo_confirm: t('.are_you_sure'), turbo_method: :delete }, class: "btn btn-ghost btn-xs text-error hover:bg-error/10" do %>
           <%= icon 'trash-2', class: 'w-4 h-4' %>
         <% end %>
       </div>

--- a/app/views/exports/index.html.erb
+++ b/app/views/exports/index.html.erb
@@ -1,17 +1,17 @@
-<% content_for :title, "Exports" %>
+<% content_for :title, t('.exports') %>
 
 <div class="w-full my-5">
-  <%= render 'shared/page_header', title: 'Exports' %>
+  <%= render 'shared/page_header', title: t('.exports') %>
 
   <div id="exports" class="min-w-full">
     <% if @exports.empty? %>
       <div class="text-center py-16 px-8 bg-base-200 rounded-xl border-2 border-dashed border-base-300">
-        <h3 class="text-xl font-bold mb-3">No exports yet</h3>
+        <h3 class="text-xl font-bold mb-3"><%= t('.no_exports_yet') %></h3>
         <p class="text-base-content/50 mb-6 max-w-sm mx-auto">
-          Exports are created from the <%= link_to 'Points', points_url, class: 'link link-primary' %> page. Select a date range and export to GeoJSON or GPX.
+          <%= t('.exports_are_created_from_the') %> <%= link_to t('.points'), points_url, class: 'link link-primary' %> <%= t('.page_select_a_date_range_and_export_to_geojson_or') %>
         </p>
         <%= link_to points_url, class: 'btn btn-primary' do %>
-          <%= icon 'map-pin', class: 'w-4 h-4' %> Go to Points
+          <%= icon 'map-pin', class: 'w-4 h-4' %> <%= t('.go_to_points') %>
         <% end %>
       </div>
     <% else %>
@@ -22,11 +22,11 @@
         <table class="table w-full">
           <thead class="bg-base-200">
             <tr>
-              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[40%]"><%= sortable_column 'Name', :name, :exports_path %></th>
+              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[40%]"><%= sortable_column t('.name'), :name, :exports_path %></th>
               <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[12%]"><%= sortable_column 'File size', :byte_size, :exports_path %></th>
-              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[15%]"><%= sortable_column 'Status', :status, :exports_path %></th>
-              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[20%]"><%= sortable_column 'Created', :created_at, :exports_path %></th>
-              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 text-right w-[13%]">Actions</th>
+              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[15%]"><%= sortable_column t('.status'), :status, :exports_path %></th>
+              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[20%]"><%= sortable_column t('.created'), :created_at, :exports_path %></th>
+              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 text-right w-[13%]"><%= t('.actions') %></th>
             </tr>
           </thead>
           <tbody>

--- a/app/views/families/_location_sharing_toggle.html.erb
+++ b/app/views/families/_location_sharing_toggle.html.erb
@@ -28,7 +28,7 @@
       <div class="grid grid-cols-[auto_auto_1fr] items-center gap-x-3 gap-y-2">
 
         <%# Row 1: Live location %>
-        <span class="text-sm text-base-content/60 text-right whitespace-nowrap">Live location:</span>
+        <span class="text-sm text-base-content/60 text-right whitespace-nowrap"><%= t('.live_location') %></span>
 
         <input type="checkbox"
                class="toggle toggle-primary toggle-md"
@@ -42,18 +42,18 @@
             <select class="select select-bordered select-md"
                     data-location-sharing-toggle-target="durationSelect"
                     data-action="change->location-sharing-toggle#changeDuration">
-              <option value="permanent" <%= 'selected' if member.family_sharing_duration == 'permanent' %>>Always</option>
-              <option value="1h" <%= 'selected' if member.family_sharing_duration == '1h' %>>1 hour</option>
-              <option value="6h" <%= 'selected' if member.family_sharing_duration == '6h' %>>6 hours</option>
-              <option value="12h" <%= 'selected' if member.family_sharing_duration == '12h' %>>12 hours</option>
-              <option value="24h" <%= 'selected' if member.family_sharing_duration == '24h' %>>24 hours</option>
+              <option value="permanent" <%= 'selected' if member.family_sharing_duration == 'permanent' %>><%= t('.always') %></option>
+              <option value="1h" <%= 'selected' if member.family_sharing_duration == '1h' %>><%= t('.hour') %></option>
+              <option value="6h" <%= 'selected' if member.family_sharing_duration == '6h' %>><%= t('.hours') %></option>
+              <option value="12h" <%= 'selected' if member.family_sharing_duration == '12h' %>><%= t('.hours_2') %></option>
+              <option value="24h" <%= 'selected' if member.family_sharing_duration == '24h' %>><%= t('.hours_3') %></option>
             </select>
           </div>
 
           <% if member.family_sharing_enabled? && member.family_sharing_expires_at.present? %>
             <span class="text-xs text-base-content/50"
                   data-location-sharing-toggle-target="expirationInfo">
-              Expires in <%= time_ago_in_words(member.family_sharing_expires_at) %>
+              <%= t('.expires_in_time', time: time_ago_in_words(member.family_sharing_expires_at)) %>
             </span>
           <% else %>
             <span class="text-xs text-base-content/50 hidden"
@@ -69,7 +69,7 @@
         <div class="<%= 'hidden' unless member.family_sharing_enabled? %> contents"
              data-location-sharing-toggle-target="historyContainer">
 
-          <span class="text-sm text-base-content/60 text-right whitespace-nowrap">Location history:</span>
+          <span class="text-sm text-base-content/60 text-right whitespace-nowrap"><%= t('.location_history') %></span>
 
           <input type="checkbox"
                  class="toggle toggle-secondary toggle-md"
@@ -82,17 +82,15 @@
             <select class="select select-bordered select-md"
                     data-location-sharing-toggle-target="historyWindowSelect"
                     data-action="change->location-sharing-toggle#changeHistoryWindow">
-              <option value="24h" <%= 'selected' if member.family_history_window == '24h' %>>Last 24 hours</option>
-              <option value="7d" <%= 'selected' if member.family_history_window == '7d' %>>Last 7 days</option>
-              <option value="30d" <%= 'selected' if member.family_history_window == '30d' %>>Last 30 days</option>
-              <option value="all" <%= 'selected' if member.family_history_window == 'all' %>>Since sharing started</option>
+              <option value="24h" <%= 'selected' if member.family_history_window == '24h' %>><%= t('.last_24_hours') %></option>
+              <option value="7d" <%= 'selected' if member.family_history_window == '7d' %>><%= t('.last_7_days') %></option>
+              <option value="30d" <%= 'selected' if member.family_history_window == '30d' %>><%= t('.last_30_days') %></option>
+              <option value="all" <%= 'selected' if member.family_history_window == 'all' %>><%= t('.since_sharing_started') %></option>
             </select>
           </div>
 
           <p class="col-span-full text-xs text-base-content/50 leading-snug">
-            A separate setting from live location. When on, family can view your recent
-            track — not just your current position — on the new map (v2). Only points
-            recorded after you enable this are ever shared.
+            <%= t('.a_separate_setting_from_live_location_when_on_family_can') %>
           </p>
 
         </div>

--- a/app/views/families/_navbar_indicator.html.erb
+++ b/app/views/families/_navbar_indicator.html.erb
@@ -3,7 +3,7 @@
        data-family-navbar-indicator-enabled-value="<%= user.family_sharing_enabled? %>">
     <div data-family-navbar-indicator-target="indicator"
          class="tooltip tooltip-bottom w-2 h-2 <%= user.family_sharing_enabled? ? 'bg-green-500 animate-pulse' : 'bg-gray-400' %> rounded-full"
-         data-tip="<%= user.family_sharing_enabled? ? 'Location is being shared with your family' : 'Location is not being shared with your family' %>">
+         data-tip="<%= t(user.family_sharing_enabled? ? '.location_shared' : '.location_not_shared') %>">
     </div>
   </div>
 <% end %>

--- a/app/views/families/edit.html.erb
+++ b/app/views/families/edit.html.erb
@@ -1,15 +1,15 @@
-<% content_for :title, "Editing Family" %>
+<% content_for :title, t('.editing_family') %>
 
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
     <div class="bg-base-200 rounded-lg p-6">
       <div class="flex items-center justify-between mb-6">
         <h1 class="text-2xl font-bold text-base-content">
-          <%= t('families.edit.title', default: 'Edit Family') %>
+          <%= t('families.edit.title') %>
         </h1>
         <%= link_to family_path,
               class: "btn btn-ghost" do %>
-          <%= t('families.edit.back', default: '← Back to Family') %>
+          <%= t('families.edit.back') %>
         <% end %>
       </div>
 
@@ -18,7 +18,7 @@
           <div class="alert alert-error">
             <div>
               <h3 class="text-sm font-medium">
-                <%= t('families.edit.error_title', default: 'There were problems with your submission:') %>
+                <%= t('families.edit.error_title') %>
               </h3>
               <div class="mt-2 text-sm">
                 <ul class="list-disc pl-5 space-y-1">
@@ -32,66 +32,66 @@
         <% end %>
 
         <div>
-          <%= form.label :name, t('families.form.name', default: 'Family Name'), class: "label label-text font-medium mb-2" %>
+          <%= form.label :name, t('families.form.name'), class: "label label-text font-medium mb-2" %>
           <%= form.text_field :name,
                 class: "input input-bordered w-full",
-                placeholder: t('families.form.name_placeholder', default: 'Enter your family name') %>
+                placeholder: t('families.form.name_placeholder') %>
           <p class="mt-1 text-sm text-base-content opacity-50">
-            <%= t('families.edit.name_help', default: 'Choose a name that all family members will recognize.') %>
+            <%= t('families.edit.name_help') %>
           </p>
         </div>
 
         <div class="bg-base-300 p-4 rounded-md">
           <h3 class="text-sm font-medium text-base-content mb-2">
-            <%= t('families.edit.family_info', default: 'Family Information') %>
+            <%= t('families.edit.family_info') %>
           </h3>
           <dl class="grid grid-cols-1 gap-x-4 gap-y-2 sm:grid-cols-2">
             <div>
               <dt class="text-sm font-medium text-base-content opacity-60">
-                <%= t('families.edit.creator', default: 'Created by') %>
+                <%= t('families.edit.creator') %>
               </dt>
               <dd class="text-sm text-base-content"><%= @family.creator.email %></dd>
             </div>
             <div>
               <dt class="text-sm font-medium text-base-content opacity-60">
-                <%= t('families.edit.created_on', default: 'Created on') %>
+                <%= t('families.edit.created_on') %>
               </dt>
-              <dd class="text-sm text-base-content"><%= @family.created_at.strftime('%B %d, %Y') %></dd>
+              <dd class="text-sm text-base-content"><%= l(@family.created_at.to_date, format: :long) %></dd>
             </div>
             <div>
               <dt class="text-sm font-medium text-base-content opacity-60">
-                <%= t('families.edit.members_count', default: 'Members') %>
+                <%= t('families.edit.members_count') %>
               </dt>
               <dd class="text-sm text-base-content">
-                <%= pluralize(@family.members.count, 'member') %>
+                <%= t('.member_count', count: @family.members.count) %>
               </dd>
             </div>
             <div>
               <dt class="text-sm font-medium text-base-content opacity-60">
-                <%= t('families.edit.last_updated', default: 'Last updated') %>
+                <%= t('families.edit.last_updated') %>
               </dt>
-              <dd class="text-sm text-base-content"><%= @family.updated_at.strftime('%B %d, %Y') %></dd>
+              <dd class="text-sm text-base-content"><%= l(@family.updated_at.to_date, format: :long) %></dd>
             </div>
           </dl>
         </div>
 
         <div class="flex items-center justify-between pt-4">
           <div class="flex space-x-3">
-            <%= form.submit t('families.edit.save_changes', default: 'Save Changes'),
+            <%= form.submit t('families.edit.save_changes'),
                   class: "btn btn-primary" %>
             <%= link_to family_path,
                   class: "btn btn-neutral" do %>
-              <%= t('families.edit.cancel', default: 'Cancel') %>
+              <%= t('families.edit.cancel') %>
             <% end %>
           </div>
 
           <% if policy(@family).destroy? %>
             <%= link_to family_path,
                   method: :delete,
-                  data: { turbo_confirm: 'Are you sure you want to delete this family? This action cannot be undone.', turbo_method: :delete },
+                  data: { turbo_confirm: t('.are_you_sure_you_want_to_delete_this_family_this'), turbo_method: :delete },
                   class: "btn btn-outline btn-error" do %>
               <%= icon 'trash-2', class: "inline-block w-4" %>
-              Delete Family
+              <%= t('.delete_family') %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/families/index.html.erb
+++ b/app/views/families/index.html.erb
@@ -1,31 +1,31 @@
-<% content_for :title, "Family Management" %>
+<% content_for :title, t('.family_management') %>
 
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
     <div class="text-center mb-8">
       <h1 class="text-3xl font-bold text-base-content mb-4">
-        <%= t('families.index.title', default: 'Family Management') %>
+        <%= t('families.index.title') %>
       </h1>
       <p class="text-base-content opacity-60">
-        <%= t('families.index.description', default: 'Create or join a family to share your location data with loved ones.') %>
+        <%= t('families.index.description') %>
       </p>
     </div>
 
     <div class="bg-base-200 rounded-lg p-6">
       <h2 class="text-xl font-semibold mb-4 text-base-content">
-        <%= t('families.index.create_family', default: 'Create Your Family') %>
+        <%= t('families.index.create_family') %>
       </h2>
 
       <%= form_with model: Family.new, local: true, class: "space-y-4" do |form| %>
         <div>
-          <%= form.label :name, t('families.form.name', default: 'Family Name'), class: "label label-text font-medium mb-1" %>
+          <%= form.label :name, t('families.form.name'), class: "label label-text font-medium mb-1" %>
           <%= form.text_field :name,
-                placeholder: t('families.form.name_placeholder', default: 'Enter your family name'),
+                placeholder: t('families.form.name_placeholder'),
                 class: "input input-bordered w-full" %>
         </div>
 
         <div class="flex justify-end">
-          <%= form.submit t('families.form.create', default: 'Create Family'),
+          <%= form.submit t('families.form.create'),
                 class: "btn btn-primary" %>
         </div>
       <% end %>
@@ -33,13 +33,13 @@
 
     <div class="mt-8 text-center">
       <h3 class="text-lg font-medium text-base-content mb-4">
-        <%= t('families.index.have_invitation', default: 'Have an invitation?') %>
+        <%= t('families.index.have_invitation') %>
       </h3>
       <p class="text-base-content opacity-60 mb-4">
-        <%= t('families.index.invitation_instructions', default: 'If someone has invited you to join their family, you should have received an email with an invitation link.') %>
+        <%= t('families.index.invitation_instructions') %>
       </p>
       <div class="text-sm text-base-content opacity-50">
-        <%= t('families.index.invitation_help', default: 'Check your email for an invitation link that looks like: ') %>
+        <%= t('families.index.invitation_help') %>
         <code class="bg-base-300 text-base-content px-2 py-1 rounded text-xs">
           <%= "#{request.base_url}/invitations/..." %>
         </code>

--- a/app/views/families/lapsed.html.erb
+++ b/app/views/families/lapsed.html.erb
@@ -1,16 +1,16 @@
-<% content_for :title, "Family" %>
+<% content_for :title, t('.family') %>
 
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
     <div class="text-center mb-8">
       <h1 class="text-3xl font-bold text-base-content mb-4">
-        Family plan no longer active
+        <%= t('.family_plan_no_longer_active') %>
       </h1>
       <p class="text-base-content opacity-60">
         <% if current_user.family_owner? %>
-          Your Family plan is no longer active, so family features are paused for everyone. Your family and its members are kept — renewing restores full access.
+          <%= t('.your_family_plan_is_no_longer_active_so_family_features') %>
         <% else %>
-          Your family's plan is no longer active, so family features are paused. They come back when the family owner renews — you don't need a subscription of your own.
+          <%= t('.your_family_s_plan_is_no_longer_active_so_family') %>
         <% end %>
       </p>
     </div>
@@ -18,7 +18,7 @@
     <div class="bg-base-200 rounded-lg p-6">
       <% if current_user.family_owner? %>
         <div class="text-center mb-6">
-          <%= link_to 'Renew Family plan',
+          <%= link_to t('.renew_family_plan'),
                 @family_upgrade_url,
                 target: '_blank', rel: 'noopener noreferrer',
                 class: 'btn btn-primary' %>
@@ -26,22 +26,22 @@
 
         <% if @family.active_invitations.any? %>
           <div class="text-center mb-6">
-            <%= link_to 'View pending invitations', family_invitations_path, class: 'link text-sm' %>
+            <%= link_to t('.view_pending_invitations'), family_invitations_path, class: 'link text-sm' %>
           </div>
         <% end %>
 
         <% other_members = @members.to_a.reject { |member| member == current_user } %>
         <% if other_members.any? %>
           <div class="mb-6">
-            <h2 class="text-sm font-medium mb-2">Members</h2>
+            <h2 class="text-sm font-medium mb-2"><%= t('.members') %></h2>
             <ul class="space-y-2">
               <% other_members.each do |member| %>
                 <li class="flex items-center justify-between">
                   <span class="text-sm"><%= member.email %></span>
                   <%= link_to family_member_path(member.family_membership),
-                        data: { turbo_confirm: "Remove #{member.email} from the family?", turbo_method: :delete },
+                        data: { turbo_confirm: t('.remove_email_from_the_family', email: member.email), turbo_method: :delete },
                         class: 'btn btn-ghost btn-xs text-warning' do %>
-                    Remove
+                    <%= t('.remove') %>
                   <% end %>
                 </li>
               <% end %>
@@ -51,22 +51,22 @@
       <% end %>
 
       <div class="mb-6">
-        <h2 class="text-sm font-medium mb-2">Your location sharing</h2>
+        <h2 class="text-sm font-medium mb-2"><%= t('.your_location_sharing') %></h2>
         <%= render 'families/location_sharing_toggle', member: current_user %>
       </div>
 
       <div class="flex gap-2 justify-end">
         <% if current_user.family_owner? %>
           <%= link_to family_path,
-                data: { turbo_confirm: 'Delete this family? This cannot be undone.', turbo_method: :delete },
+                data: { turbo_confirm: t('.delete_this_family_this_cannot_be_undone'), turbo_method: :delete },
                 class: 'btn btn-ghost btn-xs text-error' do %>
-            <%= icon 'trash-2', class: 'w-3.5 h-3.5' %> Delete Family
+            <%= icon 'trash-2', class: 'w-3.5 h-3.5' %> <%= t('.delete_family') %>
           <% end %>
         <% else %>
           <%= link_to family_member_path(current_user.family_membership),
-                data: { turbo_confirm: 'Are you sure you want to leave this family?', turbo_method: :delete },
+                data: { turbo_confirm: t('.are_you_sure_you_want_to_leave_this_family'), turbo_method: :delete },
                 class: 'btn btn-ghost btn-xs text-warning' do %>
-            Leave Family
+            <%= t('.leave_family') %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/families/new.html.erb
+++ b/app/views/families/new.html.erb
@@ -1,26 +1,25 @@
-<% content_for :title, "New Family" %>
+<% content_for :title, t('.new_family') %>
 
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-2xl mx-auto">
     <div class="text-center mb-8">
       <h1 class="text-3xl font-bold text-base-content mb-4">
-        <%= t('families.new.title', default: 'Create Your Family') %>
+        <%= t('families.new.title') %>
       </h1>
       <p class="text-base-content opacity-60">
-        <%= t('families.new.description', default: 'Create a family to share your location data with your loved ones.') %>
+        <%= t('families.new.description') %>
       </p>
     </div>
 
     <% if @can_create_family == false %>
       <div class="bg-base-200 rounded-lg p-6 text-center">
         <h2 class="text-xl font-bold mb-2">
-          <%= t('families.new.upgrade_title', default: 'Family plan required') %>
+          <%= t('families.new.upgrade_title') %>
         </h2>
         <p class="text-base-content opacity-60 mb-6">
-          <%= t('families.new.upgrade_description',
-                default: 'Creating a family requires the Family plan. Upgrade to invite up to 5 members and share full access.') %>
+          <%= t('families.new.upgrade_description') %>
         </p>
-        <%= link_to t('families.new.upgrade_cta', default: 'Upgrade to Family'),
+        <%= link_to t('families.new.upgrade_cta'),
               @family_upgrade_url,
               target: '_blank', rel: 'noopener noreferrer',
               class: 'btn btn-primary' %>
@@ -32,7 +31,7 @@
           <div class="alert alert-error">
             <div>
               <h3 class="text-sm font-medium">
-                <%= t('families.new.error_title', default: 'There were problems with your submission:') %>
+                <%= t('families.new.error_title') %>
               </h3>
               <div class="mt-2 text-sm">
                 <ul class="list-disc pl-5 space-y-1">
@@ -46,35 +45,35 @@
         <% end %>
 
         <div>
-          <%= form.label :name, t('families.form.name', default: 'Family Name'), class: "label label-text font-medium mb-2" %>
+          <%= form.label :name, t('families.form.name'), class: "label label-text font-medium mb-2" %>
           <%= form.text_field :name,
                 class: "input input-bordered w-full",
-                placeholder: t('families.form.name_placeholder', default: 'Enter your family name') %>
+                placeholder: t('families.form.name_placeholder') %>
           <p class="mt-1 text-sm text-base-content opacity-50">
-            <%= t('families.new.name_help', default: 'Choose a name that all family members will recognize, like "The Smith Family" or "Our Travel Group".') %>
+            <%= t('families.new.name_help') %>
           </p>
         </div>
 
         <div class="alert alert-info">
           <div>
             <h3 class="text-sm font-medium mb-2">
-              <%= t('families.new.what_happens_title', default: 'What happens next?') %>
+              <%= t('families.new.what_happens_title') %>
             </h3>
             <ul class="text-sm space-y-1">
-              <li>• <%= t('families.new.what_happens_1', default: 'You will become the family owner') %></li>
-              <li>• <%= t('families.new.what_happens_2', default: 'You can invite others to join your family') %></li>
-              <li>• <%= t('families.new.what_happens_3', default: 'Family members can view shared location data') %></li>
-              <li>• <%= t('families.new.what_happens_4', default: 'You can manage family settings and members') %></li>
+              <li>• <%= t('families.new.what_happens_1') %></li>
+              <li>• <%= t('families.new.what_happens_2') %></li>
+              <li>• <%= t('families.new.what_happens_3') %></li>
+              <li>• <%= t('families.new.what_happens_4') %></li>
             </ul>
           </div>
         </div>
 
         <div class="flex items-center justify-between">
-          <%= form.submit t('families.new.create_family', default: 'Create Family'),
+          <%= form.submit t('families.new.create_family'),
                 class: "btn btn-primary" %>
           <%= link_to root_path,
                 class: "btn btn-ghost" do %>
-            <%= t('families.new.back', default: '← Back') %>
+            <%= t('families.new.back') %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/families/show.html.erb
+++ b/app/views/families/show.html.erb
@@ -6,19 +6,19 @@
     <div class="flex items-center gap-2">
       <% if policy(@family).update? %>
         <%= link_to edit_family_path, class: "btn btn-outline btn-sm" do %>
-          <%= icon 'square-pen', class: 'w-4 h-4' %> Edit
+          <%= icon 'square-pen', class: 'w-4 h-4' %> <%= t('.edit') %>
         <% end %>
       <% end %>
       <% if policy(@family).invite? && @family.can_add_members? %>
         <button class="btn btn-primary btn-sm" onclick="document.getElementById('invite-section').scrollIntoView({behavior:'smooth'})">
-          <%= icon 'circle-plus', class: 'w-4 h-4' %> Invite
+          <%= icon 'circle-plus', class: 'w-4 h-4' %> <%= t('.invite') %>
         </button>
       <% end %>
     </div>
   <% end %>
 
   <div class="text-sm text-base-content/50 -mt-4 mb-6">
-    <%= @member_count %> members &middot; Created <%= @family.created_at.strftime('%B %Y') %>
+    <%= t('.members_created', count: @member_count, date: l(@family.created_at.to_date, format: :month_year)) %>
   </div>
 
   <%# Main layout: Map + Sidebar %>
@@ -36,7 +36,7 @@
               <div class="text-base-content/30 mb-2">
                 <%= icon 'map', class: 'w-12 h-12 mx-auto' %>
               </div>
-              <p class="text-base-content/50 text-sm">No family members are sharing their location</p>
+              <p class="text-base-content/50 text-sm"><%= t('.no_family_members_are_sharing_their_location') %></p>
             </div>
           </div>
         <% end %>
@@ -49,7 +49,7 @@
       <%# Your sharing controls %>
       <div class="border border-base-300 rounded-xl overflow-hidden">
         <div class="bg-base-200 px-4 py-2.5">
-          <h3 class="text-xs font-medium uppercase tracking-wider text-base-content/50">Your Sharing</h3>
+          <h3 class="text-xs font-medium uppercase tracking-wider text-base-content/50"><%= t('.your_sharing') %></h3>
         </div>
         <div class="p-4">
           <%= render 'families/location_sharing_toggle', member: current_user %>
@@ -60,7 +60,7 @@
       <div class="border border-base-300 rounded-xl overflow-hidden">
         <div class="bg-base-200 px-4 py-2.5">
           <h3 class="text-xs font-medium uppercase tracking-wider text-base-content/50">
-            Members <span class="text-base-content/30">(<%= @members.count %>)</span>
+            <%= t('.members') %> <span class="text-base-content/30">(<%= @members.count %>)</span>
           </h3>
         </div>
         <div class="divide-y divide-base-200">
@@ -85,32 +85,33 @@
                   <div class="flex items-center gap-2">
                     <span class="text-sm font-medium truncate"><%= member.email %></span>
                     <% if member.family_membership.role == 'owner' %>
-                      <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-warning/10 text-warning">Owner</span>
+                      <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-warning/10 text-warning"><%= t('.owner') %></span>
                     <% end %>
                     <% if member == current_user %>
-                      <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-primary/10 text-primary">You</span>
+                      <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-primary/10 text-primary"><%= t('.you') %></span>
                     <% end %>
                   </div>
                   <div class="flex items-center gap-2 mt-0.5">
                     <% if member.family_sharing_enabled? %>
                       <div class="w-2 h-2 bg-success rounded-full animate-pulse"></div>
                       <span class="text-xs text-success">
-                        Sharing <%= member.family_sharing_duration == 'permanent' ? 'always' : "for #{member.family_sharing_duration}" %>
+                        <% duration = member.family_sharing_duration == 'permanent' ? t('.always') : t('.for_duration', duration: member.family_sharing_duration) %>
+                        <%= t('.sharing_status', duration: duration) %>
                       </span>
                       <% if location %>
                         <span class="text-xs text-base-content/40">
-                          &middot; <%= time_ago_in_words(Time.zone.at(location[:timestamp])) %> ago
+                          <%= t('.middot') %> <%= time_ago_in_words(Time.zone.at(location[:timestamp])) %> <%= t('.ago') %>
                         </span>
                       <% end %>
                     <% else %>
                       <div class="w-2 h-2 bg-base-300 rounded-full"></div>
-                      <span class="text-xs text-base-content/40">Not sharing</span>
+                      <span class="text-xs text-base-content/40"><%= t('.not_sharing') %></span>
                       <% if member != current_user %>
                         <% pending_req = @pending_requests[member.id] %>
                         <% if pending_req %>
-                          <span class="text-xs text-info">Requested</span>
+                          <span class="text-xs text-info"><%= t('.requested') %></span>
                         <% else %>
-                          <%= button_to "Request",
+                          <%= button_to t('.request'),
                               family_location_requests_path(target_user_id: member.id),
                               method: :post,
                               class: "btn btn-outline btn-xs btn-info ml-auto" %>
@@ -123,11 +124,11 @@
                   <%= link_to family_member_path(member.family_membership),
                         method: :delete,
                         data: {
-                          turbo_confirm: "Remove #{member.email} from the family?",
+                          turbo_confirm: t('.remove_email_from_the_family', email: member.email),
                           turbo_method: :delete
                         },
                         class: "btn btn-ghost btn-xs text-error ml-auto" do %>
-                    <%= icon 'x', class: 'w-3.5 h-3.5' %> Remove
+                    <%= icon 'x', class: 'w-3.5 h-3.5' %> <%= t('.remove') %>
                   <% end %>
                 <% end %>
               </div>
@@ -140,7 +141,7 @@
       <div class="border border-base-300 rounded-xl overflow-hidden" id="invite-section">
         <div class="bg-base-200 px-4 py-2.5">
           <h3 class="text-xs font-medium uppercase tracking-wider text-base-content/50">
-            Invitations <span class="text-base-content/30">(<%= @pending_invitations.count %>)</span>
+            <%= t('.invitations') %> <span class="text-base-content/30">(<%= @pending_invitations.count %>)</span>
           </h3>
         </div>
 
@@ -152,8 +153,7 @@
                   <div class="min-w-0 flex-1 mr-2">
                     <div class="text-sm font-medium"><%= invitation.email %></div>
                     <div class="text-xs text-base-content/40">
-                      Invited <%= time_ago_in_words(invitation.created_at) %> ago
-                      &middot; expires <%= invitation.expires_at.strftime('%b %d') %>
+                      <%= t('.invited_ago_expires', ago: time_ago_in_words(invitation.created_at), date: l(invitation.expires_at.to_date, format: :short_month_day)) %>
                     </div>
                     <div class="text-xs text-base-content/50 font-mono break-all select-all mt-1">
                       <%= public_invitation_url(invitation.token) %>
@@ -169,7 +169,7 @@
                     <% if policy(@family).manage_invitations? %>
                       <%= button_to family_invitation_path(invitation.token),
                             method: :delete,
-                            form: { data: { turbo_confirm: 'Cancel this invitation?', turbo_method: :delete } },
+                            form: { data: { turbo_confirm: t('.cancel_this_invitation'), turbo_method: :delete } },
                             class: "btn btn-ghost btn-xs text-error hover:bg-error/10" do %>
                         <%= icon 'x', class: 'w-3.5 h-3.5' %>
                       <% end %>
@@ -187,9 +187,9 @@
             <%= form_with model: [@family, Family::Invitation.new], url: family_invitations_path(@family), local: true do |form| %>
               <div class="flex gap-2">
                 <%= form.email_field :email,
-                      placeholder: 'Email address',
+                      placeholder: t('.email_address'),
                       class: "input input-bordered input-sm flex-1" %>
-                <%= form.submit 'Invite',
+                <%= form.submit t('.invite'),
                       class: "btn btn-primary btn-sm" %>
               </div>
             <% end %>
@@ -198,7 +198,7 @@
           <div class="px-4 py-3 border-t border-base-200">
             <p class="text-xs text-warning">
               <%= icon 'triangle-alert', class: 'w-3.5 h-3.5 inline' %>
-              Family at capacity (<%= @family.class::MAX_MEMBERS %> members max)
+              <%= t('.family_at_capacity') %><%= @family.class::MAX_MEMBERS %> <%= t('.members_max') %>
             </p>
           </div>
         <% end %>
@@ -209,17 +209,17 @@
         <% if !current_user.family_owner? && current_user.family_membership %>
           <%= link_to family_member_path(current_user.family_membership),
                 method: :delete,
-                data: { turbo_confirm: 'Are you sure you want to leave this family?', turbo_method: :delete },
+                data: { turbo_confirm: t('.are_you_sure_you_want_to_leave_this_family'), turbo_method: :delete },
                 class: "btn btn-ghost btn-xs text-warning" do %>
-            Leave Family
+            <%= t('.leave_family') %>
           <% end %>
         <% end %>
         <% if policy(@family).destroy? %>
           <%= link_to family_path,
                 method: :delete,
-                data: { turbo_confirm: 'Delete this family? This cannot be undone.', turbo_method: :delete },
+                data: { turbo_confirm: t('.delete_this_family_this_cannot_be_undone'), turbo_method: :delete },
                 class: "btn btn-ghost btn-xs text-error" do %>
-            <%= icon 'trash-2', class: 'w-3.5 h-3.5' %> Delete Family
+            <%= icon 'trash-2', class: 'w-3.5 h-3.5' %> <%= t('.delete_family') %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/families/show.html.erb
+++ b/app/views/families/show.html.erb
@@ -153,7 +153,7 @@
                   <div class="min-w-0 flex-1 mr-2">
                     <div class="text-sm font-medium"><%= invitation.email %></div>
                     <div class="text-xs text-base-content/40">
-                      <%= t('.invited_ago_expires', ago: time_ago_in_words(invitation.created_at), date: l(invitation.expires_at.to_date, format: :short_month_day)) %>
+                      <%= t('.invited_ago_expires', ago: time_ago_in_words(invitation.created_at), date: l(invitation.expires_at.to_date, format: :short_month_day_padded)) %>
                     </div>
                     <div class="text-xs text-base-content/50 font-mono break-all select-all mt-1">
                       <%= public_invitation_url(invitation.token) %>

--- a/app/views/family/invitations/index.html.erb
+++ b/app/views/family/invitations/index.html.erb
@@ -3,11 +3,11 @@
     <div class="bg-base-200 rounded-lg p-6">
       <div class="flex items-center justify-between mb-6">
         <h1 class="text-2xl font-bold text-base-content">
-          <%= t('family_invitations.index.title', default: 'Family Invitations') %>
+          <%= t('family_invitations.index.title') %>
         </h1>
         <%= link_to family_home_path,
               class: "btn btn-neutral" do %>
-          <%= t('family_invitations.index.back_to_family', default: 'Back to Family') %>
+          <%= t('family_invitations.index.back_to_family') %>
         <% end %>
       </div>
 
@@ -18,12 +18,12 @@
               <div>
                 <div class="font-medium text-base-content"><%= invitation.email %></div>
                 <div class="text-sm text-base-content opacity-60">
-                  <%= t('family_invitations.index.invited_on', default: 'Invited') %>
-                  <%= invitation.created_at.strftime('%B %d, %Y') %>
+                  <%= t('family_invitations.index.invited_on') %>
+                  <%= l(invitation.created_at.to_date, format: :long) %>
                 </div>
                 <div class="text-xs text-base-content opacity-50">
-                  <%= t('family_invitations.index.expires_on', default: 'Expires') %>
-                  <%= invitation.expires_at.strftime('%B %d, %Y at %I:%M %p') %>
+                  <%= t('family_invitations.index.expires_on') %>
+                  <%= l(invitation.expires_at, format: :long_with_time) %>
                 </div>
               </div>
 
@@ -36,20 +36,20 @@
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
                   </svg>
-                  <%= t('family_invitations.index.copy_link', default: 'Copy Link') %>
+                  <%= t('family_invitations.index.copy_link') %>
                 </button>
 
                 <%= link_to public_invitation_path(invitation.token),
                       class: "btn btn-ghost btn-sm text-info" do %>
-                  <%= t('family_invitations.index.view_invitation', default: 'View') %>
+                  <%= t('family_invitations.index.view_invitation') %>
                 <% end %>
 
                 <% if policy(@family).manage_invitations? %>
                   <%= link_to family_invitation_path(invitation.token),
                         method: :delete,
-                        confirm: t('family_invitations.index.cancel_confirm', default: 'Are you sure you want to cancel this invitation?'),
+                        confirm: t('family_invitations.index.cancel_confirm'),
                         class: "btn btn-ghost btn-sm text-error" do %>
-                    <%= t('family_invitations.index.cancel', default: 'Cancel') %>
+                    <%= t('family_invitations.index.cancel') %>
                   <% end %>
                 <% end %>
               </div>
@@ -59,7 +59,7 @@
       <% else %>
         <div class="text-center py-8">
           <p class="text-base-content opacity-50 text-lg">
-            <%= t('family_invitations.index.no_invitations', default: 'No pending invitations') %>
+            <%= t('family_invitations.index.no_invitations') %>
           </p>
         </div>
       <% end %>

--- a/app/views/family/invitations/show.html.erb
+++ b/app/views/family/invitations/show.html.erb
@@ -7,17 +7,17 @@
       </div>
 
       <h1 class="text-5xl font-bold text-base-content mb-4">
-        Join <%= @invitation.family.name %>!
+        <%= t('.join') %> <%= @invitation.family.name %>!
       </h1>
 
       <p class="text-xl text-base-content opacity-80 mb-2">
-        You've been invited by <strong class="text-base-content"><%= @invitation.invited_by.email %></strong> to join their family. Create your account to accept the invitation and start sharing location data.
+        <%= t('.you_ve_been_invited_by') %> <strong class="text-base-content"><%= @invitation.invited_by.email %></strong> <%= t('.to_join_their_family_create_your_account_to_accept_the') %>
       </p>
 
       <div class="alert alert-info inline-flex items-center rounded-lg px-4 py-3 mt-4 gap-3">
         <%= icon 'info', class: "h-5 w-5 shrink-0" %>
         <span class="text-sm font-medium">
-          Your email (<%= @invitation.email %>) will be used for this account
+          <%= t('.your_email') %><%= @invitation.email %><%= t('.will_be_used_for_this_account') %>
         </span>
       </div>
     </div>
@@ -25,7 +25,7 @@
     <!-- Benefits Section -->
     <div class="bg-base-200 shadow-xl rounded-2xl p-8 mb-8">
       <h2 class="text-2xl font-bold text-base-content mb-6 text-center">
-        What benefits does joining a family bring?
+        <%= t('.what_benefits_does_joining_a_family_bring') %>
       </h2>
 
       <div class="grid md:grid-cols-2 gap-6 mb-8">
@@ -37,10 +37,10 @@
           </div>
           <div>
             <h3 class="font-semibold text-base-content mb-1">
-              Share Location Data
+              <%= t('.share_location_data') %>
             </h3>
             <p class="text-sm text-base-content opacity-70">
-              Share your location history with family members and see where they are
+              <%= t('.share_your_location_history_with_family_members_and_see_where') %>
             </p>
           </div>
         </div>
@@ -53,10 +53,10 @@
           </div>
           <div>
             <h3 class="font-semibold text-base-content mb-1">
-              Track your location history
+              <%= t('.track_your_location_history') %>
             </h3>
             <p class="text-sm text-base-content opacity-70">
-              Access interactive maps and personal travel statistics
+              <%= t('.access_interactive_maps_and_personal_travel_statistics') %>
             </p>
           </div>
         </div>
@@ -69,10 +69,10 @@
           </div>
           <div>
             <h3 class="font-semibold text-base-content mb-1">
-              Stay Connected
+              <%= t('.stay_connected') %>
             </h3>
             <p class="text-sm text-base-content opacity-70">
-              Keep track of your loved ones' travels and adventures in real-time
+              <%= t('.keep_track_of_your_loved_ones_travels_and_adventures_in') %>
             </p>
           </div>
         </div>
@@ -85,10 +85,10 @@
           </div>
           <div>
             <h3 class="font-semibold text-base-content mb-1">
-              Full Control & Privacy
+              <%= t('.full_control_privacy') %>
             </h3>
             <p class="text-sm text-base-content opacity-70">
-              You control what and how long you share and can leave the family anytime
+              <%= t('.you_control_what_and_how_long_you_share_and_can') %>
             </p>
           </div>
         </div>
@@ -96,23 +96,23 @@
 
       <!-- Invitation Details -->
       <div class="bg-base-300 rounded-lg p-6 mb-6">
-        <h3 class="text-lg font-semibold text-base-content mb-6">Invitation Details</h3>
+        <h3 class="text-lg font-semibold text-base-content mb-6"><%= t('.invitation_details') %></h3>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div class="space-y-2">
-            <div class="text-sm text-base-content opacity-60">Family:</div>
+            <div class="text-sm text-base-content opacity-60"><%= t('.family') %></div>
             <div class="text-base font-semibold text-base-content"><%= @invitation.family.name %></div>
           </div>
           <div class="space-y-2">
-            <div class="text-sm text-base-content opacity-60">Invited by:</div>
+            <div class="text-sm text-base-content opacity-60"><%= t('.invited_by') %></div>
             <div class="text-base font-semibold text-base-content"><%= @invitation.invited_by.email %></div>
           </div>
           <div class="space-y-2">
-            <div class="text-sm text-base-content opacity-60">Your email:</div>
+            <div class="text-sm text-base-content opacity-60"><%= t('.your_email_2') %></div>
             <div class="text-base font-semibold text-base-content"><%= @invitation.email %></div>
           </div>
           <div class="space-y-2">
-            <div class="text-sm text-base-content opacity-60">Expires:</div>
-            <div class="text-base font-semibold text-base-content"><%= @invitation.expires_at.strftime('%b %d, %Y') %></div>
+            <div class="text-sm text-base-content opacity-60"><%= t('.expires') %></div>
+            <div class="text-base font-semibold text-base-content"><%= l(@invitation.expires_at.to_date, format: :medium) %></div>
           </div>
         </div>
       </div>
@@ -123,7 +123,7 @@
           <div class="alert alert-warning">
             <%= icon 'triangle-alert', class: 'h-5 w-5 shrink-0' %>
             <span class="text-sm font-medium">
-              This family's plan is currently inactive. You can accept the invitation once the family owner renews it.
+              <%= t('.this_family_s_plan_is_currently_inactive_you_can_accept') %>
             </span>
           </div>
         <% elsif user_signed_in? %>
@@ -131,30 +131,30 @@
           <%= link_to accept_family_invitation_path(token: @invitation.token),
                 method: :post,
                 class: "btn btn-success btn-lg w-full text-lg shadow-lg" do %>
-            ✓ Accept Invitation & Join Family
+            <%= t('.accept_invitation_join_family') %>
           <% end %>
 
           <p class="text-sm text-base-content opacity-60 text-center">
-            Logged in as <%= current_user.email %>
+            <%= t('.logged_in_as') %> <%= current_user.email %>
             ·
             <%= link_to destroy_user_session_path, method: :delete, class: "link link-info" do %>
-              Logout
+              <%= t('.logout') %>
             <% end %>
           </p>
         <% else %>
           <!-- User is not logged in, show register button prominently -->
           <%= link_to new_user_registration_path(invitation_token: @invitation.token),
                 class: "btn btn-primary btn-lg w-full text-lg shadow-lg" do %>
-            Create Account & Join Family →
+            <%= t('.create_account_join_family') %>
           <% end %>
 
           <div class="text-center">
             <p class="text-sm text-gray-300 mb-2">
-              Already have an account?
+              <%= t('.already_have_an_account') %>
             </p>
             <%= link_to new_user_session_path(invitation_token: @invitation.token),
                   class: "link link-info font-medium" do %>
-              Sign in to accept invitation
+              <%= t('.sign_in_to_accept_invitation') %>
             <% end %>
           </div>
         <% end %>
@@ -162,7 +162,7 @@
         <!-- Decline Option -->
         <div class="pt-6 border-t border-base-300 text-center">
           <p class="text-sm text-base-content opacity-60">
-            Not interested? You can simply close this page.
+            <%= t('.not_interested_you_can_simply_close_this_page') %>
           </p>
         </div>
       </div>

--- a/app/views/family/invitations/show.html.erb
+++ b/app/views/family/invitations/show.html.erb
@@ -112,7 +112,7 @@
           </div>
           <div class="space-y-2">
             <div class="text-sm text-base-content opacity-60"><%= t('.expires') %></div>
-            <div class="text-base font-semibold text-base-content"><%= l(@invitation.expires_at.to_date, format: :medium) %></div>
+            <div class="text-base font-semibold text-base-content"><%= l(@invitation.expires_at.to_date, format: :medium_padded) %></div>
           </div>
         </div>
       </div>

--- a/app/views/family/location_requests/show.html.erb
+++ b/app/views/family/location_requests/show.html.erb
@@ -1,68 +1,68 @@
 <div class="container mx-auto max-w-lg py-8 px-4">
   <div class="card bg-base-100 shadow-xl">
     <div class="card-body">
-      <h2 class="card-title text-2xl mb-4">Location Request</h2>
+      <h2 class="card-title text-2xl mb-4"><%= t('.location_request') %></h2>
 
       <div class="space-y-4">
         <div>
-          <span class="text-sm text-base-content/60">Requested by</span>
+          <span class="text-sm text-base-content/60"><%= t('.requested_by') %></span>
           <p class="text-lg font-medium"><%= @request.requester.email %></p>
         </div>
 
         <div>
-          <span class="text-sm text-base-content/60">Requested</span>
-          <p class="text-lg"><%= time_ago_in_words(@request.created_at) %> ago</p>
+          <span class="text-sm text-base-content/60"><%= t('.requested') %></span>
+          <p class="text-lg"><%= time_ago_in_words(@request.created_at) %> <%= t('.ago') %></p>
         </div>
 
         <% if @request.pending? && @request.expires_at > Time.current %>
           <div>
-            <span class="text-sm text-base-content/60">Expires</span>
-            <p class="text-lg"><%= time_ago_in_words(@request.expires_at) %> from now</p>
+            <span class="text-sm text-base-content/60"><%= t('.expires') %></span>
+            <p class="text-lg"><%= time_ago_in_words(@request.expires_at) %> <%= t('.from_now') %></p>
           </div>
 
           <%= form_with url: accept_family_location_request_path(@request), method: :patch, class: "space-y-4 mt-6" do |f| %>
             <div class="form-control">
               <label class="label">
-                <span class="label-text">Share location for</span>
+                <span class="label-text"><%= t('.share_location_for') %></span>
               </label>
               <select name="duration" class="select select-bordered w-full">
-                <option value="1h">1 hour</option>
-                <option value="6h">6 hours</option>
-                <option value="12h">12 hours</option>
-                <option value="24h" selected>24 hours</option>
-                <option value="permanent">Permanently</option>
+                <option value="1h"><%= t('.hour') %></option>
+                <option value="6h"><%= t('.hours') %></option>
+                <option value="12h"><%= t('.hours_2') %></option>
+                <option value="24h" selected><%= t('.hours_3') %></option>
+                <option value="permanent"><%= t('.permanently') %></option>
               </select>
             </div>
 
             <div class="flex gap-3 mt-6">
-              <%= f.submit "Accept & Share Location", class: "btn btn-primary flex-1" %>
+              <%= f.submit t('.accept_share_location'), class: "btn btn-primary flex-1" %>
             </div>
           <% end %>
 
-          <%= button_to "Decline", decline_family_location_request_path(@request),
+          <%= button_to t('.decline'), decline_family_location_request_path(@request),
               method: :patch, class: "btn btn-outline btn-warning w-full mt-2" %>
         <% else %>
           <div class="mt-4">
             <% if @request.expired? || @request.expires_at <= Time.current %>
-              <div class="badge badge-error badge-lg">Expired</div>
+              <div class="badge badge-error badge-lg"><%= t('.expired') %></div>
             <% elsif @request.accepted? %>
-              <div class="badge badge-success badge-lg">Accepted</div>
+              <div class="badge badge-success badge-lg"><%= t('.accepted') %></div>
             <% elsif @request.declined? %>
-              <div class="badge badge-warning badge-lg">Declined</div>
+              <div class="badge badge-warning badge-lg"><%= t('.declined') %></div>
             <% end %>
           </div>
 
           <% if @request.responded_at.present? %>
             <div>
-              <span class="text-sm text-base-content/60">Responded</span>
-              <p><%= time_ago_in_words(@request.responded_at) %> ago</p>
+              <span class="text-sm text-base-content/60"><%= t('.responded') %></span>
+              <p><%= time_ago_in_words(@request.responded_at) %> <%= t('.ago') %></p>
             </div>
           <% end %>
         <% end %>
       </div>
 
       <div class="card-actions justify-end mt-6">
-        <%= link_to "Back to Family", family_path, class: "btn btn-ghost" %>
+        <%= link_to t('.back_to_family'), family_path, class: "btn btn-ghost" %>
       </div>
     </div>
   </div>

--- a/app/views/family_mailer/invitation.html.erb
+++ b/app/views/family_mailer/invitation.html.erb
@@ -1,48 +1,47 @@
 <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f9fafb;">
   <div style="background-color: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
-    <h2 style="color: #1f2937; margin-bottom: 20px; text-align: center;">You've been invited to join a family!</h2>
+    <h2 style="color: #1f2937; margin-bottom: 20px; text-align: center;"><%= t('.you_ve_been_invited_to_join_a_family') %></h2>
 
-    <p style="color: #374151; line-height: 1.6;">Hi there!</p>
+    <p style="color: #374151; line-height: 1.6;"><%= t('.hi_there') %></p>
 
     <p style="color: #374151; line-height: 1.6;">
-      <strong><%= @invited_by.email %></strong> has invited you to join their family
-      "<strong><%= @family.name %></strong>" on Dawarich.
+      <strong><%= @invited_by.email %></strong> <%= t('.has_invited_you_to_join_their_family') %><strong><%= @family.name %></strong><%= t('.on_dawarich') %>
     </p>
 
     <div style="background-color: #f3f4f6; padding: 20px; border-radius: 6px; margin: 20px 0;">
-      <h3 style="color: #1f2937; margin-bottom: 15px; font-size: 18px;">By joining this family, you'll be able to:</h3>
+      <h3 style="color: #1f2937; margin-bottom: 15px; font-size: 18px;"><%= t('.by_joining_this_family_you_ll_be_able_to') %></h3>
       <ul style="color: #374151; line-height: 1.6; margin: 0; padding-left: 20px;">
-        <li style="margin-bottom: 8px;">Share your current location with family members</li>
-        <li style="margin-bottom: 8px;">See the current location of other family members</li>
-        <li style="margin-bottom: 8px;">Stay connected with your loved ones</li>
-        <li>Control your privacy with full sharing controls</li>
+        <li style="margin-bottom: 8px;"><%= t('.share_your_current_location_with_family_members') %></li>
+        <li style="margin-bottom: 8px;"><%= t('.see_the_current_location_of_other_family_members') %></li>
+        <li style="margin-bottom: 8px;"><%= t('.stay_connected_with_your_loved_ones') %></li>
+        <li><%= t('.control_your_privacy_with_full_sharing_controls') %></li>
       </ul>
     </div>
 
     <div style="text-align: center; margin: 30px 0;">
-      <%= link_to "Accept Invitation", @accept_url,
+      <%= link_to t('.accept_invitation'), @accept_url,
           style: "background-color: #4f46e5; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: 600;" %>
     </div>
 
     <div style="background-color: #fef3cd; border: 1px solid #f59e0b; border-radius: 6px; padding: 15px; margin: 20px 0;">
       <p style="margin: 0; color: #92400e; font-size: 14px;">
-        <strong>⏰ Important:</strong> This invitation will expire in 7 days.
+        <strong><%= t('.important') %></strong> <%= t('.this_invitation_will_expire_in_7_days') %>
       </p>
     </div>
 
     <p style="color: #6b7280; font-size: 14px; line-height: 1.6;">
-      If you don't have a Dawarich account yet, you'll be able to create one when you accept the invitation.
+      <%= t('.if_you_don_t_have_a_dawarich_account_yet_you') %>
     </p>
 
     <p style="color: #6b7280; font-size: 14px; line-height: 1.6;">
-      If you didn't expect this invitation, you can safely ignore this email.
+      <%= t('.if_you_didn_t_expect_this_invitation_you_can_safely') %>
     </p>
 
     <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
 
     <p style="color: #6b7280; font-size: 14px; line-height: 1.6; text-align: center;">
-      Best regards,<br>
-      Evgenii from Dawarich
+      <%= t('.best_regards') %><br>
+      <%= t('.evgenii_from_dawarich') %>
     </p>
   </div>
 </div>

--- a/app/views/family_mailer/invitation.text.erb
+++ b/app/views/family_mailer/invitation.text.erb
@@ -1,22 +1,22 @@
-You've been invited to join a family!
+<%= t('.you_ve_been_invited_to_join_a_family') %>
 
-Hi there!
+<%= t('.hi_there') %>
 
-<%= @invited_by.email %> has invited you to join their family "<%= @family.name %>" on Dawarich.
+<%= @invited_by.email %> <%= t('.has_invited_you_to_join_their_family') %><%= @family.name %><%= t('.on_dawarich') %>
 
-By joining this family, you'll be able to:
-• Share your current location with family members
-• See the current location of other family members
-• Stay connected with your loved ones
-• Control your privacy with full sharing controls
+<%= t('.by_joining_this_family_you_ll_be_able_to') %>
+<%= t('.share_your_current_location_with_family_members_2') %>
+<%= t('.see_the_current_location_of_other_family_members_2') %>
+<%= t('.stay_connected_with_your_loved_ones_2') %>
+<%= t('.control_your_privacy_with_full_sharing_controls_2') %>
 
-Accept your invitation here: <%= @accept_url %>
+<%= t('.accept_your_invitation_here') %> <%= @accept_url %>
 
-IMPORTANT: This invitation will expire in 7 days.
+<%= t('.important_this_invitation_will_expire_in_7_days') %>
 
-If you don't have a Dawarich account yet, you'll be able to create one when you accept the invitation.
+<%= t('.if_you_don_t_have_a_dawarich_account_yet_you') %>
 
-If you didn't expect this invitation, you can safely ignore this email.
+<%= t('.if_you_didn_t_expect_this_invitation_you_can_safely') %>
 
-Best regards,
-Evgenii from Dawarich
+<%= t('.best_regards') %>
+<%= t('.evgenii_from_dawarich') %>

--- a/app/views/family_mailer/location_request.html.erb
+++ b/app/views/family_mailer/location_request.html.erb
@@ -1,40 +1,39 @@
 <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f9fafb;">
   <div style="background-color: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
-    <h2 style="color: #1f2937; margin-bottom: 20px; text-align: center;">Location Request</h2>
+    <h2 style="color: #1f2937; margin-bottom: 20px; text-align: center;"><%= t('.location_request') %></h2>
 
-    <p style="color: #374151; line-height: 1.6;">Hi there!</p>
+    <p style="color: #374151; line-height: 1.6;"><%= t('.hi_there') %></p>
 
     <p style="color: #374151; line-height: 1.6;">
-      <strong><%= @requester.email %></strong> is requesting your location on Dawarich.
+      <strong><%= @requester.email %></strong> <%= t('.is_requesting_your_location_on_dawarich') %>
     </p>
 
     <div style="background-color: #f3f4f6; padding: 20px; border-radius: 6px; margin: 20px 0;">
       <p style="color: #374151; margin: 0;">
-        You can review this request and choose to accept or decline it.
-        If you accept, you can select how long to share your location (1 hour, 6 hours, 12 hours, 24 hours, or permanently).
+        <%= t('.you_can_review_this_request_and_choose_to_accept_or') %>
       </p>
     </div>
 
     <div style="text-align: center; margin: 30px 0;">
-      <%= link_to "View Request", @request_url,
+      <%= link_to t('.view_request'), @request_url,
           style: "background-color: #4f46e5; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: 600;" %>
     </div>
 
     <div style="background-color: #fef3cd; border: 1px solid #f59e0b; border-radius: 6px; padding: 15px; margin: 20px 0;">
       <p style="margin: 0; color: #92400e; font-size: 14px;">
-        <strong>⏰ Important:</strong> This request will expire in 24 hours if not acted upon.
+        <strong><%= t('.important') %></strong> <%= t('.this_request_will_expire_in_24_hours_if_not_acted') %>
       </p>
     </div>
 
     <p style="color: #6b7280; font-size: 14px; line-height: 1.6;">
-      If you don't want to share your location, simply ignore this request or decline it.
+      <%= t('.if_you_don_t_want_to_share_your_location_simply') %>
     </p>
 
     <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
 
     <p style="color: #6b7280; font-size: 14px; line-height: 1.6; text-align: center;">
-      Best regards,<br>
-      Evgenii from Dawarich
+      <%= t('.best_regards') %><br>
+      <%= t('.evgenii_from_dawarich') %>
     </p>
   </div>
 </div>

--- a/app/views/family_mailer/location_request.text.erb
+++ b/app/views/family_mailer/location_request.text.erb
@@ -1,18 +1,18 @@
-Location Request
+<%= t('.location_request') %>
 ================
 
-Hi there!
+<%= t('.hi_there') %>
 
-<%= @requester.email %> is requesting your location on Dawarich.
+<%= @requester.email %> <%= t('.is_requesting_your_location_on_dawarich') %>
 
-You can review this request and choose to accept or decline it.
-If you accept, you can select how long to share your location (1 hour, 6 hours, 12 hours, 24 hours, or permanently).
+<%= t('.you_can_review_this_request_and_choose_to_accept_or_2') %>
+<%= t('.if_you_accept_you_can_select_how_long_to_share') %>
 
-View Request: <%= @request_url %>
+<%= t('.view_request_2') %> <%= @request_url %>
 
-⏰ Important: This request will expire in 24 hours if not acted upon.
+<%= t('.important_this_request_will_expire_in_24_hours_if_not_2') %>
 
-If you don't want to share your location, simply ignore this request or decline it.
+<%= t('.if_you_don_t_want_to_share_your_location_simply') %>
 
-Best regards,
-Evgenii from Dawarich
+<%= t('.best_regards') %>
+<%= t('.evgenii_from_dawarich') %>

--- a/app/views/family_mailer/member_joined.html.erb
+++ b/app/views/family_mailer/member_joined.html.erb
@@ -1,39 +1,38 @@
 <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #f9fafb;">
   <div style="background-color: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
-    <h2 style="color: #1f2937; margin-bottom: 20px; text-align: center;">🎉 Great news! Someone joined your family!</h2>
+    <h2 style="color: #1f2937; margin-bottom: 20px; text-align: center;"><%= t('.great_news_someone_joined_your_family') %></h2>
 
-    <p style="color: #374151; line-height: 1.6;">Hi <%= @family.owner.email %>!</p>
+    <p style="color: #374151; line-height: 1.6;"><%= t('.hi') %> <%= @family.owner.email %>!</p>
 
     <p style="color: #374151; line-height: 1.6;">
-      We're excited to let you know that <strong><%= @user.email %></strong> has just joined your family
-      "<strong><%= @family.name %></strong>" on Dawarich!
+      <%= t('.we_re_excited_to_let_you_know_that') %> <strong><%= @user.email %></strong> <%= t('.has_just_joined_your_family') %><strong><%= @family.name %></strong><%= t('.on_dawarich') %>
     </p>
 
     <div style="background-color: #f3f4f6; padding: 20px; border-radius: 6px; margin: 20px 0;">
-      <h3 style="color: #1f2937; margin-bottom: 15px; font-size: 18px;">Now you can:</h3>
+      <h3 style="color: #1f2937; margin-bottom: 15px; font-size: 18px;"><%= t('.now_you_can') %></h3>
       <ul style="color: #374151; line-height: 1.6; margin: 0; padding-left: 20px;">
-        <li style="margin-bottom: 8px;">See <%= @user.email %>'s current location (if they've enabled sharing)</li>
-        <li style="margin-bottom: 8px;">Stay connected with your growing family</li>
-        <li style="margin-bottom: 8px;">Share your location with <%= @user.email %></li>
-        <li>Manage family members and settings from your family page</li>
+        <li style="margin-bottom: 8px;"><%= t('.see') %> <%= @user.email %><%= t('.s_current_location_if_they_ve_enabled_sharing') %></li>
+        <li style="margin-bottom: 8px;"><%= t('.stay_connected_with_your_growing_family') %></li>
+        <li style="margin-bottom: 8px;"><%= t('.share_your_location_with') %> <%= @user.email %></li>
+        <li><%= t('.manage_family_members_and_settings_from_your_family_page') %></li>
       </ul>
     </div>
 
     <div style="background-color: #dbeafe; border: 1px solid #3b82f6; border-radius: 6px; padding: 15px; margin: 20px 0;">
       <p style="margin: 0; color: #1e40af; font-size: 14px;">
-        <strong>💡 Tip:</strong> You can manage your family members and privacy settings at any time from your family dashboard.
+        <strong><%= t('.tip') %></strong> <%= t('.you_can_manage_your_family_members_and_privacy_settings_at') %>
       </p>
     </div>
 
     <p style="color: #374151; line-height: 1.6;">
-      Your family now has <strong><%= @family.member_count %></strong> member<%= @family.member_count == 1 ? '' : 's' %>.
+      <%= t('.your_family_now_has') %> <strong><%= @family.member_count %></strong> <%= t('.member') %><%= @family.member_count == 1 ? '' : 's' %>.
     </p>
 
     <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">
 
     <p style="color: #6b7280; font-size: 14px; line-height: 1.6; text-align: center;">
-      Best regards,<br>
-      Evgenii from Dawarich
+      <%= t('.best_regards') %><br>
+      <%= t('.evgenii_from_dawarich') %>
     </p>
   </div>
 </div>

--- a/app/views/family_mailer/member_joined.text.erb
+++ b/app/views/family_mailer/member_joined.text.erb
@@ -1,18 +1,18 @@
-Great news! Someone joined your family!
+<%= t('.great_news_someone_joined_your_family_2') %>
 
-Hi <%= @family.owner.email %>!
+<%= t('.hi') %> <%= @family.owner.email %>!
 
-We're excited to let you know that <%= @user.email %> has just joined your family "<%= @family.name %>" on Dawarich!
+<%= t('.we_re_excited_to_let_you_know_that') %> <%= @user.email %> <%= t('.has_just_joined_your_family') %><%= @family.name %><%= t('.on_dawarich') %>
 
-Now you can:
-• See <%= @user.email %>'s current location (if they've enabled sharing)
-• Stay connected with your growing family
-• Share your location with <%= @user.email %>
-• Manage family members and settings from your family page
+<%= t('.now_you_can') %>
+<%= t('.see_2') %> <%= @user.email %><%= t('.s_current_location_if_they_ve_enabled_sharing') %>
+<%= t('.stay_connected_with_your_growing_family_2') %>
+<%= t('.share_your_location_with_2') %> <%= @user.email %>
+<%= t('.manage_family_members_and_settings_from_your_family_page_2') %>
 
-TIP: You can manage your family members and privacy settings at any time from your family dashboard.
+<%= t('.tip_you_can_manage_your_family_members_and_privacy_settings') %>
 
-Your family now has <%= @family.member_count %> member<%= @family.member_count == 1 ? '' : 's' %>.
+<%= t('.your_family_now_has') %> <%= @family.member_count %> <%= t('.member') %><%= @family.member_count == 1 ? '' : 's' %>.
 
-Best regards,
-Evgenii from Dawarich
+<%= t('.best_regards') %>
+<%= t('.evgenii_from_dawarich') %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,15 +4,15 @@
       <div class="hero-content text-center">
         <div class="max-w-md">
           <h1 class="text-5xl font-bold">
-            <a href="https://dawarich.app" class='link'>Dawarich</a>
+            <a href="https://dawarich.app" class='link'><%= t('.dawarich') %></a>
           </h1>
-          <p class="py-6 text-3xl">The only location history tracker you'll ever need.</p>
+          <p class="py-6 text-3xl"><%= t('.the_only_location_history_tracker_you_ll_ever_need') %></p>
 
           <% if email_password_registration_enabled? %>
-            <%= link_to 'Sign up', new_user_registration_path, class: "rounded-lg py-3 px-5 my-3 bg-blue-600 text-white block font-medium" %>
-            <div class="divider">or</div>
+            <%= link_to t('.sign_up'), new_user_registration_path, class: "rounded-lg py-3 px-5 my-3 bg-blue-600 text-white block font-medium" %>
+            <div class="divider"><%= t('.or') %></div>
           <% end %>
-          <%= link_to 'Sign in', new_user_session_path, class: "rounded-lg py-3 px-5 bg-neutral text-neutral-content block font-medium" %>
+          <%= link_to t('.sign_in'), new_user_session_path, class: "rounded-lg py-3 px-5 bg-neutral text-neutral-content block font-medium" %>
         </div>
       </div>
     </div>
@@ -20,27 +20,27 @@
   <div class="grid grid-cols-1 gap-4 m-auto justify-center md:grid-cols-2 xl:grid-cols-3">
     <div class="card w-full max-w-sm bg-base-100 justify-self-center shadow-xl">
       <div class="card-body">
-        <h2 class="card-title mx-auto">Location history visualisation</h2>
-        <p class='text-center'>Effortlessly import your location history from Google Maps Timeline and Owntracks. View your journeys on an interactive map, complete with customizable layers like heatmaps, points, and connecting lines to visualize your travels.</p>
+        <h2 class="card-title mx-auto"><%= t('.location_history_visualisation') %></h2>
+        <p class='text-center'><%= t('.effortlessly_import_your_location_history_from_google_maps_timeline_and') %></p>
       </div>
     </div>
 
     <div class="card w-full max-w-sm bg-base-100 justify-self-center shadow-xl">
       <div class="card-body">
-        <h2 class="card-title mx-auto">Comprehensive Travel Statistics</h2>
-        <p class='text-center'>Gain insights into your travel patterns with detailed statistics. Track the number of countries and cities visited and total distance traveled. Split your data by years and months for a clear overview of your journeys.</p>
+        <h2 class="card-title mx-auto"><%= t('.comprehensive_travel_statistics') %></h2>
+        <p class='text-center'><%= t('.gain_insights_into_your_travel_patterns_with_detailed_statistics_track') %></p>
       </div>
     </div>
 
     <div class="card w-full max-w-sm bg-base-100 justify-self-center shadow-xl md:col-span-2 xl:col-span-1">
       <div class="card-body">
-        <h2 class="card-title mx-auto">Self-Hosted and Private</h2>
-        <p class='text-center'>Maintain complete control over your data with our self-hosted solution. Dawarich ensures your location history remains private and secure, giving you peace of mind while enjoying the full functionality of a robust tracking system.</p>
+        <h2 class="card-title mx-auto"><%= t('.self_hosted_and_private') %></h2>
+        <p class='text-center'><%= t('.maintain_complete_control_over_your_data_with_our_self_hosted') %></p>
       </div>
     </div>
   </div>
 
   <div class='text-center my-10'>
-    Find more on <a href="https://dawarich.app" class='link'>the website</a>, or check out the <a href="https://github.com/Freika/dawarich" class='link'>source code</a> on GitHub.
+    <%= t('.find_more_on') %> <a href="https://dawarich.app" class='link'><%= t('.the_website') %></a><%= t('.or_check_out_the') %> <a href="https://github.com/Freika/dawarich" class='link'><%= t('.source_code') %></a> <%= t('.on_github') %>
   </div>
 </div>

--- a/app/views/imports/_extraction_card.html.erb
+++ b/app/views/imports/_extraction_card.html.erb
@@ -3,72 +3,70 @@
     <div class="card-body">
       <div class="flex items-center gap-2 mb-2">
         <%= icon 'layer', class: 'w-5 h-5 text-base-content/60' %>
-        <h3 class="text-lg font-semibold">Additional data</h3>
+        <h3 class="text-lg font-semibold"><%= t('.additional_data') %></h3>
         <%= extraction_status_badge(import) %>
       </div>
 
       <% if import.additional_data_extraction_unsupported? %>
         <p class="text-sm text-base-content/70">
-          This import format doesn't carry visits, named places, or transportation modes,
-          so there's nothing additional to extract.
+          <%= t('.this_import_format_doesn_t_carry_visits_named_places_or') %>
         </p>
       <% elsif import.additional_data_extraction_completed? %>
         <% counts = import.extraction_counts %>
         <p class="text-sm text-base-content/70 mb-4">
-          Extracted
-          <strong><%= counts[:visits] || 0 %></strong> visits,
-          <strong><%= counts[:places] || 0 %></strong> places,
-          <strong><%= counts[:tracks] || 0 %></strong> tracks,
-          <strong><%= counts[:segments] || 0 %></strong> transportation-mode segments.
+          <%= t('.extracted') %>
+          <strong><%= counts[:visits] || 0 %></strong> <%= t('.visits') %>
+          <strong><%= counts[:places] || 0 %></strong> <%= t('.places') %>
+          <strong><%= counts[:tracks] || 0 %></strong> <%= t('.tracks') %>
+          <strong><%= counts[:segments] || 0 %></strong> <%= t('.transportation_mode_segments') %>
         </p>
         <div class="flex flex-wrap gap-2">
           <button class="btn btn-sm btn-outline"
                   data-action="click->import-extraction#open"
                   data-import-extraction-dialog-id-param="extraction-dialog-<%= import.id %>">
-            Re-extract
+            <%= t('.re_extract') %>
           </button>
           <%= render 'imports/extraction_remove_button', import: import %>
         </div>
       <% elsif import.additional_data_extraction_running? || import.additional_data_extraction_pending? %>
         <% if import.extraction_stalled? %>
           <p class="text-sm text-warning mb-2">
-            This extraction stopped responding. It's safe to start it again.
+            <%= t('.this_extraction_stopped_responding_it_s_safe_to_start_it') %>
           </p>
           <div class="flex flex-wrap gap-2">
             <button class="btn btn-sm btn-outline"
                     data-action="click->import-extraction#open"
                     data-import-extraction-dialog-id-param="extraction-dialog-<%= import.id %>">
-              Start over
+              <%= t('.start_over') %>
             </button>
             <%= render 'imports/extraction_remove_button', import: import %>
           </div>
         <% else %>
           <p class="text-sm text-base-content/70 flex items-center gap-2">
             <span class="loading loading-dots loading-sm shrink-0"></span>
-            <%= import.additional_data_extraction_running? ? 'Extracting…' : 'Queued…' %>
+            <%= import.additional_data_extraction_running? ? t('.extracting') : t('.queued') %>
           </p>
         <% end %>
       <% elsif import.additional_data_extraction_failed? %>
         <p class="text-sm text-error mb-2">
-          Extraction failed: <%= import.extraction_error_message %>
+          <%= t('.extraction_failed') %> <%= import.extraction_error_message %>
         </p>
         <div class="flex flex-wrap gap-2">
           <button class="btn btn-sm btn-outline"
                   data-action="click->import-extraction#open"
                   data-import-extraction-dialog-id-param="extraction-dialog-<%= import.id %>">
-            Retry extraction
+            <%= t('.retry_extraction') %>
           </button>
           <%= render 'imports/extraction_remove_button', import: import %>
         </div>
       <% else %>
         <p class="text-sm text-base-content/70 mb-4">
-          Dawarich originally imported your file as raw GPS points. Click below to also
-          extract visits, places, tracks, and transportation modes.
+          <%= t('.dawarich_originally_imported_your_file_as_raw_gps_points_click') %>
         </p>
         <button class="btn btn-sm btn-primary"
                 data-action="click->import-extraction#open"
                 data-import-extraction-dialog-id-param="extraction-dialog-<%= import.id %>">
-          Extract additional data
+          <%= t('.extract_additional_data') %>
         </button>
       <% end %>
     </div>

--- a/app/views/imports/_extraction_dialog.html.erb
+++ b/app/views/imports/_extraction_dialog.html.erb
@@ -1,19 +1,18 @@
 <dialog id="extraction-dialog-<%= import.id %>" class="modal">
   <div class="modal-box max-w-xl">
-    <h3 class="font-bold text-lg">Extract additional data from this import</h3>
+    <h3 class="font-bold text-lg"><%= t('.extract_additional_data_from_this_import') %></h3>
 
     <div class="prose prose-sm mt-4 text-base-content/80">
       <p>
-        Dawarich originally imported your file as raw GPS points. The file also contains:
+        <%= t('.dawarich_originally_imported_your_file_as_raw_gps_points_the') %>
       </p>
       <ul>
-        <li><strong>Visits</strong> — places where the source app recorded you spending time, with start and end times.</li>
-        <li><strong>Tracks</strong> — journeys identified between those visits, with their classified transportation mode (driving, walking, cycling, transit, …).</li>
-        <li><strong>Places</strong> — the named places (home, work, frequent restaurants) the source app associated with your visits.</li>
+        <li><strong><%= t('.visits') %></strong> <%= t('.places_where_the_source_app_recorded_you_spending_time_with') %></li>
+        <li><strong><%= t('.tracks') %></strong> <%= t('.journeys_identified_between_those_visits_with_their_classified_transport') %></li>
+        <li><strong><%= t('.places') %></strong> <%= t('.the_named_places_home_work_frequent_restaurants_the_source_app') %></li>
       </ul>
       <p>
-        Click <strong>Extract</strong> to add this data to your Dawarich account. Existing points are not modified.
-        Visits and places already detected from your points by Dawarich are kept side-by-side with the imported ones.
+        <%= t('.click') %> <strong><%= t('.extract') %></strong> <%= t('.to_add_this_data_to_your_dawarich_account_existing_points') %>
       </p>
     </div>
 
@@ -22,10 +21,9 @@
         <label class="label cursor-pointer justify-start gap-3">
           <%= f.check_box :trust_source, { checked: true, class: 'checkbox checkbox-primary' }, 'true', 'false' %>
           <div>
-            <div class="label-text font-medium">Trust the source app's classification</div>
+            <div class="label-text font-medium"><%= t('.trust_the_source_app_s_classification') %></div>
             <div class="label-text-alt text-base-content/60">
-              When checked, transportation modes (driving, walking, cycling, transit) the source app
-              assigned are kept as-is. When unchecked, Dawarich re-runs its own detector using your settings.
+              <%= t('.when_checked_transportation_modes_driving_walking_cycling_transit_the_so') %>
             </div>
           </div>
         </label>
@@ -35,11 +33,11 @@
         <button type="button" class="btn btn-ghost"
                 data-action="click->import-extraction#close"
                 data-import-extraction-dialog-id-param="extraction-dialog-<%= import.id %>">
-          Cancel
+          <%= t('.cancel') %>
         </button>
-        <%= f.submit 'Extract', class: 'btn btn-primary' %>
+        <%= f.submit t('.extract'), class: 'btn btn-primary' %>
       </div>
     <% end %>
   </div>
-  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+  <form method="dialog" class="modal-backdrop"><button><%= t('.close') %></button></form>
 </dialog>

--- a/app/views/imports/_extraction_remove_button.html.erb
+++ b/app/views/imports/_extraction_remove_button.html.erb
@@ -1,5 +1,5 @@
-<%= button_to 'Remove extracted data',
+<%= button_to t('.remove_extracted_data'),
               import_extraction_path(import),
               method: :delete,
               class: 'btn btn-sm btn-ghost text-error',
-              form: { data: { turbo_confirm: 'Remove the visits, places and tracks this extraction created? Your imported GPS points are kept.' } } %>
+              form: { data: { turbo_confirm: t('.remove_the_visits_places_and_tracks_this_extraction_created_your') } } %>

--- a/app/views/imports/_form.html.erb
+++ b/app/views/imports/_form.html.erb
@@ -1,32 +1,32 @@
 <%# Supported Formats Info Card %>
 <div class="card bg-base-200 w-full max-w-md mb-5 mt-5">
   <div class="card-body p-4">
-    <h3 class="card-title text-sm">Supported Import Formats</h3>
+    <h3 class="card-title text-sm"><%= t('.supported_import_formats') %></h3>
     <ul class="text-xs space-y-1.5">
-      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>Google Maps:</strong> Records.json, Semantic History, Phone Takeout (.json)</li>
-      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>Google Photos:</strong> Takeout metadata sidecars (.json)</li>
-      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>GPX:</strong> Track files (.gpx)</li>
-      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>GeoJSON:</strong> Feature collections (.json, .geojson)</li>
-      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>OwnTracks:</strong> Recorder files (.rec)</li>
-      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>KML:</strong> KML files (.kml, .kmz)</li>
-      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>FIT:</strong> Garmin activity files (.fit)</li>
-      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>TCX:</strong> Training Center files (.tcx)</li>
-      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>CSV:</strong> Location data (.csv)</li>
-      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>Polarsteps:</strong> locations.json (.json)</li>
-      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong>ZIP:</strong> Archives containing any of the above (.zip)</li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong><%= t('.google_maps') %></strong> <%= t('.records_json_semantic_history_phone_takeout_json') %></li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong><%= t('.google_photos') %></strong> <%= t('.takeout_metadata_sidecars_json') %></li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong><%= t('.gpx') %></strong> <%= t('.track_files_gpx') %></li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong><%= t('.geojson') %></strong> <%= t('.feature_collections_json_geojson') %></li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong><%= t('.owntracks') %></strong> <%= t('.recorder_files_rec') %></li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong><%= t('.kml') %></strong> <%= t('.kml_files_kml_kmz') %></li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong><%= t('.fit') %></strong> <%= t('.garmin_activity_files_fit') %></li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong><%= t('.tcx') %></strong> <%= t('.training_center_files_tcx') %></li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong><%= t('.csv') %></strong> <%= t('.location_data_csv') %></li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong><%= t('.polarsteps') %></strong> <%= t('.locations_json_json') %></li>
+      <li class="flex items-center gap-1.5"><%= icon 'circle-check', class: 'w-3.5 h-3.5 text-success shrink-0' %> <strong><%= t('.zip') %></strong> <%= t('.archives_containing_any_of_the_above_zip') %></li>
     </ul>
     <div class="text-xs text-base-content/50 mt-2">
-      File format is automatically detected during upload.
+      <%= t('.file_format_is_automatically_detected_during_upload') %>
     </div>
     <div class="flex items-start gap-2 text-xs text-info mt-2">
       <%= icon 'info', class: 'w-3.5 h-3.5 shrink-0 mt-0.5' %>
-      <span>For files larger than 200MB, consider compressing them into a ZIP archive before uploading. This significantly reduces upload time and avoids connection timeouts.</span>
+      <span><%= t('.for_files_larger_than_200mb_consider_compressing_them_into_a') %></span>
     </div>
     <% if current_user.legacy_trial? %>
       <div class="text-xs text-warning mt-2 font-medium">
-        Trial limitations: Max 5 imports, 10MB per file.
+        <%= t('.trial_limitations_max_5_imports_10mb_per_file') %>
         <br>
-        Current imports: <%= current_user.imports.count %>/5
+        <%= t('.current_imports') %> <%= current_user.imports.count %>/5
       </div>
     <% end %>
   </div>
@@ -44,7 +44,7 @@
 } do |form| %>
   <label class="form-control w-full max-w-xs my-5">
     <div class="label">
-      <span class="label-text">Select one or multiple files</span>
+      <span class="label-text"><%= t('.select_one_or_multiple_files') %></span>
     </div>
     <%= form.file_field :files,
         multiple: true,
@@ -53,7 +53,7 @@
         class: "file-input file-input-bordered w-full max-w-xs",
         data: { upload_target: "input" } %>
     <div class="text-sm text-gray-500 mt-2">
-      Files will be uploaded directly to storage. Please be patient during upload.
+      <%= t('.files_will_be_uploaded_directly_to_storage_please_be_patient') %>
     </div>
   </label>
 

--- a/app/views/imports/_import.html.erb
+++ b/app/views/imports/_import.html.erb
@@ -2,9 +2,9 @@
   <table class="table">
     <thead>
       <tr>
-        <th>Name</th>
-        <th>Imported points</th>
-        <th>Created at</th>
+        <th><%= t('.name') %></th>
+        <th><%= t('.imported_points') %></th>
+        <th><%= t('.created_at') %></th>
       </tr>
     </thead>
     <tbody>
@@ -21,8 +21,8 @@
   </table>
 
   <% if action_name != "show" %>
-    <%= link_to "Show this import", import, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-    <%= link_to "Edit this import", edit_import_path(import), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to t('.show_this_import'), import, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to t('.edit_this_import'), edit_import_path(import), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
     <hr class="mt-6">
   <% end %>
 </div>

--- a/app/views/imports/_table_row.html.erb
+++ b/app/views/imports/_table_row.html.erb
@@ -11,20 +11,20 @@
         <div class="font-medium">
           <%= link_to import.name, import, class: 'link link-hover' %>
           <% if import.demo? %>
-            <span class="badge badge-accent badge-sm ml-1">Demo</span>
+            <span class="badge badge-accent badge-sm ml-1"><%= t('.demo') %></span>
           <% end %>
         </div>
-        <div class="text-xs text-base-content/50"><%= import.source&.humanize %></div>
+        <div class="text-xs text-base-content/50"><%= t("enums.import.source.#{import.source}") if import.source %></div>
       </div>
     </div>
   </td>
-  <td class="px-4 py-3 text-sm"><%= number_to_human_size(import.file&.byte_size) || 'N/A' %></td>
+  <td class="px-4 py-3 text-sm"><%= number_to_human_size(import.file&.byte_size) || t('common.not_available') %></td>
   <td class="px-4 py-3 text-right tabular-nums font-medium" data-points-count>
     <%= number_with_delimiter import.processed %>
     <% if import.doubles.to_i.positive? %>
       <div class="text-xs font-normal text-base-content/60 mt-0.5"
-           title="Points at coordinates and timestamps that already exist in your timeline were skipped to avoid duplicates.">
-        <%= number_with_delimiter(import.doubles) %> already imported
+           title="<%= t('.points_at_coordinates_and_timestamps_that_already_exist_in_your') %>">
+        <%= number_with_delimiter(import.doubles) %> <%= t('.already_imported') %>
       </div>
     <% end %>
   </td>
@@ -41,34 +41,34 @@
     <div class="flex items-center gap-1 justify-end">
       <% if import.deleting? && import.updated_at > 1.hour.ago %>
         <span class="loading loading-spinner loading-sm"></span>
-        <span class="text-xs text-base-content/50">Deleting...</span>
+        <span class="text-xs text-base-content/50"><%= t('.deleting') %></span>
       <% elsif import.deleting? %>
-        <span class="text-xs text-base-content/50">Deletion stalled</span>
-        <div class="tooltip tooltip-left" data-tip="Retry deletion">
-          <%= link_to import, data: { turbo_confirm: "Are you sure?", turbo_method: :delete }, class: "btn btn-ghost btn-xs text-error hover:bg-error/10" do %>
+        <span class="text-xs text-base-content/50"><%= t('.deletion_stalled') %></span>
+        <div class="tooltip tooltip-left" data-tip="<%= t('.retry_deletion') %>">
+          <%= link_to import, data: { turbo_confirm: t('.are_you_sure'), turbo_method: :delete }, class: "btn btn-ghost btn-xs text-error hover:bg-error/10" do %>
             <%= icon 'trash-2', class: 'w-4 h-4' %>
           <% end %>
         </div>
       <% else %>
-        <div class="tooltip" data-tip="View on map">
+        <div class="tooltip" data-tip="<%= t('.view_on_map') %>">
           <%= link_to preferred_map_path(import_id: import.id), class: 'btn btn-ghost btn-xs' do %>
             <%= icon 'map', class: 'w-4 h-4' %>
           <% end %>
         </div>
-        <div class="tooltip" data-tip="View points">
+        <div class="tooltip" data-tip="<%= t('.view_points') %>">
           <%= link_to points_path(import_id: import.id), class: 'btn btn-ghost btn-xs' do %>
             <%= icon 'grid-3x3', class: 'w-4 h-4' %>
           <% end %>
         </div>
         <% if import.file.present? %>
-          <div class="tooltip" data-tip="Download file">
+          <div class="tooltip" data-tip="<%= t('.download_file') %>">
             <%= link_to rails_blob_path(import.file, disposition: 'attachment'), class: "btn btn-ghost btn-xs", download: import.name do %>
               <%= icon 'arrow-big-down', class: 'w-4 h-4' %>
             <% end %>
           </div>
         <% end %>
-        <div class="tooltip tooltip-left" data-tip="Delete import">
-          <%= link_to import, data: { turbo_confirm: "Are you sure?", turbo_method: :delete }, class: "btn btn-ghost btn-xs text-error hover:bg-error/10" do %>
+        <div class="tooltip tooltip-left" data-tip="<%= t('.delete_import') %>">
+          <%= link_to import, data: { turbo_confirm: t('.are_you_sure'), turbo_method: :delete }, class: "btn btn-ghost btn-xs text-error hover:bg-error/10" do %>
             <%= icon 'trash-2', class: 'w-4 h-4' %>
           <% end %>
         </div>

--- a/app/views/imports/edit.html.erb
+++ b/app/views/imports/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl">Editing import</h1>
+  <h1 class="font-bold text-4xl"><%= t('.editing_import') %></h1>
 
   <%= form_with model: @import, class: 'form-body mt-4' do |form| %>
     <div class="form-control">
@@ -9,12 +9,12 @@
 
     <div class="form-control">
       <%= form.label :source %>
-      <%= form.select :source, options_for_select(Import.sources.keys.map { |source| [source.humanize, source] }, @import.source), {}, class: 'select select-bordered' %>
+      <%= form.select :source, options_for_select(Import.sources.keys.map { |source| [t("enums.import.source.#{source}"), source] }, @import.source), {}, class: 'select select-bordered' %>
     </div>
 
     <div class='my-4'>
       <%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
-      <%= link_to "Back to imports", imports_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+      <%= link_to t('.back_to_imports'), imports_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
     </div>
   <% end %>
 </div>

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -1,15 +1,15 @@
-<% content_for :title, 'Imports' %>
+<% content_for :title, t('.imports') %>
 
 <div class="w-full my-5">
   <% has_immich = current_user.safe_settings.immich_url.present? && current_user.safe_settings.immich_api_key.present? %>
   <% has_photoprism = current_user.safe_settings.photoprism_url.present? && current_user.safe_settings.photoprism_api_key.present? %>
   <% has_integrations = has_immich || has_photoprism %>
 
-  <%= render layout: 'shared/page_header', locals: { title: 'Imports' } do %>
+  <%= render layout: 'shared/page_header', locals: { title: t('.imports') } do %>
     <% if has_integrations %>
       <div class="join">
         <%= link_to new_import_path, class: "btn btn-primary btn-sm join-item" do %>
-          <%= icon 'circle-plus', class: 'w-4 h-4' %> New import
+          <%= icon 'circle-plus', class: 'w-4 h-4' %> <%= t('.new_import') %>
         <% end %>
         <div class="dropdown dropdown-end">
           <label tabindex="0" class="btn btn-primary btn-sm join-item">
@@ -18,15 +18,15 @@
           <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-lg w-52 mt-1 border border-base-300">
             <% if has_immich %>
               <li>
-                <%= link_to settings_background_jobs_path(job_name: 'start_immich_import'), data: { turbo_confirm: 'Are you sure?', turbo_method: :post } do %>
-                  <%= icon 'camera', class: 'w-4 h-4' %> Import from Immich
+                <%= link_to settings_background_jobs_path(job_name: 'start_immich_import'), data: { turbo_confirm: t('.are_you_sure'), turbo_method: :post } do %>
+                  <%= icon 'camera', class: 'w-4 h-4' %> <%= t('.import_from_immich') %>
                 <% end %>
               </li>
             <% end %>
             <% if has_photoprism %>
               <li>
-                <%= link_to settings_background_jobs_path(job_name: 'start_photoprism_import'), data: { turbo_confirm: 'Are you sure?', turbo_method: :post } do %>
-                  <%= icon 'camera', class: 'w-4 h-4' %> Import from Photoprism
+                <%= link_to settings_background_jobs_path(job_name: 'start_photoprism_import'), data: { turbo_confirm: t('.are_you_sure'), turbo_method: :post } do %>
+                  <%= icon 'camera', class: 'w-4 h-4' %> <%= t('.import_from_photoprism') %>
                 <% end %>
               </li>
             <% end %>
@@ -35,7 +35,7 @@
       </div>
     <% else %>
       <%= link_to new_import_path, class: "btn btn-primary btn-sm" do %>
-        <%= icon 'circle-plus', class: 'w-4 h-4' %> New import
+        <%= icon 'circle-plus', class: 'w-4 h-4' %> <%= t('.new_import') %>
       <% end %>
     <% end %>
   <% end %>
@@ -44,12 +44,12 @@
   <div id="imports" class="min-w-full">
     <% if @imports.empty? %>
       <div class="text-center py-16 px-8 bg-base-200 rounded-xl border-2 border-dashed border-base-300">
-        <h3 class="text-xl font-bold mb-3">No imports yet</h3>
+        <h3 class="text-xl font-bold mb-3"><%= t('.no_imports_yet') %></h3>
         <p class="text-base-content/50 mb-6 max-w-sm mx-auto">
-          Import your location data from Google Maps Timeline, GPX files, OwnTracks, or other sources to start tracking.
+          <%= t('.import_your_location_data_from_google_maps_timeline_gpx_files') %>
         </p>
         <%= link_to new_import_path, class: 'btn btn-primary' do %>
-          <%= icon 'circle-plus', class: 'w-4 h-4' %> Create your first import
+          <%= icon 'circle-plus', class: 'w-4 h-4' %> <%= t('.create_your_first_import') %>
         <% end %>
       </div>
     <% else %>
@@ -60,12 +60,12 @@
         <table class="table w-full">
           <thead class="bg-base-200">
             <tr>
-              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-auto"><%= sortable_column 'Name', :name, :imports_path %></th>
+              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-auto"><%= sortable_column t('.name'), :name, :imports_path %></th>
               <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[10%]"><%= sortable_column 'File size', :byte_size, :imports_path %></th>
-              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 text-right w-[10%]"><%= sortable_column 'Points', :processed, :imports_path %></th>
-              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[12%]"><%= sortable_column 'Status', :status, :imports_path %></th>
-              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[18%]"><%= sortable_column 'Created', :created_at, :imports_path %></th>
-              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 text-right w-[15%]">Actions</th>
+              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 text-right w-[10%]"><%= sortable_column t('.points'), :processed, :imports_path %></th>
+              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[12%]"><%= sortable_column t('.status'), :status, :imports_path %></th>
+              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-[18%]"><%= sortable_column t('.created'), :created_at, :imports_path %></th>
+              <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 text-right w-[15%]"><%= t('.actions') %></th>
             </tr>
           </thead>
           <tbody

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, 'New Import' %>
+<% content_for :title, t('.new_import_2') %>
 
 <div class="mx-auto md:w-2/3 w-full my-5">
-  <%= render layout: 'shared/page_header', locals: { title: 'New import' } do %>
+  <%= render layout: 'shared/page_header', locals: { title: t('.new_import') } do %>
     <%= link_to imports_path, class: "btn btn-sm" do %>
-      <%= icon 'arrow-left', class: 'w-4 h-4' %> Back to imports
+      <%= icon 'arrow-left', class: 'w-4 h-4' %> <%= t('.back_to_imports') %>
     <% end %>
   <% end %>
 
@@ -11,9 +11,9 @@
     <div class="alert alert-info my-4">
       <%= icon 'scissors', class: 'w-5 h-5 shrink-0' %>
       <span>
-        Google Timeline file too large?
-        <%= link_to 'Split it with our free private tool', 'https://dawarich.app/tools/google-timeline-splitter?utm_source=dawarich&utm_medium=import_page&utm_campaign=trial_banner',
-            target: '_blank', rel: 'noopener', class: 'link link-primary font-semibold' %> — your data never leaves your browser.
+        <%= t('.google_timeline_file_too_large') %>
+        <%= link_to t('.split_it_with_our_free_private_tool'), 'https://dawarich.app/tools/google-timeline-splitter?utm_source=dawarich&utm_medium=import_page&utm_campaign=trial_banner',
+            target: '_blank', rel: 'noopener', class: 'link link-primary font-semibold' %> <%= t('.your_data_never_leaves_your_browser') %>
       </span>
     </div>
   <% end %>

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Import' %>
+<% content_for :title, t('.import') %>
 
 <div class="mx-auto md:w-2/3 w-full flex">
   <div class="mx-auto">
@@ -11,10 +11,10 @@
     <%= turbo_stream_from "import_#{@import.id}_extraction" %>
     <%= render 'imports/extraction_card', import: @import %>
 
-    <%= link_to "Edit this import", edit_import_path(@import), class: "mt-2 rounded-lg py-3 px-5 bg-secondary-content inline-block font-medium" %>
+    <%= link_to t('.edit_this_import'), edit_import_path(@import), class: "mt-2 rounded-lg py-3 px-5 bg-secondary-content inline-block font-medium" %>
     <div class="inline-block ml-2">
-      <%= link_to "Destroy this import", import_path(@import), data: { turbo_confirm: "Are you sure? This action will delete all points imported with this file", turbo_method: :delete }, class: "mt-2 rounded-lg py-3 px-5 bg-secondary-content font-medium" %>
+      <%= link_to t('.destroy_this_import'), import_path(@import), data: { turbo_confirm: t('.are_you_sure_this_action_will_delete_all_points_imported'), turbo_method: :delete }, class: "mt-2 rounded-lg py-3 px-5 bg-secondary-content font-medium" %>
     </div>
-    <%= link_to "Back to imports", imports_path, class: "ml-2 rounded-lg py-3 px-5 bg-secondary-content inline-block font-medium" %>
+    <%= link_to t('.back_to_imports'), imports_path, class: "ml-2 rounded-lg py-3 px-5 bg-secondary-content inline-block font-medium" %>
   </div>
 </div>

--- a/app/views/insights/_activity_breakdown.html.erb
+++ b/app/views/insights/_activity_breakdown.html.erb
@@ -3,22 +3,22 @@
   <div class="card-body p-5">
     <h2 class="card-title text-lg flex items-center gap-2">
       <%= icon 'activity', class: 'w-5 h-5 text-primary' %>
-      Activity Breakdown
+      <%= t('.activity_breakdown') %>
     </h2>
 
     <div class="space-y-3 mt-3">
       <%
         activity_config = {
-          'driving' => { icon: 'car', label: 'Driving' },
-          'walking' => { icon: 'footprints', label: 'Walking' },
-          'stationary' => { icon: 'user', label: 'Stationary' },
-          'cycling' => { icon: 'bike', label: 'Cycling' },
-          'flying' => { icon: 'plane', label: 'Flying' },
-          'train' => { icon: 'train-front', label: 'Train' },
-          'running' => { icon: 'line-squiggle', label: 'Running' },
-          'bus' => { icon: 'bus', label: 'Bus' },
-          'boat' => { icon: 'ship', label: 'Boat' },
-          'motorcycle' => { icon: 'bike', label: 'Motorcycle' }
+          'driving' => { icon: 'car', label: t('.driving') },
+          'walking' => { icon: 'footprints', label: t('.walking') },
+          'stationary' => { icon: 'user', label: t('.stationary') },
+          'cycling' => { icon: 'bike', label: t('.cycling') },
+          'flying' => { icon: 'plane', label: t('.flying') },
+          'train' => { icon: 'train-front', label: t('.train') },
+          'running' => { icon: 'line-squiggle', label: t('.running') },
+          'bus' => { icon: 'bus', label: t('.bus') },
+          'boat' => { icon: 'ship', label: t('.boat') },
+          'motorcycle' => { icon: 'bike', label: t('.motorcycle') }
         }
 
         sorted_activities = @activity_breakdown
@@ -28,11 +28,11 @@
 
       <% if sorted_activities.empty? %>
         <div class="text-sm text-base-content/60 text-center py-4">
-          No activity data available for this period
+          <%= t('.no_activity_data_available_for_this_period') %>
         </div>
       <% else %>
         <% sorted_activities.each do |mode, data| %>
-          <% config = activity_config[mode] || { icon: 'circle', label: mode.humanize } %>
+          <% config = activity_config[mode] || { icon: 'circle', label: t("transportation_modes.#{mode}", default: t('transportation_modes.unknown')) } %>
           <div class="flex items-center gap-3">
             <div class="w-6 flex justify-center text-base-content/70">
               <%= icon config[:icon], class: 'w-4 h-4' %>

--- a/app/views/insights/_activity_heatmap.html.erb
+++ b/app/views/insights/_activity_heatmap.html.erb
@@ -6,10 +6,10 @@
       <div class="flex justify-between items-center mb-4">
         <div class="flex items-center gap-2">
           <%= icon 'calendar', class: 'w-5 h-5 text-base-content/60' %>
-          <h3 class="text-lg font-semibold">Activity Overview</h3>
+          <h3 class="text-lg font-semibold"><%= t('.activity_overview') %></h3>
         </div>
         <div class="badge badge-ghost">
-          <%= @activity_heatmap.active_days %> active days
+          <%= @activity_heatmap.active_days %> <%= t('.active_days') %>
         </div>
       </div>
 
@@ -32,7 +32,7 @@
           <div class="flex">
             <!-- Day labels -->
             <div class="flex flex-col gap-0.5 mr-2 text-xs text-base-content/60">
-              <% ['Mon', nil, 'Wed', nil, 'Fri', nil, nil].each do |day_label| %>
+              <% [t('.mon'), nil, t('.wed'), nil, t('.fri'), nil, nil].each do |day_label| %>
                 <span class="h-3 flex items-center leading-none"><%= day_label %></span>
               <% end %>
             </div>
@@ -45,7 +45,7 @@
 
           <!-- Legend -->
           <div class="flex items-center justify-end gap-2 mt-4 text-xs text-base-content/60">
-            <span>Less</span>
+            <span><%= t('.less') %></span>
             <div class="flex gap-0.5">
               <div class="w-3 h-3 rounded-sm bg-base-300"></div>
               <div class="w-3 h-3 rounded-sm bg-success/30"></div>
@@ -53,7 +53,7 @@
               <div class="w-3 h-3 rounded-sm bg-success/70"></div>
               <div class="w-3 h-3 rounded-sm bg-success"></div>
             </div>
-            <span>More</span>
+            <span><%= t('.more') %></span>
           </div>
         </div>
       </div>

--- a/app/views/insights/_activity_streak.html.erb
+++ b/app/views/insights/_activity_streak.html.erb
@@ -35,7 +35,7 @@
           </div>
           <% if @activity_heatmap.longest_streak_start && @activity_heatmap.longest_streak_end %>
             <div class="text-xs text-base-content/40 mt-1">
-              <%= l(@activity_heatmap.longest_streak_start, format: :short_month_day) %> - <%= l(@activity_heatmap.longest_streak_end, format: :short_month_day) %>
+              <%= l(@activity_heatmap.longest_streak_start, format: :short_month_day_padded) %> - <%= l(@activity_heatmap.longest_streak_end, format: :short_month_day_padded) %>
             </div>
           <% end %>
         </div>

--- a/app/views/insights/_activity_streak.html.erb
+++ b/app/views/insights/_activity_streak.html.erb
@@ -6,7 +6,7 @@
         <!-- Header -->
         <div class="flex items-center gap-2 mb-2">
           <%= icon 'flame', class: 'w-4 h-4 text-orange-500' %>
-          <h3 class="text-base font-semibold">Activity Streak</h3>
+          <h3 class="text-base font-semibold"><%= t('.activity_streak') %></h3>
         </div>
 
         <% if is_current_year %>
@@ -16,7 +16,7 @@
               <%= @activity_heatmap.current_streak %>
             </div>
             <div class="text-xs text-base-content/60">
-              current <%= 'day'.pluralize(@activity_heatmap.current_streak) %>
+              <%= t('.current') %> <%= 'day'.pluralize(@activity_heatmap.current_streak) %>
             </div>
           </div>
 
@@ -27,7 +27,7 @@
         <div class="text-center">
           <div class="flex items-center justify-center gap-1 mb-1">
             <%= icon 'trophy', class: 'w-3 h-3 text-warning' %>
-            <span class="text-xs font-medium text-base-content/70">Longest Streak</span>
+            <span class="text-xs font-medium text-base-content/70"><%= t('.longest_streak') %></span>
           </div>
           <div class="text-xl font-bold">
             <%= @activity_heatmap.longest_streak %>
@@ -35,7 +35,7 @@
           </div>
           <% if @activity_heatmap.longest_streak_start && @activity_heatmap.longest_streak_end %>
             <div class="text-xs text-base-content/40 mt-1">
-              <%= @activity_heatmap.longest_streak_start.strftime('%b %d') %> - <%= @activity_heatmap.longest_streak_end.strftime('%b %d') %>
+              <%= l(@activity_heatmap.longest_streak_start, format: :short_month_day) %> - <%= l(@activity_heatmap.longest_streak_end, format: :short_month_day) %>
             </div>
           <% end %>
         </div>

--- a/app/views/insights/_header.html.erb
+++ b/app/views/insights/_header.html.erb
@@ -2,8 +2,8 @@
 <div class="mb-6">
   <div class="flex items-center gap-2 mb-1">
     <%= icon 'compass', class: 'w-7 h-7 text-primary' %>
-    <h1 class="text-3xl font-bold">Insights</h1>
-    <p class="text-base-content/60 hidden sm:inline">Your personal movement analytics and travel patterns</p>
+    <h1 class="text-3xl font-bold"><%= t('.insights') %></h1>
+    <p class="text-base-content/60 hidden sm:inline"><%= t('.your_personal_movement_analytics_and_travel_patterns') %></p>
   </div>
   <div class="flex gap-2 mt-2">
     <% if @available_years.any? %>
@@ -14,13 +14,13 @@
         </label>
         <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-200 rounded-box w-52">
           <li>
-            <%= link_to "All Time", insights_path(year: 'all'), class: @all_time ? 'active' : '' %>
+            <%= link_to t('.all_time'), insights_path(year: 'all'), class: @all_time ? 'active' : '' %>
           </li>
-          <li class="menu-title"><span class='p-2'>By Year</span></li>
+          <li class="menu-title"><span class='p-2'><%= t('.by_year') %></span></li>
           <% @available_years.each do |year| %>
             <li>
               <%= link_to insights_path(year: year), class: (!@all_time && year == @selected_year) ? 'active' : '' do %>
-                <%= year %> Overview
+                <%= year %> <%= t('.overview') %>
                 <% if @locked_years.include?(year) %>
                   <%= icon 'lock', class: 'w-3 h-3 inline opacity-50' %>
                 <% end %>

--- a/app/views/insights/_location_clusters.html.erb
+++ b/app/views/insights/_location_clusters.html.erb
@@ -3,7 +3,7 @@
   <div class="card-body p-5">
     <h2 class="card-title text-lg flex items-center gap-2">
       <%= icon 'map-pin', class: 'w-5 h-5 text-primary' %>
-      Top Visited Locations
+      <%= t('.top_visited_locations') %>
     </h2>
 
     <% if @top_visited_locations.present? %>
@@ -25,7 +25,7 @@
               </div>
               <div>
                 <div class="text-xl font-bold"><%= format_location_time(location[:total_duration]) %></div>
-                <div class="text-xs text-base-content/60">total time</div>
+                <div class="text-xs text-base-content/60"><%= t('.total_time') %></div>
               </div>
             </div>
           </div>
@@ -35,8 +35,8 @@
       <div class="text-center py-8 text-base-content/60">
         <div class="flex flex-col items-center gap-2">
           <%= icon 'map-pin', class: 'w-8 h-8 opacity-50' %>
-          <p>No visit data available for this period.</p>
-          <p class="text-sm">Confirmed visits will appear here.</p>
+          <p><%= t('.no_visit_data_available_for_this_period') %></p>
+          <p class="text-sm"><%= t('.confirmed_visits_will_appear_here') %></p>
         </div>
       </div>
     <% end %>

--- a/app/views/insights/_monthly_digest.html.erb
+++ b/app/views/insights/_monthly_digest.html.erb
@@ -24,7 +24,7 @@
             <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-200 rounded-box w-40">
               <% @available_months.each do |m| %>
                 <li>
-                  <%= link_to Date::MONTHNAMES[m], details_insights_path(year: @selected_year, month: m),
+                  <%= link_to l(Date.new(@selected_year, m, 1), format: :month_name), details_insights_path(year: @selected_year, month: m),
                       class: m == @selected_month ? 'active' : '' %>
                 </li>
               <% end %>
@@ -49,34 +49,34 @@
             <%= icon 'route', class: 'w-3 h-3' %>
           </div>
           <div class="font-bold"><%= monthly_digest_distance(@monthly_digest, current_user) %></div>
-          <div class="text-xs text-base-content/60">Total Distance</div>
+          <div class="text-xs text-base-content/60"><%= t('.total_distance') %></div>
         </div>
         <div class="text-center">
           <div class="flex items-center justify-center gap-1 text-base-content/60 text-xs mb-1">
             <%= icon 'calendar', class: 'w-3 h-3' %>
           </div>
           <div class="font-bold"><%= monthly_digest_active_days(@monthly_digest) %></div>
-          <div class="text-xs text-base-content/60">Active Days</div>
+          <div class="text-xs text-base-content/60"><%= t('.active_days') %></div>
         </div>
         <div class="text-center">
           <div class="flex items-center justify-center gap-1 text-base-content/60 text-xs mb-1">
             <%= icon 'globe', class: 'w-3 h-3' %>
           </div>
           <div class="font-bold"><%= @monthly_digest.countries_count %></div>
-          <div class="text-xs text-base-content/60">Countries</div>
+          <div class="text-xs text-base-content/60"><%= t('.countries') %></div>
         </div>
         <div class="text-center">
           <div class="flex items-center justify-center gap-1 text-base-content/60 text-xs mb-1">
             <%= icon 'building', class: 'w-3 h-3' %>
           </div>
           <div class="font-bold"><%= @monthly_digest.cities_count %></div>
-          <div class="text-xs text-base-content/60">Cities</div>
+          <div class="text-xs text-base-content/60"><%= t('.cities') %></div>
         </div>
       </div>
 
       <!-- Weekly Pattern -->
       <div class="mt-4">
-        <div class="text-sm font-medium mb-2">WEEKLY PATTERN</div>
+        <div class="text-sm font-medium mb-2"><%= t('.weekly_pattern') %></div>
         <div class="h-32">
           <%= column_chart(
             weekly_pattern_chart_data(@monthly_digest, current_user),
@@ -104,7 +104,7 @@
       <!-- Top Locations & First Visits -->
       <div class="grid grid-cols-2 gap-4 mt-4">
         <div>
-          <div class="text-sm font-medium mb-2">TOP LOCATIONS</div>
+          <div class="text-sm font-medium mb-2"><%= t('.top_locations') %></div>
           <div class="space-y-1 text-sm">
             <% top_locations = top_locations_from_digest(@monthly_digest) %>
             <% if top_locations.any? %>
@@ -115,14 +115,14 @@
                 </div>
               <% end %>
             <% else %>
-              <div class="text-base-content/50">No location data</div>
+              <div class="text-base-content/50"><%= t('.no_location_data') %></div>
             <% end %>
           </div>
         </div>
         <div>
           <div class="flex items-center gap-1 text-sm font-medium mb-2">
             <%= icon 'flag', class: 'w-4 h-4 text-success' %>
-            FIRST VISITS
+            <%= t('.first_visits') %>
           </div>
           <div class="space-y-1 text-sm">
             <% first_visits = first_time_visits_from_digest(@monthly_digest) %>
@@ -130,17 +130,17 @@
               <% first_visits[:countries].first(2).each do |country| %>
                 <div class="flex justify-between">
                   <span class="text-success"><%= country %></span>
-                  <span class="badge badge-success badge-xs">Country</span>
+                  <span class="badge badge-success badge-xs"><%= t('.country') %></span>
                 </div>
               <% end %>
               <% first_visits[:cities].first(3 - first_visits[:countries].first(2).size).each do |city| %>
                 <div class="flex justify-between">
                   <span class="text-success"><%= city %></span>
-                  <span class="badge badge-info badge-xs">City</span>
+                  <span class="badge badge-info badge-xs"><%= t('.city') %></span>
                 </div>
               <% end %>
             <% else %>
-              <div class="text-base-content/50">No new places this month</div>
+              <div class="text-base-content/50"><%= t('.no_new_places_this_month') %></div>
             <% end %>
           </div>
         </div>
@@ -149,21 +149,21 @@
       <!-- Month over Month comparison -->
       <% if @monthly_digest.mom_distance_change.present? %>
         <div class="mt-4 pt-4 border-t border-base-300">
-          <div class="text-sm font-medium text-base-content/60 mb-2">VS PREVIOUS MONTH</div>
+          <div class="text-sm font-medium text-base-content/60 mb-2"><%= t('.vs_previous_month') %></div>
           <div class="flex gap-4 text-sm">
             <% mom_change = @monthly_digest.mom_distance_change %>
             <div class="flex items-center gap-1">
               <span class="badge badge-<%= mom_change.positive? ? 'success' : 'warning' %> badge-sm">
                 <%= mom_change.positive? ? '+' : '' %><%= mom_change %>%
               </span>
-              <span class="text-base-content/60">distance</span>
+              <span class="text-base-content/60"><%= t('.distance') %></span>
             </div>
             <% if @monthly_digest.mom_countries_change.present? && @monthly_digest.mom_countries_change != 0 %>
               <div class="flex items-center gap-1">
                 <span class="badge badge-<%= @monthly_digest.mom_countries_change.positive? ? 'success' : 'warning' %> badge-sm">
                   <%= @monthly_digest.mom_countries_change.positive? ? '+' : '' %><%= @monthly_digest.mom_countries_change %>
                 </span>
-                <span class="text-base-content/60">countries</span>
+                <span class="text-base-content/60"><%= t('.countries_2') %></span>
               </div>
             <% end %>
           </div>
@@ -176,12 +176,12 @@
     <div class="card-body p-5">
       <h2 class="card-title text-lg flex items-center gap-2">
         <%= icon 'calendar', class: 'w-5 h-5 text-primary' %>
-        Monthly Digest
+        <%= t('.monthly_digest') %>
       </h2>
-      <p class="text-base-content/60">Select a month to view its digest:</p>
+      <p class="text-base-content/60"><%= t('.select_a_month_to_view_its_digest') %></p>
       <div class="flex flex-wrap gap-2 mt-2">
         <% @available_months.each do |m| %>
-          <%= link_to Date::MONTHNAMES[m], details_insights_path(year: @selected_year, month: m), class: 'btn btn-sm btn-outline' %>
+          <%= link_to l(Date.new(@selected_year, m, 1), format: :month_name), details_insights_path(year: @selected_year, month: m), class: 'btn btn-sm btn-outline' %>
         <% end %>
       </div>
     </div>

--- a/app/views/insights/_movement_wellness.html.erb
+++ b/app/views/insights/_movement_wellness.html.erb
@@ -3,7 +3,7 @@
   <div class="card-body p-5">
     <h2 class="card-title text-lg flex items-center gap-2 mb-4">
       <%= icon 'heart', class: 'w-5 h-5 text-error' %>
-      Movement & Wellness
+      <%= t('.movement_wellness') %>
     </h2>
 
     <% if activity_breakdown_present?(@activity_breakdown) %>
@@ -13,15 +13,15 @@
         <!-- Left Side: Active Time -->
         <div class="space-y-4">
           <div>
-            <div class="text-sm font-medium mb-2">ACTIVE TIME</div>
+            <div class="text-sm font-medium mb-2"><%= t('.active_time') %></div>
             <div class="space-y-2">
               <% if stats[:walking].positive? %>
                 <div class="flex items-center justify-between text-sm">
                   <div class="flex items-center gap-2">
                     <%= icon 'footprints', class: 'w-4 h-4 text-base-content/70' %>
-                    <span>Walking</span>
+                    <span><%= t('.walking') %></span>
                   </div>
-                  <span class="font-medium"><%= format_activity_hours(stats[:walking]) %> total</span>
+                  <span class="font-medium"><%= format_activity_hours(stats[:walking]) %> <%= t('.total') %></span>
                 </div>
               <% end %>
 
@@ -29,9 +29,9 @@
                 <div class="flex items-center justify-between text-sm">
                   <div class="flex items-center gap-2">
                     <%= icon 'footprints', class: 'w-4 h-4 text-base-content/70' %>
-                    <span>Running</span>
+                    <span><%= t('.running') %></span>
                   </div>
-                  <span class="font-medium"><%= format_activity_hours(stats[:running]) %> total</span>
+                  <span class="font-medium"><%= format_activity_hours(stats[:running]) %> <%= t('.total') %></span>
                 </div>
               <% end %>
 
@@ -39,9 +39,9 @@
                 <div class="flex items-center justify-between text-sm">
                   <div class="flex items-center gap-2">
                     <%= icon 'bike', class: 'w-4 h-4 text-base-content/70' %>
-                    <span>Cycling</span>
+                    <span><%= t('.cycling') %></span>
                   </div>
-                  <span class="font-medium"><%= format_activity_hours(stats[:cycling]) %> total</span>
+                  <span class="font-medium"><%= format_activity_hours(stats[:cycling]) %> <%= t('.total') %></span>
                 </div>
               <% end %>
 
@@ -49,14 +49,14 @@
                 <div class="flex items-center justify-between text-sm">
                   <div class="flex items-center gap-2">
                     <%= icon 'car', class: 'w-4 h-4 text-base-content/70' %>
-                    <span>Driving</span>
+                    <span><%= t('.driving') %></span>
                   </div>
-                  <span class="font-medium"><%= format_activity_hours(stats[:driving]) %> total</span>
+                  <span class="font-medium"><%= format_activity_hours(stats[:driving]) %> <%= t('.total') %></span>
                 </div>
               <% end %>
 
               <% if stats[:walking].zero? && stats[:running].zero? && stats[:cycling].zero? && stats[:driving].zero? %>
-                <div class="text-sm text-base-content/60">No activity data available for this period</div>
+                <div class="text-sm text-base-content/60"><%= t('.no_activity_data_available_for_this_period') %></div>
               <% end %>
             </div>
           </div>
@@ -65,25 +65,25 @@
         <!-- Right Side: Sedentary vs Active -->
         <div class="space-y-4">
           <div>
-            <div class="text-sm font-medium mb-2">SEDENTARY VS ACTIVE</div>
+            <div class="text-sm font-medium mb-2"><%= t('.sedentary_vs_active') %></div>
             <div class="space-y-1 text-sm">
               <% if stats[:transport].positive? %>
                 <div class="flex justify-between">
-                  <span>In transport</span>
+                  <span><%= t('.in_transport') %></span>
                   <span><%= format_activity_hours(stats[:transport]) %></span>
                 </div>
               <% end %>
 
               <% if stats[:stationary].positive? %>
                 <div class="flex justify-between">
-                  <span>Stationary</span>
+                  <span><%= t('.stationary') %></span>
                   <span><%= format_activity_hours(stats[:stationary]) %></span>
                 </div>
               <% end %>
 
               <% if stats[:active].positive? %>
                 <div class="flex justify-between text-success">
-                  <span>Active movement</span>
+                  <span><%= t('.active_movement') %></span>
                   <span><%= format_activity_hours(stats[:active]) %></span>
                 </div>
               <% end %>
@@ -91,7 +91,7 @@
               <% sedentary = stats[:stationary] + stats[:transport] %>
               <% if stats[:active].positive? && sedentary.positive? %>
                 <div class="flex justify-between pt-1 border-t border-base-300 text-base-content/60">
-                  <span>Ratio: <%= activity_ratio(stats[:active], sedentary) %> active vs sedentary</span>
+                  <span><%= t('.ratio') %> <%= activity_ratio(stats[:active], sedentary) %> <%= t('.active_vs_sedentary') %></span>
                 </div>
               <% end %>
             </div>
@@ -102,8 +102,8 @@
       <div class="text-center py-8 text-base-content/60">
         <div class="flex flex-col items-center gap-2">
           <%= icon 'heart', class: 'w-8 h-8 opacity-50' %>
-          <p>No movement data available for this period.</p>
-          <p class="text-sm">Track data with transportation modes will appear here.</p>
+          <p><%= t('.no_movement_data_available_for_this_period') %></p>
+          <p class="text-sm"><%= t('.track_data_with_transportation_modes_will_appear_here') %></p>
         </div>
       </div>
     <% end %>

--- a/app/views/insights/_pro_locked_card.html.erb
+++ b/app/views/insights/_pro_locked_card.html.erb
@@ -16,10 +16,10 @@
       <%# Lock overlay %>
       <div class="absolute inset-0 flex flex-col items-center justify-center">
         <%= icon 'lock', class: 'w-6 h-6 opacity-30' %>
-        <p class="text-sm text-base-content/50 mt-1">Available on Pro</p>
+        <p class="text-sm text-base-content/50 mt-1"><%= t('.available_on_pro') %></p>
         <a href="<%= upgrade_url(utm_medium: 'insights', utm_content: utm_content) %>"
            class="btn btn-sm btn-primary mt-2" target="_blank" rel="noopener">
-          Upgrade to Pro
+          <%= t('.upgrade_to_pro') %>
         </a>
       </div>
     </div>

--- a/app/views/insights/_stats_row.html.erb
+++ b/app/views/insights/_stats_row.html.erb
@@ -7,7 +7,7 @@
         <div class="flex justify-between items-start">
           <div class="flex items-center gap-2 text-base-content/60 text-sm">
             <%= icon 'chart-bar', class: 'w-4 h-4' %>
-            TOTAL DISTANCE
+            <%= t('.total_distance') %>
           </div>
           <% if @distance_change && @distance_change != 0 %>
             <span class="badge badge-<%= @distance_change.positive? ? 'success' : 'warning' %> badge-sm">
@@ -18,11 +18,11 @@
         <div class="text-3xl font-bold mt-2"><%= number_with_delimiter(@total_distance) %> <%= current_user.safe_settings.distance_unit %></div>
         <div class="text-base-content/50 text-sm">
           <% if @all_time %>
-            All tracked history
+            <%= t('.all_tracked_history') %>
           <% elsif @prev_total_distance && @prev_total_distance.positive? %>
-            vs <%= number_with_delimiter(@prev_total_distance) %> <%= current_user.safe_settings.distance_unit %> in <%= @previous_year %>
+            <%= t('.vs') %> <%= number_with_delimiter(@prev_total_distance) %> <%= current_user.safe_settings.distance_unit %> <%= t('.in') %> <%= @previous_year %>
           <% else %>
-            This year
+            <%= t('.this_year') %>
           <% end %>
         </div>
       </div>
@@ -34,7 +34,7 @@
         <div class="flex justify-between items-start">
           <div class="flex items-center gap-2 text-base-content/60 text-sm">
             <%= icon 'globe', class: 'w-4 h-4' %>
-            COUNTRIES
+            <%= t('.countries') %>
           </div>
           <% if @countries_change && @countries_change != 0 %>
             <span class="badge badge-<%= @countries_change.positive? ? 'success' : 'warning' %> badge-sm">
@@ -45,13 +45,13 @@
         <div class="text-3xl font-bold mt-2"><%= @countries_count %></div>
         <div class="text-base-content/50 text-sm">
           <% if @all_time %>
-            All tracked history
+            <%= t('.all_tracked_history') %>
           <% elsif @prev_countries_count && @countries_change && @countries_change.positive? %>
-            <%= @countries_change %> new vs <%= @previous_year %>
+            <%= @countries_change %> <%= t('.new_vs') %> <%= @previous_year %>
           <% elsif @prev_countries_count %>
-            vs <%= @prev_countries_count %> in <%= @previous_year %>
+            <%= t('.vs') %> <%= @prev_countries_count %> <%= t('.in') %> <%= @previous_year %>
           <% else %>
-            This year
+            <%= t('.this_year') %>
           <% end %>
         </div>
       </div>
@@ -63,7 +63,7 @@
         <div class="flex justify-between items-start">
           <div class="flex items-center gap-2 text-base-content/60 text-sm">
             <%= icon 'building', class: 'w-4 h-4' %>
-            CITIES
+            <%= t('.cities') %>
           </div>
           <% if @cities_change && @cities_change != 0 %>
             <span class="badge badge-<%= @cities_change.positive? ? 'success' : 'warning' %> badge-sm">
@@ -74,11 +74,11 @@
         <div class="text-3xl font-bold mt-2"><%= @cities_count %></div>
         <div class="text-base-content/50 text-sm">
           <% if @all_time %>
-            All tracked history
+            <%= t('.all_tracked_history') %>
           <% elsif @prev_cities_count && @prev_cities_count.positive? %>
-            vs <%= @prev_cities_count %> in <%= @previous_year %>
+            <%= t('.vs') %> <%= @prev_cities_count %> <%= t('.in') %> <%= @previous_year %>
           <% else %>
-            This year
+            <%= t('.this_year') %>
           <% end %>
         </div>
       </div>
@@ -90,7 +90,7 @@
         <div class="flex justify-between items-start">
           <div class="flex items-center gap-2 text-base-content/60 text-sm">
             <%= icon 'calendar', class: 'w-4 h-4' %>
-            DAYS TRAVELING
+            <%= t('.days_traveling') %>
           </div>
           <% if @days_change && @days_change != 0 %>
             <span class="badge badge-<%= @days_change.positive? ? 'success' : 'warning' %> badge-sm">
@@ -101,11 +101,11 @@
         <div class="text-3xl font-bold mt-2"><%= @days_traveling %></div>
         <div class="text-base-content/50 text-sm">
           <% if @all_time %>
-            All tracked history
+            <%= t('.all_tracked_history') %>
           <% elsif @prev_days_traveling && @prev_days_traveling.positive? %>
-            vs <%= @prev_days_traveling %> in <%= @previous_year %>
+            <%= t('.vs') %> <%= @prev_days_traveling %> <%= t('.in') %> <%= @previous_year %>
           <% else %>
-            Active days this year
+            <%= t('.active_days_this_year') %>
           <% end %>
         </div>
       </div>
@@ -114,6 +114,6 @@
 <% else %>
   <div class="alert alert-info mb-6">
     <%= icon 'info', class: 'w-5 h-5' %>
-    <span>No stats data available<%= @all_time ? '' : " for #{@selected_year}" %>. Stats are calculated from your tracked points.</span>
+    <span><%= t('.no_stats_data_available') %><%= @all_time ? '' : " for #{@selected_year}" %><%= t('.stats_are_calculated_from_your_tracked_points') %></span>
   </div>
 <% end %>

--- a/app/views/insights/_top_visited_locations.html.erb
+++ b/app/views/insights/_top_visited_locations.html.erb
@@ -3,7 +3,7 @@
   <div class="card-body p-5">
     <h2 class="card-title text-lg flex items-center gap-2">
       <%= icon 'map-pin', class: 'w-5 h-5 text-primary' %>
-      Top Visited Locations
+      <%= t('.top_visited_locations') %>
     </h2>
 
     <% if @top_visited_locations.present? %>
@@ -25,7 +25,7 @@
               </div>
               <div>
                 <div class="text-lg font-bold"><%= format_location_time(location[:total_duration]) %></div>
-                <div class="text-xs text-base-content/60">total time</div>
+                <div class="text-xs text-base-content/60"><%= t('.total_time') %></div>
               </div>
             </div>
           </div>
@@ -35,8 +35,8 @@
       <div class="text-center py-8 text-base-content/60">
         <div class="flex flex-col items-center gap-2">
           <%= icon 'map-pin', class: 'w-8 h-8 opacity-50' %>
-          <p class="text-sm">No visit data available for this period.</p>
-          <p class="text-xs">Confirmed visits will appear here.</p>
+          <p class="text-sm"><%= t('.no_visit_data_available_for_this_period') %></p>
+          <p class="text-xs"><%= t('.confirmed_visits_will_appear_here') %></p>
         </div>
       </div>
     <% end %>

--- a/app/views/insights/_travel_patterns.html.erb
+++ b/app/views/insights/_travel_patterns.html.erb
@@ -3,12 +3,12 @@
   <div class="card-body p-5">
     <h2 class="card-title text-lg flex items-center gap-2">
       <%= icon 'clock', class: 'w-5 h-5 text-primary' %>
-      When Do You Travel?
+      <%= t('.when_do_you_travel') %>
     </h2>
 
     <!-- Time of Day Distribution -->
     <div class="mt-3">
-      <div class="text-sm font-medium mb-2">TIME OF DAY DISTRIBUTION</div>
+      <div class="text-sm font-medium mb-2"><%= t('.time_of_day_distribution') %></div>
       <div class="space-y-1">
         <% time_labels = { 'night' => '00-06', 'morning' => '06-12', 'afternoon' => '12-18', 'evening' => '18-24' } %>
         <% %w[night morning afternoon evening].each do |period| %>
@@ -25,7 +25,7 @@
     <!-- Day of Week + Seasonality -->
     <div class="grid grid-cols-2 gap-4 mt-4">
       <div>
-        <div class="text-sm font-medium mb-2">DAY OF WEEK</div>
+        <div class="text-sm font-medium mb-2"><%= t('.day_of_week') %></div>
         <div class="flex gap-1">
           <% days = %w[Mon Tue Wed Thu Fri Sat Sun] %>
           <% max_distance = @day_of_week.max.to_f %>
@@ -41,7 +41,7 @@
         </div>
       </div>
       <div>
-        <div class="text-sm font-medium mb-2">SEASONALITY</div>
+        <div class="text-sm font-medium mb-2"><%= t('.seasonality') %></div>
         <div class="space-y-1 text-sm">
           <% season_colors = { 'winter' => 'info', 'spring' => 'success', 'summer' => 'warning', 'fall' => 'error' } %>
           <% %w[winter spring summer fall].each do |season| %>
@@ -65,7 +65,7 @@
     <div class="flex items-start gap-3">
       <%= icon 'lightbulb', class: 'w-5 h-5 text-warning' %>
       <div>
-        <h3 class="font-bold text-warning">Insight</h3>
+        <h3 class="font-bold text-warning"><%= t('.insight') %></h3>
         <div class="text-sm"><%= insight_text %></div>
       </div>
     </div>

--- a/app/views/insights/_travel_story.html.erb
+++ b/app/views/insights/_travel_story.html.erb
@@ -3,109 +3,109 @@
   <div class="card-body p-5">
     <h2 class="card-title text-lg flex items-center gap-2">
       <%= icon 'book-open', class: 'w-5 h-5 text-primary' %>
-      Your Travel Story
+      <%= t('.your_travel_story') %>
     </h2>
-    <div class="text-sm text-base-content/60">Summer 2024</div>
+    <div class="text-sm text-base-content/60"><%= t('.summer_2024') %></div>
 
     <!-- Trip Summary -->
     <div class="flex items-center gap-4 mt-3 p-2 bg-base-300 rounded-lg text-sm">
       <div class="flex items-center gap-1">
         <%= icon 'calendar', class: 'w-4 h-4 text-info' %>
-        <span>June 15 - July 20</span>
+        <span><%= t('.june_15_july_20') %></span>
       </div>
       <div class="flex items-center gap-1">
         <%= icon 'clock', class: 'w-4 h-4' %>
-        <span class="font-medium">35 Days</span>
+        <span class="font-medium"><%= t('.days') %></span>
       </div>
       <div class="flex items-center gap-1">
         <%= icon 'route', class: 'w-4 h-4' %>
-        <span class="font-medium">4,230 km</span>
+        <span class="font-medium"><%= t('.230_km') %></span>
       </div>
     </div>
 
     <!-- Story Title -->
-    <div class="text-xl font-bold mt-4 text-info">"The Great European Road Trip"</div>
+    <div class="text-xl font-bold mt-4 text-info"><%= t('.the_great_european_road_trip') %></div>
 
     <!-- Story Content -->
     <div class="mt-3 text-sm space-y-3">
-      <p>You started in <span class="text-info font-medium">Berlin</span>, your home base. After a week of work, you headed south through <span class="text-info font-medium">Dresden</span> and <span class="text-info font-medium">Prague</span>, spending 3 days exploring the city of a hundred spires.</p>
-      <p>The journey continued through <span class="text-info font-medium">Vienna</span>, where you spent a weekend before crossing into Italy. You drove through the Alps, stopping at <span class="text-info font-medium">Lake Como</span> for two nights of swimming and pasta.</p>
-      <p><span class="text-info font-medium">Rome</span> welcomed you for 5 days of ancient history, then you traced the coast south to <span class="text-info font-medium">Amalfi</span>, with stops in Naples and Positano.</p>
+      <p><%= t('.you_started_in') %> <span class="text-info font-medium"><%= t('.berlin') %></span><%= t('.your_home_base_after_a_week_of_work_you_headed') %> <span class="text-info font-medium"><%= t('.dresden') %></span> <%= t('.and') %> <span class="text-info font-medium"><%= t('.prague') %></span><%= t('.spending_3_days_exploring_the_city_of_a_hundred_spires') %></p>
+      <p><%= t('.the_journey_continued_through') %> <span class="text-info font-medium"><%= t('.vienna') %></span><%= t('.where_you_spent_a_weekend_before_crossing_into_italy_you') %> <span class="text-info font-medium"><%= t('.lake_como') %></span> <%= t('.for_two_nights_of_swimming_and_pasta') %></p>
+      <p><span class="text-info font-medium"><%= t('.rome') %></span> <%= t('.welcomed_you_for_5_days_of_ancient_history_then_you') %> <span class="text-info font-medium"><%= t('.amalfi') %></span><%= t('.with_stops_in_naples_and_positano') %></p>
     </div>
 
     <!-- Journey Timeline -->
     <div class="mt-4 pt-4 border-t border-base-300">
-      <div class="text-sm font-medium mb-3">JOURNEY TIMELINE</div>
+      <div class="text-sm font-medium mb-3"><%= t('.journey_timeline') %></div>
       <div class="space-y-2">
         <div class="flex items-center gap-3 text-sm">
           <span class="w-3 h-3 bg-warning rounded-full"></span>
-          <span class="font-medium">Berlin</span>
-          <span class="text-base-content/60">DE</span>
-          <span class="flex-1 text-right text-base-content/60">Home base</span>
+          <span class="font-medium"><%= t('.berlin') %></span>
+          <span class="text-base-content/60"><%= t('.de') %></span>
+          <span class="flex-1 text-right text-base-content/60"><%= t('.home_base') %></span>
         </div>
         <div class="flex items-center gap-3 text-sm">
           <span class="w-3 h-3 bg-base-content/30 rounded-full border border-base-content/50"></span>
-          <span>Dresden</span>
-          <span class="text-base-content/60">DE</span>
-          <span class="flex-1 text-right text-base-content/60">Overnight</span>
+          <span><%= t('.dresden') %></span>
+          <span class="text-base-content/60"><%= t('.de') %></span>
+          <span class="flex-1 text-right text-base-content/60"><%= t('.overnight') %></span>
         </div>
         <div class="flex items-center gap-3 text-sm">
           <span class="w-3 h-3 bg-success rounded-full"></span>
-          <span>Prague</span>
-          <span class="text-base-content/60">CZ</span>
+          <span><%= t('.prague') %></span>
+          <span class="text-base-content/60"><%= t('.cz') %></span>
           <%= icon 'star', class: 'w-3 h-3 text-warning' %>
-          <span class="flex-1 text-right text-base-content/60">3 days exploring</span>
+          <span class="flex-1 text-right text-base-content/60"><%= t('.days_exploring') %></span>
         </div>
         <div class="flex items-center gap-3 text-sm">
           <span class="w-3 h-3 bg-base-content/30 rounded-full border border-base-content/50"></span>
-          <span>Vienna</span>
-          <span class="text-base-content/60">AT</span>
-          <span class="flex-1 text-right text-base-content/60">Weekend stay</span>
+          <span><%= t('.vienna') %></span>
+          <span class="text-base-content/60"><%= t('.at') %></span>
+          <span class="flex-1 text-right text-base-content/60"><%= t('.weekend_stay') %></span>
         </div>
         <div class="flex items-center gap-3 text-sm">
           <span class="w-3 h-3 bg-base-content/30 rounded-full border border-base-content/50"></span>
-          <span>Lake Como</span>
-          <span class="text-base-content/60">IT</span>
+          <span><%= t('.lake_como') %></span>
+          <span class="text-base-content/60"><%= t('.it') %></span>
           <%= icon 'star', class: 'w-3 h-3 text-warning' %>
-          <span class="flex-1 text-right text-base-content/60">Swimming & pasta</span>
+          <span class="flex-1 text-right text-base-content/60"><%= t('.swimming_pasta') %></span>
         </div>
         <div class="flex items-center gap-3 text-sm">
           <span class="w-3 h-3 bg-success rounded-full"></span>
-          <span>Rome</span>
-          <span class="text-base-content/60">IT</span>
+          <span><%= t('.rome') %></span>
+          <span class="text-base-content/60"><%= t('.it') %></span>
           <%= icon 'star', class: 'w-3 h-3 text-warning' %>
-          <span class="flex-1 text-right text-base-content/60">5 days of history</span>
+          <span class="flex-1 text-right text-base-content/60"><%= t('.days_of_history') %></span>
         </div>
         <div class="flex items-center gap-3 text-sm">
           <span class="w-3 h-3 bg-base-content/30 rounded-full border border-base-content/50"></span>
-          <span>Amalfi Coast</span>
-          <span class="text-base-content/60">IT</span>
+          <span><%= t('.amalfi_coast') %></span>
+          <span class="text-base-content/60"><%= t('.it') %></span>
           <%= icon 'star', class: 'w-3 h-3 text-warning' %>
-          <span class="flex-1 text-right text-base-content/60">Positano, Naples</span>
+          <span class="flex-1 text-right text-base-content/60"><%= t('.positano_naples') %></span>
         </div>
         <div class="flex items-center gap-3 text-sm">
           <span class="w-3 h-3 bg-base-content/30 rounded-full border border-base-content/50"></span>
-          <span>Florence</span>
-          <span class="text-base-content/60">IT</span>
-          <span class="flex-1 text-right text-base-content/60">Art & coffee</span>
+          <span><%= t('.florence') %></span>
+          <span class="text-base-content/60"><%= t('.it') %></span>
+          <span class="flex-1 text-right text-base-content/60"><%= t('.art_coffee') %></span>
         </div>
         <div class="flex items-center gap-3 text-sm">
           <span class="w-3 h-3 bg-base-content/30 rounded-full border border-base-content/50"></span>
-          <span>Milan</span>
-          <span class="text-base-content/60">IT</span>
-          <span class="flex-1 text-right text-base-content/60">Fashion district</span>
+          <span><%= t('.milan') %></span>
+          <span class="text-base-content/60"><%= t('.it') %></span>
+          <span class="flex-1 text-right text-base-content/60"><%= t('.fashion_district') %></span>
         </div>
         <div class="flex items-center gap-3 text-sm">
           <span class="w-3 h-3 bg-base-content/30 rounded-full border border-base-content/50"></span>
-          <span>Munich</span>
-          <span class="text-base-content/60">DE</span>
-          <span class="flex-1 text-right text-base-content/60">Beer gardens</span>
+          <span><%= t('.munich') %></span>
+          <span class="text-base-content/60"><%= t('.de') %></span>
+          <span class="flex-1 text-right text-base-content/60"><%= t('.beer_gardens') %></span>
         </div>
         <div class="flex items-center gap-3 text-sm">
           <span class="w-3 h-3 bg-warning rounded-full"></span>
-          <span class="font-medium">Berlin</span>
-          <span class="text-base-content/60">DE</span>
-          <span class="flex-1 text-right text-base-content/60">Back home</span>
+          <span class="font-medium"><%= t('.berlin') %></span>
+          <span class="text-base-content/60"><%= t('.de') %></span>
+          <span class="flex-1 text-right text-base-content/60"><%= t('.back_home') %></span>
         </div>
       </div>
     </div>
@@ -114,18 +114,18 @@
     <div class="grid grid-cols-3 gap-4 mt-4 pt-4 border-t border-base-300 text-center">
       <div>
         <div class="text-2xl font-bold text-info">4</div>
-        <div class="text-xs text-base-content/60">New countries</div>
-        <div class="text-xs text-info">CZ, AT, IT, FR</div>
+        <div class="text-xs text-base-content/60"><%= t('.new_countries') %></div>
+        <div class="text-xs text-info"><%= t('.cz_at_it_fr') %></div>
       </div>
       <div>
-        <div class="text-2xl font-bold text-info">890 km</div>
-        <div class="text-xs text-base-content/60">Longest drive</div>
-        <div class="text-xs text-info">Rome &rarr; Amalfi</div>
+        <div class="text-2xl font-bold text-info"><%= t('.km') %></div>
+        <div class="text-xs text-base-content/60"><%= t('.longest_drive') %></div>
+        <div class="text-xs text-info"><%= t('.rome_rarr_amalfi') %></div>
       </div>
       <div>
         <div class="text-2xl font-bold text-info">12</div>
-        <div class="text-xs text-base-content/60">Favorites marked</div>
-        <div class="text-xs text-info">places</div>
+        <div class="text-xs text-base-content/60"><%= t('.favorites_marked') %></div>
+        <div class="text-xs text-info"><%= t('.places') %></div>
       </div>
     </div>
   </div>

--- a/app/views/insights/_year_comparison.html.erb
+++ b/app/views/insights/_year_comparison.html.erb
@@ -3,7 +3,7 @@
     <div class="card-body p-5">
       <h2 class="card-title text-lg flex items-center gap-2">
         <%= icon 'git-compare', class: 'w-5 h-5 text-primary' %>
-        Your Journey: <%= @previous_year %> vs <%= @selected_year %>
+        <%= t('.your_journey') %> <%= @previous_year %> <%= t('.vs') %> <%= @selected_year %>
       </h2>
 
       <%
@@ -27,7 +27,7 @@
       <!-- Distance -->
       <div class="mt-4">
         <div class="flex justify-between text-sm mb-1">
-          <span class="font-medium">DISTANCE</span>
+          <span class="font-medium"><%= t('.distance') %></span>
           <% if @distance_change != 0 %>
             <span class="text-<%= @distance_change.positive? ? 'success' : 'warning' %>">
               <%= distance_diff.positive? ? '+' : '' %><%= number_with_delimiter(distance_diff) %> <%= current_user.safe_settings.distance_unit %>
@@ -52,7 +52,7 @@
       <!-- Countries -->
       <div class="mt-4">
         <div class="flex justify-between text-sm mb-1">
-          <span class="font-medium">COUNTRIES</span>
+          <span class="font-medium"><%= t('.countries') %></span>
           <% if @countries_change != 0 %>
             <span class="text-<%= @countries_change.positive? ? 'success' : 'warning' %>">
               <%= @countries_change.positive? ? '+' : '' %><%= @countries_change %>
@@ -76,11 +76,10 @@
       <!-- Days Traveling -->
       <div class="mt-4">
         <div class="flex justify-between text-sm mb-1">
-          <span class="font-medium">DAYS TRAVELING</span>
+          <span class="font-medium"><%= t('.days_traveling') %></span>
           <% if @days_change != 0 %>
             <span class="text-<%= @days_change.positive? ? 'success' : 'warning' %>">
-              <%= days_diff.positive? ? '+' : '' %><%= days_diff %> days
-              (<%= @days_change.positive? ? '+' : '' %><%= @days_change %>%)
+              <%= days_diff.positive? ? '+' : '' %><%= days_diff %> <%= t('.days') %><%= @days_change.positive? ? '+' : '' %><%= @days_change %>%)
             </span>
           <% end %>
         </div>
@@ -89,19 +88,19 @@
           <div class="flex-1 h-3 bg-base-300 rounded-full overflow-hidden">
             <div class="h-full rounded-full bg-base-content/25" style="width: <%= prev_days_pct %>%"></div>
           </div>
-          <span class="w-24 text-right"><%= @prev_days_traveling %> days</span>
+          <span class="w-24 text-right"><%= @prev_days_traveling %> <%= t('.days_2') %></span>
         </div>
         <div class="flex items-center gap-2 text-sm">
           <span class="w-10 text-base-content/60"><%= @selected_year %></span>
           <progress class="progress progress-accent flex-1 h-3" value="<%= curr_days_pct %>" max="100"></progress>
-          <span class="w-24 text-right"><%= @days_traveling %> days</span>
+          <span class="w-24 text-right"><%= @days_traveling %> <%= t('.days_2') %></span>
         </div>
       </div>
 
       <!-- Bottom Stats -->
       <% if @biggest_month || @prev_biggest_month %>
         <div class="mt-4 pt-4 border-t border-base-300">
-          <div class="text-sm font-medium text-base-content/60 mb-2">BIGGEST MONTH</div>
+          <div class="text-sm font-medium text-base-content/60 mb-2"><%= t('.biggest_month') %></div>
           <% if @prev_biggest_month %>
             <div class="text-sm"><%= @previous_year %>: <span class="text-primary"><%= @prev_biggest_month[:month] %></span> (<%= number_with_delimiter(@prev_biggest_month[:distance]) %> <%= current_user.safe_settings.distance_unit %>)</div>
           <% end %>

--- a/app/views/insights/details.html.erb
+++ b/app/views/insights/details.html.erb
@@ -8,21 +8,21 @@
     <!-- Left Column -->
     <div class="space-y-6">
       <% if show_plan_data_window_alert? %>
-        <%= render 'pro_locked_card', title: 'Year Comparison', utm_content: 'year_comparison' %>
+        <%= render 'pro_locked_card', title: t('.year_comparison'), utm_content: 'year_comparison' %>
       <% else %>
         <% cache insights_cache_key + ["year_comparison"], expires_in: 24.hours do %>
           <%= render 'year_comparison' %>
         <% end %>
       <% end %>
       <% if show_plan_data_window_alert? %>
-        <%= render 'pro_locked_card', title: 'Activity Breakdown', utm_content: 'activity_breakdown' %>
+        <%= render 'pro_locked_card', title: t('.activity_breakdown'), utm_content: 'activity_breakdown' %>
       <% else %>
         <% cache insights_cache_key + ["activity_breakdown"], expires_in: 24.hours do %>
           <%= render 'activity_breakdown' %>
         <% end %>
       <% end %>
       <% if show_plan_data_window_alert? %>
-        <%= render 'pro_locked_card', title: 'Location Clusters', utm_content: 'location_clusters' %>
+        <%= render 'pro_locked_card', title: t('.location_clusters'), utm_content: 'location_clusters' %>
       <% else %>
         <% cache insights_cache_key + ["location_clusters"], expires_in: 24.hours do %>
           <%= render 'location_clusters' %>
@@ -33,14 +33,14 @@
     <!-- Right Column -->
     <div class="space-y-6">
       <% if show_plan_data_window_alert? %>
-        <%= render 'pro_locked_card', title: 'Monthly Digest', utm_content: 'monthly_digest' %>
+        <%= render 'pro_locked_card', title: t('.monthly_digest'), utm_content: 'monthly_digest' %>
       <% else %>
         <% cache insights_cache_key + ["monthly_digest", @selected_month], expires_in: 24.hours do %>
           <%= render 'monthly_digest' %>
         <% end %>
       <% end %>
       <% if show_plan_data_window_alert? %>
-        <%= render 'pro_locked_card', title: 'Travel Patterns', utm_content: 'travel_patterns' %>
+        <%= render 'pro_locked_card', title: t('.travel_patterns'), utm_content: 'travel_patterns' %>
       <% else %>
         <% cache insights_cache_key + ["travel_patterns"], expires_in: 24.hours do %>
           <%= render 'travel_patterns' %>
@@ -50,7 +50,7 @@
   </div>
 
   <% if show_plan_data_window_alert? %>
-    <%= render 'pro_locked_card', title: 'Movement & Wellness', utm_content: 'movement_wellness' %>
+    <%= render 'pro_locked_card', title: t('.movement_wellness'), utm_content: 'movement_wellness' %>
   <% else %>
     <% cache insights_cache_key + ["movement_wellness"], expires_in: 24.hours do %>
       <%= render 'movement_wellness' %>

--- a/app/views/insights/index.html.erb
+++ b/app/views/insights/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Insights' %>
+<% content_for :title, t('.insights') %>
 <%= render 'shared/chartkick_scripts' %>
 
 <% insights_cache_key = [current_user.id, "insights", @selected_year, @year_stats&.maximum(:updated_at), current_user.safe_settings.distance_unit] %>
@@ -15,25 +15,25 @@
     </div>
     <div class="flex flex-col lg:flex-row gap-6">
       <div class="w-full lg:w-3/4 mb-6">
-        <%= render 'pro_locked_card', title: 'Activity Heatmap', utm_content: 'activity_heatmap' %>
+        <%= render 'pro_locked_card', title: t('.activity_heatmap'), utm_content: 'activity_heatmap' %>
       </div>
       <div class="w-full lg:w-1/4 mb-6">
-        <%= render 'pro_locked_card', title: 'Activity Streak', utm_content: 'activity_streak' %>
+        <%= render 'pro_locked_card', title: t('.activity_streak'), utm_content: 'activity_streak' %>
       </div>
     </div>
     <%= turbo_frame_tag "insights_details" do %>
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6 mt-6">
         <div class="space-y-6">
-          <%= render 'pro_locked_card', title: 'Year Comparison', utm_content: 'year_comparison' %>
-          <%= render 'pro_locked_card', title: 'Activity Breakdown', utm_content: 'activity_breakdown' %>
-          <%= render 'pro_locked_card', title: 'Location Clusters', utm_content: 'location_clusters' %>
+          <%= render 'pro_locked_card', title: t('.year_comparison'), utm_content: 'year_comparison' %>
+          <%= render 'pro_locked_card', title: t('.activity_breakdown'), utm_content: 'activity_breakdown' %>
+          <%= render 'pro_locked_card', title: t('.location_clusters'), utm_content: 'location_clusters' %>
         </div>
         <div class="space-y-6">
-          <%= render 'pro_locked_card', title: 'Monthly Digest', utm_content: 'monthly_digest' %>
-          <%= render 'pro_locked_card', title: 'Travel Patterns', utm_content: 'travel_patterns' %>
+          <%= render 'pro_locked_card', title: t('.monthly_digest'), utm_content: 'monthly_digest' %>
+          <%= render 'pro_locked_card', title: t('.travel_patterns'), utm_content: 'travel_patterns' %>
         </div>
       </div>
-      <%= render 'pro_locked_card', title: 'Movement & Wellness', utm_content: 'movement_wellness' %>
+      <%= render 'pro_locked_card', title: t('.movement_wellness'), utm_content: 'movement_wellness' %>
     <% end %>
   <% else %>
     <%= render 'stats_row' %>
@@ -56,6 +56,6 @@
 
   <!-- Footer -->
   <div class="text-center text-sm text-base-content/50 py-4">
-    Geodata Insights &bull; Powered by your location history
+    <%= t('.geodata_insights_bull_powered_by_your_location_history') %>
   </div>
 </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <%= link_to url, remote: remote, class: "join-item btn" do %>
-  &laquo;
+  <%= t('.laquo') %>
 <% end %>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <%= link_to url, remote: remote, class: "join-item btn" do %>
-  &raquo;&raquo;
+  <%= t('.raquo_raquo') %>
 <% end %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <%= link_to url, rel: 'next', remote: remote, class: "join-item btn" do %>
-  &raquo;
+  <%= t('.raquo') %>
 <% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -7,7 +7,7 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>
-  <div class="join" role="navigation" aria-label="pager">
+  <div class="join" role="navigation" aria-label="<%= t('.pager') %>">
     <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>
       <% if page.display_tag? -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -7,5 +7,5 @@
     remote:        data-remote
 -%>
 <%= link_to url, rel: 'prev', remote: remote, class: "join-item btn" do %>
-  &laquo;
+  <%= t('.laquo') %>
 <% end %>

--- a/app/views/layouts/_pwa_meta.html.erb
+++ b/app/views/layouts/_pwa_meta.html.erb
@@ -2,4 +2,4 @@
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="default">
-<meta name="apple-mobile-web-app-title" content="Dawarich">
+<meta name="apple-mobile-web-app-title" content="<%= t('common.app_name') %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="<%= app_theme %>" data-self-hosted="<%= @self_hosted %>">
+<html lang="<%= I18n.locale %>" data-theme="<%= app_theme %>" data-self-hosted="<%= @self_hosted %>">
   <head>
     <title><%= full_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -18,6 +18,7 @@
     <% if ENV['POSTHOG_ENABLED'] == 'true' %>
       <%= javascript_include_tag "posthog", "data-turbo-track": "reload" %>
     <% end %>
+    <%= javascript_translations %>
     <%= javascript_importmap_tags %>
     <%= yield :head_scripts %>
     <%= javascript_include_tag "https://unpkg.com/protomaps-leaflet@5.0.0/dist/protomaps-leaflet.js", defer: true %>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <style>

--- a/app/views/layouts/map.html.erb
+++ b/app/views/layouts/map.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-theme="<%= app_theme %>" data-self-hosted="<%= @self_hosted %>">
+<html lang="<%= I18n.locale %>" data-theme="<%= app_theme %>" data-self-hosted="<%= @self_hosted %>">
   <head>
     <title><%= full_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
@@ -15,6 +15,7 @@
 
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_translations %>
     <%= javascript_importmap_tags %>
     <%= yield :head_scripts %>
     <%= javascript_include_tag "https://unpkg.com/protomaps-leaflet@5.0.0/dist/protomaps-leaflet.js", defer: true %>
@@ -52,11 +53,11 @@
     <% if user_signed_in? && current_user.imports.exists?(demo: true) %>
       <div id="demo-data-banner" class="fixed bottom-0 left-1/2 -translate-x-1/2 z-30 mb-[calc(1rem+env(safe-area-inset-bottom))]" data-controller="demo-banner">
         <div class="alert alert-info shadow-lg py-1.5 px-3 flex items-center gap-1.5 rounded-lg whitespace-nowrap text-sm">
-          <span class="font-medium" data-demo-banner-target="label">You're viewing demo data.</span>
+          <span class="font-medium" data-demo-banner-target="label"><%= t('.you_re_viewing_demo_data') %></span>
           <span data-demo-banner-target="loadingState" class="hidden">
             <span class="loading loading-spinner loading-xs text-info"></span>
           </span>
-          <%= button_to "Delete",
+          <%= button_to t('.delete'),
               demo_data_settings_onboarding_path,
               method: :delete,
               form: {

--- a/app/views/layouts/shared.html.erb
+++ b/app/views/layouts/shared.html.erb
@@ -1,16 +1,17 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="<%= I18n.locale %>">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex, nofollow">
-  <title><%= content_for?(:title) ? yield(:title) : "Shared on Dawarich" %></title>
+  <title><%= content_for?(:title) ? yield(:title) : t('.shared_on_dawarich') %></title>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
   <%= render 'application/favicon' %>
   <%= render 'layouts/pwa_meta' %>
   <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+  <%= javascript_translations %>
   <%= javascript_importmap_tags %>
   <%= yield :head %>
 </head>
@@ -18,12 +19,12 @@
   <header class="sticky top-0 z-30 border-b border-base-300 bg-base-100/85 backdrop-blur">
     <div class="container mx-auto px-4 flex items-center justify-between h-16">
       <%= link_to root_url, class: "btn btn-ghost normal-case text-xl px-2 gap-2" do %>
-        <%= image_tag 'logo.svg', alt: 'Dawarich logo', class: 'h-8 w-8 rounded-[20%]' %>
-        <span>Dawarich</span>
+        <%= image_tag 'logo.svg', alt: t('.dawarich_logo'), class: 'h-8 w-8 rounded-[20%]' %>
+        <span><%= t('.dawarich') %></span>
       <% end %>
       <%= link_to public_share_cta_url('header'),
                   class: "inline-flex items-center gap-2 rounded-lg bg-gradient-to-b from-[#3A66E8] to-[#2A56D8] px-4 py-2 text-sm font-bold text-white shadow-[0_6px_16px_rgba(45,91,227,0.30)] transition hover:brightness-105" do %>
-        Try Dawarich Cloud <span aria-hidden="true">→</span>
+        <%= t('.try_dawarich_cloud') %> <span aria-hidden="true">→</span>
       <% end %>
     </div>
   </header>
@@ -35,11 +36,11 @@
          style="background: radial-gradient(circle, rgba(43,182,196,0.16) 0%, rgba(43,182,196,0) 70%);"></div>
     <div class="relative container mx-auto px-4 py-14 sm:py-16 flex flex-wrap items-center justify-between gap-x-12 gap-y-8">
       <div class="max-w-xl">
-        <div class="mb-3 text-xs font-bold uppercase tracking-[0.1em] text-[#7f87a3]">Shared with Dawarich</div>
-        <h2 class="mb-3 text-3xl sm:text-[40px] font-extrabold leading-[1.05] tracking-tight">Map your own journeys.</h2>
-        <p class="mb-6 max-w-lg text-lg leading-relaxed text-[#aab2c5]">Dawarich turns your own location history into maps worth sharing — open-source, self-hostable, and yours to keep.</p>
+        <div class="mb-3 text-xs font-bold uppercase tracking-[0.1em] text-[#7f87a3]"><%= t('.shared_with_dawarich') %></div>
+        <h2 class="mb-3 text-3xl sm:text-[40px] font-extrabold leading-[1.05] tracking-tight"><%= t('.map_your_own_journeys') %></h2>
+        <p class="mb-6 max-w-lg text-lg leading-relaxed text-[#aab2c5]"><%= t('.dawarich_turns_your_own_location_history_into_maps_worth_sharing') %></p>
         <div class="flex flex-wrap gap-2.5">
-          <% ['Open-source', 'Self-hostable', 'Managed Cloud — no setup'].each do |chip| %>
+          <% [t('.open_source'), t('.self_hostable'), t('.managed_cloud_no_setup')].each do |chip| %>
             <span class="rounded-full border border-white/15 bg-white/5 px-3.5 py-1.5 text-sm font-semibold text-[#c6cdda]"><%= chip %></span>
           <% end %>
         </div>
@@ -47,9 +48,9 @@
       <div class="flex flex-col items-start gap-4">
         <%= link_to public_share_cta_url('footer_cta'),
                     class: "inline-flex items-center gap-2.5 rounded-xl bg-gradient-to-b from-[#3A66E8] to-[#2A56D8] px-7 py-4 text-lg font-bold text-white shadow-[0_14px_34px_rgba(45,91,227,0.48)] transition hover:-translate-y-0.5 hover:brightness-110" do %>
-          Try Dawarich Cloud <span aria-hidden="true">→</span>
+          <%= t('.try_dawarich_cloud') %> <span aria-hidden="true">→</span>
         <% end %>
-        <%= link_to "See how it works", public_share_cta_url('footer_docs', path: '/docs/'),
+        <%= link_to t('.see_how_it_works'), public_share_cta_url('footer_docs', path: '/docs/'),
                     class: "border-b border-white/25 pb-0.5 text-[15px] text-[#cbd2e0] transition hover:text-white" %>
       </div>
     </div>

--- a/app/views/map/_onboarding_modal.html.erb
+++ b/app/views/map/_onboarding_modal.html.erb
@@ -14,9 +14,9 @@
       <%# ═══ Choice Screen ═══ %>
       <div data-onboarding-modal-target="choiceScreen">
         <div class="text-center mb-6">
-          <h3 class="text-2xl font-bold text-primary mb-2">Welcome to Dawarich!</h3>
+          <h3 class="text-2xl font-bold text-primary mb-2"><%= t('.welcome_to_dawarich') %></h3>
           <p class="text-base-content/70">
-            Your map starts with your next step — literally.
+            <%= t('.your_map_starts_with_your_next_step_literally') %>
           </p>
         </div>
 
@@ -27,11 +27,11 @@
             <div class="card-body p-5">
               <div class="flex items-center gap-2 mb-2">
                 <%= icon 'smartphone', class: 'w-6 h-6 text-primary' %>
-                <h4 class="text-lg font-semibold">Start tracking now</h4>
-                <span class="badge badge-primary badge-sm">2 minutes</span>
+                <h4 class="text-lg font-semibold"><%= t('.start_tracking_now') %></h4>
+                <span class="badge badge-primary badge-sm"><%= t('.minutes') %></span>
               </div>
               <p class="text-sm text-base-content/70">
-                Get the app, scan a QR code, and watch your first points appear on the map today.
+                <%= t('.get_the_app_scan_a_qr_code_and_watch_your') %>
               </p>
             </div>
           </button>
@@ -42,10 +42,10 @@
             <div class="card-body p-5">
               <div class="flex items-center gap-2 mb-2">
                 <%= icon 'file-up', class: 'w-6 h-6 text-secondary' %>
-                <h4 class="text-lg font-semibold">I have data</h4>
+                <h4 class="text-lg font-semibold"><%= t('.i_have_data') %></h4>
               </div>
               <p class="text-sm text-base-content/70">
-                Import Google Takeout, GPX, KML, GeoJSON, or OwnTracks files.
+                <%= t('.import_google_takeout_gpx_kml_geojson_or_owntracks_files') %>
               </p>
             </div>
           </button>
@@ -57,10 +57,10 @@
             <div class="card-body p-5">
               <div class="flex items-center gap-2 mb-2">
                 <%= icon 'map', class: 'w-6 h-6 text-accent' %>
-                <h4 class="text-lg font-semibold">Explore with demo data</h4>
+                <h4 class="text-lg font-semibold"><%= t('.explore_with_demo_data') %></h4>
               </div>
               <p class="text-sm text-base-content/70">
-                Load sample location data (3 days in Berlin) to see what your map could look like. You can delete it anytime.
+                <%= t('.load_sample_location_data_3_days_in_berlin_to_see') %>
               </p>
             </div>
           </button>
@@ -68,7 +68,7 @@
 
         <div class="text-center mt-6">
           <button class="btn btn-ghost btn-sm" data-action="onboarding-modal#dismiss">
-            Skip for now
+            <%= t('.skip_for_now') %>
           </button>
         </div>
       </div>
@@ -79,26 +79,25 @@
           <button class="btn btn-ghost btn-sm btn-circle" data-action="onboarding-modal#showChoice">
             <%= icon 'arrow-left', class: 'w-4 h-4' %>
           </button>
-          <h3 class="text-xl font-bold">Import your data</h3>
+          <h3 class="text-xl font-bold"><%= t('.import_your_data') %></h3>
         </div>
 
         <div class="card bg-base-100 shadow-sm mb-4">
           <div class="card-body p-4">
-            <h4 class="card-title text-sm">Supported formats</h4>
+            <h4 class="card-title text-sm"><%= t('.supported_formats') %></h4>
             <ul class="text-xs space-y-1">
-              <li><strong>Google Maps:</strong> Records.json, Semantic History, Phone Takeout (.json)</li>
-              <li><strong>GPX:</strong> Track files (.gpx)</li>
-              <li><strong>GeoJSON:</strong> Feature collections (.json)</li>
-              <li><strong>OwnTracks:</strong> Recorder files (.rec)</li>
-              <li><strong>KML:</strong> KML files (.kml, .kmz)</li>
+              <li><strong><%= t('.google_maps') %></strong> <%= t('.records_json_semantic_history_phone_takeout_json') %></li>
+              <li><strong><%= t('.gpx') %></strong> <%= t('.track_files_gpx') %></li>
+              <li><strong><%= t('.geojson') %></strong> <%= t('.feature_collections_json') %></li>
+              <li><strong><%= t('.owntracks') %></strong> <%= t('.recorder_files_rec') %></li>
+              <li><strong><%= t('.kml') %></strong> <%= t('.kml_files_kml_kmz') %></li>
             </ul>
             <div class="text-xs text-base-content/60 mt-2">
-              File format is automatically detected during upload.
+              <%= t('.file_format_is_automatically_detected_during_upload') %>
             </div>
             <% if current_user.legacy_trial? %>
               <div class="text-xs text-warning mt-2 font-medium">
-                Trial limitations: Max 5 imports, 10MB per file.
-                Current imports: <%= current_user.imports.count %>/5
+                <%= t('.trial_limitations_max_5_imports_10mb_per_file_current_imports') %> <%= current_user.imports.count %>/5
               </div>
             <% end %>
           </div>
@@ -116,7 +115,7 @@
         } do |form| %>
           <label class="form-control w-full mb-4">
             <div class="label">
-              <span class="label-text">Select one or multiple files</span>
+              <span class="label-text"><%= t('.select_one_or_multiple_files') %></span>
             </div>
             <%= form.file_field :files,
                 multiple: true,
@@ -125,12 +124,12 @@
                 class: "file-input file-input-bordered w-full",
                 data: { upload_target: "input" } %>
             <div class="text-xs text-base-content/60 mt-2">
-              Files will be uploaded directly to storage. Please be patient during upload.
+              <%= t('.files_will_be_uploaded_directly_to_storage_please_be_patient') %>
             </div>
           </label>
 
           <div class="flex justify-end">
-            <%= form.submit "Import files", class: "btn btn-primary",
+            <%= form.submit t('.import_files'), class: "btn btn-primary",
                 data: { upload_target: "submit" } %>
           </div>
         <% end %>
@@ -142,7 +141,7 @@
           <button class="btn btn-ghost btn-sm btn-circle" data-action="onboarding-modal#showChoice">
             <%= icon 'arrow-left', class: 'w-4 h-4' %>
           </button>
-          <h3 class="text-xl font-bold">Start tracking</h3>
+          <h3 class="text-xl font-bold"><%= t('.start_tracking') %></h3>
         </div>
 
         <div class="card bg-base-100 shadow-sm">
@@ -151,7 +150,7 @@
             <div>
               <div class="flex items-center gap-2 mb-2">
                 <div class="badge badge-primary badge-sm">1</div>
-                <h4 class="font-semibold">Download the app</h4>
+                <h4 class="font-semibold"><%= t('.download_the_app') %></h4>
               </div>
               <div class="flex justify-center items-center gap-3 flex-wrap">
                 <%= link_to 'https://apps.apple.com/de/app/dawarich/id6739544999?itscg=30200&itsct=apps_box_badge&mttnsubad=6739544999',
@@ -172,10 +171,10 @@
             <div>
               <div class="flex items-center gap-2 mb-2">
                 <div class="badge badge-primary badge-sm">2</div>
-                <h4 class="font-semibold">Scan QR code to connect</h4>
+                <h4 class="font-semibold"><%= t('.scan_qr_code_to_connect') %></h4>
               </div>
               <p class="text-sm text-base-content/70 mb-3">
-                Scan this QR code with the Dawarich app to automatically configure your connection.
+                <%= t('.scan_this_qr_code_with_the_dawarich_app_to_automatically') %>
               </p>
               <div class="flex justify-center">
                 <div class="bg-white p-3 rounded-lg shadow-inner">
@@ -185,25 +184,24 @@
             </div>
 
             <%# Manual alternative %>
-            <div class="divider text-xs">OR</div>
+            <div class="divider text-xs"><%= t('.or') %></div>
             <p class="text-sm text-base-content/70">
-              Grab your API key from
-              <%= link_to 'Settings', settings_general_index_path, class: 'link link-primary font-medium' %>
-              and follow the
-              <%= link_to 'setup guide', 'https://dawarich.app/docs/tutorials/track-your-location?utm_source=app&utm_medium=referral&utm_campaign=onboarding',
+              <%= t('.grab_your_api_key_from') %>
+              <%= link_to t('.settings'), settings_general_index_path, class: 'link link-primary font-medium' %>
+              <%= t('.and_follow_the') %>
+              <%= link_to t('.setup_guide'), 'https://dawarich.app/docs/tutorials/track-your-location?utm_source=app&utm_medium=referral&utm_campaign=onboarding',
                   class: 'link link-primary font-medium', target: '_blank', rel: 'noopener' %>.
             </p>
 
             <p class="text-xs text-base-content/60">
-              Have old location history, like a Google Takeout? Tracking works right away —
-              you can <button type="button" class="link link-primary" data-action="onboarding-modal#showImport">import your history anytime</button>.
+              <%= t('.have_old_location_history_like_a_google_takeout_tracking_works') %> <button type="button" class="link link-primary" data-action="onboarding-modal#showImport"><%= t('.import_your_history_anytime') %></button>.
             </p>
           </div>
         </div>
 
         <div class="flex justify-end mt-4">
           <button class="btn btn-primary" data-action="onboarding-modal#dismiss">
-            Got it, let's start!
+            <%= t('.got_it_let_s_start') %>
           </button>
         </div>
       </div>
@@ -212,7 +210,7 @@
 
     <%# Modal backdrop %>
     <form method="dialog" class="modal-backdrop">
-      <button>close</button>
+      <button><%= t('.close') %></button>
     </form>
   </dialog>
 </div>

--- a/app/views/map/leaflet/_settings_modals.html.erb
+++ b/app/views/map/leaflet/_settings_modals.html.erb
@@ -2,190 +2,190 @@
 <input type="checkbox" id="route_opacity_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">Route opacity</h3>
+    <h3 class="text-lg font-bold"><%= t('.route_opacity') %></h3>
     <p class="py-4">
-      Value in percent.
+      <%= t('.value_in_percent') %>
     </p>
     <p class="py-4">
-      This value is the opacity of the route on the map. The value is in percent, and it can be set from 0 to 100. The default value is 100, which means that the route is fully visible. If you set the value to 0, the route will be invisible.
+      <%= t('.this_value_is_the_opacity_of_the_route_on_the') %>
     </p>
   </div>
-  <label class="modal-backdrop" for="route_opacity_info">Close</label>
+  <label class="modal-backdrop" for="route_opacity_info"><%= t('.close') %></label>
 </div>
 
 <input type="checkbox" id="fog_of_war_meters_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">Fog of War</h3>
+    <h3 class="text-lg font-bold"><%= t('.fog_of_war') %></h3>
     <p class="py-4">
-      Value in meters.
+      <%= t('.value_in_meters') %>
     </p>
     <p class="py-4">
-      Here you can set the radius of the "cleared" area around a point when Fog of War mode is enabled. The area around the point will be cleared, and the rest of the map will be covered with fog. The cleared area will be a circle with the point as the center and the radius as the value you set here.
+      <%= t('.here_you_can_set_the_radius_of_the_cleared_area') %>
     </p>
   </div>
-  <label class="modal-backdrop" for="fog_of_war_meters_info">Close</label>
+  <label class="modal-backdrop" for="fog_of_war_meters_info"><%= t('.close') %></label>
 </div>
 
 <input type="checkbox" id="fog_of_war_threshold_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">Fog of War Line Threshold</h3>
+    <h3 class="text-lg font-bold"><%= t('.fog_of_war_line_threshold') %></h3>
     <p class="py-4">
-      Value in seconds.
+      <%= t('.value_in_seconds') %>
     </p>
     <p class="py-4">
-      Points in the fog are connected by lines. This value is the maximum time between two points to be connected by a line. If the time between two points is greater than this value, they will not be connected.
+      <%= t('.points_in_the_fog_are_connected_by_lines_this_value') %>
     </p>
   </div>
-  <label class="modal-backdrop" for="fog_of_war_threshold_info">Close</label>
+  <label class="modal-backdrop" for="fog_of_war_threshold_info"><%= t('.close') %></label>
 </div>
 
 <input type="checkbox" id="meters_between_routes_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">Meters between routes</h3>
+    <h3 class="text-lg font-bold"><%= t('.meters_between_routes') %></h3>
     <p class="py-4">
-      Value in meters.
+      <%= t('.value_in_meters') %>
     </p>
     <p class="py-4">
-      Points on the map are connected by lines. This value is the maximum distance between two points to be connected by a line. If the distance between two points is greater than this value, they will not be connected, and the line will not be drawn. This allows to split the route into smaller segments, and to avoid drawing lines between two points that are far from each other.
+      <%= t('.points_on_the_map_are_connected_by_lines_this_value') %>
     </p>
   </div>
-  <label class="modal-backdrop" for="meters_between_routes_info">Close</label>
+  <label class="modal-backdrop" for="meters_between_routes_info"><%= t('.close') %></label>
 </div>
 
 
 <input type="checkbox" id="minutes_between_routes_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">Minutes between routes</h3>
+    <h3 class="text-lg font-bold"><%= t('.minutes_between_routes') %></h3>
     <p class="py-4">
-      Value in minutes.
+      <%= t('.value_in_minutes') %>
     </p>
     <p class="py-4">
-      Points on the map are connected by lines. This value is the maximum time between two points to be connected by a line. If the time between two points is greater than this value, they will not be connected. This allows to split the route into smaller segments, and to avoid drawing lines between two points that are far in time from each other.
+      <%= t('.points_on_the_map_are_connected_by_lines_this_value_2') %>
     </p>
   </div>
-  <label class="modal-backdrop" for="minutes_between_routes_info">Close</label>
+  <label class="modal-backdrop" for="minutes_between_routes_info"><%= t('.close') %></label>
 </div>
 
 <input type="checkbox" id="time_threshold_minutes_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">Visit time threshold</h3>
+    <h3 class="text-lg font-bold"><%= t('.visit_time_threshold') %></h3>
     <p class="py-4">
-      Value in minutes.
+      <%= t('.value_in_minutes') %>
     </p>
     <p class="py-4">
-      This value is the threshold, based on which a visit is calculated. If the time between two consequent points is greater than this value, the visit is considered a new visit. If the time between two points is less than this value, the visit is considered as a continuation of the previous visit.
+      <%= t('.this_value_is_the_threshold_based_on_which_a_visit') %>
     </p>
     <p class="py-4">
-      For example, if you set this value to 30 minutes, and you have four points with a time difference of 20 minutes between them, they will be considered as one visit. If the time difference between two first points is 20 minutes, and between third and fourth point is 40 minutes, the visit will be split into two visits.
+      <%= t('.for_example_if_you_set_this_value_to_30_minutes') %>
     </p>
     <p class="py-4">
-      Default value is 30 minutes.
+      <%= t('.default_value_is_30_minutes') %>
     </p>
   </div>
-  <label class="modal-backdrop" for="time_threshold_minutes_info">Close</label>
+  <label class="modal-backdrop" for="time_threshold_minutes_info"><%= t('.close') %></label>
 </div>
 
 <input type="checkbox" id="merge_threshold_minutes_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">Merge threshold</h3>
+    <h3 class="text-lg font-bold"><%= t('.merge_threshold') %></h3>
     <p class="py-4">
-      Value in minutes.
+      <%= t('.value_in_minutes') %>
     </p>
     <p class="py-4">
-      This value is the threshold, based on which two visits are merged into one. If the time between two consequent visits is less than this value, the visits are merged into one visit. If the time between two visits is greater than this value, the visits are considered as separate visits.
+      <%= t('.this_value_is_the_threshold_based_on_which_two_visits') %>
     </p>
     <p class="py-4">
-      For example, if you set this value to 30 minutes, and you have two visits with a time difference of 20 minutes between them, they will be merged into one visit. If the time difference between two visits is 40 minutes, the visits will be considered as separate visits.
+      <%= t('.for_example_if_you_set_this_value_to_30_minutes_2') %>
     </p>
     <p class="py-4">
-      Default value is 15 minutes.
+      <%= t('.default_value_is_15_minutes') %>
     </p>
   </div>
-  <label class="modal-backdrop" for="merge_threshold_minutes_info">Close</label>
+  <label class="modal-backdrop" for="merge_threshold_minutes_info"><%= t('.close') %></label>
 </div>
 
 <input type="checkbox" id="points_rendering_mode_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">Points rendering mode</h3>
+    <h3 class="text-lg font-bold"><%= t('.points_rendering_mode') %></h3>
     <p class="py-4">
-      To improve map performance, you can set the rendering mode for points to "Simplified".
+      <%= t('.to_improve_map_performance_you_can_set_the_rendering_mode') %>
     </p>
     <p class="py-4">
-      In this mode, the points that are closer to each other than 20 seconds or 50 meters are not being rendered. This can significantly improve the performance of the map, especially if you have a lot of points on the map.
+      <%= t('.in_this_mode_the_points_that_are_closer_to_each') %>
     </p>
     <p class="py-4">
-      The "Raw" mode will render all points on the map, regardless of the distance in space and time between them.
+      <%= t('.the_raw_mode_will_render_all_points_on_the_map') %>
     </p>
   </div>
-  <label class="modal-backdrop" for="points_rendering_mode_info">Close</label>
+  <label class="modal-backdrop" for="points_rendering_mode_info"><%= t('.close') %></label>
 </div>
 
 <input type="checkbox" id="speed_colored_routes_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">Speed-colored routes</h3>
+    <h3 class="text-lg font-bold"><%= t('.speed_colored_routes') %></h3>
     <p class="py-4">
-      This checkbox will color the routes based on the speed of each segment.
+      <%= t('.this_checkbox_will_color_the_routes_based_on_the_speed') %>
     </p>
     <p class="py-4">
-      Uncheck this checkbox if you want to disable the speed-colored routes.
+      <%= t('.uncheck_this_checkbox_if_you_want_to_disable_the_speed') %>
     </p>
     <p class="py-4">
-      Speed coloring is based on the following color stops:
+      <%= t('.speed_coloring_is_based_on_the_following_color_stops') %>
 
       <code>
-        0 km/h — green, stationary or walking
+        <%= t('.km_h_green_stationary_or_walking') %>
         <br>
-        15 km/h — cyan, jogging
+        <%= t('.km_h_cyan_jogging') %>
         <br>
-        30 km/h — magenta, cycling
+        <%= t('.km_h_magenta_cycling') %>
         <br>
-        50 km/h — yellow, urban driving
+        <%= t('.km_h_yellow_urban_driving') %>
         <br>
-        100 km/h — orange-red, highway driving
+        <%= t('.km_h_orange_red_highway_driving') %>
       </code>
     </p>
   </div>
-  <label class="modal-backdrop" for="speed_colored_routes_info">Close</label>
+  <label class="modal-backdrop" for="speed_colored_routes_info"><%= t('.close') %></label>
 </div>
 
 <input type="checkbox" id="live_map_enabled_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">Live map</h3>
+    <h3 class="text-lg font-bold"><%= t('.live_map') %></h3>
     <p class="py-4">
-      This checkbox will enable the live map.
+      <%= t('.this_checkbox_will_enable_the_live_map') %>
     </p>
     <p class="py-4">
-      Uncheck this checkbox if you want to disable the live map.
+      <%= t('.uncheck_this_checkbox_if_you_want_to_disable_the_live') %>
     </p>
     <p class="py-4">
-      When the live map is enabled, the map will update in real-time with the latest points.
+      <%= t('.when_the_live_map_is_enabled_the_map_will_update') %>
     </p>
   </div>
-  <label class="modal-backdrop" for="live_map_enabled_info">Close</label>
+  <label class="modal-backdrop" for="live_map_enabled_info"><%= t('.close') %></label>
 </div>
 
 <input type="checkbox" id="speed_color_scale_info" class="modal-toggle" />
 <div class="modal focus:z-99" role="dialog">
   <div class="modal-box">
-    <h3 class="text-lg font-bold">Speed color scale</h3>
+    <h3 class="text-lg font-bold"><%= t('.speed_color_scale') %></h3>
     <p class="py-4">
-      Value in format <code>speed_kmh:hex_color|...</code>.
+      <%= t('.value_in_format') %> <code><%= t('.speed_kmh_hex_color') %></code>.
     </p>
     <p class="py-4">
-      Here you can set a custom color scale for speed colored routes. It uses color stops at specified km/h values and creates a gradient from it. The default value is <code>0:#00ff00|15:#00ffff|30:#ff00ff|50:#ffff00|100:#ff3300</code>
+      <%= t('.here_you_can_set_a_custom_color_scale_for_speed') %> <code><%= t('.00ff00_15_00ffff_30_ff00ff_50_ffff00_100_ff3300') %></code>
     </p>
     <p class="py-4">
-      You can also use the 'Edit Colors' button to edit it using an UI.
+      <%= t('.you_can_also_use_the_edit_colors_button_to_edit') %>
     </p>
   </div>
-  <label class="modal-backdrop" for="speed_color_scale_info">Close</label>
+  <label class="modal-backdrop" for="speed_color_scale_info"><%= t('.close') %></label>
 </div>

--- a/app/views/map/leaflet/_sunset_banners.html.erb
+++ b/app/views/map/leaflet/_sunset_banners.html.erb
@@ -3,14 +3,14 @@
        data-controller="dismissible"
        data-dismissible-key-value="map_v1_family_history_v2_only">
     <span class="flex-1">
-      Family location history is only shown on the new map (v2).
-      <%= link_to 'Open the new map', map_v2_path, class: 'link link-primary font-medium' %>
-      to see where your family has been.
+      <%= t('.family_location_history_is_only_shown_on_the_new_map') %>
+      <%= link_to t('.open_the_new_map'), map_v2_path, class: 'link link-primary font-medium' %>
+      <%= t('.to_see_where_your_family_has_been') %>
     </span>
     <button type="button"
             class="btn btn-ghost btn-xs btn-circle"
             data-action="dismissible#dismiss"
-            aria-label="Dismiss">✕</button>
+            aria-label="<%= t('.dismiss') %>">✕</button>
   </div>
 <% end %>
 
@@ -18,11 +18,11 @@
      data-controller="dismissible"
      data-dismissible-key-value="map_v1_sunset_aug_2026">
   <span class="flex-1">
-    You're using the classic map (v1), which will be retired in <strong>August 2026</strong>.
-    <%= link_to 'Switch to the new map', map_v2_path, class: 'link link-primary font-medium' %>.
+    <%= t('.you_re_using_the_classic_map_v1_which_will_be') %> <strong><%= t('.august_2026') %></strong>.
+    <%= link_to t('.switch_to_the_new_map'), map_v2_path, class: 'link link-primary font-medium' %>.
   </span>
   <button type="button"
           class="btn btn-ghost btn-xs btn-circle"
           data-action="dismissible#dismiss"
-          aria-label="Dismiss">✕</button>
+          aria-label="<%= t('.dismiss') %>">✕</button>
 </div>

--- a/app/views/map/leaflet/index.html.erb
+++ b/app/views/map/leaflet/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Map' %>
+<% content_for :title, t('.map') %>
 
 <%= render 'shared/map/date_navigation', start_at: @start_at, end_at: @end_at %>
 

--- a/app/views/map/maplibre/_area_creation_modal.html.erb
+++ b/app/views/map/maplibre/_area_creation_modal.html.erb
@@ -1,7 +1,7 @@
 <div data-controller="area-creation-v2">
   <div class="modal z-[10000]" data-area-creation-v2-target="modal">
     <div class="modal-box max-w-xl">
-      <h3 class="font-bold text-lg mb-4" data-area-creation-v2-target="modalTitle">Create New Area</h3>
+      <h3 class="font-bold text-lg mb-4" data-area-creation-v2-target="modalTitle"><%= t('.create_new_area') %></h3>
 
       <%= form_with url: areas_path, method: :post, data: {
         area_creation_v2_target: "form",
@@ -13,10 +13,10 @@
         <div class="space-y-4">
           <div class="form-control">
             <label class="label">
-              <span class="label-text font-semibold">Area Name *</span>
+              <span class="label-text font-semibold"><%= t('.area_name') %></span>
             </label>
             <%= f.text_field :name,
-                placeholder: "e.g. Home, Office, Gym...",
+                placeholder: t('.e_g_home_office_gym'),
                 class: "input input-bordered w-full",
                 data: { area_creation_v2_target: "nameInput" },
                 required: true %>
@@ -24,14 +24,14 @@
 
           <div class="form-control">
             <label class="label">
-              <span class="label-text font-semibold">Radius</span>
+              <span class="label-text font-semibold"><%= t('.radius') %></span>
               <span class="label-text-alt">
-                <span data-area-creation-v2-target="radiusDisplay">0</span> meters
+                <span data-area-creation-v2-target="radiusDisplay">0</span> <%= t('.meters') %>
               </span>
             </label>
             <%= f.number_field :radius,
                 min: 10,
-                placeholder: "Radius in meters",
+                placeholder: t('.radius_in_meters'),
                 class: "input input-bordered w-full",
                 data: {
                   area_creation_v2_target: "radiusInput",
@@ -42,9 +42,9 @@
         </div>
 
         <div class="modal-action">
-          <button type="button" class="btn btn-ghost" data-action="click->area-creation-v2#close">Cancel</button>
-          <%= f.submit "Create Area", class: "btn btn-primary",
-              data: { area_creation_v2_target: "submitButton", disable_with: "Creating..." } %>
+          <button type="button" class="btn btn-ghost" data-action="click->area-creation-v2#close"><%= t('.cancel') %></button>
+          <%= f.submit t('.create_area'), class: "btn btn-primary",
+              data: { area_creation_v2_target: "submitButton", disable_with: t('.creating') } %>
         </div>
       <% end %>
     </div>

--- a/app/views/map/maplibre/_button_cluster.html.erb
+++ b/app/views/map/maplibre/_button_cluster.html.erb
@@ -1,12 +1,12 @@
-<div class="map-button-cluster" data-controller="map-panel" role="toolbar" aria-label="Map controls">
+<div class="map-button-cluster" data-controller="map-panel" role="toolbar" aria-label="<%= t('.map_controls') %>">
   <button type="button"
           class="map-button-cluster__btn"
           data-action="click->map-panel#openTab"
           data-tab="timeline-feed"
           data-testid="map-button-timeline"
-          aria-label="Timeline"
+          aria-label="<%= t('.timeline') %>"
           aria-keyshortcuts="T"
-          title="Timeline (T)">
+          title="<%= t('.timeline_t') %>">
     <%= icon 'calendar-clock' %>
     <%= render 'map/timeline_feeds/suggestions_badge', count: @suggestions_pending_count.to_i %>
   </button>
@@ -16,9 +16,9 @@
           data-action="click->map-panel#openTab"
           data-tab="layers"
           data-testid="map-button-layers"
-          aria-label="Layers"
+          aria-label="<%= t('.layers') %>"
           aria-keyshortcuts="L"
-          title="Layers (L)">
+          title="<%= t('.layers_l') %>">
     <%= icon 'layer' %>
   </button>
 
@@ -27,9 +27,9 @@
           data-action="click->map-panel#openTab"
           data-tab="search"
           data-testid="map-button-search"
-          aria-label="Search"
+          aria-label="<%= t('.search') %>"
           aria-keyshortcuts="/"
-          title="Search (/)">
+          title="<%= t('.search_2') %>">
     <%= icon 'search' %>
   </button>
 
@@ -38,9 +38,9 @@
           data-action="click->map-panel#openTab"
           data-tab="tools"
           data-testid="map-button-create"
-          aria-label="Create"
+          aria-label="<%= t('.create') %>"
           aria-keyshortcuts="C"
-          title="Create (C)">
+          title="<%= t('.create_c') %>">
     <%= icon 'circle-plus' %>
   </button>
 
@@ -48,9 +48,9 @@
           class="map-button-cluster__btn"
           data-action="click->maps--maplibre#toggleReplay"
           data-testid="map-button-replay"
-          aria-label="Replay"
+          aria-label="<%= t('.replay') %>"
           aria-keyshortcuts="R"
-          title="Replay points for the current date range (R)">
+          title="<%= t('.replay_points_for_the_current_date_range_r') %>">
     <%= icon 'play', class: 'w-5 h-5', aria: { hidden: true } %>
   </button>
 
@@ -58,8 +58,8 @@
           class="map-button-cluster__btn"
           data-action="click->map-panel#openPosterStudio"
           data-testid="map-button-poster"
-          aria-label="Poster Studio"
-          title="Poster Studio">
+          aria-label="<%= t('.poster_studio') %>"
+          title="<%= t('.poster_studio') %>">
     <%= icon 'image' %>
   </button>
 
@@ -70,9 +70,9 @@
           data-action="click->map-panel#openTab"
           data-tab="settings"
           data-testid="map-button-settings"
-          aria-label="Settings"
+          aria-label="<%= t('.settings') %>"
           aria-keyshortcuts="S"
-          title="Settings (S)">
+          title="<%= t('.settings_s') %>">
     <%= icon 'settings' %>
   </button>
 
@@ -86,8 +86,8 @@
             data-action="click->map-panel#openTab"
             data-tab="links"
             data-testid="map-button-links"
-            aria-label="Links"
-            title="Links">
+            aria-label="<%= t('.links') %>"
+            title="<%= t('.links') %>">
       <%= icon 'info' %>
     </button>
   <% end %>

--- a/app/views/map/maplibre/_residency_modal.html.erb
+++ b/app/views/map/maplibre/_residency_modal.html.erb
@@ -6,7 +6,7 @@
       <div class="flex items-center justify-between mb-1">
         <div class="flex items-center gap-2">
           <%= icon 'calendar-range', class: 'w-5 h-5 opacity-70' %>
-          <h3 class="font-bold text-lg">Days per Country</h3>
+          <h3 class="font-bold text-lg"><%= t('.days_per_country') %></h3>
         </div>
         <button class="btn btn-ghost btn-sm btn-circle"
                 data-action="click->residency#close">
@@ -15,7 +15,7 @@
       </div>
 
       <p class="text-xs opacity-50 mb-4">
-        Distinct days with at least one tracked point per country. Not tax advice.
+        <%= t('.distinct_days_with_at_least_one_tracked_point_per_country') %>
       </p>
 
       <!-- Content area with loading overlay -->

--- a/app/views/map/maplibre/_settings_panel.html.erb
+++ b/app/views/map/maplibre/_settings_panel.html.erb
@@ -25,10 +25,10 @@
     <div class="panel-header">
       <button class="btn btn-ghost btn-sm btn-circle"
               data-action="click->maps--maplibre#toggleSettings"
-              title="Close panel">
+              title="<%= t('.close_panel') %>">
         <%= icon 'x' %>
       </button>
-      <h3 class="panel-title" data-map-panel-target="title">Layers</h3>
+      <h3 class="panel-title" data-map-panel-target="title"><%= t('.layers') %></h3>
     </div>
 
     <!-- Panel Body -->
@@ -37,11 +37,11 @@
       <div class="tab-content" data-tab-content="search" data-map-panel-target="tabContent">
         <div class="form-control w-full">
           <label class="label">
-            <span class="label-text">Search for a place</span>
+            <span class="label-text"><%= t('.search_for_a_place') %></span>
           </label>
           <div class="relative">
             <input type="text"
-                   placeholder="Enter name of a place"
+                   placeholder="<%= t('.enter_name_of_a_place') %>"
                    class="input input-bordered w-full"
                    data-maps--maplibre-target="searchInput"
                    autocomplete="off" />
@@ -52,7 +52,7 @@
             </div>
           </div>
           <p class="text-xs text-base-content/60 mt-2">
-            Search for a location to find places you visited
+            <%= t('.search_for_a_location_to_find_places_you_visited') %>
           </p>
         </div>
       </div>
@@ -67,21 +67,21 @@
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="pointsToggle"
                      data-action="change->maps--maplibre#togglePoints" />
-              <span class="label-text font-medium">Points</span>
+              <span class="label-text font-medium"><%= t('.points') %></span>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show individual location points</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_individual_location_points') %></p>
             <label class="label cursor-pointer justify-start gap-3 ml-14 mt-1">
               <input type="checkbox"
                      class="toggle toggle-primary toggle-sm"
                      data-maps--maplibre-target="pointsEditToggle"
                      data-action="change->maps--maplibre#togglePointsEditing" />
-              <span class="label-text">Edit points</span>
+              <span class="label-text"><%= t('.edit_points') %></span>
             </label>
             <% if current_user.plan_restricted? %>
-              <p class="text-sm text-base-content/60 ml-24">Allow dragging points to correct their position.</p>
-              <p class="text-xs text-warning ml-24 mt-1">Editing points is a Pro feature — this stays on for the current session only, and moves aren't saved on the Lite plan.</p>
+              <p class="text-sm text-base-content/60 ml-24"><%= t('.allow_dragging_points_to_correct_their_position') %></p>
+              <p class="text-xs text-warning ml-24 mt-1"><%= t('.editing_points_is_a_pro_feature_this_stays_on_for') %></p>
             <% else %>
-              <p class="text-sm text-base-content/60 ml-24">Allow dragging points to correct their position. Remembered across sessions.</p>
+              <p class="text-sm text-base-content/60 ml-24"><%= t('.allow_dragging_points_to_correct_their_position_remembered_across_sessio') %></p>
             <% end %>
           </div>
 
@@ -94,16 +94,16 @@
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="routesToggle"
                      data-action="change->maps--maplibre#toggleRoutes" />
-              <span class="label-text font-medium">Routes</span>
+              <span class="label-text font-medium"><%= t('.routes') %></span>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show connected route lines</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_connected_route_lines') %></p>
           </div>
 
           <!-- Speed-Colored Routes Options (conditionally shown) -->
           <div class="ml-14 space-y-3" data-maps--maplibre-target="routesOptions" style="display: none;">
             <div class="form-control">
               <label class="label cursor-pointer py-2">
-                <span class="label-text text-sm">Color by speed</span>
+                <span class="label-text text-sm"><%= t('.color_by_speed') %></span>
                 <input type="checkbox"
                        class="toggle toggle-sm toggle-primary"
                        data-maps--maplibre-target="speedColoredToggle"
@@ -117,7 +117,7 @@
                       class="btn btn-sm btn-outline w-full"
                       data-action="click->maps--maplibre#openSpeedColorEditor">
                 <%= icon 'palette', class: 'h-4 w-4 mr-2' %>
-                Edit Color Gradient
+                <%= t('.edit_color_gradient') %>
               </button>
               <input type="hidden" data-maps--maplibre-target="speedColorScaleInput" value="" />
             </div>
@@ -132,9 +132,9 @@
                      class="toggle toggle-warning"
                      data-maps--maplibre-target="anomaliesToggle"
                      data-action="change->maps--maplibre#toggleAnomalies" />
-              <span class="label-text font-medium">Anomalies</span>
+              <span class="label-text font-medium"><%= t('.anomalies') %></span>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show filtered GPS noise points</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_filtered_gps_noise_points') %></p>
           </div>
 
           <div class="divider"></div>
@@ -146,9 +146,9 @@
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="tracksToggle"
                      data-action="change->maps--maplibre#toggleTracks" />
-              <span class="label-text font-medium">Tracks</span>
+              <span class="label-text font-medium"><%= t('.tracks') %></span>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show backend-calculated tracks</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_backend_calculated_tracks') %></p>
           </div>
 
           <!-- Flights Layer -->
@@ -159,9 +159,9 @@
                        class="toggle toggle-primary"
                        data-maps--maplibre-target="flightsToggle"
                        data-action="change->maps--maplibre#toggleFlights" />
-                <span class="label-text font-medium">Flights</span>
+                <span class="label-text font-medium"><%= t('.flights') %></span>
               </label>
-              <p class="text-sm text-base-content/60 ml-14">Show AirTrail flights as arcs (hides overlapping GPS)</p>
+              <p class="text-sm text-base-content/60 ml-14"><%= t('.show_airtrail_flights_as_arcs_hides_overlapping_gps') %></p>
             </div>
           <% end %>
 
@@ -174,10 +174,10 @@
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="heatmapToggle"
                      data-action="change->maps--maplibre#toggleHeatmap" />
-              <span class="label-text font-medium">Heatmap</span>
+              <span class="label-text font-medium"><%= t('.heatmap') %></span>
               <%= pro_badge_tag %>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show density heatmap</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_density_heatmap') %></p>
           </div>
 
           <div class="divider"></div>
@@ -190,10 +190,10 @@
                      data-testid="hexagons-toggle"
                      data-maps--maplibre-target="hexagonsToggle"
                      data-action="change->maps--maplibre#toggleHexagons" />
-              <span class="label-text font-medium">Hexagons</span>
+              <span class="label-text font-medium"><%= t('.hexagons') %></span>
               <%= pro_badge_tag %>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show point density as hexagonal cells</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_point_density_as_hexagonal_cells') %></p>
           </div>
 
           <div class="divider"></div>
@@ -205,24 +205,24 @@
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="visitsToggle"
                      data-action="change->maps--maplibre#toggleVisits" />
-              <span class="label-text font-medium">Visits</span>
+              <span class="label-text font-medium"><%= t('.visits') %></span>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show detected area visits</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_detected_area_visits') %></p>
           </div>
 
           <!-- Visits Search (conditionally shown) -->
           <div class="ml-14 space-y-2" data-maps--maplibre-target="visitsSearch" style="display: none;">
             <input type="text"
                    id="visits-search"
-                   placeholder="Filter by name..."
+                   placeholder="<%= t('.filter_by_name') %>"
                    class="input input-sm input-bordered w-full"
                    data-action="input->maps--maplibre#searchVisits" />
 
             <select class="select select-bordered w-full"
                     data-action="change->maps--maplibre#filterVisits">
-              <option value="all">All Visits</option>
-              <option value="confirmed">Confirmed Only</option>
-              <option value="suggested">Suggested Only</option>
+              <option value="all"><%= t('.all_visits') %></option>
+              <option value="confirmed"><%= t('.confirmed_only') %></option>
+              <option value="suggested"><%= t('.suggested_only') %></option>
             </select>
           </div>
 
@@ -235,9 +235,9 @@
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="placesToggle"
                      data-action="change->maps--maplibre#togglePlaces" />
-              <span class="label-text font-medium">Places</span>
+              <span class="label-text font-medium"><%= t('.places') %></span>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show your saved places</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_your_saved_places') %></p>
           </div>
 
           <!-- Places Tags (conditionally shown) -->
@@ -248,12 +248,12 @@
                        class="toggle toggle-sm"
                        data-maps--maplibre-target="enableAllPlaceTagsToggle"
                        data-action="change->maps--maplibre#toggleAllPlaceTags">
-                <span class="label-text text-sm">Enable All Tags</span>
+                <span class="label-text text-sm"><%= t('.enable_all_tags') %></span>
               </label>
             </div>
             <div class="form-control">
               <label class="label">
-                <span class="label-text text-sm">Filter by Tags</span>
+                <span class="label-text text-sm"><%= t('.filter_by_tags') %></span>
               </label>
               <div class="flex flex-wrap gap-2">
                 <!-- Untagged option -->
@@ -266,7 +266,7 @@
                   <span class="badge badge-sm badge-outline transition-all peer-checked:scale-105"
                         style="border-color: #94a3b8; color: #94a3b8;"
                         data-checked-style="background-color: #94a3b8; color: white;">
-                    🏷️ Untagged
+                    <%= t('.untagged') %>
                   </span>
                 </label>
 
@@ -286,7 +286,7 @@
                 <% end %>
               </div>
               <label class="label">
-                <span class="label-text-alt">Click tags to filter places</span>
+                <span class="label-text-alt"><%= t('.click_tags_to_filter_places') %></span>
               </label>
             </div>
           </div>
@@ -300,9 +300,9 @@
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="photosToggle"
                      data-action="change->maps--maplibre#togglePhotos" />
-              <span class="label-text font-medium">Photos</span>
+              <span class="label-text font-medium"><%= t('.photos') %></span>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show geotagged photos</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_geotagged_photos') %></p>
           </div>
 
           <div class="divider"></div>
@@ -314,9 +314,9 @@
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="areasToggle"
                      data-action="change->maps--maplibre#toggleAreas" />
-              <span class="label-text font-medium">Areas</span>
+              <span class="label-text font-medium"><%= t('.areas') %></span>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show defined areas</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_defined_areas') %></p>
           </div>
 
           <div class="divider"></div>
@@ -328,10 +328,10 @@
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="fogToggle"
                      data-action="change->maps--maplibre#toggleFog" />
-              <span class="label-text font-medium">Fog of War</span>
+              <span class="label-text font-medium"><%= t('.fog_of_war') %></span>
               <%= pro_badge_tag %>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show explored areas</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_explored_areas') %></p>
             <div class="flex gap-4 ml-14 mt-1">
               <label class="label cursor-pointer gap-2 py-0">
                 <input type="radio"
@@ -340,7 +340,7 @@
                        class="radio radio-sm"
                        <%= 'checked' if current_user.safe_settings.fog_of_war_mode == 'points' %>
                        data-action="change->maps--maplibre#updateFogMode" />
-                <span class="label-text text-sm">Per point</span>
+                <span class="label-text text-sm"><%= t('.per_point') %></span>
               </label>
               <label class="label cursor-pointer gap-2 py-0">
                 <input type="radio"
@@ -349,7 +349,7 @@
                        class="radio radio-sm"
                        <%= 'checked' if current_user.safe_settings.fog_of_war_mode == 'hexagons' %>
                        data-action="change->maps--maplibre#updateFogMode" />
-                <span class="label-text text-sm">Per hexagon</span>
+                <span class="label-text text-sm"><%= t('.per_hexagon') %></span>
               </label>
             </div>
           </div>
@@ -363,10 +363,10 @@
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="scratchToggle"
                      data-action="change->maps--maplibre#toggleScratch" />
-              <span class="label-text font-medium">Scratch Map</span>
+              <span class="label-text font-medium"><%= t('.scratch_map') %></span>
               <%= pro_badge_tag %>
             </label>
-            <p class="text-sm text-base-content/60 ml-14">Show scratched countries</p>
+            <p class="text-sm text-base-content/60 ml-14"><%= t('.show_scratched_countries') %></p>
           </div>
 
           <% if family_feature_available? %>
@@ -379,15 +379,15 @@
                        class="toggle toggle-primary"
                        data-maps--maplibre-target="familyToggle"
                        data-action="change->maps--maplibre#toggleFamily" />
-                <span class="label-text font-medium">Family Members</span>
+                <span class="label-text font-medium"><%= t('.family_members') %></span>
               </label>
-              <p class="text-sm text-base-content/60 ml-14">Show family member locations</p>
+              <p class="text-sm text-base-content/60 ml-14"><%= t('.show_family_member_locations') %></p>
             </div>
 
             <!-- Family Members List (conditionally shown) -->
             <div class="ml-14 space-y-2" data-maps--maplibre-target="familyMembersList" style="display: none;">
               <div class="text-xs text-base-content/60 mb-2">
-                Click to center on member
+                <%= t('.click_to_center_on_member') %>
               </div>
               <div data-maps--maplibre-target="familyMembersContainer" class="space-y-1">
                 <!-- Family members will be dynamically inserted here -->
@@ -407,29 +407,29 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
               <%= icon 'palette', class: 'h-4 w-4 opacity-70 shrink-0' %>
-              Appearance
+              <%= t('.appearance') %>
               </span>
             </summary>
             <div class="collapse-content space-y-4">
               <% if current_user.plan_restricted? %>
-                <p class="text-xs text-warning">Custom map colors, layer colors, and vector tiles are Pro features — you can preview them here, but they won't be saved on the Lite plan.</p>
+                <p class="text-xs text-warning"><%= t('.custom_map_colors_layer_colors_and_vector_tiles_are_pro') %></p>
               <% end %>
               <div data-controller="map-theme-editor">
                 <!-- Map Style -->
                 <div class="form-control w-full">
                   <label class="label">
-                    <span class="label-text font-medium">Map Style</span>
+                    <span class="label-text font-medium"><%= t('.map_style') %></span>
                   </label>
                   <select class="select select-bordered w-full"
                           name="mapStyle"
                           data-map-theme-editor-target="styleSelect"
                           data-action="change->maps--maplibre#updateMapStyle change->map-theme-editor#styleChanged">
-                    <option value="light" selected>Light</option>
-                    <option value="dark">Dark</option>
-                    <option value="white">White</option>
-                    <option value="black">Black</option>
-                    <option value="grayscale">Grayscale</option>
-                    <option value="custom">Custom</option>
+                    <option value="light" selected><%= t('.light') %></option>
+                    <option value="dark"><%= t('.dark') %></option>
+                    <option value="white"><%= t('.white') %></option>
+                    <option value="black"><%= t('.black') %></option>
+                    <option value="grayscale"><%= t('.grayscale') %></option>
+                    <option value="custom"><%= t('.custom') %></option>
                   </select>
                 </div>
 
@@ -437,14 +437,14 @@
                      the map to the Custom style with that theme applied -->
                 <div class="mt-3 space-y-3">
                   <div>
-                    <span class="label-text text-sm">Color themes</span>
+                    <span class="label-text text-sm"><%= t('.color_themes') %></span>
                     <div class="grid grid-cols-6 gap-1.5 mt-1">
                       <% Array(@poster_themes).each do |theme| %>
                         <button type="button"
                                 class="w-full overflow-hidden rounded-md border border-base-300 ring-primary ring-offset-base-100 transition hover:scale-105 focus:outline-none focus-visible:ring-2"
                                 style="height: 32px; background-image: url('<%= asset_path("poster_themes/#{theme['key']}.webp") %>'); background-size: cover; background-position: center;"
                                 title="<%= theme['name'] %>"
-                                aria-label="<%= theme['name'] %> theme"
+                                aria-label="<%= t('.theme_aria_label', theme: theme['name']) %>"
                                 data-map-theme-editor-target="swatch"
                                 data-key="<%= theme['key'] %>"
                                 data-name="<%= theme['name'] %>"
@@ -456,13 +456,13 @@
 
                   <!-- Fine-tuning (shown when the Custom style is active) -->
                   <details class="hidden collapse collapse-arrow bg-base-100 rounded-lg" data-map-theme-editor-target="block">
-                    <summary class="collapse-title text-sm min-h-0 cursor-pointer select-none">Customize colors</summary>
+                    <summary class="collapse-title text-sm min-h-0 cursor-pointer select-none"><%= t('.customize_colors') %></summary>
                     <div class="collapse-content space-y-1">
                       <% [
-                        %w[bg Background], %w[water Water], %w[parks Parks],
-                        %w[buildings Buildings], %w[railway Railways], %w[boundaries Boundaries],
-                        ['road_motorway', 'Motorway roads'], ['road_primary', 'Primary roads'],
-                        ['road_residential', 'Residential roads'], ['road_default', 'Other roads']
+                        ['bg', t('.background')], ['water', t('.water')], ['parks', t('.parks')],
+                        ['buildings', t('.buildings')], ['railway', t('.railways')], ['boundaries', t('.boundaries')],
+                        ['road_motorway', t('.motorway_roads')], ['road_primary', t('.primary_roads')],
+                        ['road_residential', t('.residential_roads')], ['road_default', t('.other_roads')]
                       ].each do |token, token_label| %>
                         <label class="flex items-center gap-2">
                           <input type="color"
@@ -487,10 +487,10 @@
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="globeToggle"
                      data-action="change->maps--maplibre#toggleGlobe" />
-              <span class="label-text font-medium">Globe View</span>
+              <span class="label-text font-medium"><%= t('.globe_view') %></span>
               <%= pro_badge_tag(preview: false) %>
             </label>
-            <p class="text-sm text-base-content/60 mt-1">Render map as a 3D globe (requires page reload)</p>
+            <p class="text-sm text-base-content/60 mt-1"><%= t('.render_map_as_a_3d_globe_requires_page_reload') %></p>
           </div>
 
           <div class="divider"></div>
@@ -498,7 +498,7 @@
           <!-- Route Opacity -->
           <div class="form-control w-full">
             <label class="label">
-              <span class="label-text font-medium">Route Opacity</span>
+              <span class="label-text font-medium"><%= t('.route_opacity') %></span>
               <span class="label-text-alt">%</span>
             </label>
             <input type="range"
@@ -522,14 +522,14 @@
           <!-- Layer Colors -->
           <div class="form-control w-full space-y-1">
             <label class="label">
-              <span class="label-text font-medium">Layer Colors</span>
+              <span class="label-text font-medium"><%= t('.layer_colors') %></span>
             </label>
             <label class="flex items-center gap-2">
               <input type="color"
                      name="routeColor"
                      class="h-7 w-9 cursor-pointer rounded border border-base-300 bg-base-100 p-0.5"
                      data-action="input->maps--maplibre#updateRouteColor">
-              <span class="label-text text-sm flex-1">Routes</span>
+              <span class="label-text text-sm flex-1"><%= t('.routes') %></span>
               <span class="text-xs opacity-60 tabular-nums" data-layer-color-value="routeColor"></span>
             </label>
             <label class="flex items-center gap-2">
@@ -537,14 +537,14 @@
                      name="trackColor"
                      class="h-7 w-9 cursor-pointer rounded border border-base-300 bg-base-100 p-0.5"
                      data-action="input->maps--maplibre#updateTrackColor">
-              <span class="label-text text-sm flex-1">Tracks</span>
+              <span class="label-text text-sm flex-1"><%= t('.tracks') %></span>
               <span class="text-xs opacity-60 tabular-nums" data-layer-color-value="trackColor"></span>
             </label>
             <button type="button"
                     class="btn btn-xs btn-ghost self-start"
                     data-action="click->maps--maplibre#resetLayerColors">
               <%= icon 'rotate-ccw', class: 'h-3 w-3' %>
-              Reset to defaults
+              <%= t('.reset_to_defaults') %>
             </button>
           </div>
 
@@ -553,7 +553,7 @@
           <!-- Distance Unit -->
           <div class="form-control">
             <label class="label">
-              <span class="label-text font-medium">Distance Unit</span>
+              <span class="label-text font-medium"><%= t('.distance_unit') %></span>
             </label>
             <div class="flex gap-4">
               <label class="label cursor-pointer gap-2 py-0">
@@ -562,7 +562,7 @@
                        value="km"
                        class="radio radio-sm radio-primary"
                        data-action="change->maps--maplibre#updateDistanceUnit" />
-                <span class="label-text text-sm">Kilometers</span>
+                <span class="label-text text-sm"><%= t('.kilometers') %></span>
               </label>
               <label class="label cursor-pointer gap-2 py-0">
                 <input type="radio"
@@ -570,7 +570,7 @@
                        value="mi"
                        class="radio radio-sm radio-primary"
                        data-action="change->maps--maplibre#updateDistanceUnit" />
-                <span class="label-text text-sm">Miles</span>
+                <span class="label-text text-sm"><%= t('.miles') %></span>
               </label>
             </div>
           </div>
@@ -580,14 +580,14 @@
           <!-- Custom Basemap -->
           <div class="form-control w-full">
             <label class="label">
-              <span class="label-text font-medium">Custom Basemap URL</span>
+              <span class="label-text font-medium"><%= t('.custom_basemap_url') %></span>
             </label>
             <input type="url"
                    name="vectorTilesUrl"
                    placeholder="https://tiles.example.com/{z}/{x}/{y}.mvt"
                    class="input input-bordered input-sm w-full"
                    data-action="change->maps--maplibre#updateVectorTilesUrl" />
-            <p class="text-xs text-base-content/60 mt-1">Serve the base map from your own source. Accepts Protomaps-schema vector tiles or raster XYZ tiles (both must include {z}, {x}, and {y}), or a full MapLibre style URL. Leave empty for the built-in tiles.</p>
+            <p class="text-xs text-base-content/60 mt-1"><%= t('.serve_the_base_map_from_your_own_source_accepts_protomaps') %></p>
           </div>
             </div>
           </details>
@@ -597,28 +597,28 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
               <%= icon 'layer', class: 'h-4 w-4 opacity-70 shrink-0' %>
-              Base Map Layers <%= pro_badge_tag(preview: false) %>
+              <%= t('.base_map_layers') %> <%= pro_badge_tag(preview: false) %>
               </span>
             </summary>
             <div class="collapse-content space-y-1">
               <% if can_customize_layers %>
-                <p class="text-xs text-base-content/60 mb-2">Toggle base map elements. Changes apply immediately.</p>
+                <p class="text-xs text-base-content/60 mb-2"><%= t('.toggle_base_map_elements_changes_apply_immediately') %></p>
               <% else %>
-                <p class="text-xs text-warning mb-2">Pro feature — you can preview changes here, but they won't be saved on the Lite plan.</p>
+                <p class="text-xs text-warning mb-2"><%= t('.pro_feature_you_can_preview_changes_here_but_they_won') %></p>
               <% end %>
               <% hidden_categories = current_user.safe_settings.maps&.dig('hidden_tile_categories') || [] %>
               <% [
-                ['roads', 'Roads', 'Streets, highways, and paths', true],
-                ['road_labels', 'Road Labels', 'Street names and route shields', false],
-                ['rail', 'Railways', 'Train tracks and rail lines', true],
-                ['buildings', 'Buildings', 'Building footprints', true],
-                ['address_labels', 'Address Labels', 'Building numbers (visible at high zoom)', false],
-                ['pois', 'Points of Interest', 'Master toggle for all POI groups below', false],
-                ['place_labels', 'Place Names', 'Cities, neighborhoods, regions, and countries', false],
-                ['water_labels', 'Water Labels', 'Ocean, lake, and river names', false],
-                ['water', 'Water', 'Oceans, lakes, rivers, and streams', true],
-                ['landuse', 'Land Use', 'Parks, schools, hospitals, airports, etc.', true],
-                ['boundaries', 'Boundaries', 'Country and administrative borders', true],
+                ['roads', t('.roads'), t('.streets_highways_and_paths'), true],
+                ['road_labels', t('.road_labels'), t('.street_names_and_route_shields'), false],
+                ['rail', t('.railways'), t('.train_tracks_and_rail_lines'), true],
+                ['buildings', t('.buildings'), t('.building_footprints'), true],
+                ['address_labels', t('.address_labels'), t('.building_numbers_visible_at_high_zoom'), false],
+                ['pois', t('.points_of_interest'), t('.master_toggle_for_all_poi_groups_below'), false],
+                ['place_labels', t('.place_names'), t('.cities_neighborhoods_regions_and_countries'), false],
+                ['water_labels', t('.water_labels'), t('.ocean_lake_and_river_names'), false],
+                ['water', t('.water'), t('.oceans_lakes_rivers_and_streams'), true],
+                ['landuse', t('.land_use'), t('.parks_schools_hospitals_airports_etc'), true],
+                ['boundaries', t('.boundaries'), t('.country_and_administrative_borders'), true],
               ].each do |key, label, description, custom_supported| %>
                 <div class="form-control">
                   <label class="label cursor-pointer justify-start gap-3 py-1">
@@ -635,7 +635,7 @@
                   </label>
                 </div>
               <% end %>
-              <p class="text-xs text-base-content/60 mt-2">The Custom style draws no labels or points of interest — those toggles are disabled while it's active.</p>
+              <p class="text-xs text-base-content/60 mt-2"><%= t('.the_custom_style_draws_no_labels_or_points_of_interest') %></p>
             </div>
           </details>
 
@@ -643,25 +643,25 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
               <%= icon 'map-pin', class: 'h-4 w-4 opacity-70 shrink-0' %>
-              Points of Interest <%= pro_badge_tag(preview: false) %>
+              <%= t('.points_of_interest') %> <%= pro_badge_tag(preview: false) %>
               </span>
             </summary>
             <div class="collapse-content space-y-1">
               <% if can_customize_layers %>
-                <p class="text-xs text-base-content/60 mb-2">Choose which POI categories appear on the map.</p>
+                <p class="text-xs text-base-content/60 mb-2"><%= t('.choose_which_poi_categories_appear_on_the_map') %></p>
               <% else %>
-                <p class="text-xs text-warning mb-2">Pro feature — you can preview changes here, but they won't be saved on the Lite plan.</p>
+                <p class="text-xs text-warning mb-2"><%= t('.pro_feature_you_can_preview_changes_here_but_they_won') %></p>
               <% end %>
               <% disabled_poi_groups = current_user.safe_settings.maps&.dig('disabled_poi_groups') || [] %>
               <% [
-                ['food_drink', 'Food & Drink', 'Restaurants, cafes, bars, bakeries, fast food'],
-                ['shopping', 'Shopping', 'Supermarkets, clothes, electronics, books, beauty'],
-                ['transport', 'Transport', 'Stations, bus stops, airports, fuel, parking'],
-                ['cycling', 'Cycling', 'Bike parking, rental, and repair stations'],
-                ['nature_leisure', 'Nature & Leisure', 'Parks, forests, beaches, playgrounds, stadiums'],
-                ['tourism', 'Tourism & Culture', 'Museums, theatres, attractions, viewpoints, hotels'],
-                ['services', 'Services & Civic', 'Post offices, libraries, schools, hospitals, police, banks'],
-                ['urban_amenities', 'Urban Amenities', 'Benches, toilets, drinking water, fountains, recycling, shelters'],
+                ['food_drink', t('.food_drink'), t('.restaurants_cafes_bars_bakeries_fast_food')],
+                ['shopping', t('.shopping'), t('.supermarkets_clothes_electronics_books_beauty')],
+                ['transport', t('.transport'), t('.stations_bus_stops_airports_fuel_parking')],
+                ['cycling', t('.cycling'), t('.bike_parking_rental_and_repair_stations')],
+                ['nature_leisure', t('.nature_leisure'), t('.parks_forests_beaches_playgrounds_stadiums')],
+                ['tourism', t('.tourism_culture'), t('.museums_theatres_attractions_viewpoints_hotels')],
+                ['services', t('.services_civic'), t('.post_offices_libraries_schools_hospitals_police_banks')],
+                ['urban_amenities', t('.urban_amenities'), t('.benches_toilets_drinking_water_fountains_recycling_shelters')],
               ].each do |key, label, description| %>
                 <div class="form-control">
                   <label class="label cursor-pointer justify-start gap-3 py-1">
@@ -684,7 +684,7 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
               <%= icon 'route', class: 'h-4 w-4 opacity-70 shrink-0' %>
-              Routes
+              <%= t('.routes') %>
               <span class="badge badge-outline badge-warning badge-sm tooltip tooltip-left ml-auto mr-1 self-center hidden" data-dirty-badge></span>
               </span>
             </summary>
@@ -692,8 +692,8 @@
           <!-- Route Generation Settings -->
           <div class="form-control w-full">
             <label class="label">
-              <span class="label-text font-medium">Meters Between Routes</span>
-              <span class="label-text-alt" data-maps--maplibre-target="metersBetweenValue">500m</span>
+              <span class="label-text font-medium"><%= t('.meters_between_routes') %></span>
+              <span class="label-text-alt" data-maps--maplibre-target="metersBetweenValue"><%= t('units.meters_compact', value: 500) %></span>
             </label>
             <input type="range"
                    name="metersBetweenRoutes"
@@ -704,17 +704,17 @@
                    class="range range-sm"
                    data-action="input->maps--maplibre#updateMetersBetweenDisplay" />
             <div class="w-full flex justify-between text-xs px-2 mt-1">
-              <span>100m</span>
-              <span>2500m</span>
-              <span>5000m</span>
+              <span><%= t('units.meters_compact', value: 100) %></span>
+              <span><%= t('units.meters_compact', value: 2500) %></span>
+              <span><%= t('units.meters_compact', value: 5000) %></span>
             </div>
-            <p class="text-xs text-base-content/60 mt-1">Distance threshold for route splitting</p>
+            <p class="text-xs text-base-content/60 mt-1"><%= t('.distance_threshold_for_route_splitting') %></p>
           </div>
 
           <div class="form-control w-full">
             <label class="label">
-              <span class="label-text font-medium">Minutes Between Routes</span>
-              <span class="label-text-alt" data-maps--maplibre-target="minutesBetweenValue">60min</span>
+              <span class="label-text font-medium"><%= t('.minutes_between_routes') %></span>
+              <span class="label-text-alt" data-maps--maplibre-target="minutesBetweenValue"><%= t('.min') %></span>
             </label>
             <input type="range"
                    name="minutesBetweenRoutes"
@@ -725,11 +725,11 @@
                    class="range range-sm"
                    data-action="input->maps--maplibre#updateMinutesBetweenDisplay" />
             <div class="w-full flex justify-between text-xs px-2 mt-1">
-              <span>1min</span>
-              <span>90min</span>
-              <span>180min</span>
+              <span><%= t('.min_2') %></span>
+              <span><%= t('.min_3') %></span>
+              <span><%= t('.min_4') %></span>
             </div>
-            <p class="text-xs text-base-content/60 mt-1">Time threshold for route splitting</p>
+            <p class="text-xs text-base-content/60 mt-1"><%= t('.time_threshold_for_route_splitting') %></p>
           </div>
 
           <div class="divider"></div>
@@ -737,7 +737,7 @@
           <!-- Points Rendering Mode -->
           <div class="form-control w-full">
             <label class="label">
-              <span class="label-text font-medium">Points Rendering Mode</span>
+              <span class="label-text font-medium"><%= t('.points_rendering_mode') %></span>
             </label>
             <div class="flex flex-col gap-2">
               <label class="label cursor-pointer justify-start gap-3 py-1">
@@ -746,14 +746,14 @@
                        value="raw"
                        class="radio radio-primary radio-sm"
                        checked />
-                <span class="label-text">Raw (all points)</span>
+                <span class="label-text"><%= t('.raw_all_points') %></span>
               </label>
               <label class="label cursor-pointer justify-start gap-3 py-1">
                 <input type="radio"
                        name="pointsRenderingMode"
                        value="simplified"
                        class="radio radio-primary radio-sm" />
-                <span class="label-text">Simplified (reduced points)</span>
+                <span class="label-text"><%= t('.simplified_reduced_points') %></span>
               </label>
             </div>
           </div>
@@ -764,9 +764,9 @@
               <input type="checkbox"
                      name="speedColoredRoutes"
                      class="toggle toggle-primary" />
-              <span class="label-text font-medium">Speed-Colored Routes</span>
+              <span class="label-text font-medium"><%= t('.speed_colored_routes') %></span>
             </label>
-            <p class="text-sm text-base-content/60 mt-1">Color routes by speed</p>
+            <p class="text-sm text-base-content/60 mt-1"><%= t('.color_routes_by_speed') %></p>
           </div>
             </div>
           </details>
@@ -775,7 +775,7 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
               <%= icon 'cloud-fog', class: 'h-4 w-4 opacity-70 shrink-0' %>
-              Fog of War
+              <%= t('.fog_of_war') %>
               <span class="badge badge-outline badge-warning badge-sm tooltip tooltip-left ml-auto mr-1 self-center hidden" data-dirty-badge></span>
               </span>
             </summary>
@@ -783,8 +783,8 @@
           <!-- Fog of War Settings -->
           <div class="form-control w-full">
             <label class="label">
-              <span class="label-text font-medium">Fog of War Radius</span>
-              <span class="label-text-alt" data-maps--maplibre-target="fogRadiusValue">1000m</span>
+              <span class="label-text font-medium"><%= t('.fog_of_war_radius') %></span>
+              <span class="label-text-alt" data-maps--maplibre-target="fogRadiusValue"><%= t('units.meters_compact', value: 1000) %></span>
             </label>
             <input type="range"
                    name="fogOfWarRadius"
@@ -795,16 +795,16 @@
                    class="range range-sm"
                    data-action="input->maps--maplibre#updateFogRadiusDisplay" />
             <div class="w-full flex justify-between text-xs px-2 mt-1">
-              <span>5m</span>
-              <span>1000m</span>
-              <span>2000m</span>
+              <span><%= t('units.meters_compact', value: 5) %></span>
+              <span><%= t('units.meters_compact', value: 1000) %></span>
+              <span><%= t('units.meters_compact', value: 2000) %></span>
             </div>
-            <p class="text-xs text-base-content/60 mt-1">Clear radius around visited points</p>
+            <p class="text-xs text-base-content/60 mt-1"><%= t('.clear_radius_around_visited_points') %></p>
           </div>
 
           <div class="form-control w-full">
             <label class="label">
-              <span class="label-text font-medium">Fog of War Threshold</span>
+              <span class="label-text font-medium"><%= t('.fog_of_war_threshold') %></span>
               <span class="label-text-alt" data-maps--maplibre-target="fogThresholdValue">1</span>
             </label>
             <input type="range"
@@ -820,7 +820,7 @@
               <span>5</span>
               <span>10</span>
             </div>
-            <p class="text-xs text-base-content/60 mt-1">Minimum points to clear fog</p>
+            <p class="text-xs text-base-content/60 mt-1"><%= t('.minimum_points_to_clear_fog') %></p>
           </div>
             </div>
           </details>
@@ -829,7 +829,7 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
               <%= icon 'satellite', class: 'h-4 w-4 opacity-70 shrink-0' %>
-              GPS Noise Filtering
+              <%= t('.gps_noise_filtering') %>
               <span class="badge badge-outline badge-warning badge-sm tooltip tooltip-left ml-auto mr-1 self-center hidden" data-dirty-badge></span>
               </span>
             </summary>
@@ -841,26 +841,26 @@
                      name="gpsFilteringEnabled"
                      class="toggle toggle-primary"
                      data-maps--maplibre-target="gpsFilteringToggle" />
-              <span class="label-text font-medium">GPS Noise Filtering</span>
+              <span class="label-text font-medium"><%= t('.gps_noise_filtering') %></span>
             </label>
-            <p class="text-sm text-base-content/60 mt-1">Hide readings that cannot be a real position — impossible jumps, broken coordinates. Disable to see every raw point.</p>
+            <p class="text-sm text-base-content/60 mt-1"><%= t('.hide_readings_that_cannot_be_a_real_position_impossible_jumps') %></p>
           </div>
 
           <button type="button"
                   class="btn btn-sm btn-outline btn-block"
                   data-action="click->maps--maplibre#reapplyAnomalyFilter">
             <%= icon 'rotate-ccw' %>
-            Re-evaluate past data
+            <%= t('.re_evaluate_past_data') %>
           </button>
-          <p class="text-xs text-base-content/60 mt-1">Clears existing anomaly flags and re-runs the filter on all your points with the current settings. Tracks, stats, and digests will be rebuilt afterwards. Runs in the background.</p>
+          <p class="text-xs text-base-content/60 mt-1"><%= t('.clears_existing_anomaly_flags_and_re_runs_the_filter_on') %></p>
 
           <button type="button"
                   class="btn btn-sm btn-outline btn-block mt-2"
                   data-action="click->maps--maplibre#recalculateUserData">
             <%= icon 'refresh-ccw' %>
-            Recalculate tracks &amp; stats
+            <%= t('.recalculate_tracks_stats') %>
           </button>
-          <p class="text-xs text-base-content/60 mt-1">Rebuild tracks, stats, and digests from your current points without touching anomaly flags. Useful after changing route-splitting thresholds.</p>
+          <p class="text-xs text-base-content/60 mt-1"><%= t('.rebuild_tracks_stats_and_digests_from_your_current_points_without') %></p>
             </div>
           </details>
 
@@ -868,7 +868,7 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
               <%= icon 'chart-column', class: 'h-4 w-4 opacity-70 shrink-0' %>
-              City Statistics
+              <%= t('.city_statistics') %>
               <span class="badge badge-outline badge-warning badge-sm tooltip tooltip-left ml-auto mr-1 self-center hidden" data-dirty-badge></span>
               </span>
             </summary>
@@ -876,8 +876,8 @@
           <!-- City Statistics Settings -->
           <div class="form-control w-full">
             <label class="label">
-              <span class="label-text font-medium">Min Minutes in City</span>
-              <span class="label-text-alt" data-maps--maplibre-target="minMinutesInCityValue">60 min</span>
+              <span class="label-text font-medium"><%= t('.min_minutes_in_city') %></span>
+              <span class="label-text-alt" data-maps--maplibre-target="minMinutesInCityValue"><%= t('.min_5') %></span>
             </label>
             <input type="range"
                    name="minMinutesSpentInCity"
@@ -888,17 +888,17 @@
                    class="range range-sm"
                    data-action="input->maps--maplibre#updateMinMinutesInCityDisplay" />
             <div class="w-full flex justify-between text-xs px-2 mt-1">
-              <span>5min</span>
-              <span>60min</span>
-              <span>120min</span>
+              <span><%= t('.min_6') %></span>
+              <span><%= t('.min') %></span>
+              <span><%= t('.min_7') %></span>
             </div>
-            <p class="text-xs text-base-content/60 mt-1">How long you must stay for a city to count in statistics</p>
+            <p class="text-xs text-base-content/60 mt-1"><%= t('.how_long_you_must_stay_for_a_city_to_count') %></p>
           </div>
 
           <div class="form-control w-full">
             <label class="label">
-              <span class="label-text font-medium">Max Gap Between Points</span>
-              <span class="label-text-alt" data-maps--maplibre-target="maxGapMinutesValue">120 min</span>
+              <span class="label-text font-medium"><%= t('.max_gap_between_points') %></span>
+              <span class="label-text-alt" data-maps--maplibre-target="maxGapMinutesValue"><%= t('.min_8') %></span>
             </label>
             <input type="range"
                    name="maxGapMinutesInCity"
@@ -909,11 +909,11 @@
                    class="range range-sm"
                    data-action="input->maps--maplibre#updateMaxGapMinutesDisplay" />
             <div class="w-full flex justify-between text-xs px-2 mt-1">
-              <span>30min</span>
-              <span>195min</span>
-              <span>360min</span>
+              <span><%= t('.min_9') %></span>
+              <span><%= t('.min_10') %></span>
+              <span><%= t('.min_11') %></span>
             </div>
-            <p class="text-xs text-base-content/60 mt-1">Max gap between points before assuming you left the city</p>
+            <p class="text-xs text-base-content/60 mt-1"><%= t('.max_gap_between_points_before_assuming_you_left_the_city') %></p>
           </div>
 
           <div class="divider"></div>
@@ -921,8 +921,8 @@
           <!-- Visit Detection Settings -->
           <div class="form-control w-full">
             <label class="label">
-              <span class="label-text font-medium">Visit Max Gap</span>
-              <span class="label-text-alt" data-maps--maplibre-target="stayMaxGapMinutesValue">60 min</span>
+              <span class="label-text font-medium"><%= t('.visit_max_gap') %></span>
+              <span class="label-text-alt" data-maps--maplibre-target="stayMaxGapMinutesValue"><%= t('.min_5') %></span>
             </label>
             <input type="range"
                    name="stayMaxGapMinutes"
@@ -933,11 +933,11 @@
                    class="range range-sm"
                    data-action="input->maps--maplibre#updateStayMaxGapMinutesDisplay" />
             <div class="w-full flex justify-between text-xs px-2 mt-1">
-              <span>5min</span>
-              <span>360min</span>
-              <span>720min</span>
+              <span><%= t('.min_6') %></span>
+              <span><%= t('.min_11') %></span>
+              <span><%= t('.min_12') %></span>
             </div>
-            <p class="text-xs text-base-content/60 mt-1">Max time gap between points within one visit. Longer gaps (e.g. dead battery) split it into separate visits. Default 60.</p>
+            <p class="text-xs text-base-content/60 mt-1"><%= t('.max_time_gap_between_points_within_one_visit_longer_gaps') %></p>
           </div>
             </div>
           </details>
@@ -946,7 +946,7 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
               <%= icon 'radio', class: 'h-4 w-4 opacity-70 shrink-0' %>
-              Live Mode
+              <%= t('.live_mode') %>
               </span>
             </summary>
             <div class="collapse-content space-y-4">
@@ -957,9 +957,9 @@
                      class="toggle toggle-primary"
                      data-action="change->maps--maplibre-realtime#toggleLiveMode"
                      data-maps--maplibre-realtime-target="liveModeToggle" />
-              <span class="label-text font-medium">Live Mode</span>
+              <span class="label-text font-medium"><%= t('.live_mode') %></span>
             </label>
-            <p class="text-sm text-base-content/60 mt-1">Show new points in real-time</p>
+            <p class="text-sm text-base-content/60 mt-1"><%= t('.show_new_points_in_real_time') %></p>
           </div>
             </div>
           </details>
@@ -967,7 +967,7 @@
           <!-- Update Button -->
           <button type="submit" class="btn btn-sm btn-primary btn-block">
             <%= icon 'save' %>
-            Apply Settings
+            <%= t('.apply_settings') %>
           </button>
 
           <!-- Reset Settings -->
@@ -975,7 +975,7 @@
                   class="btn btn-sm btn-outline btn-block"
                   data-action="click->maps--maplibre#resetSettings">
             <%= icon 'rotate-ccw' %>
-            Reset to Defaults
+            <%= t('.reset_to_defaults_2') %>
           </button>
 
           <div class="divider"></div>
@@ -987,7 +987,7 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
               <%= icon 'car', class: 'h-4 w-4 opacity-70 shrink-0' %>
-              Transportation Mode Detection
+              <%= t('.transportation_mode_detection') %>
               <span class="badge badge-outline badge-warning badge-sm tooltip tooltip-left ml-auto mr-1 self-center hidden" data-dirty-badge></span>
               </span>
             </summary>
@@ -997,26 +997,25 @@
                    class="text-xs text-warning bg-warning/10 rounded p-2 mb-4 hidden"
                    data-maps--maplibre-target="transportationRecalculationAlert">
                 <span class="loading loading-spinner loading-xs"></span>
-                <span>Checking status...</span>
+                <span><%= t('.checking_status') %></span>
               </div>
 
               <!-- Locked Message -->
               <div role="alert"
                    class="text-xs text-info bg-info/10 rounded p-2 mb-4 hidden"
                    data-maps--maplibre-target="transportationLockedMessage">
-                <span>Settings are locked while recalculation is in progress.</span>
+                <span><%= t('.settings_are_locked_while_recalculation_is_in_progress') %></span>
               </div>
 
               <!-- Warning about recalculation -->
               <div class="text-xs text-warning bg-warning/10 rounded p-2 mb-4">
-                <strong>Note:</strong> Changing these thresholds will trigger a recalculation of transportation modes for all your tracks. This may take some time depending on how many tracks you have.
+                <strong><%= t('.note') %></strong> <%= t('.changing_these_thresholds_will_trigger_a_recalculation_of_transportation') %>
               </div>
 
               <fieldset class="form-control mb-4" data-testid="enabled-modes-fieldset">
-                <legend class="font-medium mb-1 text-sm">Detected modes</legend>
+                <legend class="font-medium mb-1 text-sm"><%= t('.detected_modes') %></legend>
                 <p class="text-xs text-base-content/60 mb-2">
-                  Disabled modes won't be detected. Existing tracks aren't affected
-                  until you press Re-classify below.
+                  <%= t('.disabled_modes_won_t_be_detected_existing_tracks_aren_t') %>
                 </p>
                 <div class="grid grid-cols-2 gap-1">
                   <% Track::TRANSPORTATION_MODES.keys.map(&:to_s).each do |mode| %>
@@ -1030,7 +1029,7 @@
                              data-action="change->maps--maplibre#markTransportationSettingsDirty"
                              data-testid="enabled-mode-<%= mode %>" />
                       <span class="text-sm">
-                        <%= mode_emoji(mode) %> <%= mode.titleize %>
+                        <%= mode_emoji(mode) %> <%= t("transportation_modes.#{mode}") %>
                       </span>
                     </label>
                   <% end %>
@@ -1046,9 +1045,9 @@
                          data-dirty-ignore
                          data-maps--maplibre-target="transportationExpertToggle"
                          data-action="change->maps--maplibre#toggleTransportationExpertMode" />
-                  <span class="label-text text-sm">Expert Mode</span>
+                  <span class="label-text text-sm"><%= t('.expert_mode') %></span>
                 </label>
-                <p class="text-xs text-base-content/60 ml-14">Show advanced detection thresholds</p>
+                <p class="text-xs text-base-content/60 ml-14"><%= t('.show_advanced_detection_thresholds') %></p>
               </div>
 
               <!-- Basic Settings (always visible) -->
@@ -1056,8 +1055,8 @@
                 <!-- Walking Max Speed -->
                 <div class="form-control w-full">
                   <label class="label py-1">
-                    <span class="label-text text-sm">Walking max speed</span>
-                    <span class="label-text-alt" data-maps--maplibre-target="walkingMaxSpeedValue">7 km/h</span>
+                    <span class="label-text text-sm"><%= t('.walking_max_speed') %></span>
+                    <span class="label-text-alt" data-maps--maplibre-target="walkingMaxSpeedValue"><%= t('.km_h') %></span>
                   </label>
                   <input type="range"
                          name="walkingMaxSpeed"
@@ -1078,8 +1077,8 @@
                 <!-- Cycling Max Speed -->
                 <div class="form-control w-full">
                   <label class="label py-1">
-                    <span class="label-text text-sm">Cycling max speed</span>
-                    <span class="label-text-alt" data-maps--maplibre-target="cyclingMaxSpeedValue">45 km/h</span>
+                    <span class="label-text text-sm"><%= t('.cycling_max_speed') %></span>
+                    <span class="label-text-alt" data-maps--maplibre-target="cyclingMaxSpeedValue"><%= t('.km_h_2') %></span>
                   </label>
                   <input type="range"
                          name="cyclingMaxSpeed"
@@ -1100,8 +1099,8 @@
                 <!-- Driving Max Speed -->
                 <div class="form-control w-full">
                   <label class="label py-1">
-                    <span class="label-text text-sm">Driving max speed</span>
-                    <span class="label-text-alt" data-maps--maplibre-target="drivingMaxSpeedValue">220 km/h</span>
+                    <span class="label-text text-sm"><%= t('.driving_max_speed') %></span>
+                    <span class="label-text-alt" data-maps--maplibre-target="drivingMaxSpeedValue"><%= t('.km_h_3') %></span>
                   </label>
                   <input type="range"
                          name="drivingMaxSpeed"
@@ -1122,8 +1121,8 @@
                 <!-- Flying Min Speed -->
                 <div class="form-control w-full">
                   <label class="label py-1">
-                    <span class="label-text text-sm">Flying min speed</span>
-                    <span class="label-text-alt" data-maps--maplibre-target="flyingMinSpeedValue">150 km/h</span>
+                    <span class="label-text text-sm"><%= t('.flying_min_speed') %></span>
+                    <span class="label-text-alt" data-maps--maplibre-target="flyingMinSpeedValue"><%= t('.km_h_4') %></span>
                   </label>
                   <input type="range"
                          name="flyingMinSpeed"
@@ -1144,13 +1143,13 @@
 
               <!-- Expert Settings (hidden by default) -->
               <div class="hidden space-y-3 mt-4" data-maps--maplibre-target="transportationExpertSettings">
-                <div class="divider text-xs my-2">Speed Thresholds</div>
+                <div class="divider text-xs my-2"><%= t('.speed_thresholds') %></div>
 
                 <!-- Stationary Max Speed -->
                 <div class="form-control w-full">
                   <label class="label py-1">
-                    <span class="label-text text-sm">Stationary max speed</span>
-                    <span class="label-text-alt" data-maps--maplibre-target="stationaryMaxSpeedValue">1 km/h</span>
+                    <span class="label-text text-sm"><%= t('.stationary_max_speed') %></span>
+                    <span class="label-text-alt" data-maps--maplibre-target="stationaryMaxSpeedValue"><%= t('.km_h_5') %></span>
                   </label>
                   <input type="range"
                          name="stationaryMaxSpeed"
@@ -1171,8 +1170,8 @@
                 <!-- Train Min Speed -->
                 <div class="form-control w-full">
                   <label class="label py-1">
-                    <span class="label-text text-sm">Train min speed</span>
-                    <span class="label-text-alt" data-maps--maplibre-target="trainMinSpeedValue">80 km/h</span>
+                    <span class="label-text text-sm"><%= t('.train_min_speed') %></span>
+                    <span class="label-text-alt" data-maps--maplibre-target="trainMinSpeedValue"><%= t('.km_h_6') %></span>
                   </label>
                   <input type="range"
                          name="trainMinSpeed"
@@ -1190,13 +1189,13 @@
                   </div>
                 </div>
 
-                <div class="divider text-xs my-2">Acceleration Thresholds</div>
+                <div class="divider text-xs my-2"><%= t('.acceleration_thresholds') %></div>
 
                 <!-- Running vs Cycling Acceleration -->
                 <div class="form-control w-full">
                   <label class="label py-1">
-                    <span class="label-text text-sm">Running vs cycling accel</span>
-                    <span class="label-text-alt" data-maps--maplibre-target="runningVsCyclingAccelValue">0.25 m/s²</span>
+                    <span class="label-text text-sm"><%= t('.running_vs_cycling_accel') %></span>
+                    <span class="label-text-alt" data-maps--maplibre-target="runningVsCyclingAccelValue"><%= t('units.meters_per_second_squared', value: 0.25) %></span>
                   </label>
                   <input type="range"
                          name="runningVsCyclingAccel"
@@ -1217,8 +1216,8 @@
                 <!-- Cycling vs Driving Acceleration -->
                 <div class="form-control w-full">
                   <label class="label py-1">
-                    <span class="label-text text-sm">Cycling vs driving accel</span>
-                    <span class="label-text-alt" data-maps--maplibre-target="cyclingVsDrivingAccelValue">0.4 m/s²</span>
+                    <span class="label-text text-sm"><%= t('.cycling_vs_driving_accel') %></span>
+                    <span class="label-text-alt" data-maps--maplibre-target="cyclingVsDrivingAccelValue"><%= t('units.meters_per_second_squared', value: 0.4) %></span>
                   </label>
                   <input type="range"
                          name="cyclingVsDrivingAccel"
@@ -1236,13 +1235,13 @@
                   </div>
                 </div>
 
-                <div class="divider text-xs my-2">Segment Detection</div>
+                <div class="divider text-xs my-2"><%= t('.segment_detection') %></div>
 
                 <!-- Min Segment Duration -->
                 <div class="form-control w-full">
                   <label class="label py-1">
-                    <span class="label-text text-sm">Min segment duration</span>
-                    <span class="label-text-alt" data-maps--maplibre-target="minSegmentDurationValue">60 sec</span>
+                    <span class="label-text text-sm"><%= t('.min_segment_duration') %></span>
+                    <span class="label-text-alt" data-maps--maplibre-target="minSegmentDurationValue"><%= t('.sec') %></span>
                   </label>
                   <input type="range"
                          name="minSegmentDuration"
@@ -1254,17 +1253,17 @@
                          data-maps--maplibre-target="minSegmentDurationInput"
                          data-action="input->maps--maplibre#updateTransportationThresholdDisplay change->maps--maplibre#markTransportationSettingsDirty" />
                   <div class="w-full flex justify-between text-xs px-1 mt-1 opacity-60">
-                    <span>10s</span>
-                    <span>95s</span>
-                    <span>180s</span>
+                    <span><%= t('units.seconds_compact', value: 10) %></span>
+                    <span><%= t('units.seconds_compact', value: 95) %></span>
+                    <span><%= t('units.seconds_compact', value: 180) %></span>
                   </div>
                 </div>
 
                 <!-- Time Gap Threshold -->
                 <div class="form-control w-full">
                   <label class="label py-1">
-                    <span class="label-text text-sm">Time gap threshold</span>
-                    <span class="label-text-alt" data-maps--maplibre-target="timeGapThresholdValue">180 sec</span>
+                    <span class="label-text text-sm"><%= t('.time_gap_threshold') %></span>
+                    <span class="label-text-alt" data-maps--maplibre-target="timeGapThresholdValue"><%= t('.sec_2') %></span>
                   </label>
                   <input type="range"
                          name="timeGapThreshold"
@@ -1276,17 +1275,17 @@
                          data-maps--maplibre-target="timeGapThresholdInput"
                          data-action="input->maps--maplibre#updateTransportationThresholdDisplay change->maps--maplibre#markTransportationSettingsDirty" />
                   <div class="w-full flex justify-between text-xs px-1 mt-1 opacity-60">
-                    <span>30s</span>
-                    <span>315s</span>
-                    <span>600s</span>
+                    <span><%= t('units.seconds_compact', value: 30) %></span>
+                    <span><%= t('units.seconds_compact', value: 315) %></span>
+                    <span><%= t('units.seconds_compact', value: 600) %></span>
                   </div>
                 </div>
 
                 <!-- Min Flight Distance -->
                 <div class="form-control w-full">
                   <label class="label py-1">
-                    <span class="label-text text-sm">Min flight distance</span>
-                    <span class="label-text-alt" data-maps--maplibre-target="minFlightDistanceValue">100 km</span>
+                    <span class="label-text text-sm"><%= t('.min_flight_distance') %></span>
+                    <span class="label-text-alt" data-maps--maplibre-target="minFlightDistanceValue"><%= t('.km') %></span>
                   </label>
                   <input type="range"
                          name="minFlightDistanceKm"
@@ -1312,11 +1311,11 @@
                         data-maps--maplibre-target="transportationApplyButton"
                         data-action="click->maps--maplibre#applyTransportationSettings"
                         disabled>
-                  Apply Settings
+                  <%= t('.apply_settings') %>
                 </button>
                 <p class="text-xs text-base-content/60 mt-2 text-center"
                    data-maps--maplibre-target="transportationDirtyMessage">
-                  Make changes to enable the Apply button
+                  <%= t('.make_changes_to_enable_the_apply_button') %>
                 </p>
               </div>
 
@@ -1326,7 +1325,7 @@
                     here, so any controls placed inside this <details> or after this
                     block are orphaned from outer-form submission. Keep the outer
                     submit button BEFORE the Transportation Mode <details>. %>
-                <%= button_to 'Re-classify my history',
+                <%= button_to t('.re_classify_my_history'),
                               tracks_recalculation_path,
                               method: :post,
                               disabled: Tracks::TransportationRecalculationStatus.new(current_user.id).in_progress?,
@@ -1334,8 +1333,7 @@
                               form: { data: { turbo_frame: '_top' } },
                               data: { testid: 'reclassify-history-button' } %>
                 <p class="text-xs text-base-content/60 mt-1">
-                  Re-runs auto-classification across all your tracks. Manually-corrected
-                  segments are kept. May take several minutes.
+                  <%= t('.re_runs_auto_classification_across_all_your_tracks_manually_corrected') %>
                 </p>
               </div>
             </div>
@@ -1352,29 +1350,29 @@
             <turbo-frame id="timeline-calendar-frame"
                          src="<%= calendar_map_timeline_feeds_path(month: initial_calendar_month(current_user)) %>"
                          loading="lazy">
-              <div class="text-center text-base-content/60 py-4 text-sm">Loading calendar…</div>
+              <div class="text-center text-base-content/60 py-4 text-sm"><%= t('.loading_calendar') %></div>
             </turbo-frame>
 
             <%# Heat legend %>
             <div class="timeline-rail__heat-legend">
-              <span>less</span>
+              <span><%= t('.less') %></span>
               <span class="heat-swatch heat-0"></span>
               <span class="heat-swatch heat-1"></span>
               <span class="heat-swatch heat-2"></span>
               <span class="heat-swatch heat-3"></span>
               <span class="heat-swatch heat-4"></span>
               <span class="heat-swatch heat-5"></span>
-              <span>more</span>
+              <span><%= t('.more') %></span>
             </div>
 
             <%# Filter with counts %>
             <div class="timeline-rail__section">
-              <div class="timeline-rail__section-label">Filter</div>
+              <div class="timeline-rail__section-label"><%= t('.filter') %></div>
               <label class="timeline-filter-row">
                 <input type="checkbox" class="checkbox checkbox-xs checkbox-success"
                        data-status="confirmed" data-testid="filter-confirmed"
                        data-action="change->timeline-feed#filterChanged" checked />
-                <span class="flex-1">Confirmed</span>
+                <span class="flex-1"><%= t('.confirmed') %></span>
                 <%= render 'map/timeline_feeds/filter_count',
                            status: 'confirmed', count: @status_counts&.dig('confirmed').to_i %>
               </label>
@@ -1382,7 +1380,7 @@
                 <input type="checkbox" class="checkbox checkbox-xs checkbox-warning"
                        data-status="suggested" data-testid="filter-suggested"
                        data-action="change->timeline-feed#filterChanged" checked />
-                <span class="flex-1">Suggested</span>
+                <span class="flex-1"><%= t('.suggested') %></span>
                 <%= render 'map/timeline_feeds/filter_count',
                            status: 'suggested', count: @status_counts&.dig('suggested').to_i %>
               </label>
@@ -1398,7 +1396,7 @@
               <%= icon 'search',
                        class: 'h-4 w-4 opacity-50 absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none' %>
               <input type="text"
-                     placeholder="Search visits, places…"
+                     placeholder="<%= t('.search_visits_places') %>"
                      class="input input-sm input-bordered w-full pl-8"
                      autocomplete="off"
                      data-timeline-feed-target="searchInput"
@@ -1412,12 +1410,12 @@
             <% if @timeline_tags&.any? %>
               <div class="timeline-rail__section">
                 <div class="timeline-rail__section-header">
-                  <span class="timeline-rail__section-label">Tags</span>
-                  <%= link_to 'Manage', tags_path,
+                  <span class="timeline-rail__section-label"><%= t('.tags') %></span>
+                  <%= link_to t('.manage'), tags_path,
                               class: 'timeline-rail__section-link',
                               target: '_blank',
                               rel: 'noopener',
-                              title: 'Manage tags in a new tab',
+                              title: t('.manage_tags_in_a_new_tab'),
                               data: { testid: 'tags-manage-link' } %>
                 </div>
                 <div class="timeline-rail__tags">
@@ -1441,7 +1439,7 @@
           <div class="timeline-main">
             <turbo-frame id="timeline-feed-frame" data-timeline-feed-target="visitListFrame">
               <div class="timeline-main__empty">
-                Pick a day in the calendar to see visits.
+                <%= t('.pick_a_day_in_the_calendar_to_see_visits') %>
               </div>
             </turbo-frame>
           </div>
@@ -1457,14 +1455,14 @@
                     class="btn btn-sm btn-outline flex flex-col items-center gap-1 h-auto py-3"
                     data-action="click->maps--maplibre#startCreateVisit">
               <%= icon 'map-pin-check' %>
-              <span class="text-xs">Create Visit</span>
+              <span class="text-xs"><%= t('.create_visit') %></span>
             </button>
 
             <button type="button"
                     class="btn btn-sm btn-outline flex flex-col items-center gap-1 h-auto py-3"
                     data-action="click->maps--maplibre#startCreatePlace">
               <%= icon 'map-pin-plus' %>
-              <span class="text-xs">Create Place</span>
+              <span class="text-xs"><%= t('.create_place') %></span>
             </button>
 
             <button type="button"
@@ -1472,21 +1470,21 @@
                     data-maps--maplibre-target="selectAreaButton"
                     data-action="click->maps--maplibre#startSelectArea">
               <%= icon 'square-dashed-mouse-pointer' %>
-              <span class="text-xs">Select Area</span>
+              <span class="text-xs"><%= t('.select_area') %></span>
             </button>
 
             <button type="button"
                     class="btn btn-sm btn-outline flex flex-col items-center gap-1 h-auto py-3"
                     data-action="click->maps--maplibre#startCreateArea">
               <%= icon 'circle-plus' %>
-              <span class="text-xs">Create Area</span>
+              <span class="text-xs"><%= t('.create_area') %></span>
             </button>
 
             <button type="button"
                     class="btn btn-sm btn-outline flex flex-col items-center gap-1 h-auto py-3"
                     data-action="click->maps--maplibre#toggleReplay">
               <%= icon 'clock' %>
-              <span class="text-xs">Replay</span>
+              <span class="text-xs"><%= t('.replay') %></span>
             </button>
 
             <% if current_user.full_access? %>
@@ -1494,7 +1492,7 @@
                       class="btn btn-sm btn-outline flex flex-col items-center gap-1 h-auto py-3"
                       onclick="document.dispatchEvent(new CustomEvent('residency:open'))">
                 <%= icon 'calendar-range' %>
-                <span class="text-xs">Days / Country</span>
+                <span class="text-xs"><%= t('.days_country') %></span>
               </button>
             <% end %>
 
@@ -1503,7 +1501,7 @@
                       class="btn btn-sm btn-outline flex flex-col items-center gap-1 h-auto py-3"
                       id="immich-enrich-toggle-btn">
                 <%= icon 'camera' %>
-                <span class="text-xs">Enrich Photos</span>
+                <span class="text-xs"><%= t('.enrich_photos') %></span>
               </button>
             <% end %>
           </div>
@@ -1520,9 +1518,9 @@
                   <div class="flex justify-between items-center mb-3">
                     <h4 class="card-title text-sm gap-2">
                       <%= icon 'camera', class: 'w-4 h-4 text-primary' %>
-                      Enrich Photos
+                      <%= t('.enrich_photos') %>
                     </h4>
-                    <button class="btn btn-ghost btn-xs btn-circle" data-action="click->maps--immich-enrich#toggle" title="Close">
+                    <button class="btn btn-ghost btn-xs btn-circle" data-action="click->maps--immich-enrich#toggle" title="<%= t('.close') %>">
                       <%= icon 'x', class: 'w-3 h-3' %>
                     </button>
                   </div>
@@ -1530,20 +1528,20 @@
                   <!-- Scan Form -->
                   <div data-maps--immich-enrich-target="scanForm">
                     <p class="text-xs text-base-content/60 mb-3">
-                      Match Immich photos without GPS to your location history.
+                      <%= t('.match_immich_photos_without_gps_to_your_location_history') %>
                     </p>
                     <div class="space-y-3">
                       <div class="grid grid-cols-2 gap-2">
                         <div class="form-control">
                           <label class="label py-0.5">
-                            <span class="label-text text-xs">From</span>
+                            <span class="label-text text-xs"><%= t('.from') %></span>
                           </label>
                           <input type="date" class="input input-bordered input-sm"
                                  data-maps--immich-enrich-target="startDate">
                         </div>
                         <div class="form-control">
                           <label class="label py-0.5">
-                            <span class="label-text text-xs">To</span>
+                            <span class="label-text text-xs"><%= t('.to') %></span>
                           </label>
                           <input type="date" class="input input-bordered input-sm"
                                  data-maps--immich-enrich-target="endDate">
@@ -1551,7 +1549,7 @@
                       </div>
                       <div class="form-control">
                         <label class="label py-0.5">
-                          <span class="label-text text-xs">Tolerance (minutes)</span>
+                          <span class="label-text text-xs"><%= t('.tolerance_minutes') %></span>
                         </label>
                         <input type="number" value="30" min="1" max="120"
                                class="input input-bordered input-sm"
@@ -1561,7 +1559,7 @@
                               data-action="click->maps--immich-enrich#scan"
                               data-maps--immich-enrich-target="scanButton">
                         <%= icon 'search', class: 'w-4 h-4' %>
-                        Scan for matches
+                        <%= t('.scan_for_matches') %>
                       </button>
                     </div>
                   </div>
@@ -1569,7 +1567,7 @@
                   <!-- Loading -->
                   <div class="hidden text-center py-6" data-maps--immich-enrich-target="loading">
                     <span class="loading loading-spinner loading-md text-primary"></span>
-                    <p class="text-xs text-base-content/60 mt-2" data-maps--immich-enrich-target="loadingText">Scanning Immich photos...</p>
+                    <p class="text-xs text-base-content/60 mt-2" data-maps--immich-enrich-target="loadingText"><%= t('.scanning_immich_photos') %></p>
                   </div>
 
                   <!-- Results -->
@@ -1577,7 +1575,7 @@
                     <div class="flex justify-between items-center mb-2">
                       <div class="text-xs font-medium text-base-content/70" data-maps--immich-enrich-target="resultsSummary"></div>
                       <label class="label cursor-pointer gap-1.5 py-0">
-                        <span class="label-text text-xs">All</span>
+                        <span class="label-text text-xs"><%= t('.all') %></span>
                         <input type="checkbox" class="checkbox checkbox-xs checkbox-primary" checked
                                data-action="change->maps--immich-enrich#toggleSelectAll"
                                data-maps--immich-enrich-target="selectAll">
@@ -1591,12 +1589,12 @@
                       <button class="btn btn-ghost btn-sm flex-1"
                               data-action="click->maps--immich-enrich#backToScan">
                         <%= icon 'arrow-left', class: 'w-3 h-3' %>
-                        Back
+                        <%= t('.back') %>
                       </button>
                       <button class="btn btn-primary btn-sm flex-1"
                               data-action="click->maps--immich-enrich#enrich"
                               data-maps--immich-enrich-target="enrichButton">
-                        Enrich
+                        <%= t('.enrich') %>
                       </button>
                     </div>
                   </div>
@@ -1611,7 +1609,7 @@
               <div class="card-body p-4">
                 <div class="flex justify-between items-start mb-2">
                   <h4 class="card-title text-base" data-maps--maplibre-target="infoTitle"></h4>
-                  <button class="btn btn-ghost btn-xs btn-circle" data-action="click->maps--maplibre#closeInfo" title="Close">✕</button>
+                  <button class="btn btn-ghost btn-xs btn-circle" data-action="click->maps--maplibre#closeInfo" title="<%= t('.close') %>">✕</button>
                 </div>
                 <div class="space-y-2 text-sm" data-maps--maplibre-target="infoContent">
                   <!-- Content will be dynamically inserted -->
@@ -1627,27 +1625,27 @@
           <template data-maps--maplibre-target="routeInfoTemplate">
             <div class="space-y-2">
               <div>
-                <span class="font-semibold">Start:</span>
+                <span class="font-semibold"><%= t('.start') %></span>
                 <span data-maps--maplibre-target="routeStartTime"></span>
               </div>
               <div>
-                <span class="font-semibold">End:</span>
+                <span class="font-semibold"><%= t('.end') %></span>
                 <span data-maps--maplibre-target="routeEndTime"></span>
               </div>
               <div>
-                <span class="font-semibold">Duration:</span>
+                <span class="font-semibold"><%= t('.duration') %></span>
                 <span data-maps--maplibre-target="routeDuration"></span>
               </div>
               <div>
-                <span class="font-semibold">Distance:</span>
+                <span class="font-semibold"><%= t('.distance') %></span>
                 <span data-maps--maplibre-target="routeDistance"></span>
               </div>
               <div data-maps--maplibre-target="routeSpeedContainer">
-                <span class="font-semibold">Avg Speed:</span>
+                <span class="font-semibold"><%= t('.avg_speed') %></span>
                 <span data-maps--maplibre-target="routeSpeed"></span>
               </div>
               <div>
-                <span class="font-semibold">Points:</span>
+                <span class="font-semibold"><%= t('.points_2') %></span>
                 <span data-maps--maplibre-target="routePoints"></span>
               </div>
             </div>
@@ -1661,7 +1659,7 @@
                       data-action="click->maps--maplibre#deleteSelectedPoints"
                       data-maps--maplibre-target="deletePointsButton">
                 <%= icon 'trash-2' %>
-                <span data-maps--maplibre-target="deleteButtonText">Delete Selected Points</span>
+                <span data-maps--maplibre-target="deleteButtonText"><%= t('.delete_selected_points') %></span>
               </button>
 
               <button type="button"
@@ -1669,7 +1667,7 @@
                       data-action="click->maps--maplibre#deleteSelectedAnomalies"
                       data-maps--maplibre-target="deleteAnomaliesButton">
                 <%= icon 'trash-2' %>
-                <span data-maps--maplibre-target="deleteAnomaliesButtonText">Delete Anomaly Points</span>
+                <span data-maps--maplibre-target="deleteAnomaliesButtonText"><%= t('.delete_anomaly_points') %></span>
               </button>
             <% end %>
 
@@ -1692,12 +1690,12 @@
           <div class="space-y-6">
             <!-- Community Section -->
             <div>
-              <h4 class="font-semibold text-base mb-3">Community</h4>
+              <h4 class="font-semibold text-base mb-3"><%= t('.community') %></h4>
               <div class="flex flex-col gap-2">
-                <a href="https://discord.gg/pHsBjpt5J8" target="_blank" class="link-hover text-sm">Discord</a>
+                <a href="https://discord.gg/pHsBjpt5J8" target="_blank" class="link-hover text-sm"><%= t('.discord') %></a>
                 <a href="https://x.com/freymakesstuff" target="_blank" class="link-hover text-sm">X</a>
-                <a href="https://github.com/Freika/dawarich" target="_blank" class="link-hover text-sm">Github</a>
-                <a href="https://mastodon.social/@dawarich" target="_blank" class="link-hover text-sm">Mastodon</a>
+                <a href="https://github.com/Freika/dawarich" target="_blank" class="link-hover text-sm"><%= t('.github') %></a>
+                <a href="https://mastodon.social/@dawarich" target="_blank" class="link-hover text-sm"><%= t('.mastodon') %></a>
               </div>
             </div>
 
@@ -1705,13 +1703,13 @@
 
             <!-- Docs Section -->
             <div>
-              <h4 class="font-semibold text-base mb-3">Docs</h4>
+              <h4 class="font-semibold text-base mb-3"><%= t('.docs') %></h4>
               <div class="flex flex-col gap-2">
-                <a href="https://dawarich.app/docs/intro" target="_blank" class="link-hover text-sm">Tutorial</a>
-                <a href="https://dawarich.app/docs/tutorials/import-existing-data" target="_blank" class="link-hover text-sm">Import existing data</a>
-                <a href="https://dawarich.app/docs/tutorials/export-your-data" target="_blank" class="link-hover text-sm">Exporting data</a>
-                <a href="https://dawarich.app/docs/FAQ" target="_blank" class="link-hover text-sm">FAQ</a>
-                <a href="https://dawarich.app/contact" target="_blank" class="link-hover text-sm">Contact</a>
+                <a href="https://dawarich.app/docs/intro" target="_blank" class="link-hover text-sm"><%= t('.tutorial') %></a>
+                <a href="https://dawarich.app/docs/tutorials/import-existing-data" target="_blank" class="link-hover text-sm"><%= t('.import_existing_data') %></a>
+                <a href="https://dawarich.app/docs/tutorials/export-your-data" target="_blank" class="link-hover text-sm"><%= t('.exporting_data') %></a>
+                <a href="https://dawarich.app/docs/FAQ" target="_blank" class="link-hover text-sm"><%= t('.faq') %></a>
+                <a href="https://dawarich.app/contact" target="_blank" class="link-hover text-sm"><%= t('.contact') %></a>
               </div>
             </div>
 
@@ -1719,13 +1717,13 @@
 
             <!-- More Section -->
             <div>
-              <h4 class="font-semibold text-base mb-3">More</h4>
+              <h4 class="font-semibold text-base mb-3"><%= t('.more_2') %></h4>
               <div class="flex flex-col gap-2">
-                <a href="https://dawarich.app/privacy-policy" target="_blank" class="link-hover text-sm">Privacy policy</a>
-                <a href="https://dawarich.app/terms-and-conditions" target="_blank" class="link-hover text-sm">Terms and Conditions</a>
-                <a href="https://dawarich.app/refund-policy" target="_blank" class="link-hover text-sm">Refund policy</a>
-                <a href="https://dawarich.app/impressum" target="_blank" class="link-hover text-sm">Impressum</a>
-                <a href="https://dawarich.app/blog" target="_blank" class="link-hover text-sm">Blog</a>
+                <a href="https://dawarich.app/privacy-policy" target="_blank" class="link-hover text-sm"><%= t('.privacy_policy') %></a>
+                <a href="https://dawarich.app/terms-and-conditions" target="_blank" class="link-hover text-sm"><%= t('.terms_and_conditions') %></a>
+                <a href="https://dawarich.app/refund-policy" target="_blank" class="link-hover text-sm"><%= t('.refund_policy') %></a>
+                <a href="https://dawarich.app/impressum" target="_blank" class="link-hover text-sm"><%= t('.impressum') %></a>
+                <a href="https://dawarich.app/blog" target="_blank" class="link-hover text-sm"><%= t('.blog') %></a>
               </div>
             </div>
           </div>
@@ -1735,4 +1733,3 @@
     </div>
   </div>
 </div>
-

--- a/app/views/map/maplibre/_visit_creation_modal.html.erb
+++ b/app/views/map/maplibre/_visit_creation_modal.html.erb
@@ -1,7 +1,7 @@
 <div data-controller="visit-creation-v2" data-visit-creation-v2-api-key-value="<%= current_user.api_key %>" data-visit-creation-v2-timezone-value="<%= current_user.timezone %>">
   <div class="modal z-[10000]" data-visit-creation-v2-target="modal">
     <div class="modal-box max-w-2xl">
-      <h3 class="font-bold text-lg mb-4" data-visit-creation-v2-target="modalTitle">Create New Visit</h3>
+      <h3 class="font-bold text-lg mb-4" data-visit-creation-v2-target="modalTitle"><%= t('.create_new_visit') %></h3>
 
       <form data-visit-creation-v2-target="form" data-action="submit->visit-creation-v2#submit">
         <input type="hidden" name="latitude" data-visit-creation-v2-target="latitudeInput">
@@ -10,12 +10,12 @@
         <div class="space-y-4">
           <div class="form-control">
             <label class="label">
-              <span class="label-text font-semibold">Visit Name *</span>
+              <span class="label-text font-semibold"><%= t('.visit_name') %></span>
             </label>
             <input
               type="text"
               name="name"
-              placeholder="Enter visit name..."
+              placeholder="<%= t('.enter_visit_name') %>"
               class="input input-bordered w-full"
               data-visit-creation-v2-target="nameInput"
               required>
@@ -24,7 +24,7 @@
           <div class="grid grid-cols-2 gap-4">
             <div class="form-control">
               <label class="label">
-                <span class="label-text font-semibold">Start Time *</span>
+                <span class="label-text font-semibold"><%= t('.start_time') %></span>
               </label>
               <input
                 type="datetime-local"
@@ -37,7 +37,7 @@
 
             <div class="form-control">
               <label class="label">
-                <span class="label-text font-semibold">End Time *</span>
+                <span class="label-text font-semibold"><%= t('.end_time') %></span>
               </label>
               <input
                 type="datetime-local"
@@ -52,8 +52,8 @@
         </div>
 
         <div class="modal-action">
-          <button type="button" class="btn btn-ghost" data-action="click->visit-creation-v2#close">Cancel</button>
-          <button type="submit" class="btn btn-primary" data-visit-creation-v2-target="submitButton">Create Visit</button>
+          <button type="button" class="btn btn-ghost" data-action="click->visit-creation-v2#close"><%= t('.cancel') %></button>
+          <button type="submit" class="btn btn-primary" data-visit-creation-v2-target="submitButton"><%= t('.create_visit') %></button>
         </div>
       </form>
     </div>

--- a/app/views/map/maplibre/_webgl_error.html.erb
+++ b/app/views/map/maplibre/_webgl_error.html.erb
@@ -1,15 +1,14 @@
 <div data-maps--maplibre-target="webglError" class="hidden">
   <div class="flex items-center justify-center h-full bg-base-200 text-center p-8">
     <div>
-      <h3 class="text-lg font-bold mb-2">WebGL is not available</h3>
+      <h3 class="text-lg font-bold mb-2"><%= t('.webgl_is_not_available') %></h3>
       <p class="text-sm text-base-content/70">
-        Map v2 requires WebGL to render maps. Please enable hardware acceleration
-        in your browser settings or try a different browser.
+        <%= t('.map_v2_requires_webgl_to_render_maps_please_enable_hardware') %>
       </p>
       <p class="text-sm text-base-content/50 mt-2">
-        Map v1 (Leaflet) is available at
-        <%= link_to '/map/v1', map_v1_path, class: 'link link-primary' %>
-        but will be deprecated and removed in one of future releases.
+        <%= t('.map_v1_leaflet_is_available_at') %>
+        <%= link_to t('.map_v1'), map_v1_path, class: 'link link-primary' %>
+        <%= t('.but_will_be_deprecated_and_removed_in_one_of_future') %>
       </p>
     </div>
   </div>

--- a/app/views/map/maplibre/index.html.erb
+++ b/app/views/map/maplibre/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Map' %>
+<% content_for :title, t('.map') %>
 
 <%= render 'shared/map/date_navigation_v2', start_at: @start_at, end_at: @end_at %>
 
@@ -31,7 +31,7 @@
   <!-- Loading progress badge -->
   <div data-maps--maplibre-target="progressBadge" class="map-progress-badge">
     <span class="map-progress-badge-dot"></span>
-    <span data-maps--maplibre-target="progressBadgeText">Loading...</span>
+    <span data-maps--maplibre-target="progressBadgeText"><%= t('.loading') %></span>
   </div>
 
   <!-- Map-edge button cluster (top-right corner) -->
@@ -39,12 +39,12 @@
 
   <!-- Timeline map-corner overlays (shown only when Timeline tab is active; CSS handles visibility) -->
   <div class="timeline-map-overlay timeline-map-overlay--scope" data-timeline-feed-target="scopeBadge">
-    <span class="font-semibold">Pick a day</span>
+    <span class="font-semibold"><%= t('.pick_a_day') %></span>
   </div>
   <div class="timeline-map-overlay timeline-map-overlay--legend">
-    <div><span class="visit-status-dot visit-status-dot--confirmed"></span> Confirmed</div>
-    <div><span class="visit-status-dot visit-status-dot--suggested"></span> Suggested</div>
-    <div><span class="visit-status-dot visit-status-dot--declined"></span> Declined</div>
+    <div><span class="visit-status-dot visit-status-dot--confirmed"></span> <%= t('.confirmed') %></div>
+    <div><span class="visit-status-dot visit-status-dot--suggested"></span> <%= t('.suggested') %></div>
+    <div><span class="visit-status-dot visit-status-dot--declined"></span> <%= t('.declined') %></div>
   </div>
 
   <!-- Settings panel -->

--- a/app/views/map/residency/show.html.erb
+++ b/app/views/map/residency/show.html.erb
@@ -21,7 +21,7 @@
 
     <div class="flex items-center gap-2 text-sm opacity-70">
       <%= icon 'calendar-range', class: 'w-4 h-4' %>
-      <span><%= @total_tracked_days %> / <%= @days_in_year %> days</span>
+      <span><%= @total_tracked_days %> / <%= @days_in_year %> <%= t('.days') %></span>
     </div>
   </div>
 
@@ -46,9 +46,9 @@
           <!-- Grid with day labels -->
           <div class="flex">
             <div class="flex flex-col justify-around mr-2 text-xs text-base-content/60" style="height: 98px;">
-              <span>Mon</span>
-              <span>Wed</span>
-              <span>Fri</span>
+              <span><%= t('.mon') %></span>
+              <span><%= t('.wed') %></span>
+              <span><%= t('.fri') %></span>
             </div>
 
             <div class="flex gap-0.5">
@@ -66,7 +66,7 @@
 
                     <% if is_in_year && !is_future && cell_color %>
                       <div class="w-3 h-3 rounded-sm cursor-pointer transition-opacity hover:opacity-80 hover:z-50 tooltip tooltip-top <%= cell_color %>"
-                           data-tip="<%= country_name %> — <%= date.strftime('%a, %b %-d') %>">
+                           data-tip="<%= country_name %> — <%= l(date, format: :short_weekday_month_day) %>">
                       </div>
                     <% elsif is_in_year && !is_future %>
                       <div class="w-3 h-3 rounded-sm bg-base-300"></div>
@@ -88,7 +88,7 @@
               </div>
             <% end %>
             <% if @countries.size > 7 %>
-              <span class="opacity-40">+<%= @countries.size - 7 %> more</span>
+              <span class="opacity-40">+<%= @countries.size - 7 %> <%= t('.more') %></span>
             <% end %>
           </div>
         </div>
@@ -126,7 +126,7 @@
             <!-- Days count -->
             <div class="text-right flex-shrink-0">
               <span class="font-mono font-semibold"><%= country[:days] %></span>
-              <span class="text-xs opacity-60 ml-0.5">days</span>
+              <span class="text-xs opacity-60 ml-0.5"><%= t('.days') %></span>
               <span class="text-xs opacity-40 ml-1">(<%= country[:year_percentage] %>%)</span>
             </div>
 
@@ -139,18 +139,18 @@
           <!-- Expanded periods -->
           <div class="px-4 pb-3">
             <div class="border-t border-base-300 pt-2 space-y-1.5">
-              <p class="text-[10px] font-medium opacity-40 uppercase tracking-wider">Stay periods</p>
+              <p class="text-[10px] font-medium opacity-40 uppercase tracking-wider"><%= t('.stay_periods') %></p>
               <% country[:periods].each do |period| %>
                 <div class="flex items-center justify-between text-sm">
                   <div class="flex items-center gap-2">
                     <%= icon 'calendar', class: 'w-3.5 h-3.5 opacity-40' %>
                     <span>
-                      <%= Date.parse(period[:start_date]).strftime('%b %-d') %> –
-                      <%= Date.parse(period[:end_date]).strftime('%b %-d, %Y') %>
+                      <%= l(Date.parse(period[:start_date]), format: :short_month_day) %> –
+                      <%= l(Date.parse(period[:end_date]), format: :medium) %>
                     </span>
                   </div>
                   <span class="font-mono text-xs bg-base-300 px-2 py-0.5 rounded">
-                    <%= period[:consecutive_days] %> days
+                    <%= period[:consecutive_days] %> <%= t('.days') %>
                   </span>
                 </div>
               <% end %>
@@ -163,14 +163,14 @@
     <% if @countries.any? { |c| c[:threshold_warning] } %>
       <div class="flex items-center gap-2 mt-3 text-xs opacity-50 flex-shrink-0">
         <%= icon 'triangle-alert', class: 'w-3.5 h-3.5 text-warning' %>
-        <span>Exceeds 183-day threshold common in many tax jurisdictions.</span>
+        <span><%= t('.exceeds_183_day_threshold_common_in_many_tax_jurisdictions') %></span>
       </div>
     <% end %>
   <% else %>
     <div class="flex flex-col items-center justify-center flex-1 opacity-50">
       <%= icon 'globe', class: 'w-10 h-10 mb-3' %>
-      <p class="text-sm">No country data for <%= @year %>.</p>
-      <p class="text-xs mt-1">Points need reverse geocoding to detect countries.</p>
+      <p class="text-sm"><%= t('.no_country_data_for') %> <%= @year %>.</p>
+      <p class="text-xs mt-1"><%= t('.points_need_reverse_geocoding_to_detect_countries') %></p>
     </div>
   <% end %>
 <% end %>

--- a/app/views/map/timeline_feeds/_calendar.html.erb
+++ b/app/views/map/timeline_feeds/_calendar.html.erb
@@ -15,7 +15,7 @@
                           target_month: nav[:prev],
                           action: 'click->timeline-feed#previewMonth' },
                   class: 'btn btn-ghost btn-xs btn-square',
-                  'aria-label': 'Previous month' do %>
+                  'aria-label': t('.previous_month') do %>
         <%= icon 'chevron-left', class: 'w-4 h-4' %>
       <% end %>
       <div class="font-semibold text-sm" data-testid="calendar-title">
@@ -26,7 +26,7 @@
                           target_month: nav[:next],
                           action: 'click->timeline-feed#previewMonth' },
                   class: 'btn btn-ghost btn-xs btn-square',
-                  'aria-label': 'Next month' do %>
+                  'aria-label': t('.next_month') do %>
         <%= icon 'chevron-right', class: 'w-4 h-4' %>
       <% end %>
     </div>
@@ -49,7 +49,7 @@
                   <% if cell[:disabled] %>disabled<% end %>>
             <span class="cal-cell__day"><%= calendar_day_number(cell) %></span>
             <% if cell[:suggested_count].to_i.positive? %>
-              <span class="suggestion-dot" aria-label="Has suggested visits"></span>
+              <span class="suggestion-dot" aria-label="<%= t('.has_suggested_visits') %>"></span>
             <% end %>
           </button>
         <% end %>

--- a/app/views/map/timeline_feeds/_day.html.erb
+++ b/app/views/map/timeline_feeds/_day.html.erb
@@ -11,13 +11,13 @@
   <div class="timeline-day-header">
     <%= render 'map/timeline_feeds/day_nav', date: day[:date] %>
     <div class="timeline-day-header__meta">
-      <%= pluralize(day_total_visits_count(day), 'visit') %>
+      <%= t('.visit_count', count: day_total_visits_count(day)) %>
       <% if day_total_visits_count(day) >= 2 %>
         <button type="button"
                 class="day-select-toggle"
                 data-testid="day-select-toggle"
                 data-action="click->timeline-feed#enterSelection">
-          Select
+          <%= t('.select') %>
         </button>
       <% end %>
     </div>
@@ -28,22 +28,22 @@
 
   <dl class="timeline-day-rollup">
     <div>
-      <dt>Visits</dt>
+      <dt><%= t('.visits') %></dt>
       <dd><%= total_visits %></dd>
     </div>
     <div>
-      <dt>Tracks</dt>
+      <dt><%= t('.tracks') %></dt>
       <dd><%= total_tracks %></dd>
     </div>
     <% if total_distance.to_f.positive? %>
       <div>
-        <dt>Distance</dt>
+        <dt><%= t('.distance') %></dt>
         <dd><%= total_distance %> <%= distance_unit %></dd>
       </div>
     <% end %>
     <% if moving_minutes.positive? %>
       <div>
-        <dt>Moving</dt>
+        <dt><%= t('.moving') %></dt>
         <dd><%= format_duration_short(moving_minutes * 60) %></dd>
       </div>
     <% end %>
@@ -69,16 +69,16 @@
     <div class="timeline-entries-empty-filtered hidden"
          data-timeline-feed-target="emptyFiltered">
       <p class="text-sm text-base-content/70">
-        No visits match the current search or filter.
+        <%= t('.no_visits_match_the_current_search_or_filter') %>
       </p>
       <button type="button"
               class="btn btn-ghost btn-xs"
               data-action="click->timeline-feed#clearVisitFilters">
-        Clear search & filters
+        <%= t('.clear_search_filters') %>
       </button>
     </div>
   <% else %>
-    <p class="text-center text-sm text-base-content/60 py-6">No visits tracked this day.</p>
+    <p class="text-center text-sm text-base-content/60 py-6"><%= t('.no_visits_tracked_this_day') %></p>
   <% end %>
 
   <footer class="timeline-day-footer">
@@ -86,8 +86,8 @@
             class="btn btn-ghost btn-xs btn-square"
             data-action="click->timeline-feed#navigateDay"
             data-direction="prev"
-            title="Previous day"
-            aria-label="Previous day">
+            title="<%= t('.previous_day') %>"
+            aria-label="<%= t('.previous_day') %>">
       <%= icon 'chevron-left', class: 'w-4 h-4' %>
     </button>
 
@@ -95,8 +95,8 @@
             class="btn btn-ghost btn-xs btn-square"
             data-action="click->timeline-feed#navigateDay"
             data-direction="next"
-            title="Next day"
-            aria-label="Next day">
+            title="<%= t('.next_day') %>"
+            aria-label="<%= t('.next_day') %>">
       <%= icon 'chevron-right', class: 'w-4 h-4' %>
     </button>
   </footer>

--- a/app/views/map/timeline_feeds/_day_banner.html.erb
+++ b/app/views/map/timeline_feeds/_day_banner.html.erb
@@ -11,18 +11,18 @@
   <% if suggested_count.to_i.positive? %>
     <div class="timeline-bulk-banner">
       <span class="timeline-bulk-banner__text">
-        <%= pluralize(suggested_count, 'suggestion') %> waiting
+        <%= t('.suggestions_waiting', count: suggested_count) %>
       </span>
       <div class="timeline-bulk-banner__actions">
-        <%= button_to 'Confirm all',
+        <%= button_to t('.confirm_all'),
                       bulk_update_visits_path(status: :confirmed, source_status: :suggested, date: date),
                       method: :patch,
                       data: { testid: 'bulk-confirm-day' },
                       class: 'btn btn-xs btn-success' %>
-        <%= button_to 'Delete all',
+        <%= button_to t('.delete_all'),
                       bulk_destroy_visits_path(source_status: :suggested, date: date),
                       method: :delete,
-                      data: { turbo_confirm: "Delete all #{pluralize(suggested_count, 'suggested visit')} for this day? Your location points stay." },
+                      data: { turbo_confirm: t('.delete_all_suggestions', count: suggested_count) },
                       class: 'btn btn-xs btn-outline btn-error' %>
       </div>
     </div>

--- a/app/views/map/timeline_feeds/_day_nav.html.erb
+++ b/app/views/map/timeline_feeds/_day_nav.html.erb
@@ -6,17 +6,17 @@
   <button data-testid="day-prev"
           data-action="click->timeline-feed#navigateDay"
           data-direction="prev"
-          title="Previous day"
-          aria-label="Previous day"
+          title="<%= t('.previous_day') %>"
+          aria-label="<%= t('.previous_day') %>"
           class="btn btn-ghost btn-xs btn-square">
     <%= icon 'chevron-left', class: 'w-4 h-4' %>
   </button>
-  <div class="font-semibold text-sm text-center flex-1" data-testid="day-header-label"><%= Date.parse(date.to_s).strftime('%A, %B %-d') %></div>
+  <div class="font-semibold text-sm text-center flex-1" data-testid="day-header-label"><%= l(Date.parse(date.to_s), format: :weekday_month_day) %></div>
   <button data-testid="day-next"
           data-action="click->timeline-feed#navigateDay"
           data-direction="next"
-          title="Next day"
-          aria-label="Next day"
+          title="<%= t('.next_day') %>"
+          aria-label="<%= t('.next_day') %>"
           class="btn btn-ghost btn-xs btn-square">
     <%= icon 'chevron-right', class: 'w-4 h-4' %>
   </button>

--- a/app/views/map/timeline_feeds/_day_summary.html.erb
+++ b/app/views/map/timeline_feeds/_day_summary.html.erb
@@ -10,16 +10,16 @@
 <div class="space-y-2 py-1">
   <div class="timeline-summary-stats">
     <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-primary/10 text-primary"
-          title="Total distance traveled this day">
+          title="<%= t('.total_distance_traveled_this_day') %>">
       <%= summary[:total_distance] %> <%= summary[:distance_unit] %>
     </span>
     <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-secondary/10 text-secondary"
-          title="Distinct places visited this day">
-      <%= summary[:places_visited] %> places
+          title="<%= t('.distinct_places_visited_this_day') %>">
+      <%= summary[:places_visited] %> <%= t('.places') %>
     </span>
     <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-base-content/5 text-base-content/60"
           title="<%= moving_label %> · <%= stationary_label %>">
-      <%= format_duration_short(moving * 60) %> moving
+      <%= format_duration_short(moving * 60) %> <%= t('.moving') %>
     </span>
   </div>
   <% if total_minutes > 0 %>
@@ -32,8 +32,8 @@
            title="<%= stationary_label %>"></div>
     </div>
     <div class="flex justify-between text-[0.625rem] text-base-content/40 px-0.5">
-      <span title="<%= moving_label %>">moving</span>
-      <span title="<%= stationary_label %>">stationary</span>
+      <span title="<%= moving_label %>"><%= t('.moving') %></span>
+      <span title="<%= stationary_label %>"><%= t('.stationary') %></span>
     </div>
   <% end %>
 </div>

--- a/app/views/map/timeline_feeds/_feed.html.erb
+++ b/app/views/map/timeline_feeds/_feed.html.erb
@@ -10,8 +10,8 @@
       <% end %>
       <div class="text-center text-base-content/60 py-8">
         <%= render 'shared/plan_data_window_alert', utm_content: 'timeline_feed' %>
-        <p class="text-sm">No visits tracked this day.</p>
-        <p class="text-xs mt-1">Visits are auto-detected daily from your location data.</p>
+        <p class="text-sm"><%= t('.no_visits_tracked_this_day') %></p>
+        <p class="text-xs mt-1"><%= t('.visits_are_auto_detected_daily_from_your_location_data') %></p>
       </div>
     </div>
   <% else %>

--- a/app/views/map/timeline_feeds/_journey_entry.html.erb
+++ b/app/views/map/timeline_feeds/_journey_entry.html.erb
@@ -18,12 +18,12 @@
   config = mode_config[mode] || mode_config['unknown']
   continuation_date = entry[:continuation_of_date]
   if continuation_date
-    leg_time = Time.zone.parse(entry[:ended_at]).strftime('%H:%M')
+    leg_time = l(Time.zone.parse(entry[:ended_at]), format: :hour_minute)
     duration = format_duration_short(entry[:day_duration] || entry[:duration])
     day_distance = entry[:day_distance] || entry[:distance]
     distance_text = day_distance > 0 ? "#{day_distance} #{entry[:distance_unit]} of #{entry[:distance]} #{entry[:distance_unit]}" : nil
   else
-    leg_time = Time.zone.parse(entry[:started_at]).strftime('%H:%M')
+    leg_time = l(Time.zone.parse(entry[:started_at]), format: :hour_minute)
     duration = format_duration_short(entry[:duration])
     distance_text = entry[:distance] > 0 ? "#{entry[:distance]} #{entry[:distance_unit]}" : nil
   end
@@ -51,16 +51,16 @@
     </div>
     <div class="journey-leg__summary">
       <% if continuation_date %>
-        <span class="journey-leg__verb">continued from <%= Date.parse(continuation_date).strftime('%b %-d') %>, arrived</span>
+        <span class="journey-leg__verb"><%= t('.continued_from_date_arrived', date: l(Date.parse(continuation_date), format: :short_month_day)) %></span>
       <% else %>
         <% if config[:emoji] %><span class="journey-leg__emoji"><%= config[:emoji] %></span><% end %>
         <span class="journey-leg__verb"><%= config[:verb] %></span>
       <% end %>
       <% if distance_text %>
-        <span class="journey-leg__sep">&middot;</span>
+        <span class="journey-leg__sep"><%= t('.middot') %></span>
         <span><%= distance_text %></span>
       <% end %>
-      <span class="journey-leg__sep">&middot;</span>
+      <span class="journey-leg__sep"><%= t('.middot') %></span>
       <span><%= duration %></span>
     </div>
     <% if track_id %>

--- a/app/views/map/timeline_feeds/_selection_bar.html.erb
+++ b/app/views/map/timeline_feeds/_selection_bar.html.erb
@@ -1,12 +1,12 @@
 <div data-timeline-feed-target="selectionBar"
      data-max-bulk-visits="<%= VisitsController::MAX_BULK_VISIT_IDS %>"
      class="selection-bar" hidden>
-  <span class="selection-bar__count" data-timeline-feed-target="selectionCount">0 selected</span>
+  <span class="selection-bar__count" data-timeline-feed-target="selectionCount"><%= t('.selected') %></span>
   <span class="selection-bar__actions">
     <button type="button"
             class="selection-bar__cancel"
             data-action="click->timeline-feed#exitSelection">
-      Cancel
+      <%= t('.cancel') %>
     </button>
 
     <%= form_with url: bulk_update_visits_path, method: :patch,
@@ -17,9 +17,9 @@
       <button type="submit"
               class="selection-bar__action selection-bar__confirm"
               data-timeline-feed-target="confirmButton"
-              title="Mark these visits as confirmed (yes, I was there)"
+              title="<%= t('.mark_these_visits_as_confirmed_yes_i_was_there') %>"
               disabled>
-        Confirm
+        <%= t('.confirm') %>
       </button>
     <% end %>
 
@@ -30,9 +30,9 @@
       <button type="submit"
               class="selection-bar__action selection-bar__merge"
               data-timeline-feed-target="mergeButton"
-              title="Combine the selected visits into one"
+              title="<%= t('.combine_the_selected_visits_into_one') %>"
               disabled>
-        Merge
+        <%= t('.merge') %>
       </button>
     <% end %>
 
@@ -43,9 +43,9 @@
       <button type="submit"
               class="selection-bar__action selection-bar__delete"
               data-timeline-feed-target="deleteButton"
-              title="Remove the visit grouping (your location points stay)"
+              title="<%= t('.remove_the_visit_grouping_your_location_points_stay') %>"
               disabled>
-        Delete
+        <%= t('.delete') %>
       </button>
     <% end %>
   </span>

--- a/app/views/map/timeline_feeds/_suggested_picker.html.erb
+++ b/app/views/map/timeline_feeds/_suggested_picker.html.erb
@@ -6,25 +6,25 @@
 
     <div class="suggested-picker__header">
       <div class="suggested-picker__heading">
-        <span class="suggested-picker__badge">Needs review</span>
-        <span class="suggested-picker__prompt">Confirm this visit?</span>
+        <span class="suggested-picker__badge"><%= t('.needs_review') %></span>
+        <span class="suggested-picker__prompt"><%= t('.confirm_this_visit') %></span>
       </div>
-      <%= f.submit 'Confirm',
+      <%= f.submit t('.confirm'),
                    data: { testid: 'visit-confirm' },
                    class: 'suggested-picker__confirm' %>
     </div>
 
     <p class="suggested-picker__note" data-testid="visit-no-alternatives">
       <% if place_name %>
-        Assigned to <%= place_name %>. Use the search button to pick a different place.
+        <%= t('.assigned_to') %> <%= place_name %><%= t('.use_the_search_button_to_pick_a_different_place') %>
       <% else %>
-        No place for this visit. Confirm to keep it as is.
+        <%= t('.no_place_for_this_visit_confirm_to_keep_it_as') %>
       <% end %>
     </p>
   <% end %>
 
-  <%= button_to 'Delete', visit_path(entry[:visit_id]),
+  <%= button_to t('.delete'), visit_path(entry[:visit_id]),
                 method: :delete,
-                data: { testid: 'visit-delete', turbo_confirm: 'Delete this visit? Your location points stay.' },
+                data: { testid: 'visit-delete', turbo_confirm: t('.delete_this_visit_your_location_points_stay') },
                 class: 'suggested-picker__decline' %>
 </div>

--- a/app/views/map/timeline_feeds/_track_info.html.erb
+++ b/app/views/map/timeline_feeds/_track_info.html.erb
@@ -1,26 +1,26 @@
 <%
   unit = local_assigns[:distance_unit] || @distance_unit || 'km'
-  mode_label = track.dominant_mode&.titleize || 'Unknown'
+  mode_label = track.dominant_mode ? t("transportation_modes.#{track.dominant_mode}") : t('.unknown')
   distance_val = Stat.convert_distance(track.distance, unit).round(1)
   speed_kmh = track.avg_speed.to_f
   avg_speed = unit == 'mi' ? (speed_kmh * 0.621371).round(1) : speed_kmh.round(1)
-  speed_label = unit == 'mi' ? 'mph' : 'km/h'
+  speed_label = t(unit == 'mi' ? 'units.miles_per_hour' : 'units.kilometers_per_hour')
   elev_gain = track.elevation_gain
   elev_loss = track.elevation_loss
 %>
 <div class="track-info-card">
-  <div class="track-info-card__id">Track #<%= track.id %></div>
+  <div class="track-info-card__id"><%= t('.track') %><%= track.id %></div>
   <%# Inline stat row — labels live to the left of values to keep height low.
       Elevation entries only render when present so quick walks/cycles stay
       single-line. %>
   <div class="track-info-stats">
-    <span><span class="track-info-stats__label">Dist</span> <strong><%= distance_val %> <%= unit %></strong></span>
-    <span><span class="track-info-stats__label">Avg</span> <strong><%= avg_speed %> <%= speed_label %></strong></span>
+    <span><span class="track-info-stats__label"><%= t('.dist') %></span> <strong><%= distance_val %> <%= unit %></strong></span>
+    <span><span class="track-info-stats__label"><%= t('.avg') %></span> <strong><%= avg_speed %> <%= speed_label %></strong></span>
     <% if elev_gain.present? && elev_gain > 0 %>
-      <span><span class="track-info-stats__label">↑</span> <strong><%= elev_gain.round %> m</strong></span>
+      <span><span class="track-info-stats__label">↑</span> <strong><%= t('units.meters', value: elev_gain.round) %></strong></span>
     <% end %>
     <% if elev_loss.present? && elev_loss > 0 %>
-      <span><span class="track-info-stats__label">↓</span> <strong><%= elev_loss.round %> m</strong></span>
+      <span><span class="track-info-stats__label">↓</span> <strong><%= t('units.meters', value: elev_loss.round) %></strong></span>
     <% end %>
     <span id="track-info-mode-<%= track.id %>" class="track-info-mode capitalize"><%= mode_label %></span>
   </div>
@@ -31,7 +31,7 @@
              class="toggle toggle-xs toggle-success"
              data-track-id="<%= track.id %>"
              data-action="change->maps--maplibre#toggleTrackPoints" />
-      <span>Show points</span>
+      <span><%= t('.show_points') %></span>
     </label>
     <button type="button"
             class="btn btn-xs btn-ghost gap-1 px-2"
@@ -39,13 +39,13 @@
             data-track-start="<%= track.start_at.iso8601 %>">
       <%= icon 'play', id: 'track-replay-play-icon', class: 'w-3 h-3' %>
       <%= icon 'pause', id: 'track-replay-pause-icon', class: 'w-3 h-3 hidden' %>
-      <span id="track-replay-label">Replay</span>
+      <span id="track-replay-label"><%= t('.replay') %></span>
     </button>
     <%= link_to new_track_share_link_path(track),
                 class: "btn btn-xs btn-ghost gap-1 px-2",
                 data: { turbo_frame: "share-link-modal" } do %>
       <%= icon 'share', class: 'w-3 h-3' %>
-      <span>Share</span>
+      <span><%= t('.share') %></span>
     <% end %>
   </div>
 

--- a/app/views/map/timeline_feeds/_visit_entry.html.erb
+++ b/app/views/map/timeline_feeds/_visit_entry.html.erb
@@ -27,13 +27,13 @@
            data-timeline-feed-target="rowCheck"
            data-visit-id="<%= entry[:visit_id] %>"
            data-action="change->timeline-feed#rowCheckChanged click->timeline-feed#stopPropagation"
-           aria-label="Select visit for merge"
+           aria-label="<%= t('.select_visit_for_merge') %>"
            tabindex="-1">
   </span>
 
   <div class="visit-row__time">
     <% if all_day %>
-      <span class="text-xs">All day</span>
+      <span class="text-xs"><%= t('.all_day') %></span>
     <% else %>
       <div class="font-mono text-xs"><%= times[:start_label] %></div>
       <div class="font-mono text-[10px] text-base-content/50"><%= times[:end_label] %></div>
@@ -53,7 +53,7 @@
                  suggested: status == 'suggested' %>
     </div>
     <div class="visit-row__meta text-xs text-base-content/60">
-      <%= format_dwell_minutes(entry[:duration]) %> · <%= entry[:point_count] %> pts
+      <%= format_dwell_minutes(entry[:duration]) %> · <%= entry[:point_count] %> <%= t('.pts') %>
       <% Array(entry[:tags]).each do |t| %>
         <span class="tag-chip" style="background-color: <%= t[:color] %>;">#<%= t[:name] %></span>
       <% end %>
@@ -66,16 +66,16 @@
       <% if coords %>
         <button type="button"
                 class="btn btn-xs btn-ghost btn-square"
-                title="Search for a place"
+                title="<%= t('.search_for_a_place') %>"
                 data-testid="visit-search-trigger"
                 data-action="click->visit-place-search#toggle click->timeline-feed#stopPropagation">
           <%= icon 'search', class: 'w-4 h-4' %>
         </button>
       <% end %>
       <% if status != 'suggested' %>
-        <%= button_to 'Delete', visit_path(entry[:visit_id]),
+        <%= button_to t('.delete'), visit_path(entry[:visit_id]),
                       method: :delete,
-                      data: { testid: 'visit-delete', turbo_confirm: 'Delete this visit? Your location points stay.' },
+                      data: { testid: 'visit-delete', turbo_confirm: t('.delete_this_visit_your_location_points_stay') },
                       class: 'btn btn-xs btn-ghost' %>
       <% end %>
     </div>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -3,7 +3,7 @@
     <h3 class="font-bold text-xl">
       <%= link_to notification.title, notification, class: "link hover:no-underline #{notification_link_color(notification)}" %>
     </h3>
-    <div class="text-sm text-gray-500"><%= time_ago_in_words notification.created_at %> ago</div>
+    <div class="text-sm text-gray-500"><%= time_ago_in_words notification.created_at %> <%= t('.ago') %></div>
 
     <% if params[:action] == 'show' %>
       <div class="mt-2">
@@ -11,7 +11,7 @@
 
         <% if notification.error? %>
           <div class="mt-2">
-            Please, when reporting a bug to <a href="https://github.com/Freika/dawarich/issues" class="link hover:no-underline text-blue-600">Github Issues</a>, don't forget to include logs from <code>dawarich_app</code> and <code>dawarich_sidekiq</code> docker containers. Thank you!
+            <%= t('.please_when_reporting_a_bug_to') %> <a href="https://github.com/Freika/dawarich/issues" class="link hover:no-underline text-blue-600"><%= t('.github_issues') %></a><%= t('.don_t_forget_to_include_logs_from') %> <code><%= t('.dawarich_app') %></code> <%= t('.and') %> <code><%= t('.dawarich_sidekiq') %></code> <%= t('.docker_containers_thank_you') %>
           </div>
         <% end %>
       </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,11 +1,11 @@
-<% content_for :title, "Notifications" %>
+<% content_for :title, t('.notifications') %>
 <div class="w-full my-5">
-  <%= render layout: 'shared/page_header', locals: { title: 'Notifications' } do %>
+  <%= render layout: 'shared/page_header', locals: { title: t('.notifications') } do %>
     <% if @notifications.unread.any? %>
-      <%= link_to "Mark all as read", mark_notifications_as_read_path, data: { turbo_method: :post }, class: "btn btn-sm btn-primary" %>
+      <%= link_to t('.mark_all_as_read'), mark_notifications_as_read_path, data: { turbo_method: :post }, class: "btn btn-sm btn-primary" %>
     <% end %>
     <% if @notifications.any? %>
-      <%= link_to "Delete all", delete_all_notifications_path, data: { turbo_method: :post, turbo_confirm: 'Are you sure you want to delete all notifications?' }, class: "btn btn-sm btn-warning" %>
+      <%= link_to t('.delete_all'), delete_all_notifications_path, data: { turbo_method: :post, turbo_confirm: t('.are_you_sure_you_want_to_delete_all_notifications') }, class: "btn btn-sm btn-warning" %>
     <% end %>
   <% end %>
   <div class="flex justify-center mb-4">

--- a/app/views/notifications/show.html.erb
+++ b/app/views/notifications/show.html.erb
@@ -3,9 +3,9 @@
     <%= render @notification %>
 
     <div class='my-5'>
-      <%= link_to "Back to notifications", notifications_path, class: "btn btn-small" %>
+      <%= link_to t('.back_to_notifications'), notifications_path, class: "btn btn-small" %>
       <div class="inline-block ml-2">
-        <%= button_to "Destroy this notification", @notification, data: { turbo_confirm: "Are you sure?" }, method: :delete, class: "btn btn-small btn-warning" %>
+        <%= button_to t('.destroy_this_notification'), @notification, data: { turbo_confirm: t('.are_you_sure') }, method: :delete, class: "btn btn-small btn-warning" %>
       </div>
     </div>
   </div>

--- a/app/views/places/_drawer.html.erb
+++ b/app/views/places/_drawer.html.erb
@@ -15,29 +15,29 @@
         <%= place.name %>
         <% if place.name_locked? %>
           <span class="place-drawer__name-lock"
-                title="You named this place, so automatic naming will not change it. Rename it to &quot;<%= Place::DEFAULT_NAME %>&quot; to hand it back to automatic naming."
+                title="<%= t('.manual_name_title', default_name: Place::DEFAULT_NAME) %>"
                 data-testid="place-name-lock"><%= icon 'lock', class: 'w-4 h-4 inline' %></span>
         <% end %>
       </h2>
       <% if stats[:location_line].present? %>
         <p class="place-drawer__location"><%= stats[:location_line] %></p>
       <% end %>
-      <p class="place-drawer__source">Source: <%= place.source.to_s.humanize %></p>
+      <p class="place-drawer__source"><%= t('.source') %> <%= t("enums.place.source.#{place.source}") %></p>
     </div>
   </header>
 
   <section class="place-drawer__stats">
     <div class="place-drawer__stat">
       <span class="place-drawer__stat-value"><%= stats[:visit_count] %></span>
-      <span class="place-drawer__stat-label"><%= pluralize(stats[:visit_count], 'visit') %></span>
+      <span class="place-drawer__stat-label"><%= t('.visit_count', count: stats[:visit_count]) %></span>
     </div>
     <div class="place-drawer__stat">
       <span class="place-drawer__stat-value"><%= stats[:total_hours] %></span>
-      <span class="place-drawer__stat-label">total hours</span>
+      <span class="place-drawer__stat-label"><%= t('.total_hours') %></span>
     </div>
     <div class="place-drawer__stat">
       <span class="place-drawer__stat-value"><%= stats[:avg_label] %></span>
-      <span class="place-drawer__stat-label">avg dwell</span>
+      <span class="place-drawer__stat-label"><%= t('.avg_dwell') %></span>
     </div>
   </section>
 
@@ -51,43 +51,43 @@
         <% end %>
       </ul>
     <% else %>
-      <p class="place-drawer__tags-empty">No tags</p>
+      <p class="place-drawer__tags-empty"><%= t('.no_tags') %></p>
     <% end %>
   </section>
 
   <section class="place-drawer__notes">
     <%= form_with model: place, method: :patch, data: { turbo_frame: 'place-drawer' } do |f| %>
-      <%= f.label :note, 'Notes', class: 'place-drawer__notes-label' %>
+      <%= f.label :note, t('.notes'), class: 'place-drawer__notes-label' %>
       <%= f.text_area :note, rows: 3, class: 'place-drawer__notes-input' %>
-      <%= f.submit 'Save', class: 'place-drawer__notes-submit' %>
+      <%= f.submit t('.save'), class: 'place-drawer__notes-submit' %>
     <% end %>
   </section>
 
   <section class="place-drawer__visits">
-    <h3 class="place-drawer__visits-heading">Recent visits</h3>
+    <h3 class="place-drawer__visits-heading"><%= t('.recent_visits') %></h3>
     <% if recent_visits.any? %>
       <ul class="place-drawer__visits-list">
         <% recent_visits.each do |visit| %>
           <% range = place_visit_time_range(visit) %>
           <li class="place-drawer__visit">
             <span class="place-drawer__visit-name"><%= visit.name %></span>
-            <span class="place-drawer__visit-time"><%= range[:start_label] %> &rarr; <%= range[:end_label] %> on <%= range[:date_label] %></span>
+            <span class="place-drawer__visit-time"><%= range[:start_label] %> <%= t('.rarr') %> <%= range[:end_label] %> <%= t('.on') %> <%= range[:date_label] %></span>
             <span class="place-drawer__visit-duration"><%= range[:duration_label] %></span>
           </li>
         <% end %>
       </ul>
     <% else %>
-      <p class="place-drawer__visits-empty">No visits yet</p>
+      <p class="place-drawer__visits-empty"><%= t('.no_visits_yet') %></p>
     <% end %>
   </section>
 
   <footer class="place-drawer__actions">
-    <button type="button" class="place-drawer__action place-drawer__action--rename" disabled>Rename</button>
-    <button type="button" class="place-drawer__action place-drawer__action--merge" disabled>Merge</button>
-    <%= button_to 'Delete',
+    <button type="button" class="place-drawer__action place-drawer__action--rename" disabled><%= t('.rename') %></button>
+    <button type="button" class="place-drawer__action place-drawer__action--merge" disabled><%= t('.merge') %></button>
+    <%= button_to t('.delete'),
                   places_path(place),
                   method: :delete,
                   class: 'place-drawer__action place-drawer__action--delete',
-                  data: { turbo_confirm: 'Delete this place? This cannot be undone.' } %>
+                  data: { turbo_confirm: t('.delete_this_place_this_cannot_be_undone') } %>
   </footer>
 </div>

--- a/app/views/places/_nearby_places.html.erb
+++ b/app/views/places/_nearby_places.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag "nearby-places" do %>
   <div class="space-y-2 max-h-48 overflow-y-auto">
     <% if places.blank? %>
-      <p class="text-sm text-gray-500">No nearby places found</p>
+      <p class="text-sm text-gray-500"><%= t('.no_nearby_places_found') %></p>
     <% else %>
       <% places.each_with_index do |place, index| %>
         <div class="card card-compact bg-base-200 cursor-pointer hover:bg-base-300 transition"
@@ -31,7 +31,7 @@
   <% if radius < max_radius %>
     <div class="mt-2 text-center">
       <% next_radius = [radius + 0.5, max_radius].min %>
-      <%= link_to "Load More (search up to #{(next_radius * 1000).round}m)",
+      <%= link_to t('.load_more_search_up_to_distance_m', distance: (next_radius * 1000).round),
             nearby_places_path(
               latitude: params[:latitude],
               longitude: params[:longitude],

--- a/app/views/places/index.html.erb
+++ b/app/views/places/index.html.erb
@@ -1,10 +1,10 @@
-<% content_for :title, "Places" %>
+<% content_for :title, t('.places') %>
 
 <div class="w-full my-5">
   <div class="overflow-x-auto pb-1">
     <div role="tablist" class="tabs tabs-lifted tabs-lg inline-flex min-w-max flex-nowrap">
-      <%= link_to 'Timeline', '/map/v2?panel=timeline&date=today&status=confirmed', role: 'tab', class: 'tab font-bold text-xl' %>
-      <%= link_to 'Places', places_path, role: 'tab', class: 'tab font-bold text-xl tab-active' %>
+      <%= link_to t('.timeline'), '/map/v2?panel=timeline&date=today&status=confirmed', role: 'tab', class: 'tab font-bold text-xl' %>
+      <%= link_to t('.places'), places_path, role: 'tab', class: 'tab font-bold text-xl tab-active' %>
     </div>
   </div>
 
@@ -13,9 +13,9 @@
       <div class="hero min-h-80 bg-base-200">
         <div class="hero-content text-center">
           <div class="max-w-md">
-            <h1 class="text-5xl font-bold">Hello there!</h1>
+            <h1 class="text-5xl font-bold"><%= t('.hello_there') %></h1>
             <p class="py-6">
-              Here you'll find your places, created by Visits suggestion process. But now there are none.
+              <%= t('.here_you_ll_find_your_places_created_by_visits_suggestion') %>
             </p>
           </div>
         </div>
@@ -28,10 +28,10 @@
         <table class="table">
           <thead>
             <tr>
-              <th>Name</th>
-              <th>Created at</th>
-              <th>Coordinates</th>
-              <th>Actions</th>
+              <th><%= t('.name') %></th>
+              <th><%= t('.created_at') %></th>
+              <th><%= t('.coordinates') %></th>
+              <th><%= t('.actions') %></th>
             </tr>
           </thead>
           <tbody>
@@ -41,7 +41,7 @@
                 <td><%= human_datetime(place.created_at, current_user.safe_settings.timezone) %></td>
                 <td><%= "#{place.lat}, #{place.lon}" %></td>
                 <td>
-                  <%= link_to 'Delete', place_path(place, page: params[:page]), data: { turbo_confirm: "Are you sure? Deleting a place will result in deleting all visits for this place.", turbo_method: :delete }, class: "px-4 py-2 bg-red-500 text-white rounded-md" %>
+                  <%= link_to t('.delete'), place_path(place, page: params[:page]), data: { turbo_confirm: t('.are_you_sure_deleting_a_place_will_result_in_deleting'), turbo_method: :delete }, class: "px-4 py-2 bg-red-500 text-white rounded-md" %>
                 </td>
               </tr>
             <% end %>

--- a/app/views/points/address.html.erb
+++ b/app/views/points/address.html.erb
@@ -4,7 +4,7 @@
     <% parts = [props['street'], props['city'], props['country']].compact_blank %>
     <% if parts.any? %>
       <div>
-        <span class="font-semibold">Address:</span> <%= parts.join(', ') %>
+        <span class="font-semibold"><%= t('.address') %></span> <%= parts.join(', ') %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/points/index.html.erb
+++ b/app/views/points/index.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, 'Points' %>
+<% content_for :title, t('.points') %>
 
 <div class="w-full my-5">
-  <%= render 'shared/page_header', title: 'Points' %>
+  <%= render 'shared/page_header', title: t('.points') %>
 
   <%# Filter form %>
   <div class="border border-base-300 rounded-xl bg-base-200/50 p-4 mb-5">
@@ -19,7 +19,7 @@
           <%= f.label :import, class: "text-xs font-medium text-base-content/50 uppercase tracking-wider mb-1 block" %>
           <%= f.select :import_id, options_for_select(@imports.map { |i| [i.name, i.id] }, params[:import_id]), { include_blank: 'All imports' }, class: "select select-bordered select-sm text-sm w-full" %>
         </div>
-        <%= f.submit "Search", class: "btn btn-primary btn-sm" %>
+        <%= f.submit t('.search'), class: "btn btn-primary btn-sm" %>
       </div>
     <% end %>
   </div>
@@ -32,18 +32,18 @@
     <div class="flex flex-wrap items-center gap-2">
       <div class="dropdown dropdown-end">
         <label tabindex="0" class="btn btn-outline btn-xs gap-1">
-          <%= icon 'arrow-big-down', class: 'w-3.5 h-3.5' %> Export
+          <%= icon 'arrow-big-down', class: 'w-3.5 h-3.5' %> <%= t('.export') %>
           <%= icon 'chevron-down', class: 'w-3 h-3' %>
         </label>
         <ul tabindex="0" class="dropdown-content z-[50] menu p-2 shadow-lg bg-base-100 rounded-lg w-48 mt-1 border border-base-300">
           <li>
-            <%= link_to exports_path(start_at: @start_at, end_at: @end_at, file_format: :json), data: { turbo_confirm: "Export as GeoJSON?", turbo_method: :post } do %>
-              <%= icon 'earth', class: 'w-4 h-4' %> GeoJSON
+            <%= link_to exports_path(start_at: @start_at, end_at: @end_at, file_format: :json), data: { turbo_confirm: t('.export_as_geojson'), turbo_method: :post } do %>
+              <%= icon 'earth', class: 'w-4 h-4' %> <%= t('.geojson') %>
             <% end %>
           </li>
           <li>
-            <%= link_to exports_path(start_at: @start_at, end_at: @end_at, file_format: :gpx), data: { turbo_confirm: "Export as GPX?", turbo_method: :post } do %>
-              <%= icon 'route', class: 'w-4 h-4' %> GPX
+            <%= link_to exports_path(start_at: @start_at, end_at: @end_at, file_format: :gpx), data: { turbo_confirm: t('.export_as_gpx'), turbo_method: :post } do %>
+              <%= icon 'route', class: 'w-4 h-4' %> <%= t('.gpx') %>
             <% end %>
           </li>
         </ul>
@@ -58,15 +58,16 @@
   <%# Points table %>
   <div id="points" data-controller='checkbox-select-all'>
     <%= form_with url: bulk_destroy_points_path(params.permit!), method: :delete, id: :bulk_destroy_form do |f| %>
-      <%= f.submit "Delete Selected", class: "btn btn-error btn-sm mb-3", data: { turbo_confirm: "Are you sure?", checkbox_select_all_target: "deleteButton" }, style: "display: none;" %>
+      <%= f.submit t('.delete_selected'), class: "btn btn-error btn-sm mb-3", data: { turbo_confirm: t('.are_you_sure'), checkbox_select_all_target: "deleteButton" }, style: "display: none;" %>
 
       <div class="border border-base-300 rounded-xl overflow-x-auto">
         <table class="table table-sm w-full">
           <thead class="bg-base-200">
             <tr>
               <th class="px-3 py-2.5 w-1/12">
-                <%= check_box_tag 'Select all',
+                <%= check_box_tag 'select_all',
                   id: :select_all_points,
+                  'aria-label': t('.select_all'),
                   data: {
                     checkbox_select_all_target: 'parent',
                     action: 'change->checkbox-select-all#toggleChildren'
@@ -75,15 +76,15 @@
                 %>
               </th>
               <% if DawarichSettings.reverse_geocoding_enabled? %>
-                <th class="px-3 py-2.5 text-xs uppercase tracking-wider text-left text-base-content/50 w-4/12">Address</th>
+                <th class="px-3 py-2.5 text-xs uppercase tracking-wider text-left text-base-content/50 w-4/12"><%= t('.address') %></th>
               <% end %>
-              <th class="px-3 py-2.5 text-xs uppercase tracking-wider text-base-content/50 text-right w-1/12">Speed</th>
-              <th class="px-3 py-2.5 text-xs uppercase tracking-wider text-base-content/50 w-3/12">Coordinates</th>
+              <th class="px-3 py-2.5 text-xs uppercase tracking-wider text-base-content/50 text-right w-1/12"><%= t('.speed') %></th>
+              <th class="px-3 py-2.5 text-xs uppercase tracking-wider text-base-content/50 w-3/12"><%= t('.coordinates') %></th>
               <th class="px-3 py-2.5 text-xs uppercase tracking-wider text-base-content/50 w-3/12">
                 <% next_order = params[:order_by] == 'asc' ? 'desc' : 'asc' %>
                 <%= link_to points_path(order_by: next_order, import_id: params[:import_id], start_at: params[:start_at], end_at: params[:end_at]),
                     class: "inline-flex items-center gap-1 link link-hover font-bold" do %>
-                  Recorded at
+                  <%= t('.recorded_at') %>
                   <%= icon(params[:order_by] == 'asc' ? 'chevron-up' : 'chevron-down', class: 'w-4 h-4 inline-block') %>
                 <% end %>
               </th>

--- a/app/views/posters/_poster.html.erb
+++ b/app/views/posters/_poster.html.erb
@@ -15,16 +15,16 @@
     <% end %>
     <div class="card-actions justify-end">
       <% if poster.completed? && poster.image.attached? %>
-        <%= link_to 'Download PNG', rails_blob_path(poster.image, disposition: 'attachment', only_path: true),
+        <%= link_to t('.download_png'), rails_blob_path(poster.image, disposition: 'attachment', only_path: true),
               class: 'btn btn-xs btn-ghost' %>
       <% end %>
       <% if poster.completed? && poster.print_pdf.attached? %>
-        <%= link_to 'Download PDF', rails_blob_path(poster.print_pdf, disposition: 'attachment', only_path: true),
+        <%= link_to t('.download_pdf'), rails_blob_path(poster.print_pdf, disposition: 'attachment', only_path: true),
               class: 'btn btn-xs btn-primary' %>
       <% end %>
-      <%= link_to 'Delete', poster_path(poster),
+      <%= link_to t('.delete'), poster_path(poster),
             class: 'btn btn-xs btn-ghost',
-            data: { turbo_method: :delete, turbo_confirm: 'Delete this poster?' } %>
+            data: { turbo_method: :delete, turbo_confirm: t('.delete_this_poster') } %>
     </div>
   </div>
 </div>

--- a/app/views/posters/_studio.html.erb
+++ b/app/views/posters/_studio.html.erb
@@ -15,7 +15,7 @@
     <header class="flex items-center justify-between gap-4 border-b border-base-content/10 bg-base-200 px-4 py-2">
       <h2 class="text-sm font-semibold tracking-wide flex items-center gap-2 shrink-0">
         <%= icon 'map', class: 'h-4 w-4 opacity-70' %>
-        Poster Studio
+        <%= t('.poster_studio') %>
       </h2>
       <% if show_date_controls %>
         <div class="flex items-center gap-2 min-w-0">
@@ -29,15 +29,15 @@
                   data-action="poster-studio-editor#applyDates">
             <span class="hidden h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-r-transparent"
                   data-poster-studio-editor-target="loadSpinner"></span>
-            <span data-poster-studio-editor-target="loadLabel">Load</span>
+            <span data-poster-studio-editor-target="loadLabel"><%= t('.load') %></span>
           </button>
           <div class="hidden items-center gap-1 lg:flex">
             <button type="button" class="btn btn-sm btn-ghost"
-                    data-range="today" data-action="poster-studio-editor#presetRange">Today</button>
+                    data-range="today" data-action="poster-studio-editor#presetRange"><%= t('.today') %></button>
             <button type="button" class="btn btn-sm btn-ghost"
-                    data-range="week" data-action="poster-studio-editor#presetRange">Last 7 days</button>
+                    data-range="week" data-action="poster-studio-editor#presetRange"><%= t('.last_7_days') %></button>
             <button type="button" class="btn btn-sm btn-ghost"
-                    data-range="month" data-action="poster-studio-editor#presetRange">Last month</button>
+                    data-range="month" data-action="poster-studio-editor#presetRange"><%= t('.last_month') %></button>
           </div>
         </div>
       <% else %>
@@ -46,7 +46,7 @@
           <span><%= local_assigns[:date_range_label] %></span>
         </div>
       <% end %>
-      <button type="button" class="btn btn-ghost btn-sm btn-circle shrink-0" title="Close studio"
+      <button type="button" class="btn btn-ghost btn-sm btn-circle shrink-0" title="<%= t('.close_studio') %>"
               data-action="poster-studio-editor#close">
         <%= icon 'x' %>
       </button>
@@ -75,11 +75,11 @@
           <button type="button" class="btn btn-sm"
                   data-action="poster-studio-editor#recenter">
             <%= icon 'compass', class: 'h-4 w-4' %>
-            Recenter
+            <%= t('.recenter') %>
           </button>
         </div>
         <p class="mt-2 text-xs opacity-60">
-          Drag to pan, scroll to zoom — the frame is what gets exported.
+          <%= t('.drag_to_pan_scroll_to_zoom_the_frame_is_what') %>
         </p>
       </div>
 
@@ -90,7 +90,7 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
                 <%= icon 'grid2x2', class: 'h-4 w-4 opacity-70 shrink-0' %>
-                Layout
+                <%= t('.layout') %>
               </span>
             </summary>
             <div class="collapse-content space-y-2">
@@ -105,7 +105,7 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
                 <%= icon 'palette', class: 'h-4 w-4 opacity-70 shrink-0' %>
-                Theme
+                <%= t('.theme') %>
               </span>
             </summary>
             <div class="collapse-content space-y-2">
@@ -115,7 +115,7 @@
                           class="w-full overflow-hidden rounded-md border border-base-300 ring-primary ring-offset-base-100 transition hover:scale-105 focus:outline-none focus-visible:ring-2"
                           style="height: 32px; background-image: url('<%= asset_path("poster_themes/#{theme['key']}.webp") %>'); background-size: cover; background-position: center;"
                           title="<%= theme['name'] %>"
-                          aria-label="<%= theme['name'] %> theme"
+                          aria-label="<%= t('.theme_aria_label', theme: theme['name']) %>"
                           data-poster-studio-editor-target="swatch"
                           data-key="<%= theme['key'] %>"
                           data-name="<%= theme['name'] %>"
@@ -124,14 +124,14 @@
               </div>
               <p class="text-xs opacity-70" data-poster-studio-editor-target="themeLabel"></p>
               <details class="collapse collapse-arrow bg-base-200 rounded-lg">
-                <summary class="collapse-title text-sm min-h-0 cursor-pointer select-none">Customize colors</summary>
+                <summary class="collapse-title text-sm min-h-0 cursor-pointer select-none"><%= t('.customize_colors') %></summary>
                 <div class="collapse-content space-y-1">
                   <% [
-                    %w[bg Background], %w[water Water], %w[parks Parks],
-                    %w[buildings Buildings], %w[railway Railways], %w[boundaries Boundaries],
-                    ['road_motorway', 'Motorway roads'], ['road_primary', 'Primary roads'],
-                    ['road_residential', 'Residential roads'], ['road_default', 'Other roads'],
-                    %w[route Track], %w[text Text]
+                    ['bg', t('.background')], ['water', t('.water')], ['parks', t('.parks')],
+                    ['buildings', t('.buildings')], ['railway', t('.railways')], ['boundaries', t('.boundaries')],
+                    ['road_motorway', t('.motorway_roads')], ['road_primary', t('.primary_roads')],
+                    ['road_residential', t('.residential_roads')], ['road_default', t('.other_roads')],
+                    ['route', t('.track')], ['text', t('.text')]
                   ].each do |token, token_label| %>
                     <label class="flex items-center gap-2">
                       <input type="color"
@@ -154,7 +154,7 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
                 <%= icon 'square-pen', class: 'h-4 w-4 opacity-70 shrink-0' %>
-                Text
+                <%= t('.text') %>
               </span>
             </summary>
             <div class="collapse-content space-y-2">
@@ -162,17 +162,17 @@
                 <input type="checkbox" class="toggle toggle-sm toggle-primary" checked
                        data-poster-studio-editor-target="textToggle"
                        data-action="change->poster-studio-editor#textChanged">
-                <span class="label-text text-sm">Show text</span>
+                <span class="label-text text-sm"><%= t('.show_text') %></span>
               </label>
               <label class="form-control">
-                <span class="label-text text-xs">Title</span>
-                <input type="text" class="input input-bordered input-sm w-full" placeholder="Berlin"
+                <span class="label-text text-xs"><%= t('.title') %></span>
+                <input type="text" class="input input-bordered input-sm w-full" placeholder="<%= t('.berlin') %>"
                        data-poster-studio-editor-target="titleInput"
                        data-action="input->poster-studio-editor#textChanged">
               </label>
               <label class="form-control">
-                <span class="label-text text-xs">Subtitle</span>
-                <input type="text" class="input input-bordered input-sm w-full" placeholder="Germany"
+                <span class="label-text text-xs"><%= t('.subtitle') %></span>
+                <input type="text" class="input input-bordered input-sm w-full" placeholder="<%= t('.germany') %>"
                        data-poster-studio-editor-target="subtitleInput"
                        data-action="input->poster-studio-editor#textChanged">
               </label>
@@ -180,10 +180,10 @@
                 <input type="checkbox" class="toggle toggle-sm toggle-primary" checked
                        data-poster-studio-editor-target="coordsToggle"
                        data-action="change->poster-studio-editor#textChanged">
-                <span class="label-text text-sm">Coordinates line</span>
+                <span class="label-text text-sm"><%= t('.coordinates_line') %></span>
               </label>
               <label class="form-control">
-                <span class="label-text text-xs">Font</span>
+                <span class="label-text text-xs"><%= t('.font') %></span>
                 <select class="select select-bordered select-sm py-0 w-full"
                         data-poster-studio-editor-target="fontSelect"
                         data-action="change->poster-studio-editor#fontChanged"></select>
@@ -195,17 +195,17 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
                 <%= icon 'layer', class: 'h-4 w-4 opacity-70 shrink-0' %>
-                Layers
+                <%= t('.layers') %>
               </span>
             </summary>
             <div class="collapse-content space-y-1">
               <% [
-                ['roads', 'Roads', true],
-                ['water', 'Water', true],
-                ['landuse', 'Parks & land use', true],
-                ['buildings', 'Buildings', false],
-                ['rail', 'Railways', false],
-                ['boundaries', 'Boundaries', false]
+                ['roads', t('.roads'), true],
+                ['water', t('.water'), true],
+                ['landuse', t('.parks_land_use'), true],
+                ['buildings', t('.buildings'), false],
+                ['rail', t('.railways'), false],
+                ['boundaries', t('.boundaries'), false]
               ].each do |key, label, default_on| %>
                 <label class="label cursor-pointer justify-start gap-3 py-1">
                   <input type="checkbox" class="toggle toggle-sm toggle-primary"
@@ -217,7 +217,7 @@
               <% end %>
               <div class="pt-2">
                 <div class="flex items-center justify-between py-1">
-                  <span class="label-text text-xs">Track opacity</span>
+                  <span class="label-text text-xs"><%= t('.track_opacity') %></span>
                   <span class="text-xs font-medium tabular-nums opacity-80"
                         data-poster-studio-editor-target="trackOpacityLabel"></span>
                 </div>
@@ -228,7 +228,7 @@
               </div>
               <div class="pt-2">
                 <div class="flex items-center justify-between py-1">
-                  <span class="label-text text-xs">Track width</span>
+                  <span class="label-text text-xs"><%= t('.track_width') %></span>
                   <span class="text-xs font-medium tabular-nums opacity-80"
                         data-poster-studio-editor-target="trackWidthLabel"></span>
                 </div>
@@ -244,11 +244,11 @@
             <summary class="collapse-title font-medium min-h-0 cursor-pointer">
               <span class="flex items-center gap-2">
                 <%= icon 'camera', class: 'h-4 w-4 opacity-70 shrink-0' %>
-                Recent posters
+                <%= t('.recent_posters') %>
               </span>
             </summary>
             <div class="collapse-content space-y-3">
-              <p class="text-xs opacity-60">Server-rendered posters from "Save to gallery" — they stay here across sessions.</p>
+              <p class="text-xs opacity-60"><%= t('.server_rendered_posters_from_save_to_gallery_they_stay_here') %></p>
               <div id="poster-gallery-list" class="space-y-3">
                 <%= render partial: 'posters/poster', collection: @recent_posters %>
               </div>
@@ -259,19 +259,19 @@
         <div class="space-y-2 border-t border-base-content/10 p-3">
           <div class="text-xs opacity-70 space-y-0.5" data-poster-studio-editor-target="summary"></div>
 
-          <div class="divider my-0 text-xs font-medium opacity-50">Export a file</div>
+          <div class="divider my-0 text-xs font-medium opacity-50"><%= t('.export_a_file') %></div>
           <div class="grid grid-cols-2 gap-2">
             <label class="form-control">
-              <span class="label-text text-xs">Format</span>
+              <span class="label-text text-xs"><%= t('.format') %></span>
               <select class="select select-bordered select-sm py-0"
                       data-poster-studio-editor-target="format"
                       data-action="change->poster-studio-editor#updateSummary">
-                <option value="png" selected>PNG</option>
-                <option value="pdf">PDF</option>
+                <option value="png" selected><%= t('.png') %></option>
+                <option value="pdf"><%= t('.pdf') %></option>
               </select>
             </label>
             <label class="form-control" data-poster-studio-editor-target="dpiField">
-              <span class="label-text text-xs">Print DPI</span>
+              <span class="label-text text-xs"><%= t('.print_dpi') %></span>
               <select class="select select-bordered select-sm py-0"
                       data-poster-studio-editor-target="dpi"
                       data-action="change->poster-studio-editor#updateSummary">
@@ -284,14 +284,14 @@
                   data-poster-studio-editor-target="downloadButton"
                   data-action="poster-studio-editor#download">
             <%= icon 'download', class: 'h-4 w-4' %>
-            Download
+            <%= t('.download') %>
           </button>
           <button type="button" class="btn btn-ghost btn-xs w-full gap-1 opacity-70"
                   data-poster-studio-editor-target="saveButton"
                   data-action="poster-studio-editor#saveToGallery"
-                  title="Render this area server-side as the classic 3:4 print poster and keep it in Recent posters">
+                  title="<%= t('.render_this_area_server_side_as_the_classic_3_4') %>">
             <%= icon 'camera', class: 'h-3.5 w-3.5' %>
-            Save to gallery
+            <%= t('.save_to_gallery') %>
           </button>
           <p class="text-xs text-warning hidden" data-poster-studio-editor-target="saveNotice"></p>
 
@@ -302,52 +302,50 @@
               a time. %>
           <% if poster_ordering_enabled? %>
           <div class="hidden space-y-2" data-poster-studio-editor-target="orderSection">
-            <div class="divider my-0 text-xs font-medium opacity-50">Order a print</div>
+            <div class="divider my-0 text-xs font-medium opacity-50"><%= t('.order_a_print') %></div>
 
             <div class="space-y-1.5" data-poster-studio-editor-target="orderCta">
               <button type="button" class="btn btn-secondary btn-sm w-full"
                       data-poster-studio-editor-target="orderButton"
                       data-action="poster-studio-editor#openOrder">
                 <%= icon 'package', class: 'h-4 w-4' %>
-                Order a printed poster
+                <%= t('.order_a_printed_poster') %>
               </button>
               <p class="text-xs flex flex-wrap items-center gap-x-2 gap-y-1">
-                <span class="badge badge-success badge-outline badge-sm">Free EU shipping</span>
+                <span class="badge badge-success badge-outline badge-sm"><%= t('.free_eu_shipping') %></span>
                 <span class="badge badge-outline badge-sm"><%= paper_spec %></span>
               </p>
             </div>
 
             <div class="hidden rounded-lg border border-base-300 bg-base-100 p-3 space-y-2"
                  data-poster-studio-editor-target="sizePicker">
-              <p class="text-sm font-semibold">Choose a print size</p>
+              <p class="text-sm font-semibold"><%= t('.choose_a_print_size') %></p>
               <p class="text-xs flex flex-wrap items-center gap-x-1.5 gap-y-1">
-                <span class="badge badge-success badge-outline badge-sm">Free EU shipping</span>
+                <span class="badge badge-success badge-outline badge-sm"><%= t('.free_eu_shipping') %></span>
                 <span class="badge badge-outline badge-sm"><%= paper_spec %></span>
               </p>
               <div class="space-y-1" data-poster-studio-editor-target="sizePickerOptions"></div>
               <button type="button" class="btn btn-ghost btn-xs w-full"
-                      data-action="poster-studio-editor#closeSizePicker">Cancel</button>
+                      data-action="poster-studio-editor#closeSizePicker"><%= t('.cancel') %></button>
             </div>
 
             <div class="hidden rounded-lg border border-base-300 bg-base-100 p-3 space-y-2"
                  data-poster-studio-editor-target="orderDialog">
               <p class="text-sm font-semibold" data-poster-studio-editor-target="orderSummary"></p>
               <p class="text-xs flex flex-wrap items-center gap-x-1.5 gap-y-1">
-                <span class="badge badge-success badge-outline badge-sm">Free EU shipping</span>
+                <span class="badge badge-success badge-outline badge-sm"><%= t('.free_eu_shipping') %></span>
                 <span class="badge badge-outline badge-sm"><%= paper_spec %></span>
-                <span class="opacity-60">· pay via Stripe</span>
+                <span class="opacity-60"><%= t('.pay_via_stripe') %></span>
               </p>
               <p class="text-xs opacity-70 leading-snug">
-                Printed by Gelato, exactly as previewed. Made to order, so the
-                statutory 14-day right of withdrawal does not apply once
-                production starts (§312g Abs. 2 Nr. 1 BGB).
+                <%= t('.printed_by_gelato_exactly_as_previewed_made_to_order_so') %>
               </p>
               <p class="text-xs text-error hidden" data-poster-studio-editor-target="orderError"></p>
               <div class="flex gap-2" data-poster-studio-editor-target="orderActions">
                 <button type="button" class="btn btn-primary btn-sm flex-1"
-                        data-action="poster-studio-editor#confirmOrder">Order this poster</button>
+                        data-action="poster-studio-editor#confirmOrder"><%= t('.order_this_poster') %></button>
                 <button type="button" class="btn btn-ghost btn-sm"
-                        data-action="poster-studio-editor#openSizePicker">Back</button>
+                        data-action="poster-studio-editor#openSizePicker"><%= t('.back') %></button>
               </div>
 
               <%# Order progress: steps activate one after another; the checkout
@@ -357,7 +355,7 @@
                   <p class="flex items-center gap-1.5 text-xs font-medium">
                     <span class="hidden h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-current border-r-transparent" data-role="spinner"></span>
                     <span class="hidden text-success" data-role="done"><%= icon 'circle-check', class: 'h-3.5 w-3.5' %></span>
-                    <span>1. Preparing poster</span>
+                    <span><%= t('.preparing_poster') %></span>
                   </p>
                   <progress class="progress progress-primary hidden h-1.5 w-full" data-role="bar"></progress>
                 </li>
@@ -365,21 +363,21 @@
                   <p class="flex items-center gap-1.5 text-xs font-medium">
                     <span class="hidden h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-current border-r-transparent" data-role="spinner"></span>
                     <span class="hidden text-success" data-role="done"><%= icon 'circle-check', class: 'h-3.5 w-3.5' %></span>
-                    <span>2. Uploading poster</span>
+                    <span><%= t('.uploading_poster') %></span>
                   </p>
                   <progress class="progress progress-primary hidden h-1.5 w-full" value="0" max="100"
                             data-role="bar" data-poster-studio-editor-target="uploadBar"></progress>
                 </li>
                 <li class="space-y-1.5 opacity-40" data-poster-studio-editor-target="orderStep" data-step="checkout">
-                  <p class="text-xs font-medium">3. Continue to order</p>
+                  <p class="text-xs font-medium"><%= t('.continue_to_order') %></p>
                   <a class="btn btn-primary btn-sm btn-disabled w-full" aria-disabled="true"
                      target="_blank" rel="noopener"
-                     data-poster-studio-editor-target="checkoutLink">Continue to payment</a>
+                     data-poster-studio-editor-target="checkoutLink"><%= t('.continue_to_payment') %></a>
                   <a class="link hidden text-xs" target="_blank" rel="noopener"
-                     data-poster-studio-editor-target="orderPageLink">Checkout not working? Open your order page</a>
+                     data-poster-studio-editor-target="orderPageLink"><%= t('.checkout_not_working_open_your_order_page') %></a>
                   <button type="button" class="btn btn-ghost btn-xs hidden w-full"
                           data-poster-studio-editor-target="orderDoneButton"
-                          data-action="poster-studio-editor#closeOrder">Close</button>
+                          data-action="poster-studio-editor#closeOrder"><%= t('.close') %></button>
                 </li>
               </ol>
             </div>

--- a/app/views/settings/_navigation.html.erb
+++ b/app/views/settings/_navigation.html.erb
@@ -1,17 +1,17 @@
 <div class="mb-6 overflow-x-auto pb-1">
   <div class="tabs tabs-boxed inline-flex min-w-max flex-nowrap">
-    <%= link_to 'General', settings_general_index_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_general_index_path)}" %>
-    <%= link_to 'Integrations', settings_integrations_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_integrations_path)}" %>
-    <%= link_to 'Map', settings_maps_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_maps_path)}" %>
-    <%= link_to 'Visits', settings_visits_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_visits_path)}" %>
+    <%= link_to t('.general'), settings_general_index_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_general_index_path)}" %>
+    <%= link_to t('.integrations'), settings_integrations_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_integrations_path)}" %>
+    <%= link_to t('.map'), settings_maps_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_maps_path)}" %>
+    <%= link_to t('.visits'), settings_visits_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_visits_path)}" %>
     <% if DawarichSettings.two_factor_available? %>
-      <%= link_to 'Two-Factor Authentication', settings_two_factor_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_two_factor_path)}" %>
+      <%= link_to t('.two_factor_authentication'), settings_two_factor_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_two_factor_path)}" %>
     <% end %>
     <% if DawarichSettings.self_hosted? %>
       <% if current_user.admin? %>
-        <%= link_to 'Users', settings_users_path, role: 'tab', class: "tab tab-lg #{controller_path == 'settings/users' ? 'tab-active' : ''}" %>
+        <%= link_to t('.users'), settings_users_path, role: 'tab', class: "tab tab-lg #{controller_path == 'settings/users' ? 'tab-active' : ''}" %>
       <% end %>
-      <%= link_to 'Background Jobs', settings_background_jobs_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_background_jobs_path)}" %>
+      <%= link_to t('.background_jobs'), settings_background_jobs_path, role: 'tab', class: "tab tab-lg #{active_tab?(settings_background_jobs_path)}" %>
     <% end %>
   </div>
 </div>

--- a/app/views/settings/background_jobs/index.html.erb
+++ b/app/views/settings/background_jobs/index.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, "Background jobs" %>
+<% content_for :title, t('.background_jobs') %>
 
 <div class="min-h-content w-full my-5">
-  <%= render 'shared/page_header', title: 'Background jobs' %>
+  <%= render 'shared/page_header', title: t('.background_jobs') %>
   <%= render 'settings/navigation' %>
 
   <div role="alert" class="alert m-5">
@@ -16,7 +16,7 @@
         stroke-width="2"
         d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
     </svg>
-    <span>Spamming many new jobs at once is a bad idea. Let them work or clear the queue beforehand.</span>
+    <span><%= t('.spamming_many_new_jobs_at_once_is_a_bad_idea') %></span>
   </div>
 
   <% if current_user.gps_noise_recheck_pending? %>
@@ -32,27 +32,27 @@
           stroke-width="2"
           d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
       </svg>
-      <span>GPS noise detection changed in this release, so your existing points are queued for a one-time re-check. Your tracks, stats and digests are rebuilt from the result, which can take a while on a large history — some points may appear or disappear on the map when it finishes. No points are deleted, and the pass runs on the lowest-priority queue so everything else stays ahead of it.</span>
+      <span><%= t('.gps_noise_detection_changed_in_this_release_so_your_existing') %></span>
     </div>
   <% end %>
 
   <div class='flex flex-wrap'>
     <div class="card bg-base-300 w-96 shadow-xl m-5">
       <div class="card-body">
-        <h2 class="card-title">Start Reverse Geocoding</h2>
-        <p>This job will re-run reverse geocoding process for all the points in your database. Might take a few days or even weeks based on the amount of points you have!</p>
+        <h2 class="card-title"><%= t('.start_reverse_geocoding') %></h2>
+        <p><%= t('.this_job_will_re_run_reverse_geocoding_process_for_all') %></p>
         <div class="card-actions justify-end">
-          <%= link_to 'Start Job', settings_background_jobs_path(job_name: 'start_reverse_geocoding'), data: { turbo_confirm: 'Are you sure?', turbo_method: :post }, class: 'btn btn-primary' %>
+          <%= link_to t('.start_job'), settings_background_jobs_path(job_name: 'start_reverse_geocoding'), data: { turbo_confirm: t('.are_you_sure'), turbo_method: :post }, class: 'btn btn-primary' %>
         </div>
       </div>
     </div>
 
     <div class="card bg-base-300 w-96 shadow-xl m-5">
       <div class="card-body">
-        <h2 class="card-title">Continue Reverse Geocoding</h2>
-        <p>This job will process reverse geocoding for all points that don't have geocoding data yet.</p>
+        <h2 class="card-title"><%= t('.continue_reverse_geocoding') %></h2>
+        <p><%= t('.this_job_will_process_reverse_geocoding_for_all_points_that') %></p>
         <div class="card-actions justify-end">
-          <%= link_to 'Start Job', settings_background_jobs_path(job_name: 'continue_reverse_geocoding'), data: { turbo_confirm: 'Are you sure?', turbo_method: :post }, class: 'btn btn-primary' %>
+          <%= link_to t('.start_job'), settings_background_jobs_path(job_name: 'continue_reverse_geocoding'), data: { turbo_confirm: t('.are_you_sure'), turbo_method: :post }, class: 'btn btn-primary' %>
         </div>
       </div>
     </div>
@@ -60,10 +60,10 @@
     <% if current_user.admin? %>
       <div class="card bg-base-300 w-96 shadow-xl m-5">
         <div class="card-body">
-          <h2 class="card-title">Background Jobs Dashboard</h2>
-          <p>This will open the background jobs dashboard in a new tab.</p>
+          <h2 class="card-title"><%= t('.background_jobs_dashboard') %></h2>
+          <p><%= t('.this_will_open_the_background_jobs_dashboard_in_a_new') %></p>
           <div class="card-actions justify-end">
-            <%= link_to 'Open Dashboard', '/sidekiq', target: '_blank', class: 'btn btn-primary' %>
+            <%= link_to t('.open_dashboard'), '/sidekiq', target: '_blank', class: 'btn btn-primary' %>
           </div>
         </div>
       </div>
@@ -71,13 +71,13 @@
 
     <div class="card bg-base-300 w-96 shadow-xl m-5">
       <div class="card-body">
-        <h2 class="card-title">Visits suggestions</h2>
-        <p>Enable or disable visits suggestions. It's a background task that runs every day at midnight. Disabling it might be useful if you don't want to receive visits suggestions or if you're using the Dawarich iOS app, which has its own visits suggestions.</p>
+        <h2 class="card-title"><%= t('.visits_suggestions') %></h2>
+        <p><%= t('.enable_or_disable_visits_suggestions_it_s_a_background_task') %></p>
         <div class="card-actions justify-end">
           <% if current_user.safe_settings.visits_suggestions_enabled? %>
-            <%= link_to 'Disable', settings_background_jobs_path(settings: { 'visits_suggestions_enabled' => 'false' }), data: { turbo_confirm: 'Are you sure?', turbo_method: :patch }, class: 'btn btn-error' %>
+            <%= link_to t('.disable'), settings_background_jobs_path(settings: { 'visits_suggestions_enabled' => 'false' }), data: { turbo_confirm: t('.are_you_sure'), turbo_method: :patch }, class: 'btn btn-error' %>
           <% else %>
-            <%= link_to 'Enable', settings_background_jobs_path(settings: { 'visits_suggestions_enabled' => 'true' }), data: { turbo_confirm: 'Are you sure?', turbo_method: :patch }, class: 'btn btn-success' %>
+            <%= link_to t('.enable'), settings_background_jobs_path(settings: { 'visits_suggestions_enabled' => 'true' }), data: { turbo_confirm: t('.are_you_sure'), turbo_method: :patch }, class: 'btn btn-success' %>
           <% end %>
         </div>
       </div>

--- a/app/views/settings/general/_changelog_consent.html.erb
+++ b/app/views/settings/general/_changelog_consent.html.erb
@@ -1,30 +1,24 @@
 <div id="changelog-consent-setting" class="card bg-base-200 shadow-xl">
   <div class="card-body">
     <h2 class="text-2xl font-bold mb-4 flex items-center">
-      <%= icon 'bell', class: "text-primary mr-2" %> What's New notices
+      <%= icon 'bell', class: "text-primary mr-2" %> <%= t('.what_s_new_notices') %>
     </h2>
     <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
       <% if current_user.changelog_consent_granted? %>
         <p class="text-sm text-base-content/70">
-          A "What's New" notice is shown when a new Dawarich version ships,
-          including security fixes. It loads a small widget from
-          <%= changelog_widget_host %>, which — like any web request — sees your
-          IP address, browser, and the page URL, plus your Dawarich version.
-          It never receives your account, email, or location.
+          <%= t('.a_what_s_new_notice_is_shown_when_a_new') %>
+          <%= changelog_widget_host %><%= t('.which_like_any_web_request_sees_your_ip_address_browser') %>
         </p>
-        <%= button_to "Turn off notices", changelog_consent_path,
+        <%= button_to t('.turn_off_notices'), changelog_consent_path,
               method: :patch, params: { decision: "declined" },
               class: "btn btn-ghost btn-sm",
               form: { data: { turbo_stream: true } } %>
       <% else %>
         <p class="text-sm text-base-content/70">
-          Get a "What's New" notice when a new Dawarich version ships, including
-          security fixes. The notice loads a small widget from
-          <%= changelog_widget_host %>, which — like any web request — sees your
-          IP address, browser, and the page URL, plus your Dawarich version.
-          It never receives your account, email, or location.
+          <%= t('.get_a_what_s_new_notice_when_a_new_dawarich') %>
+          <%= changelog_widget_host %><%= t('.which_like_any_web_request_sees_your_ip_address_browser') %>
         </p>
-        <%= button_to "Turn on notices", changelog_consent_path,
+        <%= button_to t('.turn_on_notices'), changelog_consent_path,
               method: :patch, params: { decision: "granted" },
               class: "btn btn-primary btn-sm",
               form: { data: { turbo_stream: true } } %>

--- a/app/views/settings/general/_supporter_status.html.erb
+++ b/app/views/settings/general/_supporter_status.html.erb
@@ -3,74 +3,74 @@
   <div class="card bg-base-200 shadow-xl">
     <div class="card-body">
       <h2 class="text-2xl font-bold mb-4 flex items-center">
-        <%= icon 'heart', class: 'mr-2 text-pink-500' %> Supporter Status
+        <%= icon 'heart', class: 'mr-2 text-pink-500' %> <%= t('.supporter_status') %>
       </h2>
       <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
         <% if current_user.supporter? %>
           <div class="alert alert-success">
             <%= icon 'circle-check', class: 'w-5 h-5' %>
-            <span>Thank you for supporting Dawarich<%= " via #{current_user.supporter_platform&.titleize}" if current_user.supporter_platform %>!</span>
+            <span><%= t('.supporter_thanks', platform: current_user.supporter_platform ? t('.supporter_platform', platform: t("supporter_platforms.#{current_user.supporter_platform}")) : '') %></span>
           </div>
         <% end %>
 
         <%= form_with url: settings_verify_supporter_path, method: :post, data: { turbo: false } do |vf| %>
           <div class="form-control">
             <%= vf.label :supporter_email, class: 'label' do %>
-              <span class="label-text font-medium">Email used for Patreon/GitHub/Ko-fi</span>
+              <span class="label-text font-medium"><%= t('.email_used_for_patreon_github_ko_fi') %></span>
             <% end %>
             <%= vf.email_field :supporter_email,
                 value: current_user.safe_settings.supporter_email,
                 class: 'input input-bordered w-full',
-                placeholder: 'supporter@example.com' %>
+                placeholder: t('.supporter_example_com') %>
           </div>
 
           <div class="form-control mt-3">
             <%= vf.label :supporter_github_username, class: 'label' do %>
-              <span class="label-text font-medium">GitHub username (for GitHub Sponsors with a private email)</span>
+              <span class="label-text font-medium"><%= t('.github_username_for_github_sponsors_with_a_private_email') %></span>
             <% end %>
             <%= vf.text_field :supporter_github_username,
                 value: current_user.safe_settings.supporter_github_username,
                 class: 'input input-bordered w-full',
-                placeholder: 'octocat',
+                placeholder: t('.octocat'),
                 autocapitalize: 'none',
                 autocorrect: 'off' %>
           </div>
 
-          <%= vf.submit 'Verify', class: 'btn btn-primary mt-3' %>
+          <%= vf.submit t('.verify'), class: 'btn btn-primary mt-3' %>
         <% end %>
 
         <% if (current_user.safe_settings.supporter_email.present? || current_user.safe_settings.supporter_github_username.present?) && !current_user.supporter? %>
           <div class="alert">
             <%= icon 'triangle-alert', class: 'w-5 h-5 text-warning' %>
-            <span>Not found in supporter list. Make sure you're using the same email or GitHub username as your donation platform.</span>
+            <span><%= t('.not_found_in_supporter_list_make_sure_you_re_using') %></span>
           </div>
         <% end %>
 
         <!-- Info panel -->
         <div class="bg-base-200 p-4 rounded-lg space-y-3">
           <h3 class="font-semibold flex items-center gap-2">
-            <%= icon 'info', class: 'w-4 h-4 text-primary' %> How to support Dawarich
+            <%= icon 'info', class: 'w-4 h-4 text-primary' %> <%= t('.how_to_support_dawarich') %>
           </h3>
           <p class="text-sm text-base-content/70">
-            Dawarich is a free and open-source project. Your support helps cover hosting costs, fund development, and keep the project alive. You can support us through any of these platforms:
+            <%= t('.dawarich_is_a_free_and_open_source_project_your_support') %>
           </p>
           <div class="flex flex-wrap gap-2">
             <a href="https://www.patreon.com/freika" class="btn btn-sm btn-outline" target="_blank" rel="noopener noreferrer">
-              Patreon
+              <%= t('.patreon') %>
             </a>
             <a href="https://github.com/sponsors/Freika" class="btn btn-sm btn-outline" target="_blank" rel="noopener noreferrer">
-              GitHub Sponsors
+              <%= t('.github_sponsors') %>
             </a>
             <a href="https://ko-fi.com/freika" class="btn btn-sm btn-outline" target="_blank" rel="noopener noreferrer">
-              Ko-fi
+              <%= t('.ko_fi') %>
             </a>
           </div>
 
-          <h3 class="font-semibold mt-3">Supporter benefits</h3>
+          <h3 class="font-semibold mt-3"><%= t('.supporter_benefits') %></h3>
           <ul class="text-sm text-base-content/70 list-disc list-inside space-y-1">
-            <li>Access to reverse geocoding API (see Patreon tier)</li>
-            <li>Mention in Github Releases</li>
-            <li>Supporter badge displayed in the navbar</li>
+            <li><%= t('.access_to_reverse_geocoding_api_see_patreon_tier') %></li>
+            <li><%= t('.mention_in_github_releases') %></li>
+            <li><%= t('.supporter_badge_displayed_in_the_navbar') %></li>
           </ul>
         </div>
       </div>

--- a/app/views/settings/general/index.html.erb
+++ b/app/views/settings/general/index.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, "General settings" %>
+<% content_for :title, t('.general_settings') %>
 
 <div class="min-h-content w-full my-5">
-  <%= render 'shared/page_header', title: 'General settings' %>
+  <%= render 'shared/page_header', title: t('.general_settings') %>
   <%= render 'settings/navigation' %>
 
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -12,7 +12,7 @@
             <!-- Email Preferences Section -->
             <div id="email-digests">
               <h2 class="text-2xl font-bold mb-4 flex items-center">
-                <%= icon 'mail', class: "text-primary mr-2" %> Email Preferences
+                <%= icon 'mail', class: "text-primary mr-2" %> <%= t('.email_preferences') %>
               </h2>
               <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
                 <div class="form-control">
@@ -21,9 +21,9 @@
                                     checked: current_user.safe_settings.monthly_digest_emails_enabled?,
                                     class: "toggle toggle-primary" %>
                     <div>
-                      <span class="label-text font-medium">Monthly Digest Emails</span>
+                      <span class="label-text font-medium"><%= t('.monthly_digest_emails') %></span>
                       <p class="text-sm text-base-content/70 mt-1">
-                        Summary of your last month, sent on the 2nd.
+                        <%= t('.summary_of_your_last_month_sent_on_the_2nd') %>
                       </p>
                     </div>
                   </label>
@@ -34,9 +34,9 @@
                                     checked: current_user.safe_settings.yearly_digest_emails_enabled?,
                                     class: "toggle toggle-primary" %>
                     <div>
-                      <span class="label-text font-medium">Year-End Digest Emails</span>
+                      <span class="label-text font-medium"><%= t('.year_end_digest_emails') %></span>
                       <p class="text-sm text-base-content/70 mt-1">
-                        Receive an annual summary on January 2nd with your year in review.
+                        <%= t('.receive_an_annual_summary_on_january_2nd_with_your_year') %>
                       </p>
                     </div>
                   </label>
@@ -47,9 +47,9 @@
                                     checked: current_user.safe_settings.news_emails_enabled?,
                                     class: "toggle toggle-primary" %>
                     <div>
-                      <span class="label-text font-medium">News & Updates</span>
+                      <span class="label-text font-medium"><%= t('.news_updates') %></span>
                       <p class="text-sm text-base-content/70 mt-1">
-                        Receive occasional emails about new features and important updates
+                        <%= t('.receive_occasional_emails_about_new_features_and_important_updates') %>
                       </p>
                     </div>
                   </label>
@@ -60,12 +60,12 @@
             <!-- Timezone Section -->
             <div>
               <h2 class="text-2xl font-bold mb-4 flex items-center">
-                <%= icon 'clock', class: "text-primary mr-2" %> Timezone
+                <%= icon 'clock', class: "text-primary mr-2" %> <%= t('.timezone') %>
               </h2>
               <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
                 <div class="form-control">
                   <label class="label">
-                    <span class="label-text font-medium">Your timezone</span>
+                    <span class="label-text font-medium"><%= t('.your_timezone') %></span>
                   </label>
                   <%= f.select :timezone,
                                ActiveSupport::TimeZone.all
@@ -76,7 +76,7 @@
                                { selected: current_user.timezone },
                                class: "select select-bordered w-full" %>
                   <p class="text-sm text-base-content/70 mt-1">
-                    All dates and times will be displayed in this timezone
+                    <%= t('.all_dates_and_times_will_be_displayed_in_this_timezone') %>
                   </p>
                 </div>
               </div>
@@ -86,7 +86,7 @@
               <!-- Badge Toggle (only for verified supporters) -->
               <div>
                 <h2 class="text-2xl font-bold mb-4 flex items-center">
-                  <%= icon 'gem', class: 'mr-2 text-sky-400' %> Supporter Badge
+                  <%= icon 'gem', class: 'mr-2 text-sky-400' %> <%= t('.supporter_badge') %>
                 </h2>
                 <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
                   <div class="form-control">
@@ -95,9 +95,9 @@
                                       checked: current_user.safe_settings.show_supporter_badge?,
                                       class: "toggle toggle-primary" %>
                       <div>
-                        <span class="label-text font-medium">Show supporter badge in navbar</span>
+                        <span class="label-text font-medium"><%= t('.show_supporter_badge_in_navbar') %></span>
                         <p class="text-sm text-base-content/70 mt-1">
-                          Display a gem icon next to your profile to show your supporter status
+                          <%= t('.display_a_gem_icon_next_to_your_profile_to_show') %>
                         </p>
                       </div>
                     </label>
@@ -107,7 +107,7 @@
             <% end %>
           </div>
           <div class="card-actions justify-end mt-6">
-            <%= f.submit 'Save changes', class: "btn btn-primary" %>
+            <%= f.submit t('.save_changes'), class: "btn btn-primary" %>
           </div>
         </div>
       <% end %>

--- a/app/views/settings/integrations/index.html.erb
+++ b/app/views/settings/integrations/index.html.erb
@@ -1,22 +1,21 @@
-<% content_for :title, 'Settings' %>
+<% content_for :title, t('.settings') %>
 
 <div class="min-h-content w-full my-5">
-  <%= render 'shared/page_header', title: 'User Settings' %>
+  <%= render 'shared/page_header', title: t('.user_settings') %>
   <%= render 'settings/navigation' %>
 
   <% if @pro_required %>
     <div class="card bg-base-200 shadow-xl">
       <div class="card-body text-center items-center py-12">
         <h2 class="text-2xl flex font-bold mb-2 items-center">
-          <%= icon 'shield-check', class: 'mr-2 text-primary' %> Immich & Photoprism Integrations
+          <%= icon 'shield-check', class: 'mr-2 text-primary' %> <%= t('.immich_photoprism_integrations') %>
         </h2>
         <p class="text-gray-600 mb-6 max-w-md">
-          Connect your photo management tools to see your photos on the map.
-          Immich and Photoprism integrations are available on the Pro plan.
+          <%= t('.connect_your_photo_management_tools_to_see_your_photos_on') %>
         </p>
         <a href="<%= upgrade_url(utm_medium: 'settings', utm_content: 'integrations') %>"
            class="btn btn-primary">
-          Upgrade to Pro
+          <%= t('.upgrade_to_pro') %>
         </a>
       </div>
     </div>
@@ -27,24 +26,24 @@
           <div class="space-y-8 lg:grid lg:grid-cols-2 lg:gap-6 lg:space-y-0 animate-fade-in">
             <div>
               <h2 class="text-2xl font-bold mb-4 flex items-center">
-                <%= icon 'camera', class: 'mr-2 text-primary' %> Immich Integration
+                <%= icon 'camera', class: 'mr-2 text-primary' %> <%= t('.immich_integration') %>
               </h2>
               <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
                 <div class="form-control w-full">
                   <%= f.label :immich_url, class: 'label' do %>
-                    <span class="label-text font-medium">Immich URL</span>
+                    <span class="label-text font-medium"><%= t('.immich_url') %></span>
                   <% end %>
                   <%= f.url_field :immich_url, value: current_user.safe_settings.immich_url, class: "input input-bordered w-full pr-10", placeholder: 'http://192.168.0.1:2283' %>
-                  <span class="label-text-alt mt-1">The base URL of your Immich instance</span>
+                  <span class="label-text-alt mt-1"><%= t('.the_base_url_of_your_immich_instance') %></span>
                 </div>
                 <div class="form-control w-full">
                   <%= f.label :immich_api_key, class: 'label' do %>
-                    <span class="label-text font-medium">Immich API Key</span>
+                    <span class="label-text font-medium"><%= t('.immich_api_key') %></span>
                   <% end %>
                   <div class="relative">
-                    <%= f.password_field :immich_api_key, value: current_user.safe_settings.immich_api_key, class: "input input-bordered w-full pr-10", placeholder: 'xxxxxxxxxxxxxx' %>
+                    <%= f.password_field :immich_api_key, value: current_user.safe_settings.immich_api_key, class: "input input-bordered w-full pr-10", placeholder: t('.xxxxxxxxxxxxxx') %>
                   </div>
-                  <span class="label-text-alt mt-1">Found in your Immich admin panel under API settings. Required permissions: <code class="text-xs">asset.read</code>, <code class="text-xs">asset.view</code>, and <code class="text-xs">asset.update</code> (for photo enrichment).</span>
+                  <span class="label-text-alt mt-1"><%= t('.found_in_your_immich_admin_panel_under_api_settings_required') %> <code class="text-xs"><%= t('.asset_read') %></code>, <code class="text-xs"><%= t('.asset_view') %></code><%= t('.and') %> <code class="text-xs"><%= t('.asset_update') %></code> <%= t('.for_photo_enrichment') %></span>
                 </div>
                 <div class="form-control">
                   <label class="label cursor-pointer justify-start gap-3">
@@ -52,47 +51,46 @@
                         checked: current_user.safe_settings.immich_skip_ssl_verification,
                         class: "toggle toggle-warning",
                         onchange: "document.getElementById('immich-ssl-warning').classList.toggle('hidden', !this.checked)" %>
-                    <span class="label-text">Skip SSL certificate verification (self-signed certificates)</span>
+                    <span class="label-text"><%= t('.skip_ssl_certificate_verification_self_signed_certificates') %></span>
                   </label>
                   <div id="immich-ssl-warning" class="alert alert-warning mt-2 <%= 'hidden' unless current_user.safe_settings.immich_skip_ssl_verification %>">
                     <%= icon 'triangle-alert'%>
                     <span>
-                      <strong>Security Warning:</strong> Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks.
-                      Only enable this for self-signed certificates you trust on your local network.
+                      <strong><%= t('.security_warning') %></strong> <%= t('.disabling_ssl_verification_makes_your_connection_vulnerable_to_man_in') %>
                     </span>
                   </div>
                 </div>
                 <div class="flex flex-wrap items-center gap-2">
-                  <%= button_tag 'Refresh photo cache',
+                  <%= button_tag t('.refresh_photo_cache'),
                     name: 'refresh_photos_cache',
                     value: '1',
                     class: 'btn btn-sm btn-outline' %>
-                  <span class="label-text-alt">Clears cached photo metadata and thumbnails for all integrations.</span>
+                  <span class="label-text-alt"><%= t('.clears_cached_photo_metadata_and_thumbnails_for_all_integrations') %></span>
                 </div>
               </div>
             </div>
             <div>
               <h2 class="text-2xl font-bold mb-4 flex items-center">
-                <%= icon 'camera', class: 'mr-2 text-primary' %> Photoprism Integration
+                <%= icon 'camera', class: 'mr-2 text-primary' %> <%= t('.photoprism_integration') %>
               </h2>
               <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
                 <div class="form-control w-full">
                   <%= f.label :photoprism_url, class: 'label' do %>
-                    <span class="label-text font-medium">Photoprism URL</span>
+                    <span class="label-text font-medium"><%= t('.photoprism_url') %></span>
                   <% end %>
                   <div class="relative">
                     <%= f.url_field :photoprism_url, value: current_user.safe_settings.photoprism_url, class: "input input-bordered w-full pr-10", placeholder: 'http://192.168.0.1:2342' %>
                   </div>
-                  <span class="label-text-alt mt-1">The base URL of your Photoprism instance</span>
+                  <span class="label-text-alt mt-1"><%= t('.the_base_url_of_your_photoprism_instance') %></span>
                 </div>
                 <div class="form-control w-full">
                   <%= f.label :photoprism_api_key, class: 'label' do %>
-                    <span class="label-text font-medium">Photoprism API Key</span>
+                    <span class="label-text font-medium"><%= t('.photoprism_api_key') %></span>
                   <% end %>
                   <div class="relative">
-                    <%= f.password_field :photoprism_api_key, value: current_user.safe_settings.photoprism_api_key, class: "input input-bordered w-full pr-10", placeholder: 'xxxxxxxxxxxxxx' %>
+                    <%= f.password_field :photoprism_api_key, value: current_user.safe_settings.photoprism_api_key, class: "input input-bordered w-full pr-10", placeholder: t('.xxxxxxxxxxxxxx') %>
                   </div>
-                  <span class="label-text-alt mt-1">Found in your Photoprism settings under Library</span>
+                  <span class="label-text-alt mt-1"><%= t('.found_in_your_photoprism_settings_under_library') %></span>
                 </div>
                 <div class="form-control">
                   <label class="label cursor-pointer justify-start gap-3">
@@ -100,13 +98,12 @@
                         checked: current_user.safe_settings.photoprism_skip_ssl_verification,
                         class: "toggle toggle-warning",
                         onchange: "document.getElementById('photoprism-ssl-warning').classList.toggle('hidden', !this.checked)" %>
-                    <span class="label-text">Skip SSL certificate verification (self-signed certificates)</span>
+                    <span class="label-text"><%= t('.skip_ssl_certificate_verification_self_signed_certificates') %></span>
                   </label>
                   <div id="photoprism-ssl-warning" class="alert alert-warning mt-2 <%= 'hidden' unless current_user.safe_settings.photoprism_skip_ssl_verification %>">
                     <%= icon 'triangle-alert'%>
                     <span>
-                      <strong>Security Warning:</strong> Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks.
-                      Only enable this for self-signed certificates you trust on your local network.
+                      <strong><%= t('.security_warning') %></strong> <%= t('.disabling_ssl_verification_makes_your_connection_vulnerable_to_man_in') %>
                     </span>
                   </div>
                 </div>
@@ -115,24 +112,24 @@
 
             <div class="lg:col-span-2">
               <h2 class="text-2xl font-bold mb-4 flex items-center">
-                <%= icon 'plane', class: 'mr-2 text-primary' %> AirTrail Integration
+                <%= icon 'plane', class: 'mr-2 text-primary' %> <%= t('.airtrail_integration') %>
               </h2>
               <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
                 <div class="form-control w-full">
                   <%= f.label :airtrail_url, class: 'label' do %>
-                    <span class="label-text font-medium">AirTrail URL</span>
+                    <span class="label-text font-medium"><%= t('.airtrail_url') %></span>
                   <% end %>
                   <%= f.url_field :airtrail_url, value: current_user.safe_settings.airtrail_url, class: "input input-bordered w-full pr-10", placeholder: 'https://airtrail.example.com' %>
-                  <span class="label-text-alt mt-1">The base URL of your AirTrail instance. Your flights are shown as arcs on the map.</span>
+                  <span class="label-text-alt mt-1"><%= t('.the_base_url_of_your_airtrail_instance_your_flights_are') %></span>
                 </div>
                 <div class="form-control w-full">
                   <%= f.label :airtrail_api_key, class: 'label' do %>
-                    <span class="label-text font-medium">AirTrail API Key</span>
+                    <span class="label-text font-medium"><%= t('.airtrail_api_key') %></span>
                   <% end %>
                   <div class="relative">
-                    <%= f.password_field :airtrail_api_key, value: current_user.safe_settings.airtrail_api_key, class: "input input-bordered w-full pr-10", placeholder: 'xxxxxxxxxxxxxx' %>
+                    <%= f.password_field :airtrail_api_key, value: current_user.safe_settings.airtrail_api_key, class: "input input-bordered w-full pr-10", placeholder: t('.xxxxxxxxxxxxxx') %>
                   </div>
-                  <span class="label-text-alt mt-1">Create an API key in AirTrail under Settings &rarr; Security.</span>
+                  <span class="label-text-alt mt-1"><%= t('.create_an_api_key_in_airtrail_under_settings_rarr_security') %></span>
                 </div>
                 <div class="form-control">
                   <label class="label cursor-pointer justify-start gap-3">
@@ -140,18 +137,17 @@
                         checked: current_user.safe_settings.airtrail_skip_ssl_verification,
                         class: "toggle toggle-warning",
                         onchange: "document.getElementById('airtrail-ssl-warning').classList.toggle('hidden', !this.checked)" %>
-                    <span class="label-text">Skip SSL certificate verification (self-signed certificates)</span>
+                    <span class="label-text"><%= t('.skip_ssl_certificate_verification_self_signed_certificates') %></span>
                   </label>
                   <div id="airtrail-ssl-warning" class="alert alert-warning mt-2 <%= 'hidden' unless current_user.safe_settings.airtrail_skip_ssl_verification %>">
                     <%= icon 'triangle-alert'%>
                     <span>
-                      <strong>Security Warning:</strong> Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks.
-                      Only enable this for self-signed certificates you trust on your local network.
+                      <strong><%= t('.security_warning') %></strong> <%= t('.disabling_ssl_verification_makes_your_connection_vulnerable_to_man_in') %>
                     </span>
                   </div>
                 </div>
                 <% if current_user.safe_settings.settings['airtrail_last_synced_at'].present? %>
-                  <p class="label-text-alt">Last synced: <%= current_user.safe_settings.settings['airtrail_last_synced_at'] %></p>
+                  <p class="label-text-alt"><%= t('.last_synced') %> <%= current_user.safe_settings.settings['airtrail_last_synced_at'] %></p>
                 <% end %>
               </div>
             </div>
@@ -159,11 +155,11 @@
             <% unless DawarichSettings.self_hosted? || current_user.provider.blank? %>
               <div class="lg:col-span-2">
                 <h2 class="text-2xl font-bold mb-4 flex items-center">
-                  <%= icon 'link', class: "text-primary mr-1" %> Connected Accounts
+                  <%= icon 'link', class: "text-primary mr-1" %> <%= t('.connected_accounts') %>
                 </h2>
                 <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
                   <p class="text-sm text-base-content/70">
-                    You've connected your account using the following OAuth provider:
+                    <%= t('.you_ve_connected_your_account_using_the_following_oauth_provider') %>
                     <strong><%= current_user.provider.capitalize %></strong>
                   </p>
                 </div>
@@ -171,7 +167,7 @@
             <% end %>
           </div>
           <div class="card-actions justify-end mt-6">
-            <%= f.submit "Save & Test Connection", class: "btn btn-primary" %>
+            <%= f.submit t('.save_test_connection'), class: "btn btn-primary" %>
           </div>
         </div>
       <% end %>
@@ -182,11 +178,11 @@
         <div class="card-body flex-row items-center justify-between flex-wrap gap-3">
           <div>
             <h2 class="text-lg font-bold flex items-center">
-              <%= icon 'plane', class: 'mr-2 text-primary' %> Sync AirTrail flights
+              <%= icon 'plane', class: 'mr-2 text-primary' %> <%= t('.sync_airtrail_flights') %>
             </h2>
-            <span class="label-text-alt">Flights also sync automatically once a day.</span>
+            <span class="label-text-alt"><%= t('.flights_also_sync_automatically_once_a_day') %></span>
           </div>
-          <%= button_to 'Sync now', settings_background_jobs_path(job_name: 'start_airtrail_import'),
+          <%= button_to t('.sync_now'), settings_background_jobs_path(job_name: 'start_airtrail_import'),
               method: :post, class: 'btn btn-primary btn-sm' %>
         </div>
       </div>

--- a/app/views/settings/maps/index.html.erb
+++ b/app/views/settings/maps/index.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, "Map settings" %>
+<% content_for :title, t('.map_settings') %>
 
 <div class="min-h-content w-full my-5">
-  <%= render 'shared/page_header', title: 'Map settings' %>
+  <%= render 'shared/page_header', title: t('.map_settings') %>
   <%= render 'settings/navigation' %>
 
   <div class="card bg-base-200 shadow-xl">
@@ -16,32 +16,31 @@
           <div role="alert" class="alert alert-info">
             <%= icon 'info', class: 'h-6 w-6 shrink-0' %>
             <span>
-              Map appearance, colors, layers, and points of interest for the current map (V2)
-              are configured directly on the <%= link_to 'map page', map_v2_path, class: 'link' %>
-              — open the settings panel there. This page only covers the legacy V1 (Leaflet) map.
+              <%= t('.map_appearance_colors_layers_and_points_of_interest_for_the') %> <%= link_to t('.map_page'), map_v2_path, class: 'link' %>
+              <%= t('.open_the_settings_panel_there_this_page_only_covers_the') %>
             </span>
           </div>
 
           <div>
             <h2 class="text-2xl font-bold mb-4 flex items-center">
               <%= icon 'map', class: 'mr-2 text-primary' %>
-              General
+              <%= t('.general') %>
             </h2>
             <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
               <div class="form-control">
                 <label class="label cursor-pointer justify-start">
                   <span class="label-text mr-4 flex items-center">
                     <%= icon 'map', class: 'mr-2 w-4 h-4' %>
-                    Preferred Map Version
+                    <%= t('.preferred_map_version') %>
                   </span>
                   <div class="flex items-center space-x-2">
-                    <%= f.label :preferred_version_v1, 'V1 (Leaflet)', class: 'cursor-pointer' %>
+                    <%= f.label :preferred_version_v1, t('.v1_leaflet'), class: 'cursor-pointer' %>
                     <%= f.radio_button :preferred_version, 'v1', id: 'maps_preferred_version_v1', class: 'radio radio-primary ml-1 mr-4', checked: @maps['preferred_version'] == 'v1' %>
-                    <%= f.label :preferred_version_v2, 'V2 (MapLibre)', class: 'cursor-pointer' %>
+                    <%= f.label :preferred_version_v2, t('.v2_maplibre'), class: 'cursor-pointer' %>
                     <%= f.radio_button :preferred_version, 'v2', id: 'maps_preferred_version_v2', class: 'radio radio-primary ml-1', checked: @maps['preferred_version'] != 'v1' %>
                   </div>
                 </label>
-                <span class="label-text-alt mt-1">V2 (MapLibre) is the default. V1 (Leaflet) is available for compatibility.</span>
+                <span class="label-text-alt mt-1"><%= t('.v2_maplibre_is_the_default_v1_leaflet_is_available_for') %></span>
               </div>
             </div>
           </div>
@@ -51,27 +50,27 @@
               <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-current">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
               </svg>
-              <span>Using a custom tile URL may result in extra costs. Check your map tile provider's terms of service.</span>
+              <span><%= t('.using_a_custom_tile_url_may_result_in_extra_costs') %></span>
             </div>
 
             <h2 class="text-2xl font-bold mb-4 flex items-center">
               <%= icon 'map-pin', class: 'mr-2 text-primary' %>
-              Custom Tiles (V1)
+              <%= t('.custom_tiles_v1') %>
             </h2>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6" data-controller="map-preview">
               <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
                 <div class="form-control w-full">
                   <%= f.label :name, class: 'label' do %>
-                    <span class="label-text font-medium">Map Name</span>
+                    <span class="label-text font-medium"><%= t('.map_name') %></span>
                   <% end %>
                   <div class="relative">
-                    <%= f.text_field :name, value: @maps['name'], placeholder: 'Example: OpenStreetMap', class: "input input-bordered w-full pr-10" %>
+                    <%= f.text_field :name, value: @maps['name'], placeholder: t('.example_openstreetmap'), class: "input input-bordered w-full pr-10" %>
                   </div>
-                  <span class="label-text-alt mt-1">A descriptive name for your map configuration</span>
+                  <span class="label-text-alt mt-1"><%= t('.a_descriptive_name_for_your_map_configuration') %></span>
                 </div>
                 <div class="form-control w-full">
                   <%= f.label :url, class: 'label' do %>
-                    <span class="label-text font-medium">Tile URL</span>
+                    <span class="label-text font-medium"><%= t('.tile_url') %></span>
                   <% end %>
                   <div class="relative">
                     <%= f.text_field :url,
@@ -84,11 +83,11 @@
                         action: "input->map-preview#updatePreview"
                       } %>
                   </div>
-                  <span class="label-text-alt mt-1">URL pattern for map tiles. Must include {x}, {y}, and {z} placeholders</span>
+                  <span class="label-text-alt mt-1"><%= t('.url_pattern_for_map_tiles_must_include_x_y_and') %></span>
                 </div>
               </div>
               <div class="bg-base-100 p-5 rounded-lg shadow-sm">
-                <h3 class="font-semibold mb-2">Map Preview</h3>
+                <h3 class="font-semibold mb-2"><%= t('.map_preview') %></h3>
                 <div class="h-[250px] w-full rounded-lg overflow-hidden border border-base-300">
                   <div class="h-full w-full relative">
                     <div style="height: 500px;">
@@ -105,7 +104,7 @@
         </div>
 
         <div class="card-actions justify-end mt-6">
-          <%= f.submit 'Save changes', class: "btn btn-primary", data: { map_preview_target: "saveButton" } %>
+          <%= f.submit t('.save_changes'), class: "btn btn-primary", data: { map_preview_target: "saveButton" } %>
         </div>
       </div>
     <% end %>

--- a/app/views/settings/subscriptions/index.html.erb
+++ b/app/views/settings/subscriptions/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Subscriptions" %>
+<% content_for :title, t('.subscriptions') %>
 
 <div class="min-h-content w-full my-5">
   <%= render 'settings/navigation' %>
@@ -6,23 +6,23 @@
   <div class="hero bg-base-200 min-h-80">
     <div class="hero-content text-center">
       <div class="max-w-md">
-        <h1 class="text-5xl font-bold">Hello there!</h1>
+        <h1 class="text-5xl font-bold"><%= t('.hello_there') %></h1>
         <% if current_user.active_until&.future? %>
           <p class="py-6">
-            You are currently subscribed to Dawarich, hurray!
+            <%= t('.you_are_currently_subscribed_to_dawarich_hurray') %>
           </p>
 
           <p>
-            Your subscription will be valid for the next <span class="text-accent"><%= days_left(current_user.active_until) %></span>.
+            <%= t('.your_subscription_will_be_valid_for_the_next') %> <span class="text-accent"><%= days_left(current_user.active_until) %></span>.
           </p>
 
-          <%= link_to 'Manage subscription', "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}", class: 'btn btn-primary my-4' %>
+          <%= link_to t('.manage_subscription'), "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}", class: 'btn btn-primary my-4' %>
         <% else %>
           <p class="py-6">
-            You are currently not subscribed to Dawarich. How about we fix that?
+            <%= t('.you_are_currently_not_subscribed_to_dawarich_how_about_we') %>
           </p>
 
-          <%= link_to 'Manage subscription', "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}", class: 'btn btn-primary my-4' %>
+          <%= link_to t('.manage_subscription'), "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}", class: 'btn btn-primary my-4' %>
         <% end %>
       </div>
     </div>

--- a/app/views/settings/two_factor/backup_codes.html.erb
+++ b/app/views/settings/two_factor/backup_codes.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, "Backup Codes" %>
+<% content_for :title, t('.backup_codes') %>
 
 <div class="min-h-content w-full my-5">
-  <%= render 'shared/page_header', title: 'Two-Factor Authentication Enabled' %>
+  <%= render 'shared/page_header', title: t('.two_factor_authentication_enabled') %>
   <%= render 'settings/navigation' %>
 
   <div class="max-w-lg">
@@ -9,12 +9,11 @@
       <div class="card-body">
         <div class="flex items-center gap-3 mb-4">
           <%= icon 'shield-check', class: "text-success w-8 h-8" %>
-          <h2 class="text-xl font-bold">Save your backup codes</h2>
+          <h2 class="text-xl font-bold"><%= t('.save_your_backup_codes') %></h2>
         </div>
 
         <div class="alert alert-warning mb-4">
-          <span>Store these codes in a safe place. Each code can only be used once.
-          If you lose access to your authenticator app, you can use these codes to sign in.</span>
+          <span><%= t('.store_these_codes_in_a_safe_place_each_code_can') %></span>
         </div>
 
         <div class="bg-base-100 rounded-lg p-4 mb-4">
@@ -25,7 +24,7 @@
           </div>
         </div>
 
-        <%= link_to 'Done', settings_two_factor_path, class: 'btn btn-primary w-full' %>
+        <%= link_to t('.done'), settings_two_factor_path, class: 'btn btn-primary w-full' %>
       </div>
     </div>
   </div>

--- a/app/views/settings/two_factor/show.html.erb
+++ b/app/views/settings/two_factor/show.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, "Two-Factor Authentication" %>
+<% content_for :title, t('.two_factor_authentication') %>
 
 <div class="min-h-content w-full my-5">
-  <%= render 'shared/page_header', title: 'Two-Factor Authentication' %>
+  <%= render 'shared/page_header', title: t('.two_factor_authentication') %>
   <%= render 'settings/navigation' %>
 
   <div class="max-w-lg">
@@ -11,52 +11,51 @@
           <div class="flex items-center gap-3 mb-4">
             <%= icon 'shield-check', class: "text-success w-8 h-8" %>
             <div>
-              <h2 class="text-xl font-bold">2FA is enabled</h2>
-              <p class="text-sm text-base-content/70">Your account is protected with two-factor authentication.</p>
+              <h2 class="text-xl font-bold"><%= t('.fa_is_enabled') %></h2>
+              <p class="text-sm text-base-content/70"><%= t('.your_account_is_protected_with_two_factor_authentication') %></p>
             </div>
           </div>
 
           <div class="divider"></div>
 
           <p class="text-sm text-base-content/70 mb-4">
-            To disable 2FA, enter your password and a current authenticator code (or backup code).
+            <%= t('.to_disable_2fa_enter_your_password_and_a_current_authenticator') %>
           </p>
 
           <%= form_with url: settings_two_factor_path, method: :delete, data: { turbo: false }, class: "space-y-4" do |f| %>
             <div class="form-control">
               <%= f.label :password, class: 'label' do %>
-                <span class="label-text">Current password</span>
+                <span class="label-text"><%= t('.current_password') %></span>
               <% end %>
               <%= f.password_field :password, class: 'input input-bordered w-full', required: true, autocomplete: 'current-password' %>
             </div>
             <div class="form-control">
               <%= f.label :otp_attempt, class: 'label' do %>
-                <span class="label-text">Authenticator code or backup code</span>
+                <span class="label-text"><%= t('.authenticator_code_or_backup_code') %></span>
               <% end %>
               <%= f.text_field :otp_attempt, class: 'input input-bordered w-full', required: true, autocomplete: 'one-time-code', inputmode: 'text' %>
             </div>
             <div class="form-control">
-              <%= f.submit 'Disable 2FA', class: 'btn btn-error w-full' %>
+              <%= f.submit t('.disable_2fa'), class: 'btn btn-error w-full' %>
             </div>
           <% end %>
         <% else %>
           <div class="flex items-center gap-3 mb-4">
             <%= icon 'shield', class: "text-warning w-8 h-8" %>
             <div>
-              <h2 class="text-xl font-bold">2FA is not enabled</h2>
-              <p class="text-sm text-base-content/70">Add an extra layer of security to your account.</p>
+              <h2 class="text-xl font-bold"><%= t('.fa_is_not_enabled') %></h2>
+              <p class="text-sm text-base-content/70"><%= t('.add_an_extra_layer_of_security_to_your_account') %></p>
             </div>
           </div>
 
           <div class="divider"></div>
 
           <p class="text-sm text-base-content/70 mb-4">
-            Two-factor authentication adds an extra layer of security by requiring a code
-            from your authenticator app (Google Authenticator, Authy, etc.) when you sign in.
+            <%= t('.two_factor_authentication_adds_an_extra_layer_of_security_by') %>
           </p>
 
           <%= form_with url: settings_two_factor_path, method: :post, data: { turbo: false } do %>
-            <%= submit_tag 'Enable 2FA', class: 'btn btn-primary w-full' %>
+            <%= submit_tag t('.enable_2fa'), class: 'btn btn-primary w-full' %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/settings/two_factor/verify.html.erb
+++ b/app/views/settings/two_factor/verify.html.erb
@@ -1,15 +1,15 @@
-<% content_for :title, "Set up Two-Factor Authentication" %>
+<% content_for :title, t('.set_up_two_factor_authentication') %>
 
 <div class="min-h-content w-full my-5">
-  <%= render 'shared/page_header', title: 'Set up Two-Factor Authentication' %>
+  <%= render 'shared/page_header', title: t('.set_up_two_factor_authentication') %>
   <%= render 'settings/navigation' %>
 
   <div class="max-w-lg">
     <div class="card bg-base-200 shadow-xl">
       <div class="card-body">
-        <h2 class="text-xl font-bold mb-2">Scan QR code</h2>
+        <h2 class="text-xl font-bold mb-2"><%= t('.scan_qr_code') %></h2>
         <p class="text-sm text-base-content/70 mb-4">
-          Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.).
+          <%= t('.scan_this_qr_code_with_your_authenticator_app_google_authenticator') %>
         </p>
 
         <div class="mx-auto max-w-xs overflow-hidden rounded-2xl bg-white p-4 shadow-lg flex justify-center mb-4">
@@ -18,7 +18,7 @@
 
         <details class="bg-base-100 rounded-lg mb-4">
           <summary class="cursor-pointer text-sm font-medium p-4">
-            Can't scan? Enter the code manually
+            <%= t('.can_t_scan_enter_the_code_manually') %>
           </summary>
           <div class="px-4 pb-4 mb-4">
             <code class="block break-all text-sm bg-base-300 p-3 rounded"><%= @otp_secret %></code>
@@ -27,20 +27,20 @@
 
         <div class="divider"></div>
 
-        <h2 class="text-xl font-bold mb-2">Verify setup</h2>
+        <h2 class="text-xl font-bold mb-2"><%= t('.verify_setup') %></h2>
         <p class="text-sm text-base-content/70 mb-4">
-          Enter the 6-digit code from your authenticator app to verify the setup.
+          <%= t('.enter_the_6_digit_code_from_your_authenticator_app_to') %>
         </p>
 
         <%= form_with url: verify_settings_two_factor_path, method: :post, data: { turbo: false }, class: "space-y-4" do |f| %>
           <div class="form-control">
-            <%= f.label :otp_attempt, 'Verification code', class: 'label' %>
+            <%= f.label :otp_attempt, t('.verification_code'), class: 'label' %>
             <%= f.text_field :otp_attempt, class: 'input input-bordered w-full text-center text-2xl tracking-widest',
                 maxlength: 6, pattern: '[0-9]{6}', inputmode: 'numeric', autocomplete: 'one-time-code',
                 autofocus: true, required: true, placeholder: '000000' %>
           </div>
           <div class="form-control">
-            <%= f.submit 'Verify and enable', class: 'btn btn-primary w-full' %>
+            <%= f.submit t('.verify_and_enable'), class: 'btn btn-primary w-full' %>
           </div>
         <% end %>
       </div>

--- a/app/views/settings/users/edit.html.erb
+++ b/app/views/settings/users/edit.html.erb
@@ -1,39 +1,39 @@
-<% content_for :title, 'Editing user' %>
+<% content_for :title, t('.editing_user') %>
 
 <div class="min-h-content w-full">
   <%= render 'settings/navigation' %>
 
   <div class="flex w-full my-10 space-x-4">
     <div class="overflow-x-auto w-4/12 mx-auto">
-      <h1 class="text-2xl font-bold">Editing user</h1>
+      <h1 class="text-2xl font-bold"><%= t('.editing_user') %></h1>
       <p class="text-base-content/70 mb-4"><%= @user.email %></p>
       <%= form_for @user, url: settings_user_path(@user), method: :put, data: { turbo_method: :put, turbo: false } do |f| %>
         <div class="form-control">
           <%= f.label :email do %>
-            Email
+            <%= t('.email') %>
           <% end %>
           <%= f.email_field :email, value: @user.email, class: "input input-bordered" %>
         </div>
         <div class="form-control mt-4">
           <%= f.label :password do %>
-            Password <span class="text-base-content/50 text-sm">(leave blank to keep current)</span>
+            <%= t('.password') %> <span class="text-base-content/50 text-sm"><%= t('.leave_blank_to_keep_current') %></span>
           <% end %>
           <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered" %>
         </div>
         <div class="form-control mt-4">
           <label class="label cursor-pointer justify-start gap-4">
             <%= f.check_box :admin, class: "toggle toggle-primary" %>
-            <span class="label-text">Admin</span>
+            <span class="label-text"><%= t('.admin') %></span>
           </label>
         </div>
         <div class="form-control mt-4">
           <%= f.label :status do %>
-            Status
+            <%= t('.status') %>
           <% end %>
           <%= f.select :status, User.statuses.keys.map { |s| [s.capitalize, s] }, {}, class: "select select-bordered w-full" %>
         </div>
         <div class="form-control mt-5">
-          <%= f.submit "Update", class: "btn btn-primary" %>
+          <%= f.submit t('.update'), class: "btn btn-primary" %>
         </div>
       <% end %>
     </div>

--- a/app/views/settings/users/index.html.erb
+++ b/app/views/settings/users/index.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, 'Users' %>
+<% content_for :title, t('.users') %>
 
 <div class="min-h-content w-full my-5">
-  <%= render 'shared/page_header', title: 'Users management' %>
+  <%= render 'shared/page_header', title: t('.users_management') %>
   <%= render 'settings/navigation' %>
 
   <!-- Registration Settings -->
@@ -9,8 +9,8 @@
     <div class="card bg-base-200 compact">
       <div class="card-body flex-row items-center justify-between">
         <div>
-          <h3 class="font-semibold">User registration</h3>
-          <p class="text-sm text-base-content/70">Allow new users to register via email and password</p>
+          <h3 class="font-semibold"><%= t('.user_registration') %></h3>
+          <p class="text-sm text-base-content/70"><%= t('.allow_new_users_to_register_via_email_and_password') %></p>
         </div>
         <%= form_with url: update_registration_settings_settings_users_path, method: :patch, data: { turbo: false }, class: 'flex items-center gap-3' do %>
           <input type="hidden" name="registration_enabled" value="0" />
@@ -26,24 +26,24 @@
   <div class="flex flex-col lg:flex-row w-full my-10 space-x-4">
     <div class="overflow-x-auto w-10/12 mx-auto">
       <div class="flex items-center justify-between mb-4">
-        <button class="btn" onclick="create_user.showModal()">Add new user</button>
+        <button class="btn" onclick="create_user.showModal()"><%= t('.add_new_user') %></button>
         <%= form_with url: settings_users_path, method: :get, data: { turbo: false }, class: 'flex gap-2' do %>
-          <input type="text" name="search" value="<%= params[:search] %>" placeholder="Search by email..." class="input input-bordered input-sm w-64" />
-          <button type="submit" class="btn btn-sm btn-ghost">Search</button>
+          <input type="text" name="search" value="<%= params[:search] %>" placeholder="<%= t('.search_by_email') %>" class="input input-bordered input-sm w-64" />
+          <button type="submit" class="btn btn-sm btn-ghost"><%= t('.search') %></button>
           <% if params[:search].present? %>
-            <%= link_to 'Clear', settings_users_path, class: 'btn btn-sm btn-ghost' %>
+            <%= link_to t('.clear'), settings_users_path, class: 'btn btn-sm btn-ghost' %>
           <% end %>
         <% end %>
       </div>
       <table class="table w-full">
         <thead>
           <tr>
-            <th>Email</th>
-            <th>Role</th>
-            <th>Status</th>
-            <th>Points</th>
-            <th>Last sign in</th>
-            <th>Created at</th>
+            <th><%= t('.email') %></th>
+            <th><%= t('.role') %></th>
+            <th><%= t('.status') %></th>
+            <th><%= t('.points') %></th>
+            <th><%= t('.last_sign_in') %></th>
+            <th><%= t('.created_at') %></th>
             <th></th>
           </tr>
         </thead>
@@ -57,18 +57,18 @@
               </td>
               <td>
                 <% if user.admin? %>
-                  <span class="badge badge-primary">Admin</span>
+                  <span class="badge badge-primary"><%= t('.admin') %></span>
                 <% else %>
-                  <span class="badge badge-ghost">User</span>
+                  <span class="badge badge-ghost"><%= t('.user') %></span>
                 <% end %>
               </td>
               <td>
                 <% if user.active? %>
-                  <span class="badge badge-success">Active</span>
+                  <span class="badge badge-success"><%= t('.active') %></span>
                 <% elsif user.inactive? %>
-                  <span class="badge badge-error">Inactive</span>
+                  <span class="badge badge-error"><%= t('.inactive') %></span>
                 <% elsif user.trial? %>
-                  <span class="badge badge-warning">Trial</span>
+                  <span class="badge badge-warning"><%= t('.trial') %></span>
                 <% end %>
               </td>
               <td>
@@ -78,16 +78,16 @@
                 <% if user.last_sign_in_at.present? %>
                   <%= human_datetime(user.last_sign_in_at, current_user.safe_settings.timezone) %>
                 <% else %>
-                  <span class="text-base-content/50">Never</span>
+                  <span class="text-base-content/50"><%= t('.never') %></span>
                 <% end %>
               </td>
               <td>
                 <%= human_datetime(user.created_at, current_user.safe_settings.timezone) %>
               </td>
               <td class="flex gap-2">
-                <%= link_to 'Edit', edit_settings_user_path(user), class: 'btn btn-ghost btn-sm' %>
+                <%= link_to t('.edit'), edit_settings_user_path(user), class: 'btn btn-ghost btn-sm' %>
                 <% unless user == current_user %>
-                  <button class="btn btn-error btn-sm" onclick="delete_user_<%= user.id %>.showModal()">Delete</button>
+                  <button class="btn btn-error btn-sm" onclick="delete_user_<%= user.id %>.showModal()"><%= t('.delete') %></button>
                 <% end %>
               </td>
             </tr>
@@ -104,27 +104,27 @@
 
 <dialog id="create_user" class="modal">
   <div class="modal-box">
-    <h2 class="text-2xl font-bold">Create a new user!</h2>
+    <h2 class="text-2xl font-bold"><%= t('.create_a_new_user') %></h2>
     <%= form_for :user, url: settings_users_path, method: :post, data: { turbo_method: :post, turbo: false } do |f| %>
       <div class="form-control">
         <%= f.label :email do %>
-          Email
+          <%= t('.email') %>
         <% end %>
         <%= f.email_field :email, value: '', class: "input input-bordered" %>
       </div>
       <div class="form-control mt-5">
         <%= f.label :password do %>
-          Password
+          <%= t('.password') %>
         <% end %>
         <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "input input-bordered", minlength: 6 %>
       </div>
       <div class="form-control mt-5">
-        <%= f.submit "Create", class: "btn btn-primary" %>
+        <%= f.submit t('.create'), class: "btn btn-primary" %>
       </div>
     <% end %>
   </div>
   <form method="dialog" class="modal-backdrop">
-    <button>close</button>
+    <button><%= t('.close') %></button>
   </form>
 </dialog>
 
@@ -132,21 +132,19 @@
   <% unless user == current_user %>
     <dialog id="delete_user_<%= user.id %>" class="modal">
       <div class="modal-box">
-        <h3 class="text-lg font-bold">Delete user</h3>
+        <h3 class="text-lg font-bold"><%= t('.delete_user') %></h3>
         <p class="py-4">
-          Are you sure you want to delete <strong><%= user.email %></strong>?
-          This will permanently remove their account and all associated data.
-          This action cannot be undone.
+          <%= t('.are_you_sure_you_want_to_delete') %> <strong><%= user.email %></strong><%= t('.this_will_permanently_remove_their_account_and_all_associated_data') %>
         </p>
         <div class="modal-action">
           <form method="dialog">
-            <button class="btn">Cancel</button>
+            <button class="btn"><%= t('.cancel') %></button>
           </form>
-          <%= button_to "Delete", settings_user_path(user), method: :delete, class: "btn btn-error", data: { turbo: false } %>
+          <%= button_to t('.delete'), settings_user_path(user), method: :delete, class: "btn btn-error", data: { turbo: false } %>
         </div>
       </div>
       <form method="dialog" class="modal-backdrop">
-        <button>close</button>
+        <button><%= t('.close') %></button>
       </form>
     </dialog>
   <% end %>

--- a/app/views/settings/users/show.html.erb
+++ b/app/views/settings/users/show.html.erb
@@ -1,7 +1,7 @@
-<% content_for :title, "User: #{@user.email}" %>
+<% content_for :title, t('.user_email', email: @user.email) %>
 
 <div class="min-h-content w-full my-5">
-  <h1 class="text-3xl font-bold mb-6">User details</h1>
+  <h1 class="text-3xl font-bold mb-6"><%= t('.user_details') %></h1>
   <%= render 'settings/navigation' %>
 
   <div class="flex flex-col w-full my-10">
@@ -12,22 +12,22 @@
           <h2 class="text-2xl font-bold"><%= @user.email %></h2>
           <div class="flex gap-2 mt-2">
             <% if @user.admin? %>
-              <span class="badge badge-primary">Admin</span>
+              <span class="badge badge-primary"><%= t('.admin') %></span>
             <% else %>
-              <span class="badge badge-ghost">User</span>
+              <span class="badge badge-ghost"><%= t('.user') %></span>
             <% end %>
             <% if @user.active? %>
-              <span class="badge badge-success">Active</span>
+              <span class="badge badge-success"><%= t('.active') %></span>
             <% elsif @user.inactive? %>
-              <span class="badge badge-error">Inactive</span>
+              <span class="badge badge-error"><%= t('.inactive') %></span>
             <% elsif @user.trial? %>
-              <span class="badge badge-warning">Trial</span>
+              <span class="badge badge-warning"><%= t('.trial') %></span>
             <% end %>
           </div>
         </div>
         <div class="flex gap-2">
-          <%= link_to 'Edit', edit_settings_user_path(@user), class: 'btn btn-primary btn-sm' %>
-          <%= link_to 'Back to users', settings_users_path, class: 'btn btn-ghost btn-sm' %>
+          <%= link_to t('.edit'), edit_settings_user_path(@user), class: 'btn btn-primary btn-sm' %>
+          <%= link_to t('.back_to_users'), settings_users_path, class: 'btn btn-ghost btn-sm' %>
         </div>
       </div>
 
@@ -35,28 +35,28 @@
         <!-- Data Overview -->
         <div class="card bg-base-200">
           <div class="card-body">
-            <h3 class="card-title">Data overview</h3>
+            <h3 class="card-title"><%= t('.data_overview') %></h3>
             <div class="overflow-x-auto">
               <table class="table">
                 <tbody>
                   <tr>
-                    <td class="font-semibold">Points</td>
+                    <td class="font-semibold"><%= t('.points') %></td>
                     <td><%= number_with_delimiter @user.points_count.to_i %></td>
                   </tr>
                   <tr>
-                    <td class="font-semibold">Tracks</td>
+                    <td class="font-semibold"><%= t('.tracks') %></td>
                     <td><%= number_with_delimiter @user.tracks.count %></td>
                   </tr>
                   <tr>
-                    <td class="font-semibold">Imports</td>
+                    <td class="font-semibold"><%= t('.imports') %></td>
                     <td><%= number_with_delimiter @user.imports.count %></td>
                   </tr>
                   <tr>
-                    <td class="font-semibold">Exports</td>
+                    <td class="font-semibold"><%= t('.exports') %></td>
                     <td><%= number_with_delimiter @user.exports.count %></td>
                   </tr>
                   <tr>
-                    <td class="font-semibold">Areas</td>
+                    <td class="font-semibold"><%= t('.areas') %></td>
                     <td><%= number_with_delimiter @user.areas.count %></td>
                   </tr>
                 </tbody>
@@ -68,34 +68,34 @@
         <!-- Sign-in History -->
         <div class="card bg-base-200">
           <div class="card-body">
-            <h3 class="card-title">Sign-in history</h3>
+            <h3 class="card-title"><%= t('.sign_in_history') %></h3>
             <div class="overflow-x-auto">
               <table class="table">
                 <tbody>
                   <tr>
-                    <td class="font-semibold">Total sign-ins</td>
+                    <td class="font-semibold"><%= t('.total_sign_ins') %></td>
                     <td><%= @user.sign_in_count %></td>
                   </tr>
                   <tr>
-                    <td class="font-semibold">Last sign-in</td>
+                    <td class="font-semibold"><%= t('.last_sign_in') %></td>
                     <td>
                       <% if @user.last_sign_in_at.present? %>
                         <%= human_datetime(@user.last_sign_in_at, current_user.safe_settings.timezone) %>
                       <% else %>
-                        <span class="text-base-content/50">Never</span>
+                        <span class="text-base-content/50"><%= t('.never') %></span>
                       <% end %>
                     </td>
                   </tr>
                   <tr>
-                    <td class="font-semibold">Last sign-in IP</td>
+                    <td class="font-semibold"><%= t('.last_sign_in_ip') %></td>
                     <td><%= @user.last_sign_in_ip || '—' %></td>
                   </tr>
                   <tr>
-                    <td class="font-semibold">Current sign-in IP</td>
+                    <td class="font-semibold"><%= t('.current_sign_in_ip') %></td>
                     <td><%= @user.current_sign_in_ip || '—' %></td>
                   </tr>
                   <tr>
-                    <td class="font-semibold">Account created</td>
+                    <td class="font-semibold"><%= t('.account_created') %></td>
                     <td><%= human_datetime(@user.created_at, current_user.safe_settings.timezone) %></td>
                   </tr>
                 </tbody>
@@ -107,7 +107,7 @@
         <!-- API Key -->
         <div class="card bg-base-200">
           <div class="card-body">
-            <h3 class="card-title">API key</h3>
+            <h3 class="card-title"><%= t('.api_key') %></h3>
             <div class="flex items-center gap-2">
               <code class="bg-base-300 px-3 py-2 rounded-lg text-sm flex-1 break-all"><%= @user.api_key.first(8) %><%= '•' * 24 %></code>
               <button class="btn btn-ghost btn-sm"
@@ -115,15 +115,15 @@
                       data-clipboard-text-value="<%= @user.api_key %>"
                       data-action="click->clipboard#copy">
                 <%= icon 'copy', class: "inline-block w-4" %>
-                Copy
+                <%= t('.copy') %>
               </button>
             </div>
             <div class="card-actions mt-4">
-              <%= button_to 'Regenerate API key',
+              <%= button_to t('.regenerate_api_key'),
                     regenerate_api_key_settings_user_path(@user),
                     method: :post,
                     class: 'btn btn-warning btn-sm',
-                    data: { turbo_confirm: 'Are you sure? This will invalidate the current API key.' } %>
+                    data: { turbo_confirm: t('.are_you_sure_this_will_invalidate_the_current_api_key') } %>
             </div>
           </div>
         </div>
@@ -131,13 +131,13 @@
         <!-- Actions -->
         <div class="card bg-base-200">
           <div class="card-body">
-            <h3 class="card-title">Actions</h3>
+            <h3 class="card-title"><%= t('.actions') %></h3>
             <div class="flex flex-col gap-3">
-              <%= button_to 'Send password reset email',
+              <%= button_to t('.send_password_reset_email'),
                     send_password_reset_settings_user_path(@user),
                     method: :post,
                     class: 'btn btn-outline btn-sm' %>
-              <%= link_to 'Edit user', edit_settings_user_path(@user), class: 'btn btn-primary btn-sm' %>
+              <%= link_to t('.edit_user'), edit_settings_user_path(@user), class: 'btn btn-primary btn-sm' %>
             </div>
           </div>
         </div>

--- a/app/views/settings/visits/_redetect_panel.html.erb
+++ b/app/views/settings/visits/_redetect_panel.html.erb
@@ -2,26 +2,24 @@
 
 <div class="card bg-base-200 shadow-xl">
   <div class="card-body">
-    <h3 class="text-xl font-bold">Re-run detection on full history</h3>
+    <h3 class="text-xl font-bold"><%= t('.re_run_detection_on_full_history') %></h3>
     <p class="text-sm opacity-80">
-      Replaces all suggested visits across your entire history with fresh detections using the settings above.
-      Confirmed visits and the places you've named are preserved. Small accounts usually finish in a few minutes;
-      multi-year histories can take 30&ndash;60 minutes and will temporarily increase server load.
+      <%= t('.replaces_all_suggested_visits_across_your_entire_history_with_fresh') %>
     </p>
     <% if current_user.respond_to?(:plan_restricted?) && current_user.plan_restricted? %>
-      <p class="text-xs opacity-70">On the Lite plan, re-detection covers your visible 12-month window only.</p>
+      <p class="text-xs opacity-70"><%= t('.on_the_lite_plan_re_detection_covers_your_visible_12') %></p>
     <% end %>
 
     <%= button_to visits_redetections_path,
                   method: :post,
-                  data: { turbo_confirm: "Replace all suggested visits across your full history. Confirmed visits stay. Continue?" },
+                  data: { turbo_confirm: t('.replace_all_suggested_visits_across_your_full_history_confirmed_visits') },
                   class: "btn btn-warning #{'btn-disabled' if cooldown_active}",
                   disabled: cooldown_active do %>
-      Re-run detection on full history
+      <%= t('.re_run_detection_on_full_history') %>
     <% end %>
 
     <% if cooldown_active %>
-      <span class="text-xs opacity-70">Available again at <%= (current_user.visits_redetected_at + 1.hour).to_fs(:short) %>.</span>
+      <span class="text-xs opacity-70"><%= t('.available_again_at') %> <%= (current_user.visits_redetected_at + 1.hour).to_fs(:short) %>.</span>
     <% end %>
   </div>
 </div>

--- a/app/views/settings/visits/show.html.erb
+++ b/app/views/settings/visits/show.html.erb
@@ -1,43 +1,43 @@
-<% content_for :title, 'Visit detection' %>
+<% content_for :title, t('.visit_detection') %>
 
 <div class="min-h-content w-full my-5">
-  <%= render 'shared/page_header', title: 'Visit detection' %>
+  <%= render 'shared/page_header', title: t('.visit_detection') %>
   <%= render 'settings/navigation' %>
 
   <div class="card bg-base-200 shadow-xl mb-6" data-controller="visit-detection-settings">
     <%= form_with url: settings_visits_path, method: :patch, local: true do |f| %>
       <div class="card-body">
-        <h2 class="text-2xl font-bold mb-2">Tune how Dawarich decides where you actually were</h2>
+        <h2 class="text-2xl font-bold mb-2"><%= t('.tune_how_dawarich_decides_where_you_actually_were') %></h2>
         <p class="text-sm opacity-80 mb-4">
-          These settings control how the app groups your GPS points into visits to places.
+          <%= t('.these_settings_control_how_the_app_groups_your_gps_points') %>
         </p>
 
         <%= fields_for :settings do |sf| %>
           <div class="form-control mb-4">
-            <%= sf.label :visit_radius_meters, 'Visit radius (meters)', class: 'label-text font-semibold' %>
+            <%= sf.label :visit_radius_meters, t('.visit_radius_meters'), class: 'label-text font-semibold' %>
             <%= sf.number_field :visit_radius_meters,
                                 value: current_user.safe_settings.visit_radius_meters,
                                 in: 5..500, step: 1,
                                 class: 'input input-bordered w-32' %>
-            <span class="text-xs opacity-70 mt-1">Points within this radius are treated as the same visit. Default 100.</span>
+            <span class="text-xs opacity-70 mt-1"><%= t('.points_within_this_radius_are_treated_as_the_same_visit') %></span>
           </div>
 
           <div class="form-control mb-4">
-            <%= sf.label :visit_min_points, 'Minimum points to count as a visit', class: 'label-text font-semibold' %>
+            <%= sf.label :visit_min_points, t('.minimum_points_to_count_as_a_visit'), class: 'label-text font-semibold' %>
             <%= sf.number_field :visit_min_points,
                                 value: current_user.safe_settings.visit_min_points,
                                 in: 2..20, step: 1,
                                 class: 'input input-bordered w-32' %>
-            <span class="text-xs opacity-70 mt-1">Lower = more visits suggested, including brief stops. Default 3.</span>
+            <span class="text-xs opacity-70 mt-1"><%= t('.lower_more_visits_suggested_including_brief_stops_default_3') %></span>
           </div>
 
           <div class="form-control mb-4">
-            <%= sf.label :visit_min_duration_minutes, 'Minimum visit duration (minutes)', class: 'label-text font-semibold' %>
+            <%= sf.label :visit_min_duration_minutes, t('.minimum_visit_duration_minutes'), class: 'label-text font-semibold' %>
             <%= sf.number_field :visit_min_duration_minutes,
                                 value: current_user.safe_settings.visit_min_duration_minutes,
                                 in: 1..60, step: 1,
                                 class: 'input input-bordered w-32' %>
-            <span class="text-xs opacity-70 mt-1">Skip stops shorter than this. Raise to ignore short drive-bys; lower to catch brief errands. Default 5.</span>
+            <span class="text-xs opacity-70 mt-1"><%= t('.skip_stops_shorter_than_this_raise_to_ignore_short_drive') %></span>
           </div>
 
           <div class="form-control mb-4">
@@ -46,14 +46,14 @@
                                { checked: current_user.safe_settings.visit_density_fill_enabled?,
                                  class: 'checkbox' },
                                '1', '0' %>
-              <span class="label-text font-semibold">Smart density fill</span>
+              <span class="label-text font-semibold"><%= t('.smart_density_fill') %></span>
             </label>
-            <span class="text-xs opacity-70 mt-1">Better visits when your tracker reports points unevenly. Leave on unless you know you want it off.</span>
+            <span class="text-xs opacity-70 mt-1"><%= t('.better_visits_when_your_tracker_reports_points_unevenly_leave_on') %></span>
           </div>
         <% end %>
 
         <div class="card-actions justify-end">
-          <%= f.submit 'Save settings', class: 'btn btn-primary' %>
+          <%= f.submit t('.save_settings'), class: 'btn btn-primary' %>
         </div>
       </div>
     <% end %>

--- a/app/views/share_links/hubs/_body.html.erb
+++ b/app/views/share_links/hubs/_body.html.erb
@@ -22,19 +22,19 @@
 <div data-controller="hub-tabs" data-hub-tabs-active-value="<%= active_tab %>">
   <div role="tablist" class="tabs tabs-bordered mb-2">
     <a role="tab" class="tab" data-hub-tabs-target="tab" data-tab="live"
-       data-action="click->hub-tabs#select" data-testid="hub-tab-live">Live location</a>
+       data-action="click->hub-tabs#select" data-testid="hub-tab-live"><%= t('.live_location') %></a>
     <a role="tab" class="tab" data-hub-tabs-target="tab" data-tab="timeline"
-       data-action="click->hub-tabs#select" data-testid="hub-tab-timeline">Time period</a>
+       data-action="click->hub-tabs#select" data-testid="hub-tab-timeline"><%= t('.time_period') %></a>
     <% if hub.any_shares? %>
       <a role="tab" class="tab" data-hub-tabs-target="tab" data-tab="shared"
-         data-action="click->hub-tabs#select" data-testid="hub-tab-shared">Shared</a>
+         data-action="click->hub-tabs#select" data-testid="hub-tab-shared"><%= t('.shared') %></a>
     <% end %>
   </div>
 
   <div data-hub-tabs-target="panel" style="min-height: 24rem;" data-tab="live" class="hidden pt-2">
     <% if hub.live_share %>
       <%= render 'shared_links/modal_active', share: hub.live_share, paths: live_paths,
-                 subtitle: 'Your live location is shared via a public link.' %>
+                 subtitle: t('.your_live_location_is_shared_via_a_public_link') %>
     <% else %>
       <%= render 'shared_links/modal_live_create_form', resource: nil, paths: live_paths, close_path: map_v2_path %>
     <% end %>

--- a/app/views/share_links/hubs/_modal.html.erb
+++ b/app/views/share_links/hubs/_modal.html.erb
@@ -1,15 +1,15 @@
 <div class="modal modal-open" data-controller="share-link-modal" style="z-index: 10000;">
   <div class="modal-box max-w-xl">
     <%= link_to map_v2_path, class: "btn btn-sm btn-circle btn-ghost absolute right-3 top-3",
-                data: { turbo_frame: "_top", action: "share-link-modal#close" }, aria: { label: "Close" } do %>
+                data: { turbo_frame: "_top", action: "share-link-modal#close" }, aria: { label: t('.close') } do %>
       ✕
     <% end %>
-    <h3 class="font-bold text-lg mb-4">Share</h3>
+    <h3 class="font-bold text-lg mb-4"><%= t('.share') %></h3>
 
     <div id="share-hub-body">
       <%= render 'share_links/hubs/body', hub: hub, active_tab: active_tab, errors: local_assigns[:errors] %>
     </div>
   </div>
   <%= link_to '', map_v2_path, class: "modal-backdrop",
-              data: { turbo_frame: "_top", action: "share-link-modal#close" }, aria: { label: "Close" } %>
+              data: { turbo_frame: "_top", action: "share-link-modal#close" }, aria: { label: t('.close') } %>
 </div>

--- a/app/views/share_links/hubs/_shared_list.html.erb
+++ b/app/views/share_links/hubs/_shared_list.html.erb
@@ -1,26 +1,26 @@
 <div class="space-y-2">
   <% shares.each do |share| %>
     <div class="flex items-center gap-2 p-2 rounded-lg border border-base-300">
-      <span class="badge badge-sm whitespace-nowrap"><%= share.resource_type.titleize %></span>
+      <span class="badge badge-sm whitespace-nowrap"><%= t("enums.shared_link.resource_type.#{share.resource_type}") %></span>
       <input type="text" readonly value="<%= public_shared_link_url(share.id) %>"
              class="input input-bordered input-sm flex-1 font-mono text-xs" onclick="this.select();">
       <button type="button" class="btn btn-ghost btn-sm btn-square"
               data-controller="clipboard"
               data-clipboard-text-value="<%= public_shared_link_url(share.id) %>"
-              data-action="click->clipboard#copy" title="Copy link" aria-label="Copy link">
+              data-action="click->clipboard#copy" title="<%= t('.copy_link') %>" aria-label="<%= t('.copy_link') %>">
         <%= icon 'copy', class: 'w-4 h-4' %>
       </button>
       <%= link_to public_shared_link_path(share.id), target: '_blank', rel: 'noopener',
                   class: 'btn btn-ghost btn-sm btn-square',
-                  data: { turbo: false }, title: 'Open in new tab', aria: { label: 'Open in new tab' } do %>
+                  data: { turbo: false }, title: t('.open_in_new_tab'), aria: { label: t('.open_in_new_tab') } do %>
         <%= icon 'external-link', class: 'w-4 h-4' %>
       <% end %>
       <%= button_to revoke_share_links_share_path(share, query), method: :patch,
-                    form: { data: { turbo_frame: "share-link-modal" }, title: "Revoke link" },
+                    form: { data: { turbo_frame: "share-link-modal" }, title: t('.revoke_link') },
                     class: "btn btn-ghost btn-sm btn-square text-warning",
-                    data: { turbo_confirm: "Revoke this link? It will stop working immediately." },
-                    title: "Revoke link",
-                    aria: { label: 'Revoke' } do %>
+                    data: { turbo_confirm: t('.revoke_this_link_it_will_stop_working_immediately') },
+                    title: t('.revoke_link'),
+                    aria: { label: t('.revoke') } do %>
         <%= icon 'shield', class: 'w-4 h-4' %>
       <% end %>
     </div>

--- a/app/views/share_links/lives/new.html.erb
+++ b/app/views/share_links/lives/new.html.erb
@@ -1,8 +1,8 @@
 <%= render 'shared_links/modal',
            resource: nil,
            share: @share,
-           title: "Share your live location",
-           subtitle: "Your live location is shared via a public link.",
+           title: t('.share_your_live_location'),
+           subtitle: t('.your_live_location_is_shared_via_a_public_link'),
            close_path: map_v2_path,
            paths: {
              create:            share_links_live_path,

--- a/app/views/share_links/timelines/new.html.erb
+++ b/app/views/share_links/timelines/new.html.erb
@@ -1,7 +1,7 @@
 <%= render 'shared_links/modal',
            resource: nil,
            share: @share,
-           title: "Share a date range",
+           title: t('.share_a_date_range'),
            subtitle: timeline_share_subtitle(@share),
            close_path: map_v2_path,
            paths: {

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -9,7 +9,7 @@
   <button type="button"
           data-action="click->removals#remove"
           class="btn btn-sm btn-circle btn-ghost"
-          aria-label="Close">
+          aria-label="<%= t('.close') %>">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
     </svg>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="footer bg-base-200 text-content-neutral p-4">
   <aside>
-    <p><a href="https://dawarich.app/" class="link hover:no-underline" target="_blank">Dawarich</a> 2023-<%=Time.zone.now.year %></p>
+    <p><a href="https://dawarich.app/" class="link hover:no-underline" target="_blank"><%= t('.dawarich') %></a> 2023-<%=Time.zone.now.year %></p>
   </aside>
 </footer>

--- a/app/views/shared/_legal_footer.html.erb
+++ b/app/views/shared/_legal_footer.html.erb
@@ -1,34 +1,34 @@
 <footer class="footer bg-base-200 text-content-neutral p-4">
   <nav>
-    <h6 class="footer-title"><strong>Dawarich</strong></h6>
+    <h6 class="footer-title"><strong><%= t('.dawarich') %></strong></h6>
     <p>
-      Made and hosted in 🇪🇺 Europe
+      <%= t('.made_and_hosted_in_europe') %>
     </p>
     <p>
-      Copyright © <%= Time.zone.now.year %> ZeitFlow UG
+      <%= t('.copyright') %> <%= Time.zone.now.year %> <%= t('.zeitflow_ug') %>
     </p>
   </nav>
   <nav>
-    <h6 class="footer-title"><strong>Community</strong></h6>
-    <a class="hover:underline" href="https://discord.gg/pHsBjpt5J8" target="_blank">Discord</a>
+    <h6 class="footer-title"><strong><%= t('.community') %></strong></h6>
+    <a class="hover:underline" href="https://discord.gg/pHsBjpt5J8" target="_blank"><%= t('.discord') %></a>
     <a class="hover:underline" href="https://x.com/freymakesstuff" target="_blank">X</a>
-    <a class="hover:underline" href="https://github.com/Freika/dawarich" target="_blank">Github</a>
-    <a class="hover:underline" href="https://mastodon.social/@dawarich" target="_blank">Mastodon</a>
+    <a class="hover:underline" href="https://github.com/Freika/dawarich" target="_blank"><%= t('.github') %></a>
+    <a class="hover:underline" href="https://mastodon.social/@dawarich" target="_blank"><%= t('.mastodon') %></a>
   </nav>
   <nav>
-    <h6 class="footer-title"><strong>Docs</strong></h6>
-    <a class="hover:underline" href="https://dawarich.app/docs/intro" target="_blank">Tutorial</a>
-    <a class="hover:underline" href="https://dawarich.app/docs/tutorials/import-existing-data" target="_blank">Import existing data</a>
-    <a class="hover:underline" href="https://dawarich.app/docs/tutorials/export-your-data" target="_blank">Exporting data</a>
-    <a class="hover:underline" href="https://dawarich.app/docs/FAQ" target="_blank">FAQ</a>
-    <a class="hover:underline" href="https://dawarich.app/contact" target="_blank">Contact</a>
+    <h6 class="footer-title"><strong><%= t('.docs') %></strong></h6>
+    <a class="hover:underline" href="https://dawarich.app/docs/intro" target="_blank"><%= t('.tutorial') %></a>
+    <a class="hover:underline" href="https://dawarich.app/docs/tutorials/import-existing-data" target="_blank"><%= t('.import_existing_data') %></a>
+    <a class="hover:underline" href="https://dawarich.app/docs/tutorials/export-your-data" target="_blank"><%= t('.exporting_data') %></a>
+    <a class="hover:underline" href="https://dawarich.app/docs/FAQ" target="_blank"><%= t('.faq') %></a>
+    <a class="hover:underline" href="https://dawarich.app/contact" target="_blank"><%= t('.contact') %></a>
   </nav>
   <nav>
-    <h6 class="footer-title"><strong>More</strong></h6>
-    <a class="hover:underline" href="https://dawarich.app/privacy-policy" target="_blank">Privacy policy</a>
-    <a class="hover:underline" href="https://dawarich.app/terms-and-conditions" target="_blank">Terms and Conditions</a>
-    <a class="hover:underline" href="https://dawarich.app/refund-policy" target="_blank">Refund policy</a>
-    <a class="hover:underline" href="https://dawarich.app/impressum" target="_blank">Impressum</a>
-    <a class="hover:underline" href="https://dawarich.app/blog" target="_blank">Blog</a>
+    <h6 class="footer-title"><strong><%= t('.more') %></strong></h6>
+    <a class="hover:underline" href="https://dawarich.app/privacy-policy" target="_blank"><%= t('.privacy_policy') %></a>
+    <a class="hover:underline" href="https://dawarich.app/terms-and-conditions" target="_blank"><%= t('.terms_and_conditions') %></a>
+    <a class="hover:underline" href="https://dawarich.app/refund-policy" target="_blank"><%= t('.refund_policy') %></a>
+    <a class="hover:underline" href="https://dawarich.app/impressum" target="_blank"><%= t('.impressum') %></a>
+    <a class="hover:underline" href="https://dawarich.app/blog" target="_blank"><%= t('.blog') %></a>
   </nav>
 </footer>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -5,37 +5,37 @@
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h8m-8 6h16" /></svg>
       </label>
       <ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[50] p-2 shadow bg-base-100 rounded-box w-52">
-        <li><%= link_to 'Map', preferred_map_path, class: "#{active_class?(preferred_map_path)}" %></li>
-        <li><%= link_to 'Trips'.html_safe, trips_url, class: "#{active_class?(trips_url)}" %></li>
-        <li><%= link_to 'Stats', stats_url, class: "#{active_class?(stats_url)}" %></li>
-        <li><%= link_to 'Insights<sup>α</sup>'.html_safe, insights_url, class: "#{active_class?(insights_url)}" %></li>
+        <li><%= link_to t('.map'), preferred_map_path, class: "#{active_class?(preferred_map_path)}" %></li>
+        <li><%= link_to t('.trips').html_safe, trips_url, class: "#{active_class?(trips_url)}" %></li>
+        <li><%= link_to t('.stats'), stats_url, class: "#{active_class?(stats_url)}" %></li>
+        <li><%= link_to t('.insights_sup_sup_html').html_safe, insights_url, class: "#{active_class?(insights_url)}" %></li>
         <% if user_signed_in? && (family_feature_available? || current_user.in_family?) %>
           <li>
             <% if current_user.in_family? %>
               <%= link_to family_home_path, class: "#{active_class?(family_home_path)} flex items-center space-x-2" do %>
-                <span>Family</span>
+                <span><%= t('.family') %></span>
                 <%= render 'families/navbar_indicator', user: current_user %>
               <% end %>
             <% else %>
-              <%= link_to 'Family<sup>α</sup>'.html_safe, new_family_path, class: "#{active_class?(new_family_path)}" %>
+              <%= link_to t('.family_sup_sup_html').html_safe, new_family_path, class: "#{active_class?(new_family_path)}" %>
             <% end %>
           </li>
         <% end %>
         <li>
           <details>
-            <summary>My data</summary>
+            <summary><%= t('.my_data') %></summary>
             <ul class="p-2 bg-base-100">
-              <li><%= link_to 'Points', points_url, class: "#{active_class?(points_url)}" %></li>
-              <li><%= link_to 'Places', places_url, class: "#{active_class?(places_url)}" %></li>
-              <li><%= link_to 'Imports', imports_url, class: "#{active_class?(imports_url)}" %></li>
-              <li><%= link_to 'Exports', exports_url, class: "#{active_class?(exports_url)}" %></li>
-              <li><%= link_to 'Tags', tags_url, class: "#{active_class?(tags_url)}" %></li>
+              <li><%= link_to t('.points'), points_url, class: "#{active_class?(points_url)}" %></li>
+              <li><%= link_to t('.places'), places_url, class: "#{active_class?(places_url)}" %></li>
+              <li><%= link_to t('.imports'), imports_url, class: "#{active_class?(imports_url)}" %></li>
+              <li><%= link_to t('.exports'), exports_url, class: "#{active_class?(exports_url)}" %></li>
+              <li><%= link_to t('.tags'), tags_url, class: "#{active_class?(tags_url)}" %></li>
             </ul>
           </details>
         </li>
         <% if user_signed_in? && current_user.can_subscribe? && !current_user.auto_converting_trial? %>
           <li>
-            <%= link_to 'Subscribe', "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}", class: 'btn btn-sm btn-success' %>
+            <%= link_to t('.subscribe'), "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}", class: 'btn btn-sm btn-success' %>
           </li>
         <% end %>
         <% if user_signed_in? %>
@@ -43,7 +43,7 @@
           <li><%= render 'shared/navbar/theme_toggle', show_label: true, css_class: 'flex items-center gap-2' %></li>
           <li>
             <details>
-              <summary><%= icon 'message-circle-question-mark' %> Help</summary>
+              <summary><%= icon 'message-circle-question-mark' %> <%= t('.help') %></summary>
               <ul class="p-2 bg-base-100">
                 <%= render 'shared/navbar/help_links' %>
               </ul>
@@ -54,7 +54,7 @@
     </div>
     <%= link_to (user_signed_in? ? preferred_map_path : root_path), class: 'btn btn-ghost normal-case text-xl gap-2' do %>
       <%= image_tag 'logo.svg', alt: 'Dawarich logo', class: 'h-8 w-8 rounded-[20%]' %>
-      <span>Dawarich<sup>β</sup></span>
+      <span><%= t('.dawarich') %><sup>β</sup></span>
     <% end %>
     <%= render "shared/navbar/version_indicator" %>
 
@@ -66,31 +66,31 @@
   </div>
   <div class="navbar-center hidden lg:flex">
     <ul class="menu menu-horizontal px-1">
-      <li><%= link_to 'Map', preferred_map_path, class: "mx-1 #{active_class?(preferred_map_path)}" %></li>
-      <li><%= link_to 'Trips'.html_safe, trips_url, class: "mx-1 #{active_class?(trips_url)}" %></li>
-      <li><%= link_to 'Stats', stats_url, class: "mx-1 #{active_class?(stats_url)}" %></li>
-      <li><%= link_to 'Insights<sup>α</sup>'.html_safe, insights_url, class: "mx-1 #{active_class?(insights_url)}" %></li>
+      <li><%= link_to t('.map'), preferred_map_path, class: "mx-1 #{active_class?(preferred_map_path)}" %></li>
+      <li><%= link_to t('.trips').html_safe, trips_url, class: "mx-1 #{active_class?(trips_url)}" %></li>
+      <li><%= link_to t('.stats'), stats_url, class: "mx-1 #{active_class?(stats_url)}" %></li>
+      <li><%= link_to t('.insights_sup_sup_html').html_safe, insights_url, class: "mx-1 #{active_class?(insights_url)}" %></li>
       <% if user_signed_in? && (family_feature_available? || current_user.in_family?) %>
         <li>
           <% if current_user.in_family? %>
             <%= link_to family_home_path, class: "mx-1 #{active_class?(family_home_path)} flex items-center space-x-2" do %>
-              <span>Family<sup>α</sup></span>
+              <span><%= t('.family') %><sup>α</sup></span>
               <%= render 'families/navbar_indicator', user: current_user %>
             <% end %>
           <% else %>
-            <%= link_to 'Family<sup>α</sup>'.html_safe, new_family_path, class: "mx-1 #{active_class?(new_family_path)}" %>
+            <%= link_to t('.family_sup_sup_html').html_safe, new_family_path, class: "mx-1 #{active_class?(new_family_path)}" %>
           <% end %>
         </li>
       <% end %>
       <li>
         <details>
-          <summary>My data</summary>
+          <summary><%= t('.my_data') %></summary>
           <ul class="p-2 bg-base-100 rounded-box shadow-md z-[50]">
-            <li><%= link_to 'Points', points_url, class: "#{active_class?(points_url)}" %></li>
-            <li><%= link_to 'Places', places_url, class: "#{active_class?(places_url)}" %></li>
-            <li><%= link_to 'Imports', imports_url, class: "#{active_class?(imports_url)}" %></li>
-            <li><%= link_to 'Exports', exports_url, class: "#{active_class?(exports_url)}" %></li>
-            <li><%= link_to 'Tags', tags_url, class: "#{active_class?(tags_url)}" %></li>
+            <li><%= link_to t('.points'), points_url, class: "#{active_class?(points_url)}" %></li>
+            <li><%= link_to t('.places'), places_url, class: "#{active_class?(places_url)}" %></li>
+            <li><%= link_to t('.imports'), imports_url, class: "#{active_class?(imports_url)}" %></li>
+            <li><%= link_to t('.exports'), exports_url, class: "#{active_class?(exports_url)}" %></li>
+            <li><%= link_to t('.tags'), tags_url, class: "#{active_class?(tags_url)}" %></li>
           </ul>
         </details>
       </li>
@@ -124,20 +124,20 @@
             <% end %>
           </label>
           <ul tabindex="0" class="dropdown-content menu menu-sm mt-3 z-[50] p-2 shadow bg-base-100 rounded-box w-52">
-            <li><%= link_to 'Account', edit_user_registration_path %></li>
-            <li><%= link_to 'Settings', settings_general_index_path %></li>
+            <li><%= link_to t('.account'), edit_user_registration_path %></li>
+            <li><%= link_to t('.settings'), settings_general_index_path %></li>
             <% if !DawarichSettings.self_hosted? %>
-              <li><%= link_to 'Subscription', "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}" %></li>
+              <li><%= link_to t('.subscription'), "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}" %></li>
             <% end %>
             <li>
               <a onclick="getting_started.showModal()" class="relative">
-                Get started
+                <%= t('.get_started') %>
                 <% if onboarding_modal_showable?(current_user) %>
                   <span class="indicator-item badge badge-secondary badge-xs"></span>
                 <% end %>
               </a>
             </li>
-            <li><%= link_to 'Logout', destroy_user_session_path, method: :delete, data: { turbo: false } %></li>
+            <li><%= link_to t('.logout'), destroy_user_session_path, method: :delete, data: { turbo: false } %></li>
           </ul>
         </div>
       </div>
@@ -149,17 +149,17 @@
                       class: "join flex-nowrap" do %>
             <span class="join-item btn btn-sm <%= trial_button_class(current_user) %>">
               <% if current_user.pending_payment? %>
-                <span class="tooltip tooltip-bottom" data-tip="Finish setting up your account" title="Finish setting up your account">Finish signup</span>
+                <span class="tooltip tooltip-bottom" data-tip="<%= t('.finish_setting_up_your_account') %>" title="<%= t('.finish_setting_up_your_account') %>"><%= t('.finish_signup') %></span>
               <% else %>
                 <% expiry = current_user.active_until %>
                 <% if expiry.blank? || expiry.past? %>
-                  <span class="tooltip tooltip-bottom" data-tip="Trial expired" title="Trial expired">Trial expired 🥺</span>
+                  <span class="tooltip tooltip-bottom" data-tip="<%= t('.trial_expired') %>" title="<%= t('.trial_expired') %>"><%= t('.trial_expired_2') %></span>
                 <% else %>
                   <% days_left = [(expiry.to_date - Time.zone.today).to_i, 0].max %>
                   <span class="tooltip tooltip-bottom"
-                        data-tip="Your trial will end in <%= distance_of_time_in_words(expiry, Time.current) %>"
-                        title="Your trial will end in <%= distance_of_time_in_words(expiry, Time.current) %>">
-                    <%= pluralize(days_left, 'day') %> remaining
+                        data-tip="<%= t('.trial_ends_in', time: distance_of_time_in_words(expiry, Time.current)) %>"
+                        title="<%= t('.trial_ends_in', time: distance_of_time_in_words(expiry, Time.current)) %>">
+                    <%= t('.days_remaining', count: days_left) %>
                   </span>
                 <% end %>
               <% end %>
@@ -178,7 +178,7 @@
               <%= render 'notifications/badge', count: @unread_notifications&.size || 0 %>
             </summary>
             <ul class="p-2 bg-base-100 rounded-t-none z-[50] min-w-52" id="notifications-list">
-              <li><%= link_to 'See all', notifications_path %></li>
+              <li><%= link_to t('.see_all'), notifications_path %></li>
               <% @unread_notifications&.first(10)&.each do |notification| %>
                 <%= render 'notifications/navbar_item', notification: notification %>
               <% end %>
@@ -201,12 +201,12 @@
                 <span class="indicator-item badge badge-secondary badge-xs"></span>
               <% end %>
               <% if current_user.admin? %>
-                <span class='tooltip tooltip-left' data-tip="You're an admin, Harry!">
+                <span class='tooltip tooltip-left' data-tip="<%= t('.you_re_an_admin_harry') %>">
                   <%= icon 'star' %>
                 </span>
               <% end %>
               <% if current_user.supporter? && current_user.safe_settings.show_supporter_badge? %>
-                <span class='tooltip tooltip-left' data-tip="Dawarich Supporter">
+                <span class='tooltip tooltip-left' data-tip="<%= t('.dawarich_supporter') %>">
                   <span class="text-sky-400 inline-block animate-[supporter-rainbow-glow_8s_linear_infinite]">
                     <%= icon 'gem' %>
                   </span>
@@ -214,21 +214,21 @@
               <% end %>
             </summary>
             <ul class="p-2 bg-base-100 rounded-t-none z-[50]">
-              <li><%= link_to 'Account', edit_user_registration_path %></li>
-              <li><%= link_to 'Settings', settings_general_index_path %></li>
+              <li><%= link_to t('.account'), edit_user_registration_path %></li>
+              <li><%= link_to t('.settings'), settings_general_index_path %></li>
               <% if !DawarichSettings.self_hosted? %>
-                <li><%= link_to 'Subscription', "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}" %></li>
+                <li><%= link_to t('.subscription'), "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}" %></li>
               <% end %>
               <li>
                 <a onclick="getting_started.showModal()" class="relative">
-                  Get started
+                  <%= t('.get_started') %>
                   <% if onboarding_modal_showable?(current_user) %>
                     <span class="indicator-item badge badge-secondary badge-xs"></span>
                   <% end %>
                 </a>
               </li>
 
-              <li><%= link_to 'Logout', destroy_user_session_path, method: :delete, data: { turbo: false } %></li>
+              <li><%= link_to t('.logout'), destroy_user_session_path, method: :delete, data: { turbo: false } %></li>
             </ul>
           </details>
         </li>
@@ -236,9 +236,9 @@
       </div>
     <% else %>
       <ul class="menu menu-horizontal bg-base-100 rounded-box px-1">
-        <li><%= link_to 'Login', new_user_session_path %></li>
+        <li><%= link_to t('.login'), new_user_session_path %></li>
         <% if !SELF_HOSTED && defined?(devise_mapping) && devise_mapping&.registerable? %>
-          <li><%= link_to 'Register', new_user_registration_path %></li>
+          <li><%= link_to t('.register'), new_user_registration_path %></li>
         <% end %>
       </ul>
     <% end %>

--- a/app/views/shared/_place_creation_modal.html.erb
+++ b/app/views/shared/_place_creation_modal.html.erb
@@ -1,7 +1,7 @@
 <div data-controller="place-creation">
   <div class="modal z-[10000]" data-place-creation-target="modal">
     <div class="modal-box max-w-2xl">
-      <h3 class="font-bold text-lg mb-4" data-place-creation-target="modalTitle">Create New Place</h3>
+      <h3 class="font-bold text-lg mb-4" data-place-creation-target="modalTitle"><%= t('.create_new_place') %></h3>
 
       <%= form_with scope: :place, url: places_path, method: :post, data: {
         place_creation_target: "form",
@@ -16,10 +16,10 @@
         <div class="space-y-4">
           <div class="form-control">
             <label class="label">
-              <span class="label-text font-semibold">Place Name *</span>
+              <span class="label-text font-semibold"><%= t('.place_name') %></span>
             </label>
             <%= f.text_field :name,
-                placeholder: "Enter place name...",
+                placeholder: t('.enter_place_name'),
                 class: "input input-bordered w-full",
                 data: { place_creation_target: "nameInput" },
                 required: true %>
@@ -27,21 +27,21 @@
 
           <div class="form-control">
             <label class="label">
-              <span class="label-text font-semibold">Note</span>
+              <span class="label-text font-semibold"><%= t('.note') %></span>
             </label>
             <%= f.text_area :note,
-                placeholder: "Add a personal note about this place...",
+                placeholder: t('.add_a_personal_note_about_this_place'),
                 class: "textarea textarea-bordered w-full bg-base-100",
                 rows: 3,
                 data: { place_creation_target: "noteInput" } %>
             <label class="label">
-              <span class="label-text-alt">Optional - Add any notes or details about this place</span>
+              <span class="label-text-alt"><%= t('.optional_add_any_notes_or_details_about_this_place') %></span>
             </label>
           </div>
 
           <div class="form-control">
             <label class="label">
-              <span class="label-text font-semibold">Tags</span>
+              <span class="label-text font-semibold"><%= t('.tags') %></span>
             </label>
             <div class="flex flex-wrap gap-2" data-place-creation-target="tagCheckboxes">
               <% current_user.tags.ordered.each do |tag| %>
@@ -54,29 +54,29 @@
               <% end %>
             </div>
             <label class="label">
-              <span class="label-text-alt">Click tags to select them for this place</span>
+              <span class="label-text-alt"><%= t('.click_tags_to_select_them_for_this_place') %></span>
             </label>
           </div>
 
-          <div class="divider">Suggested Places</div>
+          <div class="divider"><%= t('.suggested_places') %></div>
 
           <div class="form-control">
             <label class="label">
-              <span class="label-text font-semibold">Nearby Places</span>
+              <span class="label-text font-semibold"><%= t('.nearby_places') %></span>
             </label>
             <div class="relative">
               <%# Turbo Frame for server-rendered nearby places %>
               <%= turbo_frame_tag "nearby-places", data: { place_creation_target: "nearbyFrame" } do %>
-                <p class="text-sm text-gray-500">Open modal to load nearby suggestions</p>
+                <p class="text-sm text-gray-500"><%= t('.open_modal_to_load_nearby_suggestions') %></p>
               <% end %>
             </div>
           </div>
         </div>
 
         <div class="modal-action">
-          <button type="button" class="btn btn-ghost" data-action="click->place-creation#close">Cancel</button>
-          <%= f.submit "Create Place", class: "btn btn-primary",
-              data: { place_creation_target: "submitButton", disable_with: "Saving..." } %>
+          <button type="button" class="btn btn-ghost" data-action="click->place-creation#close"><%= t('.cancel') %></button>
+          <%= f.submit t('.create_place'), class: "btn btn-primary",
+              data: { place_creation_target: "submitButton", disable_with: t('.saving') } %>
         </div>
       <% end %>
     </div>

--- a/app/views/shared/_plan_data_window_alert.html.erb
+++ b/app/views/shared/_plan_data_window_alert.html.erb
@@ -5,17 +5,16 @@
     <div class="flex items-center gap-2 min-w-0">
       <%= icon 'info', class: 'flex-shrink-0' %>
       <span>
-        Your Lite plan includes the last 12 months of data.
-        Upgrade to Pro to access your full history.
+        <%= t('.your_lite_plan_includes_the_last_12_months_of_data') %>
       </span>
     </div>
     <div class="flex items-center gap-2 flex-shrink-0">
       <a href="<%= upgrade_url(utm_medium: 'data_window', utm_content: local_assigns[:utm_content] || 'general') %>"
          class="btn btn-sm btn-primary" target="_blank" rel="noopener">
-        Upgrade to Pro
+        <%= t('.upgrade_to_pro') %>
       </a>
       <button type="button" data-action="click->removals#remove"
-              class="btn btn-sm btn-circle btn-ghost" aria-label="Close">
+              class="btn btn-sm btn-circle btn-ghost" aria-label="<%= t('.close') %>">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>

--- a/app/views/shared/_replay_panel.html.erb
+++ b/app/views/shared/_replay_panel.html.erb
@@ -8,9 +8,9 @@
   <button type="button"
           class="replay-close"
           data-action="click-><%= stimulus %>#toggleReplay"
-          title="Close replay"
-          aria-label="Close replay">
-    &times;
+          title="<%= t('.close_replay') %>"
+          aria-label="<%= t('.close_replay') %>">
+    <%= t('.times') %>
   </button>
 
   <%# Controls row: Day nav | Time display | Replay + Cycle controls %>
@@ -21,14 +21,14 @@
         <button type="button"
                 data-action="click-><%= stimulus %>#replayPrevDay"
                 data-<%= stimulus %>-target="replayPrevDayButton"
-                title="Previous day"
-                aria-label="Previous day">
-          &larr;
+                title="<%= t('.previous_day') %>"
+                aria-label="<%= t('.previous_day') %>">
+          <%= t('.larr') %>
         </button>
       <% end %>
       <div class="replay-day-info">
         <span class="replay-day-display" data-<%= stimulus %>-target="replayDayDisplay">
-          No data loaded
+          <%= t('.no_data_loaded') %>
         </span>
         <span class="replay-day-count" data-<%= stimulus %>-target="replayDayCount"></span>
       </div>
@@ -36,9 +36,9 @@
         <button type="button"
                 data-action="click-><%= stimulus %>#replayNextDay"
                 data-<%= stimulus %>-target="replayNextDayButton"
-                title="Next day"
-                aria-label="Next day">
-          &rarr;
+                title="<%= t('.next_day') %>"
+                aria-label="<%= t('.next_day') %>">
+          <%= t('.rarr') %>
         </button>
       <% end %>
     </div>
@@ -51,7 +51,7 @@
       <span class="replay-speed-display" data-<%= stimulus %>-target="replaySpeedDisplay">
       </span>
       <span class="replay-data-indicator hidden" data-<%= stimulus %>-target="replayDataIndicator" role="status">
-        No data
+        <%= t('.no_data') %>
       </span>
     </div>
 
@@ -61,8 +61,8 @@
               class="replay-play-btn"
               data-<%= stimulus %>-target="replayPlayButton"
               data-action="click-><%= stimulus %>#replayTogglePlayback"
-              title="Play/Pause"
-              aria-label="Play or pause replay">
+              title="<%= t('.play_pause') %>"
+              aria-label="<%= t('.play_or_pause_replay') %>">
         <span class="play-icon" data-<%= stimulus %>-target="replayPlayIcon">&#9658;</span>
         <span class="pause-icon hidden" data-<%= stimulus %>-target="replayPauseIcon">&#10074;&#10074;</span>
       </button>
@@ -70,8 +70,8 @@
               class="replay-follow-btn"
               data-<%= stimulus %>-target="replayFollowButton"
               data-action="click-><%= stimulus %>#replayRecenterFollow"
-              title="Recenter & follow marker"
-              aria-label="Recenter and follow the marker">
+              title="<%= t('.recenter_follow_marker') %>"
+              aria-label="<%= t('.recenter_and_follow_the_marker') %>">
         <%= icon "locate-fixed", class: "replay-follow-icon" %>
       </button>
       <div class="replay-speed-control">
@@ -83,25 +83,25 @@
                step="1"
                data-<%= stimulus %>-target="replaySpeedSlider"
                data-action="input-><%= stimulus %>#replaySpeedChange"
-               title="Replay speed"
-               aria-label="Replay speed">
+               title="<%= t('.replay_speed') %>"
+               aria-label="<%= t('.replay_speed') %>">
         <span class="replay-speed-label" data-<%= stimulus %>-target="replaySpeedLabel">2x</span>
       </div>
       <div class="replay-cycle-controls hidden" data-<%= stimulus %>-target="replayCycleControls">
         <button type="button"
                 data-action="click-><%= stimulus %>#replayCyclePrev"
-                title="Previous point"
-                aria-label="Previous point">
-          &larr;
+                title="<%= t('.previous_point') %>"
+                aria-label="<%= t('.previous_point') %>">
+          <%= t('.larr') %>
         </button>
         <span class="replay-point-counter" data-<%= stimulus %>-target="replayPointCounter">
-          Point 1 of 1
+          <%= t('.point_1_of_1') %>
         </span>
         <button type="button"
                 data-action="click-><%= stimulus %>#replayCycleNext"
-                title="Next point"
-                aria-label="Next point">
-          &rarr;
+                title="<%= t('.next_point') %>"
+                aria-label="<%= t('.next_point') %>">
+          <%= t('.rarr') %>
         </button>
       </div>
     </div>
@@ -119,7 +119,7 @@
              value="720"
              data-<%= stimulus %>-target="replayScrubber"
              data-action="input-><%= stimulus %>#replayScrubberHover"
-             aria-label="Replay scrubber - time of day">
+             aria-label="<%= t('.replay_scrubber_time_of_day') %>">
     </div>
     <span class="replay-time-label">23:59</span>
   </div>

--- a/app/views/shared/_sharing_link.html.erb
+++ b/app/views/shared/_sharing_link.html.erb
@@ -1,6 +1,6 @@
 <div id="sharing-link-display" class="form-control mb-4">
   <label class="label">
-    <span class="label-text font-medium">Sharing link</span>
+    <span class="label-text font-medium"><%= t('.sharing_link') %></span>
   </label>
   <div class="join w-full">
     <input type="text"
@@ -11,10 +11,10 @@
     <button type="button"
             class="btn btn-outline join-item"
             data-action="click->sharing-modal#copyLink">
-      <%= icon 'copy' %> Copy
+      <%= icon 'copy' %> <%= t('.copy') %>
     </button>
   </div>
   <div class="label">
-    <span class="label-text-alt text-gray-500">Share this link to allow others to view your stats</span>
+    <span class="label-text-alt text-gray-500"><%= t('.share_this_link_to_allow_others_to_view_your_stats') %></span>
   </div>
 </div>

--- a/app/views/shared/_sharing_modal.html.erb
+++ b/app/views/shared/_sharing_modal.html.erb
@@ -6,19 +6,18 @@
     </form>
 
     <h3 class="font-bold text-lg mb-4 flex items-center gap-2">
-      <%= icon 'link' %> Sharing Settings
+      <%= icon 'link' %> <%= t('.sharing_settings') %>
     </h3>
 
     <% unless local_assigns.fetch(:sharing_allowed, true) %>
       <%# Upgrade prompt for Lite users %>
       <div class="text-center py-4">
         <p class="text-gray-600 mb-4">
-          Share your monthly stats publicly with friends and family.
-          Public stats sharing is available on the Pro plan.
+          <%= t('.share_your_monthly_stats_publicly_with_friends_and_family_public') %>
         </p>
         <a href="<%= upgrade_url(utm_medium: 'stats', utm_content: 'sharing') %>"
            class="btn btn-primary">
-          Upgrade to Pro
+          <%= t('.upgrade_to_pro') %>
         </a>
       </div>
     <% else %>
@@ -29,7 +28,7 @@
           <%# Enable/Disable Sharing Toggle %>
           <div class="form-control mb-4">
             <label class="label cursor-pointer">
-              <span class="label-text font-medium">Enable public access</span>
+              <span class="label-text font-medium"><%= t('.enable_public_access') %></span>
               <input type="checkbox"
                      name="enabled"
                      value="1"
@@ -39,7 +38,7 @@
                      data-sharing-modal-target="enableToggle" />
             </label>
             <div class="label">
-              <span class="label-text-alt text-gray-500">Allow others to view this monthly digest • Auto-saves on change</span>
+              <span class="label-text-alt text-gray-500"><%= t('.allow_others_to_view_this_monthly_digest_auto_saves_on') %></span>
             </div>
           </div>
 
@@ -49,7 +48,7 @@
 
             <div class="form-control mb-4">
               <label class="label">
-                <span class="label-text font-medium">Link expiration</span>
+                <span class="label-text font-medium"><%= t('.link_expiration') %></span>
               </label>
               <select name="expiration"
                       class="select select-bordered w-full"
@@ -76,10 +75,10 @@
         <div class="alert alert-info mb-4">
           <%= icon 'info' %>
           <div>
-            <h3 class="font-bold">Privacy Protection</h3>
+            <h3 class="font-bold"><%= t('.privacy_protection') %></h3>
             <div class="text-sm">
-              • Exact coordinates are hidden<br>
-              • Personal information is not included
+              <%= t('.exact_coordinates_are_hidden') %><br>
+              <%= t('.personal_information_is_not_included') %>
             </div>
           </div>
         </div>
@@ -89,7 +88,7 @@
           <button type="button"
                   class="btn btn-primary"
                   onclick="sharing_modal.close()">
-            Done
+            <%= t('.done') %>
           </button>
         </div>
       </div>

--- a/app/views/shared/links/_live.html.erb
+++ b/app/views/shared/links/_live.html.erb
@@ -4,9 +4,9 @@
          data-shared-live-map-show-route-value="<%= ActiveModel::Type::Boolean.new.cast(link.settings['show_route']) %>">
   <div class="flex items-center gap-3 mb-2">
     <h1 class="text-3xl font-bold"><%= link.name %></h1>
-    <span class="badge badge-error gap-1">● Live</span>
+    <span class="badge badge-error gap-1"><%= t('.live') %></span>
   </div>
-  <p data-shared-live-map-target="status" class="text-base-content/70">Connecting…</p>
+  <p data-shared-live-map-target="status" class="text-base-content/70"><%= t('.connecting') %></p>
   <p data-shared-live-map-target="lastSeen" class="text-sm text-base-content/50 mb-4"></p>
 
   <div id="shared-live-map"

--- a/app/views/shared/links/_missing_resource.html.erb
+++ b/app/views/shared/links/_missing_resource.html.erb
@@ -1,8 +1,8 @@
 <section class="hero min-h-[60vh]">
   <div class="hero-content text-center">
     <div class="max-w-md">
-      <h1 class="text-3xl font-bold">This share is no longer available</h1>
-      <p class="py-4">The original content was removed by the owner.</p>
+      <h1 class="text-3xl font-bold"><%= t('.this_share_is_no_longer_available') %></h1>
+      <p class="py-4"><%= t('.the_original_content_was_removed_by_the_owner') %></p>
     </div>
   </div>
 </section>

--- a/app/views/shared/links/_timeline.html.erb
+++ b/app/views/shared/links/_timeline.html.erb
@@ -10,7 +10,7 @@
       <%= formatted_date_range(start_date, end_date) %>
     </h1>
     <p class="text-sm text-base-content/60 mt-1">
-      <%= pluralize(days, 'day') %> · Shared on Dawarich
+      <%= t('.days_shared_on_dawarich', count: days) %>
     </p>
   </header>
 

--- a/app/views/shared/links/_track.html.erb
+++ b/app/views/shared/links/_track.html.erb
@@ -14,33 +14,33 @@
     <div class="stats shadow w-full">
       <% if resource.distance.present? %>
         <div class="stat">
-          <div class="stat-title">Distance</div>
+          <div class="stat-title"><%= t('.distance') %></div>
           <div class="stat-value text-2xl"><%= resource.distance_in_unit(unit).round(1) %> <%= unit %></div>
         </div>
       <% end %>
       <% if resource.duration.present? && resource.duration.positive? %>
         <div class="stat">
-          <div class="stat-title">Duration</div>
+          <div class="stat-title"><%= t('.duration') %></div>
           <div class="stat-value text-2xl"><%= distance_of_time_in_words(resource.duration) %></div>
         </div>
       <% end %>
       <% if resource.avg_speed.present? %>
         <% speed = unit == 'mi' ? (resource.avg_speed.to_f * 0.621371).round(1) : resource.avg_speed.to_f.round(1) %>
         <div class="stat">
-          <div class="stat-title">Avg speed</div>
-          <div class="stat-value text-2xl"><%= speed %> <%= unit == 'mi' ? 'mph' : 'km/h' %></div>
+          <div class="stat-title"><%= t('.avg_speed') %></div>
+          <div class="stat-value text-2xl"><%= t(unit == 'mi' ? 'units.speed_mph' : 'units.speed_kmh', value: speed) %></div>
         </div>
       <% end %>
       <% if resource.elevation_gain.present? && resource.elevation_gain.positive? %>
         <div class="stat">
-          <div class="stat-title">Elevation gain</div>
-          <div class="stat-value text-2xl"><%= resource.elevation_gain.round %> m</div>
+          <div class="stat-title"><%= t('.elevation_gain') %></div>
+          <div class="stat-value text-2xl"><%= t('units.meters', value: resource.elevation_gain.round) %></div>
         </div>
       <% end %>
       <% if resource.elevation_loss.present? && resource.elevation_loss.positive? %>
         <div class="stat">
-          <div class="stat-title">Elevation loss</div>
-          <div class="stat-value text-2xl"><%= resource.elevation_loss.round %> m</div>
+          <div class="stat-title"><%= t('.elevation_loss') %></div>
+          <div class="stat-value text-2xl"><%= t('units.meters', value: resource.elevation_loss.round) %></div>
         </div>
       <% end %>
     </div>

--- a/app/views/shared/links/_trip.html.erb
+++ b/app/views/shared/links/_trip.html.erb
@@ -15,12 +15,12 @@
       <div class="mb-6">
         <div class="flex items-start justify-between gap-3 mb-1">
           <h1 class="text-3xl font-bold leading-tight"><%= resource.name %></h1>
-          <span class="badge badge-success badge-sm shrink-0 gap-1" aria-label="Publicly shared">
-            <%= icon 'map-pin', class: 'w-3 h-3' %> Public
+          <span class="badge badge-success badge-sm shrink-0 gap-1" aria-label="<%= t('.publicly_shared') %>">
+            <%= icon 'map-pin', class: 'w-3 h-3' %> <%= t('.public') %>
           </span>
         </div>
         <p class="text-md text-base-content/60 mb-4">
-          <%= human_date(resource.started_at) %> &ndash; <%= human_date(resource.ended_at) %>
+          <%= human_date(resource.started_at) %> <%= t('.ndash') %> <%= human_date(resource.ended_at) %>
         </p>
 
         <% if trip.show_stats? %>
@@ -30,7 +30,7 @@
 
       <% if trip.description? %>
         <div class="mb-6">
-          <h3 class="text-lg font-semibold mb-2">Trip Notes</h3>
+          <h3 class="text-lg font-semibold mb-2"><%= t('.trip_notes') %></h3>
           <div class="prose max-w-none"><%= resource.description.body %></div>
         </div>
       <% end %>
@@ -42,7 +42,7 @@
                   data-shared-trip-map-target="replayToggleBtn"
                   data-action="click->shared-trip-map#toggleReplay">
             <%= icon 'play', class: 'w-4 h-4' %>
-            <span>Replay</span>
+            <span><%= t('.replay') %></span>
           </button>
         </div>
       <% end %>

--- a/app/views/shared/links/_trip_day_header.html.erb
+++ b/app/views/shared/links/_trip_day_header.html.erb
@@ -1,8 +1,8 @@
 <span class="inline-block w-3 h-3 rounded-full flex-shrink-0 bg-base-content/30" data-day-dot="<%= day_key %>"></span>
-<span><%= day[:date].strftime('%b %-d, %A') %></span>
+<span><%= l(day[:date], format: :short_month_day_weekday) %></span>
 <% if day[:has_data] %>
-  <span class="text-base-content/50 text-xs"><%= day[:first_time].strftime('%H:%M') %> – <%= day[:last_time].strftime('%H:%M') %></span>
-  <span class="text-base-content/50 ml-auto mr-6 text-xs">&middot; <%= day[:distance_label] %></span>
+  <span class="text-base-content/50 text-xs"><%= l(day[:first_time], format: :hour_minute) %> – <%= l(day[:last_time], format: :hour_minute) %></span>
+  <span class="text-base-content/50 ml-auto mr-6 text-xs"><%= t('.middot') %> <%= day[:distance_label] %></span>
 <% else %>
-  <span class="text-base-content/50 ml-auto mr-6 text-xs">No data</span>
+  <span class="text-base-content/50 ml-auto mr-6 text-xs"><%= t('.no_data') %></span>
 <% end %>

--- a/app/views/shared/links/_unsupported.html.erb
+++ b/app/views/shared/links/_unsupported.html.erb
@@ -1,4 +1,4 @@
 <section class="container mx-auto px-4 py-16 text-center">
-  <h1 class="text-2xl font-bold mb-2">This share type is no longer supported</h1>
-  <p class="text-base-content/70">The link may have been created by a newer or older version of Dawarich.</p>
+  <h1 class="text-2xl font-bold mb-2"><%= t('.this_share_type_is_no_longer_supported') %></h1>
+  <p class="text-base-content/70"><%= t('.the_link_may_have_been_created_by_a_newer_or') %></p>
 </section>

--- a/app/views/shared/links/not_found.html.erb
+++ b/app/views/shared/links/not_found.html.erb
@@ -1,9 +1,9 @@
-<% content_for(:title, "Not found — Dawarich") %>
+<% content_for(:title, t('.not_found_dawarich')) %>
 <section class="hero min-h-[60vh]">
   <div class="hero-content text-center">
     <div class="max-w-md">
-      <h1 class="text-3xl font-bold">This shared link is no longer available</h1>
-      <p class="py-4">The owner may have revoked the link or it may have expired.</p>
+      <h1 class="text-3xl font-bold"><%= t('.this_shared_link_is_no_longer_available') %></h1>
+      <p class="py-4"><%= t('.the_owner_may_have_revoked_the_link_or_it_may') %></p>
     </div>
   </div>
 </section>

--- a/app/views/shared/links/phrase_prompt.html.erb
+++ b/app/views/shared/links/phrase_prompt.html.erb
@@ -1,15 +1,15 @@
-<% content_for(:title, "Enter phrase — Dawarich") %>
+<% content_for(:title, t('.enter_phrase_dawarich')) %>
 <section class="hero min-h-[60vh]">
   <div class="hero-content text-center">
     <div class="max-w-md">
-      <h1 class="text-3xl font-bold">Enter the magic phrase</h1>
-      <p class="py-4">This shared link is protected. Ask the owner for the phrase.</p>
+      <h1 class="text-3xl font-bold"><%= t('.enter_the_magic_phrase') %></h1>
+      <p class="py-4"><%= t('.this_shared_link_is_protected_ask_the_owner_for_the') %></p>
       <% if flash.now[:error] %>
         <div class="alert alert-error mb-4"><%= flash.now[:error] %></div>
       <% end %>
       <%= form_with url: unlock_public_shared_link_path(@link.id), method: :post, local: true, class: "form-control" do |f| %>
-        <%= f.text_field :phrase, required: true, autofocus: true, class: "input input-bordered w-full", placeholder: "magic phrase" %>
-        <%= f.submit "Unlock", class: "btn btn-primary mt-4" %>
+        <%= f.text_field :phrase, required: true, autofocus: true, class: "input input-bordered w-full", placeholder: t('.magic_phrase') %>
+        <%= f.submit t('.unlock'), class: "btn btn-primary mt-4" %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/links/show.html.erb
+++ b/app/views/shared/links/show.html.erb
@@ -1,9 +1,9 @@
-<% content_for(:title, "#{@link.name} — Shared on Dawarich") %>
+<% content_for(:title, t('.name_shared_on_dawarich', name: @link.name)) %>
 
 <% content_for :head do %>
   <meta property="og:type" content="article">
   <meta property="og:title" content="<%= @link.name %>">
-  <meta property="og:description" content="Shared from Dawarich">
+  <meta property="og:description" content="<%= t('.shared_from_dawarich') %>">
   <meta property="og:image" content="<%= image_url('og_default.png') %>">
   <meta name="twitter:card" content="summary_large_image">
 <% end %>

--- a/app/views/shared/map/_date_navigation.html.erb
+++ b/app/views/shared/map/_date_navigation.html.erb
@@ -28,10 +28,10 @@
             </span>
           </div>
         </div>
-        <div class="w-full lg:w-2/12 tooltip tooltip-bottom" data-tip="Start date and time">
+        <div class="w-full lg:w-2/12 tooltip tooltip-bottom" data-tip="<%= t('.start_date_and_time') %>">
           <%= f.datetime_local_field :start_at, include_seconds: false, max: "9999-12-31T23:59", class: "input input-sm input-bordered hover:cursor-pointer hover:input-primary w-full", value: start_at %>
         </div>
-        <div class="w-full lg:w-2/12 tooltip tooltip-bottom" data-tip="End date and time">
+        <div class="w-full lg:w-2/12 tooltip tooltip-bottom" data-tip="<%= t('.end_date_and_time') %>">
           <%= f.datetime_local_field :end_at, include_seconds: false, max: "9999-12-31T23:59", class: "input input-sm input-bordered hover:cursor-pointer hover:input-primary w-full", value: end_at %>
         </div>
         <div class="w-full lg:w-1/12">
@@ -45,24 +45,24 @@
         </div>
         <div class="w-full lg:w-1/12">
           <div class="flex flex-col space-y-2">
-            <%= f.submit "Search", class: "btn btn-sm btn-primary hover:btn-info w-full" %>
+            <%= f.submit t('.search'), class: "btn btn-sm btn-primary hover:btn-info w-full" %>
           </div>
         </div>
         <div class="w-full lg:w-1/12">
           <div class="flex flex-col space-y-2 text-center">
-            <%= link_to "Today",
+            <%= link_to t('.today'),
               map_path(start_at: Time.current.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id]),
               class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
           </div>
         </div>
         <div class="w-full lg:w-2/12">
           <div class="flex flex-col space-y-2 text-center">
-            <%= link_to "Last 7 days", map_path(start_at: 1.week.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
+            <%= link_to t('.last_7_days'), map_path(start_at: 1.week.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
           </div>
         </div>
         <div class="w-full lg:w-2/12">
           <div class="flex flex-col space-y-2 text-center">
-            <%= link_to "Last month", map_path(start_at: 1.month.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
+            <%= link_to t('.last_month'), map_path(start_at: 1.month.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
           </div>
         </div>
       </div>

--- a/app/views/shared/map/_date_navigation_v2.html.erb
+++ b/app/views/shared/map/_date_navigation_v2.html.erb
@@ -29,10 +29,10 @@
             <%= icon 'chevron-left' %>
           <% end %>
         </div>
-        <div class="w-full lg:w-2/12 tooltip tooltip-bottom" data-tip="Start date and time">
+        <div class="w-full lg:w-2/12 tooltip tooltip-bottom" data-tip="<%= t('.start_date_and_time') %>">
           <%= f.datetime_local_field :start_at, include_seconds: false, max: "9999-12-31T23:59", class: "input input-sm input-bordered hover:cursor-pointer hover:input-primary w-full", value: start_at %>
         </div>
-        <div class="w-full lg:w-2/12 tooltip tooltip-bottom" data-tip="End date and time">
+        <div class="w-full lg:w-2/12 tooltip tooltip-bottom" data-tip="<%= t('.end_date_and_time') %>">
           <%= f.datetime_local_field :end_at, include_seconds: false, max: "9999-12-31T23:59", class: "input input-sm input-bordered hover:cursor-pointer hover:input-primary w-full", value: end_at %>
         </div>
         <div class="w-full lg:w-1/12 tooltip tooltip-bottom" data-tip="<%= human_date(start_at + 1.day) %>">
@@ -42,24 +42,24 @@
         </div>
         <div class="w-full lg:w-1/12">
           <div class="flex flex-col space-y-2">
-            <%= f.submit "Search", class: "btn btn-sm btn-primary hover:btn-info w-full" %>
+            <%= f.submit t('.search'), class: "btn btn-sm btn-primary hover:btn-info w-full" %>
           </div>
         </div>
         <div class="w-full lg:w-1/12">
           <div class="flex flex-col space-y-2 text-center">
-            <%= link_to "Today",
+            <%= link_to t('.today'),
               map_v2_path(start_at: Time.current.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id], panel: params[:panel]),
               class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
           </div>
         </div>
         <div class="w-full lg:w-2/12">
           <div class="flex flex-col space-y-2 text-center">
-            <%= link_to "Last 7 days", map_v2_path(start_at: 1.week.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id], panel: params[:panel]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
+            <%= link_to t('.last_7_days'), map_v2_path(start_at: 1.week.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id], panel: params[:panel]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
           </div>
         </div>
         <div class="w-full lg:w-2/12">
           <div class="flex flex-col space-y-2 text-center">
-            <%= link_to "Last month", map_v2_path(start_at: 1.month.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id], panel: params[:panel]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
+            <%= link_to t('.last_month'), map_v2_path(start_at: 1.month.ago.beginning_of_day.iso8601, end_at: Time.current.end_of_day.iso8601, import_id: params[:import_id], panel: params[:panel]), class: "btn btn-sm border border-base-300 hover:btn-ghost w-full" %>
           </div>
         </div>
         <div class="w-full lg:w-1/12 relative">
@@ -67,7 +67,7 @@
                       class: "btn btn-sm border border-base-300 hover:btn-ghost w-full flex-nowrap",
                       data: { turbo_frame: "share-link-modal", testid: "timeline-share-button" } do %>
             <%= icon 'share', class: 'w-4 h-4' %>
-            <span class="ml-1">Share</span>
+            <span class="ml-1"><%= t('.share') %></span>
           <% end %>
           <%= render "shared/map/share_indicator" %>
         </div>

--- a/app/views/shared/map/_share_indicator.html.erb
+++ b/app/views/shared/map/_share_indicator.html.erb
@@ -2,6 +2,6 @@
   <% if current_user.shared_links.active.where(resource_type: :live).exists? %>
     <span class="absolute -top-1 -right-1 w-2.5 h-2.5 bg-green-500 rounded-full animate-pulse ring-2 ring-base-100 pointer-events-none"
           data-testid="live-share-dot"
-          title="Live location is being shared"></span>
+          title="<%= t('.live_location_is_being_shared') %>"></span>
   <% end %>
 <% end %>

--- a/app/views/shared/map/_upgrade_banner.html.erb
+++ b/app/views/shared/map/_upgrade_banner.html.erb
@@ -4,13 +4,13 @@
        role="status" style="pointer-events: auto;">
     <span class="map-upgrade-banner-icon" aria-hidden="true"><%= icon 'info', class: 'w-4 h-4' %></span>
     <span class="map-upgrade-banner-text">
-      Your Lite plan includes the last 12 months of data.
+      <%= t('.your_lite_plan_includes_the_last_12_months_of_data') %>
     </span>
     <a href="<%= upgrade_url(utm_medium: 'data_window', utm_content: local_assigns[:utm_content] || 'map') %>"
        class="btn btn-sm btn-primary map-upgrade-banner-cta" target="_blank" rel="noopener">
-      Upgrade to Pro
+      <%= t('.upgrade_to_pro') %>
     </a>
     <button data-action="click->removals#remove"
-            class="map-upgrade-banner-dismiss" aria-label="Dismiss">✕</button>
+            class="map-upgrade-banner-dismiss" aria-label="<%= t('.dismiss') %>">✕</button>
   </div>
 <% end %>

--- a/app/views/shared/navbar/_changelog_prompt.html.erb
+++ b/app/views/shared/navbar/_changelog_prompt.html.erb
@@ -1,20 +1,16 @@
 <div class="dropdown dropdown-end dropdown-open">
   <div class="card card-compact w-72 bg-base-100 shadow-lg border border-base-300 absolute right-0 mt-2 z-[60]">
     <div class="card-body">
-      <h3 class="font-semibold text-sm">Stay up to date?</h3>
+      <h3 class="font-semibold text-sm"><%= t('.stay_up_to_date') %></h3>
       <p class="text-xs opacity-80">
-        Get a "What's New" notice when a new Dawarich version ships, including
-        security fixes. The notice loads a small widget from <%= changelog_widget_host %>.
-        Like any web request, that host sees your IP address, browser, and the
-        page URL, plus your Dawarich version — never your account, email, or
-        location. You can change this anytime.
+        <%= t('.get_a_what_s_new_notice_when_a_new_dawarich') %> <%= changelog_widget_host %><%= t('.like_any_web_request_that_host_sees_your_ip_address') %>
       </p>
       <div class="card-actions justify-end mt-1">
-        <%= button_to "No thanks", changelog_consent_path,
+        <%= button_to t('.no_thanks'), changelog_consent_path,
               method: :patch, params: { decision: "declined" },
               class: "btn btn-ghost btn-xs",
               form: { data: { turbo_stream: true } } %>
-        <%= button_to "Yes, notify me", changelog_consent_path,
+        <%= button_to t('.yes_notify_me'), changelog_consent_path,
               method: :patch, params: { decision: "granted" },
               class: "btn btn-primary btn-xs",
               form: { data: { turbo_stream: true } } %>

--- a/app/views/shared/navbar/_help_links.html.erb
+++ b/app/views/shared/navbar/_help_links.html.erb
@@ -1,6 +1,6 @@
-<li><p>Need help? Ping us! <%= icon 'arrow-big-down' %></p></li>
-<li><%= link_to 'X (Twitter)', 'https://x.com/freymakesstuff', target: '_blank', rel: 'noopener noreferrer' %></li>
-<li><%= link_to 'Mastodon', 'https://mastodon.social/@dawarich', target: '_blank', rel: 'noopener noreferrer' %></li>
-<li><%= link_to 'Email', 'mailto:hi@dawarich.app' %></li>
-<li><%= link_to 'Forum', 'https://discourse.dawarich.app', target: '_blank', rel: 'noopener noreferrer' %></li>
-<li><%= link_to 'Discord', 'https://discord.gg/pHsBjpt5J8', target: '_blank', rel: 'noopener noreferrer' %></li>
+<li><p><%= t('.need_help_ping_us') %> <%= icon 'arrow-big-down' %></p></li>
+<li><%= link_to t('.x_twitter'), 'https://x.com/freymakesstuff', target: '_blank', rel: 'noopener noreferrer' %></li>
+<li><%= link_to t('.mastodon'), 'https://mastodon.social/@dawarich', target: '_blank', rel: 'noopener noreferrer' %></li>
+<li><%= link_to t('.email'), 'mailto:hi@dawarich.app' %></li>
+<li><%= link_to t('.forum'), 'https://discourse.dawarich.app', target: '_blank', rel: 'noopener noreferrer' %></li>
+<li><%= link_to t('.discord'), 'https://discord.gg/pHsBjpt5J8', target: '_blank', rel: 'noopener noreferrer' %></li>

--- a/app/views/shared/navbar/_theme_toggle.html.erb
+++ b/app/views/shared/navbar/_theme_toggle.html.erb
@@ -3,6 +3,6 @@
             class: local_assigns.fetch(:css_class, 'btn btn-ghost') do %>
   <%= icon(target_theme == 'dark' ? 'moon' : 'sun') %>
   <% if local_assigns[:show_label] %>
-    <span><%= target_theme == 'dark' ? 'Dark mode' : 'Light mode' %></span>
+    <span><%= t(target_theme == 'dark' ? '.dark_mode' : '.light_mode') %></span>
   <% end %>
 <% end %>

--- a/app/views/shared/navbar/_version_indicator.html.erb
+++ b/app/views/shared/navbar/_version_indicator.html.erb
@@ -4,8 +4,8 @@
   <div class="badge mx-4 <%= 'badge-outline' if github_update %>">
     <a href="https://github.com/Freika/dawarich/releases/latest" target="_blank" class="inline-flex items-center">
       <% if github_update %>
-        <span class="tooltip tooltip-bottom" data-tip="New version available! Check out Github releases!">
-          <span class="hidden sm:inline"><%= APP_VERSION %>&nbsp;!</span>
+        <span class="tooltip tooltip-bottom" data-tip="<%= t('.new_version_available_check_out_github_releases') %>">
+          <span class="hidden sm:inline"><%= APP_VERSION %><%= t('.nbsp') %></span>
         </span>
       <% else %>
         <span class="hidden sm:inline"><%= APP_VERSION %></span>

--- a/app/views/shared_links/_expires_field.html.erb
+++ b/app/views/shared_links/_expires_field.html.erb
@@ -1,7 +1,7 @@
 <%# Locals: f (form builder) %>
 <div class="form-control mt-4">
-  <label class="label"><span class="label-text">Expires (optional)</span></label>
+  <label class="label"><span class="label-text"><%= t('.expires_optional') %></span></label>
   <%= f.date_field :expires_at, class: 'input input-bordered', min: Date.current.tomorrow, value: 7.days.from_now.to_date %>
-  <span class="label-text-alt mt-1">Stays active through the end of the day before the selected date.</span>
-  <span class="label-text-alt">Defaults to one week from today. Leave blank for a link that never expires.</span>
+  <span class="label-text-alt mt-1"><%= t('.stays_active_through_the_end_of_the_day_before_the') %></span>
+  <span class="label-text-alt"><%= t('.defaults_to_one_week_from_today_leave_blank_for_a') %></span>
 </div>

--- a/app/views/shared_links/_modal.html.erb
+++ b/app/views/shared_links/_modal.html.erb
@@ -15,7 +15,7 @@
       <%= link_to close_path,
                   class: "btn btn-sm btn-circle btn-ghost absolute right-3 top-3",
                   data: { turbo_frame: "_top", action: "share-link-modal#close" },
-                  aria: { label: "Close" } do %>
+                  aria: { label: t('.close') } do %>
         ✕
       <% end %>
 
@@ -23,10 +23,10 @@
         <%= render 'shared_links/modal_active', share: share, paths: paths, subtitle: local_assigns[:subtitle] %>
       <% else %>
         <h3 class="font-bold text-lg mb-1"><%= title %></h3>
-        <p class="text-sm text-base-content/70 mb-5">Anyone with the link will be able to view this.</p>
+        <p class="text-sm text-base-content/70 mb-5"><%= t('.anyone_with_the_link_will_be_able_to_view_this') %></p>
         <%= render create_form_partial, resource: resource, paths: paths, close_path: close_path %>
       <% end %>
     </div>
-    <%= link_to '', close_path, class: "modal-backdrop", data: { turbo_frame: "_top", action: "share-link-modal#close" }, aria: { label: "Close" } %>
+    <%= link_to '', close_path, class: "modal-backdrop", data: { turbo_frame: "_top", action: "share-link-modal#close" }, aria: { label: t('.close') } %>
   </div>
 </turbo-frame>

--- a/app/views/shared_links/_modal_active.html.erb
+++ b/app/views/shared_links/_modal_active.html.erb
@@ -1,9 +1,9 @@
 <%# Active-state modal contents. Locals: share, paths %>
 <div class="flex items-center gap-2 mb-4">
-  <h3 class="font-bold text-lg">Sharing</h3>
+  <h3 class="font-bold text-lg"><%= t('.sharing') %></h3>
   <span class="badge badge-success badge-sm gap-1">
     <span class="w-1.5 h-1.5 rounded-full bg-success-content/80"></span>
-    Public
+    <%= t('.public') %>
   </span>
 </div>
 
@@ -13,7 +13,7 @@
 
 <div class="space-y-4">
   <div>
-    <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide" for="share-url">Public link</label>
+    <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide" for="share-url"><%= t('.public_link') %></label>
     <div class="join w-full mt-1">
       <input id="share-url" type="text" readonly value="<%= public_shared_link_url(share.id) %>"
              class="input input-bordered join-item flex-1 font-mono text-sm" onclick="this.select();">
@@ -21,13 +21,13 @@
               data-controller="clipboard"
               data-clipboard-text-value="<%= public_shared_link_url(share.id) %>"
               data-action="click->clipboard#copy"
-              title="Copy link"
-              aria-label="Copy public link">
+              title="<%= t('.copy_link') %>"
+              aria-label="<%= t('.copy_public_link') %>">
         <%= icon 'copy', class: 'w-4 h-4' %>
       </button>
       <%= link_to public_shared_link_url(share.id), target: '_blank', rel: 'noopener',
                   class: 'btn btn-outline join-item', data: { turbo: false },
-                  title: 'Open in new tab', aria: { label: 'Open in new tab' } do %>
+                  title: t('.open_in_new_tab'), aria: { label: t('.open_in_new_tab') } do %>
         <%= icon 'external-link', class: 'w-4 h-4' %>
       <% end %>
     </div>
@@ -35,7 +35,7 @@
 
   <% if share.magic_phrase.present? %>
     <div>
-      <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide" for="share-phrase">Magic phrase</label>
+      <label class="text-xs font-medium text-base-content/60 uppercase tracking-wide" for="share-phrase"><%= t('.magic_phrase') %></label>
       <div class="join w-full mt-1">
         <input id="share-phrase" type="text" readonly value="<%= share.magic_phrase %>"
                class="input input-bordered join-item flex-1 font-mono text-sm" onclick="this.select();">
@@ -43,7 +43,7 @@
                 data-controller="clipboard"
                 data-clipboard-text-value="<%= share.magic_phrase %>"
                 data-action="click->clipboard#copy"
-                aria-label="Copy magic phrase">
+                aria-label="<%= t('.copy_magic_phrase') %>">
           <%= icon 'copy', class: 'w-4 h-4' %>
         </button>
       </div>
@@ -51,13 +51,13 @@
   <% end %>
 
   <div class="flex flex-wrap gap-4 text-sm text-base-content/70">
-    <span><%= pluralize(share.view_count, 'view') %></span>
+    <span><%= t('.view_count', count: share.view_count) %></span>
     <span class="flex items-center gap-1.5">
       <%= icon 'clock', class: 'w-4 h-4' %>
       <% if share.last_accessed_at %>
-        Last viewed <%= time_ago_in_words(share.last_accessed_at) %> ago
+        <%= t('.last_viewed') %> <%= time_ago_in_words(share.last_accessed_at) %> <%= t('.ago') %>
       <% else %>
-        Not viewed yet
+        <%= t('.not_viewed_yet') %>
       <% end %>
     </span>
   </div>
@@ -67,21 +67,21 @@
       <%= button_to paths[:regenerate], method: :post,
                     form: { data: { turbo_frame: "share-link-modal" } },
                     class: "btn btn-outline btn-sm",
-                    data: { turbo_confirm: "Generate a new URL? The current URL will stop working." } do %>
-        <%= icon 'refresh-ccw', class: 'w-4 h-4' %> Regenerate URL
+                    data: { turbo_confirm: t('.generate_a_new_url_the_current_url_will_stop_working') } do %>
+        <%= icon 'refresh-ccw', class: 'w-4 h-4' %> <%= t('.regenerate_url') %>
       <% end %>
       <%= button_to paths[:regenerate_phrase], method: :post,
                     form: { data: { turbo_frame: "share-link-modal" } },
                     class: "btn btn-outline btn-sm",
-                    data: { turbo_confirm: "Generate a new phrase?" } do %>
-        <%= icon 'refresh-ccw', class: 'w-4 h-4' %> Regenerate phrase
+                    data: { turbo_confirm: t('.generate_a_new_phrase') } do %>
+        <%= icon 'refresh-ccw', class: 'w-4 h-4' %> <%= t('.regenerate_phrase') %>
       <% end %>
     </div>
     <%= button_to paths[:revoke], method: :patch,
                   form: { data: { turbo_frame: "share-link-modal" } },
                   class: "btn btn-warning btn-sm",
-                  data: { turbo_confirm: "Revoke this link? It will stop working immediately." } do %>
-      <%= icon 'shield', class: 'w-4 h-4' %> Revoke
+                  data: { turbo_confirm: t('.revoke_this_link_it_will_stop_working_immediately') } do %>
+      <%= icon 'shield', class: 'w-4 h-4' %> <%= t('.revoke') %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared_links/_modal_live_create_form.html.erb
+++ b/app/views/shared_links/_modal_live_create_form.html.erb
@@ -2,23 +2,23 @@
 <%= form_with model: SharedLink.new, url: paths[:create], method: :post,
               data: { turbo_frame: "share-link-modal" } do |f| %>
   <div class="alert alert-warning text-sm mb-4">
-    <span>This shares your <strong>current location in real time</strong> with anyone who has the link, until it expires or you revoke it.</span>
+    <span><%= t('.this_shares_your') %> <strong><%= t('.current_location_in_real_time') %></strong> <%= t('.with_anyone_who_has_the_link_until_it_expires_or') %></span>
   </div>
   <div class="form-control">
-    <label class="label"><span class="label-text">Magic phrase (optional)</span></label>
+    <label class="label"><span class="label-text"><%= t('.magic_phrase_optional') %></span></label>
     <%= f.text_field :magic_phrase, class: 'input input-bordered', value: SharedLink::PhraseGenerator.call %>
-    <span class="label-text-alt mt-1">Leave blank to share without a phrase, or use the auto-generated one.</span>
+    <span class="label-text-alt mt-1"><%= t('.leave_blank_to_share_without_a_phrase_or_use_the') %></span>
   </div>
   <%= render 'shared_links/expires_field', f: f %>
   <div class="form-control mt-4">
     <label class="label cursor-pointer justify-start gap-3">
       <%= check_box_tag 'shared_link[settings][show_route]', '1', false, class: 'checkbox checkbox-primary' %>
-      <span class="label-text">Share the route</span>
+      <span class="label-text"><%= t('.share_the_route') %></span>
     </label>
-    <span class="label-text-alt mt-1">Also show the path travelled since this link was created.</span>
+    <span class="label-text-alt mt-1"><%= t('.also_show_the_path_travelled_since_this_link_was_created') %></span>
   </div>
   <div class="modal-action">
-    <%= link_to 'Cancel', close_path, class: 'btn btn-ghost', data: { turbo_frame: '_top', action: 'share-link-modal#close' } %>
-    <%= f.submit 'Create share link', class: 'btn btn-primary' %>
+    <%= link_to t('.cancel'), close_path, class: 'btn btn-ghost', data: { turbo_frame: '_top', action: 'share-link-modal#close' } %>
+    <%= f.submit t('.create_share_link'), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/shared_links/_modal_timeline_create_form.html.erb
+++ b/app/views/shared_links/_modal_timeline_create_form.html.erb
@@ -3,14 +3,14 @@
               data: { turbo_frame: "share-link-modal" } do |f| %>
   <div class="grid grid-cols-2 gap-3">
     <div class="form-control">
-      <label class="label"><span class="label-text">Start date</span></label>
+      <label class="label"><span class="label-text"><%= t('.start_date') %></span></label>
       <%= f.date_field :start_date,
                        value: (@shared_link&.settings&.dig('start_date') || 7.days.ago.to_date),
                        class: 'input input-bordered',
                        required: true %>
     </div>
     <div class="form-control">
-      <label class="label"><span class="label-text">End date</span></label>
+      <label class="label"><span class="label-text"><%= t('.end_date') %></span></label>
       <%= f.date_field :end_date,
                        value: (@shared_link&.settings&.dig('end_date') || Date.current),
                        class: 'input input-bordered',
@@ -19,16 +19,16 @@
   </div>
 
   <div class="form-control mt-4">
-    <label class="label"><span class="label-text">Magic phrase (optional)</span></label>
+    <label class="label"><span class="label-text"><%= t('.magic_phrase_optional') %></span></label>
     <%= f.text_field :magic_phrase, class: 'input input-bordered', value: SharedLink::PhraseGenerator.call %>
-    <span class="label-text-alt mt-1">Leave blank to share without a phrase, or use the auto-generated one.</span>
+    <span class="label-text-alt mt-1"><%= t('.leave_blank_to_share_without_a_phrase_or_use_the') %></span>
   </div>
 
   <%= render 'shared_links/expires_field', f: f %>
 
   <div class="form-control mt-4">
     <label class="label cursor-pointer">
-      <span class="label-text">Show photos</span>
+      <span class="label-text"><%= t('.show_photos') %></span>
       <%= hidden_field_tag 'shared_link[settings][show_photos]', '0' %>
       <%= check_box_tag 'shared_link[settings][show_photos]', '1', false, class: 'checkbox' %>
     </label>
@@ -41,7 +41,7 @@
   <% end %>
 
   <div class="modal-action">
-    <%= link_to 'Cancel', close_path, class: 'btn btn-ghost', data: { turbo_frame: '_top', action: 'share-link-modal#close' } %>
-    <%= f.submit 'Create share link', class: 'btn btn-primary' %>
+    <%= link_to t('.cancel'), close_path, class: 'btn btn-ghost', data: { turbo_frame: '_top', action: 'share-link-modal#close' } %>
+    <%= f.submit t('.create_share_link'), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/shared_links/_modal_track_create_form.html.erb
+++ b/app/views/shared_links/_modal_track_create_form.html.erb
@@ -2,25 +2,25 @@
 <%= form_with model: SharedLink.new, url: paths[:create], method: :post,
               data: { turbo_frame: "share-link-modal" } do |f| %>
   <div class="form-control">
-    <label class="label"><span class="label-text">Magic phrase (optional)</span></label>
+    <label class="label"><span class="label-text"><%= t('.magic_phrase_optional') %></span></label>
     <%= f.text_field :magic_phrase, class: 'input input-bordered', value: SharedLink::PhraseGenerator.call %>
-    <span class="label-text-alt mt-1">Leave blank to share without a phrase, or use the auto-generated one.</span>
+    <span class="label-text-alt mt-1"><%= t('.leave_blank_to_share_without_a_phrase_or_use_the') %></span>
   </div>
   <%= render 'shared_links/expires_field', f: f %>
   <div class="form-control mt-4">
     <label class="label cursor-pointer">
-      <span class="label-text">Show photos</span>
+      <span class="label-text"><%= t('.show_photos') %></span>
       <%= hidden_field_tag 'shared_link[settings][show_photos]', '0' %>
       <%= check_box_tag 'shared_link[settings][show_photos]', '1', false, class: 'checkbox' %>
     </label>
     <label class="label cursor-pointer">
-      <span class="label-text">Show stats</span>
+      <span class="label-text"><%= t('.show_stats') %></span>
       <%= hidden_field_tag 'shared_link[settings][show_stats]', '0' %>
       <%= check_box_tag 'shared_link[settings][show_stats]', '1', false, class: 'checkbox' %>
     </label>
   </div>
   <div class="modal-action">
-    <%= link_to 'Cancel', close_path, class: 'btn btn-ghost', data: { turbo_frame: '_top', action: 'share-link-modal#close' } %>
-    <%= f.submit 'Create share link', class: 'btn btn-primary' %>
+    <%= link_to t('.cancel'), close_path, class: 'btn btn-ghost', data: { turbo_frame: '_top', action: 'share-link-modal#close' } %>
+    <%= f.submit t('.create_share_link'), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/shared_links/_modal_trip_create_form.html.erb
+++ b/app/views/shared_links/_modal_trip_create_form.html.erb
@@ -2,21 +2,21 @@
 <%= form_with model: SharedLink.new, url: paths[:create], method: :post,
               data: { turbo_frame: "share-link-modal" } do |f| %>
   <div class="form-control">
-    <label class="label"><span class="label-text">Magic phrase (optional)</span></label>
+    <label class="label"><span class="label-text"><%= t('.magic_phrase_optional') %></span></label>
     <%= f.text_field :magic_phrase, class: 'input input-bordered', value: SharedLink::PhraseGenerator.call %>
-    <span class="label-text-alt mt-1">Leave blank to share without a phrase, or use the auto-generated one.</span>
+    <span class="label-text-alt mt-1"><%= t('.leave_blank_to_share_without_a_phrase_or_use_the') %></span>
   </div>
   <%= render 'shared_links/expires_field', f: f %>
   <div class="form-control mt-4">
-    <span class="label-text font-semibold">What to include on the public page</span>
+    <span class="label-text font-semibold"><%= t('.what_to_include_on_the_public_page') %></span>
     <%
       sections = [
-        ['show_route',       'Route map',                              true],
-        ['show_stats',       'Stats & countries (distance, duration)', true],
-        ['show_days',        'Day-by-day breakdown',                   true],
-        ['show_day_notes',   'Per-day notes',                          false],
-        ['show_description', 'Trip description',                       true],
-        ['show_photos',      'Photos on map',                          false]
+        ['show_route',       t('.route_map'),                          true],
+        ['show_stats',       t('.stats_countries_distance_duration'), true],
+        ['show_days',        t('.day_by_day_breakdown'),                true],
+        ['show_day_notes',   t('.per_day_notes'),                      false],
+        ['show_description', t('.trip_description'),                   true],
+        ['show_photos',      t('.photos_on_map'),                      false]
       ]
     %>
     <% sections.each do |key, label, checked| %>
@@ -28,7 +28,7 @@
     <% end %>
   </div>
   <div class="modal-action">
-    <%= link_to 'Cancel', close_path, class: 'btn btn-ghost', data: { turbo_frame: '_top', action: 'share-link-modal#close' } %>
-    <%= f.submit 'Create share link', class: 'btn btn-primary' %>
+    <%= link_to t('.cancel'), close_path, class: 'btn btn-ghost', data: { turbo_frame: '_top', action: 'share-link-modal#close' } %>
+    <%= f.submit t('.create_share_link'), class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/stats/_locked_year_card.html.erb
+++ b/app/views/stats/_locked_year_card.html.erb
@@ -10,7 +10,7 @@
       <%# Blurred placeholder chart %>
       <div class="opacity-20 blur-[3px] pointer-events-none select-none" aria-hidden="true">
         <%= column_chart(
-          (1..12).map { |m| [Date::MONTHNAMES[m], rand(5_000..80_000)] },
+          (1..12).map { |month| [l(Date.new(year, month, 1), format: :month_name), rand(5_000..80_000)] },
           id: "chart-year-locked-#{year}",
           height: '200px',
           suffix: " #{current_user.safe_settings.distance_unit}",
@@ -26,10 +26,10 @@
       <%# Centered lock overlay — only covers chart area %>
       <div class="absolute inset-0 flex flex-col items-center justify-center">
         <%= icon 'lock', class: 'w-6 h-6 opacity-30' %>
-        <p class="text-sm text-base-content/50 mt-1">Available on Pro</p>
+        <p class="text-sm text-base-content/50 mt-1"><%= t('.available_on_pro') %></p>
         <a href="<%= upgrade_url(utm_medium: 'stats', utm_content: "stats_year_#{year}") %>"
            class="btn btn-sm btn-primary mt-2" target="_blank" rel="noopener">
-          Upgrade to Pro
+          <%= t('.upgrade_to_pro') %>
         </a>
       </div>
     </div>

--- a/app/views/stats/_month.html.erb
+++ b/app/views/stats/_month.html.erb
@@ -5,12 +5,12 @@
   <div class="hero-content text-center relative w-full">
     <div class="max-w-md mt-5">
       <h1 class="text-4xl font-bold flex items-center justify-center gap-2">
-        <%= "#{icon month_icon(stat)} #{Date::MONTHNAMES[month]} #{year}".html_safe %>
+        <%= icon month_icon(stat) %> <%= l(Date.new(year, month, 1), format: :month_year) %>
       </h1>
-      <p class="py-4">Monthly Digest</p>
+      <p class="py-4"><%= t('.monthly_digest') %></p>
       <button class="btn btn-outline btn-sm text-neutral border-neutral hover:bg-white hover:text-primary"
               onclick="sharing_modal.showModal()">
-        <%= icon 'share' %> Share
+        <%= icon 'share' %> <%= t('.share') %>
       </button>
     </div>
   </div>
@@ -19,7 +19,7 @@
 <div class="stats shadow shadow-lg mx-auto mb-8 w-full">
   <div class="stat place-items-center text-center">
     <div class="stat-title flex items-center justify-center gap-1">
-      <%= icon 'map-plus' %> Distance traveled
+      <%= icon 'map-plus' %> <%= t('.distance_traveled') %>
     </div>
     <div class="stat-value text-success">~<%= distance_traveled(current_user, stat) %></div>
     <div class="stat-desc"><%= x_than_average_distance(stat, @average_distance_this_year) %></div>
@@ -27,7 +27,7 @@
 
   <div class="stat place-items-center text-center">
     <div class="stat-title flex items-center justify-center gap-1">
-      <%= icon 'calendar-check-2' %> Active days
+      <%= icon 'calendar-check-2' %> <%= t('.active_days') %>
     </div>
     <div class="stat-value text-secondary">
       <%= active_days(stat) %>
@@ -39,7 +39,7 @@
 
   <div class="stat place-items-center text-center">
     <div class="stat-title flex items-center justify-center gap-1">
-      <%= icon 'map-pin-plus' %> Countries visited
+      <%= icon 'map-pin-plus' %> <%= t('.countries_visited') %>
     </div>
     <div class="stat-value text-accent">
       <%= countries_visited(stat) %>
@@ -61,14 +61,14 @@
     <div class="flex justify-between items-center mb-4">
       <h2 class="card-title">
         <%= icon 'map' %>
-        Map Summary
+        <%= t('.map_summary') %>
       </h2>
       <div class="flex gap-2">
         <button class="btn btn-sm btn-outline btn-active" data-stat-page-target="heatmapBtn" data-action="click->stat-page#toggleHeatmap">
-          <%= icon 'flame' %> Heatmap
+          <%= icon 'flame' %> <%= t('.heatmap') %>
         </button>
         <button class="btn btn-sm btn-outline" data-stat-page-target="pointsBtn" data-action="click->stat-page#togglePoints">
-          <%= icon 'map-pin' %> Points
+          <%= icon 'map-pin' %> <%= t('.points') %>
         </button>
       </div>
     </div>
@@ -113,7 +113,7 @@
 <div class="card bg-base-100 shadow-xl mb-8">
   <div class="card-body">
     <h2 class="card-title">
-      <%= icon 'activity' %> Daily Activity
+      <%= icon 'activity' %> <%= t('.daily_activity') %>
     </h2>
     <div class="w-full h-48 bg-base-200 rounded-lg p-4 relative">
       <%= column_chart(
@@ -123,8 +123,8 @@
           id: "chart-month-daily-#{stat.year}-#{stat.month}",
           height: '200px',
           suffix: " #{current_user.safe_settings.distance_unit}",
-          xtitle: 'Day',
-          ytitle: 'Distance',
+          xtitle: t('.day'),
+          ytitle: t('.distance'),
           colors: [
             '#570df8', '#f000b8', '#ffea00',
             '#00d084', '#3abff8', '#ff5724',
@@ -149,7 +149,7 @@
         ) %>
     </div>
     <div class="text-sm opacity-70 text-center mt-2">
-      Peak day: <%= peak_day(stat) %> • Quietest week: <%= quietest_week(stat) %>
+      <%= t('.peak_day') %> <%= peak_day(stat) %> <%= t('.quietest_week') %> <%= quietest_week(stat) %>
     </div>
   </div>
 </div>
@@ -209,7 +209,7 @@
 <div class="card bg-base-100 shadow-xl mb-8">
   <div class="card-body">
     <h2 class="card-title">
-      <%= icon 'globe' %> Countries & Cities
+      <%= icon 'globe' %> <%= t('.countries_cities') %>
     </h2>
     <div class="space-y-4">
       <% visited_toponyms = stat.toponyms.select { |t| t['country'].present? && t['cities']&.any? } %>
@@ -226,7 +226,7 @@
             <div class="flex justify-between items-center">
               <span class="font-semibold"><%= country['country'] %></span>
               <span class="text-sm">
-                <%= pluralize(cities_count, 'city') %>
+                <%= t('.city_count', count: cities_count) %>
                 <% if progress_value > 0 %>
                   (<%= progress_value %>%)
                 <% end %>
@@ -237,7 +237,7 @@
         <% end %>
       <% else %>
         <div class="text-center text-gray-500">
-          <p>No location data available for this month</p>
+          <p><%= t('.no_location_data_available_for_this_month') %></p>
         </div>
       <% end %>
     </div>
@@ -245,7 +245,7 @@
     <div class="divider"></div>
 
     <div class="flex flex-wrap gap-2">
-      <span class="text-sm font-medium">Cities visited:</span>
+      <span class="text-sm font-medium"><%= t('.cities_visited') %></span>
       <% visited_toponyms.each do |country| %>
         <% country['cities'].each do |city| %>
           <div class="badge badge-outline"><%= city['city'] %></div>
@@ -312,9 +312,9 @@
 
 <!-- Action Buttons -->
 <div class="flex flex-wrap gap-4 mt-8 justify-center">
-  <a href="/stats/<%= year %>" class="btn btn-outline">← Back to <%= year %></a>
+  <a href="/stats/<%= year %>" class="btn btn-outline"><%= t('.back_to') %> <%= year %></a>
   <button class="btn btn-outline" onclick="sharing_modal.showModal()">
-    <%= icon 'share' %> Share
+    <%= icon 'share' %> <%= t('.share') %>
   </button>
 </div>
 

--- a/app/views/stats/_reverse_geocoding_stats.html.erb
+++ b/app/views/stats/_reverse_geocoding_stats.html.erb
@@ -3,10 +3,10 @@
     <div class="stat-value text-secondary">
       <%= number_with_delimiter @points_reverse_geocoded %>
     </div>
-    <div class="stat-title">Reverse geocoded points</div>
+    <div class="stat-title"><%= t('.reverse_geocoded_points') %></div>
     <div class="stat-title">
-      <span class="tooltip underline decoration-dotted" data-tip="Points that were reverse geocoded but had no data">
-        <%= number_with_delimiter @points_reverse_geocoded_without_data %> points without data
+      <span class="tooltip underline decoration-dotted" data-tip="<%= t('.points_that_were_reverse_geocoded_but_had_no_data') %>">
+        <%= number_with_delimiter @points_reverse_geocoded_without_data %> <%= t('.points_without_data') %>
       </span>
     </div>
   </div>
@@ -16,11 +16,11 @@
   <div class="stat-value text-warning underline hover:no-underline  hover:cursor-pointer" onclick="countries_visited.showModal()">
     <%= number_with_delimiter current_user.total_countries %>
   </div>
-  <div class="stat-title">Countries visited</div>
+  <div class="stat-title"><%= t('.countries_visited') %></div>
 
   <dialog id="countries_visited" class="modal">
     <div class="modal-box">
-      <h3 class="font-bold text-lg">Countries visited</h3>
+      <h3 class="font-bold text-lg"><%= t('.countries_visited') %></h3>
       <p class="py-4">
         <% current_user.countries_visited.each do |country| %>
           <p><%= country %></p>
@@ -28,7 +28,7 @@
       </p>
     </div>
     <form method="dialog" class="modal-backdrop">
-      <button>close</button>
+      <button><%= t('.close') %></button>
     </form>
   </dialog>
 </div>
@@ -37,10 +37,10 @@
   <div class="stat-value hover:cursor-pointer hover:no-underline underline" onclick="cities_visited.showModal()">
     <%= current_user.total_cities %>
   </div>
-  <div class="stat-title">Cities visited</div>
+  <div class="stat-title"><%= t('.cities_visited') %></div>
     <dialog id="cities_visited" class="modal">
       <div class="modal-box">
-        <h3 class="font-bold text-lg">Cities visited</h3>
+        <h3 class="font-bold text-lg"><%= t('.cities_visited') %></h3>
         <p class="py-4">
           <% current_user.cities_visited.each do |city| %>
             <p><%= city %></p>
@@ -48,7 +48,7 @@
         </p>
       </div>
       <form method="dialog" class="modal-backdrop">
-        <button>close</button>
+        <button><%= t('.close') %></button>
       </form>
     </dialog>
   </div>

--- a/app/views/stats/_stat.html.erb
+++ b/app/views/stats/_stat.html.erb
@@ -1,10 +1,10 @@
-<%= link_to "#{stat.year}/#{stat.month}",
+<%= link_to t('.year_month', year: stat.year, month: stat.month),
     class: "group block p-6 bg-base-100 hover:bg-base-200/50 rounded-xl border border-base-300 hover:border-primary/40 hover:shadow-lg transition-all duration-200 hover:scale-[1.02]" do %>
 
   <!-- Month and Year -->
   <div class="flex items-center justify-between mb-4">
     <h3 class="text-lg font-medium text-base-content group-hover:text-primary transition-colors flex items-center gap-2" style="color: <%= month_color(stat) %>;">
-      <%= "#{icon month_icon(stat)} #{Date::MONTHNAMES[stat.month]} #{stat.year}".html_safe %>
+      <%= icon month_icon(stat) %> <%= l(Date.new(stat.year, stat.month, 1), format: :month_year) %>
     </h3>
     <div class="opacity-0 group-hover:opacity-100 transition-opacity">
       <svg class="w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -21,7 +21,7 @@
         <%= number_with_delimiter stat.distance_in_unit(current_user.safe_settings.distance_unit).round %>
         <span class="text-sm font-normal text-base-content/60 ml-1"><%= current_user.safe_settings.distance_unit %></span>
       </div>
-      <div class="text-sm text-base-content/60">Total distance</div>
+      <div class="text-sm text-base-content/60"><%= t('.total_distance') %></div>
     </div>
 
     <!-- Location Summary -->

--- a/app/views/stats/_year.html.erb
+++ b/app/views/stats/_year.html.erb
@@ -1,6 +1,6 @@
 <h2 class='text-3xl font-bold mt-10'>
   <%= link_to year, "/stats/#{year}", class: "underline hover:no-underline text-#{header_colors.sample}" %>
-  <%= link_to '[Map]', preferred_map_path(year_timespan(year)), class: 'underline hover:no-underline' %>
+  <%= link_to t('.map'), preferred_map_path(year_timespan(year)), class: 'underline hover:no-underline' %>
 </h2>
 <div class='my-10'>
   <%= column_chart(
@@ -10,8 +10,8 @@
     id: "chart-year-distance-#{year}",
     height: '200px',
     suffix: " #{current_user.safe_settings.distance_unit}",
-    xtitle: 'Days',
-    ytitle: 'Distance',
+    xtitle: t('.days'),
+    ytitle: t('.distance'),
     colors: [
       '#397bb5', '#5A4E9D', '#3B945E',
       '#7BC96F', '#FFD54F', '#FFA94D',

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,11 +1,11 @@
-<% content_for :title, 'Statistics' %>
+<% content_for :title, t('.statistics') %>
 <%= render 'shared/chartkick_scripts' %>
 
 <div class="w-full my-5">
-  <%= render layout: 'shared/page_header', locals: { title: 'Statistics' } do %>
+  <%= render layout: 'shared/page_header', locals: { title: t('.statistics') } do %>
     <% if Date.today >= Date.new(2025, 12, 31) %>
       <%= link_to users_digests_path, class: 'btn btn-outline btn-sm' do %>
-        <%= icon 'earth' %> Year-End Digests
+        <%= icon 'earth' %> <%= t('.year_end_digests') %>
       <% end %>
     <% end %>
   <% end %>
@@ -18,14 +18,14 @@
         <div class="stat-value text-primary">
           <%= number_with_delimiter(current_user.total_distance.round) %> <%= current_user.safe_settings.distance_unit %>
         </div>
-        <div class="stat-title">Total distance</div>
+        <div class="stat-title"><%= t('.total_distance') %></div>
       </div>
 
       <div class="stat text-center">
         <div class="stat-value text-success">
           <%= number_with_delimiter @points_total %>
         </div>
-        <div class="stat-title">Geopoints tracked</div>
+        <div class="stat-title"><%= t('.geopoints_tracked') %></div>
       </div>
 
     <% if DawarichSettings.reverse_geocoding_enabled? %>
@@ -36,11 +36,11 @@
   <% end %>
 
   <div class='text-xs text-gray-500 text-center mt-5'>
-    All stats data above except for total distance and number of geopoints tracked is being updated daily
+    <%= t('.all_stats_data_above_except_for_total_distance_and_number') %>
   </div>
 
   <% if current_user.active? %>
-    <%= link_to 'Update stats', update_all_stats_path, data: { turbo_method: :put }, class: 'btn btn-primary mt-5' %>
+    <%= link_to t('.update_stats'), update_all_stats_path, data: { turbo_method: :put }, class: 'btn btn-primary mt-5' %>
   <% end %>
 
   <div class="mt-6 grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
@@ -51,10 +51,10 @@
           <h2 class="card-title justify-between text-<%= header_colors[year % header_colors.size] %>">
             <div>
               <%= link_to year, "/stats/#{year}", class: 'underline hover:no-underline' %>
-              <%= link_to '[Map]', preferred_map_path(year_timespan(year)), class: 'underline hover:no-underline' %>
+              <%= link_to t('.map'), preferred_map_path(year_timespan(year)), class: 'underline hover:no-underline' %>
             </div>
             <div class="flex items-center gap-2">
-              <span class='text-xs text-gray-500'>Last update: <%= human_date(stats.first.updated_at) %></span>
+              <span class='text-xs text-gray-500'><%= t('.last_update') %> <%= human_date(stats.first.updated_at) %></span>
               <%= link_to icon('refresh-ccw'), update_year_month_stats_path(year, :all), data: { turbo_method: :put }, class: 'text-sm text-gray-500 hover:text-primary' %>
             </div>
           </h2>
@@ -64,7 +64,7 @@
           <% if DawarichSettings.reverse_geocoding_enabled? %>
             <div class="card-actions justify-end">
               <% location_data = countries_and_cities_stat_for_year(year, stats) %>
-              <%= link_to "#{location_data[:countries_count]} countries, #{location_data[:cities_count]} cities",
+              <%= link_to t('.countries_count_countries_cities_count_cities', countries_count: location_data[:countries_count], cities_count: location_data[:cities_count]),
                          "#",
                          class: "link link-primary",
                          data: { turbo: false },
@@ -75,7 +75,7 @@
                 <input type="checkbox" id="<%= location_data[:modal_id] %>" class="modal-toggle" />
                 <div class="modal" role="dialog">
                   <div class="modal-box max-w-3xl">
-                    <h3 class="text-lg font-bold mb-4">Countries and Cities visited in <%= location_data[:year] %></h3>
+                    <h3 class="text-lg font-bold mb-4"><%= t('.countries_and_cities_visited_in') %> <%= location_data[:year] %></h3>
                     <div class="max-h-96 overflow-y-auto">
                       <% location_data[:grouped_by_country].each do |country, cities| %>
                         <div class="mb-4">
@@ -90,7 +90,7 @@
                               <% end %>
                             </div>
                           <% else %>
-                            <p class="text-sm text-gray-500 italic pl-4">No specific cities recorded</p>
+                            <p class="text-sm text-gray-500 italic pl-4"><%= t('.no_specific_cities_recorded') %></p>
                           <% end %>
                         </div>
                       <% end %>
@@ -110,8 +110,8 @@
             id: "chart-year-distance-#{year}",
             height: '200px',
             suffix: " #{current_user.safe_settings.distance_unit}",
-            xtitle: 'Days',
-            ytitle: 'Distance',
+            xtitle: t('.days'),
+            ytitle: t('.distance'),
             colors: month_colors,
             library: {
               datasets: {

--- a/app/views/stats/month.html.erb
+++ b/app/views/stats/month.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{Date::MONTHNAMES[@month]} #{@year} Monthly Digest" %>
+<% content_for :title, t('.month_year_monthly_digest', month: l(Date.new(@year, @month, 1), format: :month_name), year: @year) %>
 <%= render 'shared/chartkick_scripts' %>
 
 <div class="w-full my-5">

--- a/app/views/stats/public_month.html.erb
+++ b/app/views/stats/public_month.html.erb
@@ -7,37 +7,37 @@
     <div class="hero-content text-center py-8">
       <div class="max-w-lg">
         <h1 class="text-4xl font-bold flex items-center justify-center gap-2">
-          <%= "#{icon month_icon(@stat)} #{Date::MONTHNAMES[@month]} #{@year}".html_safe %>
+          <%= icon month_icon(@stat) %> <%= l(Date.new(@year, @month, 1), format: :month_year) %>
         </h1>
-        <p class="pt-6 pb-2">Monthly Digest</p>
+        <p class="pt-6 pb-2"><%= t('.monthly_digest') %></p>
       </div>
     </div>
   </div>
 
   <div class="stats shadow mx-auto mb-8 w-full">
     <div class="stat place-items-center text-center">
-      <div class="stat-title">Distance traveled</div>
+      <div class="stat-title"><%= t('.distance_traveled') %></div>
       <div class="stat-value"><%= distance_traveled(@user, @stat) %></div>
-      <div class="stat-desc">Total distance for this month</div>
+      <div class="stat-desc"><%= t('.total_distance_for_this_month') %></div>
     </div>
 
     <div class="stat place-items-center text-center">
-      <div class="stat-title">Active days</div>
+      <div class="stat-title"><%= t('.active_days') %></div>
       <div class="stat-value text-secondary">
         <%= active_days(@stat) %>
       </div>
       <div class="stat-desc text-secondary">
-        Days with tracked activity
+        <%= t('.days_with_tracked_activity') %>
       </div>
     </div>
 
     <div class="stat place-items-center text-center">
-      <div class="stat-title">Countries visited</div>
+      <div class="stat-title"><%= t('.countries_visited') %></div>
       <div class="stat-value">
         <%= countries_visited(@stat) %>
       </div>
       <div class="stat-desc">
-        Different countries
+        <%= t('.different_countries') %>
       </div>
     </div>
   </div>
@@ -50,7 +50,7 @@
         <div class="flex justify-between items-center">
           <div class="flex items-center gap-4">
             <h3 class="font-semibold text-lg flex items-center gap-2">
-              <%= icon 'map' %> Location Hexagons
+              <%= icon 'map' %> <%= t('.location_hexagons') %>
             </h3>
           </div>
         </div>
@@ -72,7 +72,7 @@
         <div id="map-loading" class="absolute inset-0 bg-base-200 bg-opacity-80 flex items-center justify-center z-50">
           <div class="text-center">
             <span class="loading loading-spinner loading-lg text-primary"></span>
-            <p class="text-sm mt-2 text-base-content">Loading hexagons...</p>
+            <p class="text-sm mt-2 text-base-content"><%= t('.loading_hexagons') %></p>
           </div>
         </div>
       </div>
@@ -83,7 +83,7 @@
   <div class="card bg-base-100 shadow-xl mb-8">
     <div class="card-body">
       <h2 class="card-title">
-        <%= icon 'trending-up' %> Daily Activity
+        <%= icon 'trending-up' %> <%= t('.daily_activity') %>
         </h2>
       <div class="w-full h-48 bg-base-200 rounded-lg p-4 relative">
         <%= column_chart(
@@ -91,9 +91,9 @@
               [day, Stat.convert_distance(distance_meters, 'km').round]
             },
             height: '200px',
-            suffix: " km",
-            xtitle: 'Day',
-            ytitle: 'Distance',
+            suffix: t('units.kilometers_suffix'),
+            xtitle: t('.day'),
+            ytitle: t('.distance'),
             colors: [
               '#570df8', '#f000b8', '#ffea00',
               '#00d084', '#3abff8', '#ff5724',
@@ -118,7 +118,7 @@
           ) %>
       </div>
       <div class="text-sm opacity-70 text-center mt-2">
-        Peak day: <%= peak_day(@stat) %> • Quietest week: <%= quietest_week(@stat) %>
+        <%= t('.peak_day') %> <%= peak_day(@stat) %> <%= t('.quietest_week') %> <%= quietest_week(@stat) %>
       </div>
     </div>
   </div>
@@ -127,7 +127,7 @@
   <div class="card bg-base-100 shadow-xl mb-8">
     <div class="card-body">
       <h2 class="card-title">
-        <%= icon 'earth' %> Countries & Cities
+        <%= icon 'earth' %> <%= t('.countries_cities') %>
       </h2>
       <div class="space-y-4">
         <% visited_toponyms = @stat.toponyms.select { |t| t['country'].present? && t['cities']&.any? } %>
@@ -135,7 +135,7 @@
           <div class="space-y-2">
             <div class="flex justify-between items-center">
               <span class="font-semibold"><%= country['country'] %></span>
-              <span class="text-sm"><%= country['cities'].length %> cities</span>
+              <span class="text-sm"><%= country['cities'].length %> <%= t('.cities') %></span>
             </div>
             <progress class="progress progress-primary w-full" value="<%= 100 - (index * 20) %>" max="100"></progress>
           </div>
@@ -145,13 +145,13 @@
       <div class="divider"></div>
 
       <div class="flex flex-wrap gap-2">
-        <span class="text-sm font-medium">Cities visited:</span>
+        <span class="text-sm font-medium"><%= t('.cities_visited') %></span>
         <% visited_toponyms.each do |country| %>
           <% country['cities'].first(5).each do |city| %>
             <div class="badge badge-outline"><%= city['city'] %></div>
           <% end %>
           <% if country['cities'].length > 5 %>
-            <div class="badge badge-ghost">+<%= country['cities'].length - 5 %> more</div>
+            <div class="badge badge-ghost">+<%= country['cities'].length - 5 %> <%= t('.more') %></div>
           <% end %>
         <% end %>
       </div>
@@ -161,7 +161,7 @@
   <!-- Footer -->
   <div class="text-center py-8">
     <div class="text-sm text-gray-500">
-      Powered by <a href="https://dawarich.app" class="link link-primary" target="_blank">Dawarich</a>, your personal memories mapper.
+      <%= t('.powered_by') %> <a href="https://dawarich.app" class="link link-primary" target="_blank"><%= t('.dawarich') %></a><%= t('.your_personal_memories_mapper') %>
     </div>
   </div>
 </div>

--- a/app/views/stats/show.html.erb
+++ b/app/views/stats/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Statistics for #{@year} year" %>
+<% content_for :title, t('.statistics_for_year_year', year: @year) %>
 <%= render 'shared/chartkick_scripts' %>
 
 <div class="w-full my-5">

--- a/app/views/tags/_form.html.erb
+++ b/app/views/tags/_form.html.erb
@@ -2,7 +2,7 @@
   <% if tag.errors.any? %>
     <div class="alert alert-error">
       <div>
-        <h3 class="font-bold"><%= pluralize(tag.errors.count, "error") %> prohibited this tag from being saved:</h3>
+        <h3 class="font-bold"><%= t('.errors_prohibited_save', count: tag.errors.count) %></h3>
         <ul class="list-disc list-inside">
           <% tag.errors.full_messages.each do |message| %>
             <li><%= message %></li>
@@ -14,7 +14,7 @@
 
   <div class="form-control">
     <%= f.label :name, class: "label" %>
-    <%= f.text_field :name, class: "input input-bordered w-full", placeholder: "Home, Work, Restaurant..." %>
+    <%= f.text_field :name, class: "input input-bordered w-full", placeholder: t('.home_work_restaurant') %>
   </div>
 
   <div class="grid grid-cols-2 gap-4">
@@ -40,7 +40,7 @@
         <%= f.hidden_field :icon, value: default_emoji, data: { emoji_picker_target: "input" } %>
       </div>
       <label class="label">
-        <span class="label-text-alt">Click to select an emoji</span>
+        <span class="label-text-alt"><%= t('.click_to_select_an_emoji') %></span>
       </label>
     </div>
 
@@ -71,7 +71,7 @@
         <!-- Custom Color Picker -->
         <div class="flex items-center gap-3">
           <label class="flex items-center gap-2 cursor-pointer group">
-            <span class="text-sm font-medium">Custom:</span>
+            <span class="text-sm font-medium"><%= t('.custom') %></span>
             <input type="color"
                    class="w-12 h-12 rounded-lg cursor-pointer border-2 border-base-300 hover:scale-105 transition-transform color-input"
                    value="<%= tag.color.presence || '#6ab0a4' %>"
@@ -94,7 +94,7 @@
       <%= f.hidden_field :color, value: tag.color.presence || '#6ab0a4', data: { color_picker_target: "input" } %>
 
       <label class="label">
-        <span class="label-text-alt">Choose from swatches or pick a custom color</span>
+        <span class="label-text-alt"><%= t('.choose_from_swatches_or_pick_a_custom_color') %></span>
       </label>
     </div>
   </div>
@@ -103,7 +103,7 @@
   <div data-controller="privacy-radius">
     <div class="form-control">
       <label class="label cursor-pointer">
-        <span class="label-text font-semibold"><%= icon 'lock-open', class: "inline-block w-4" %> Privacy Zone</span>
+        <span class="label-text font-semibold"><%= icon 'lock-open', class: "inline-block w-4" %> <%= t('.privacy_zone') %></span>
         <input type="checkbox"
                class="toggle toggle-error"
                data-privacy-radius-target="toggle"
@@ -111,13 +111,13 @@
                <%= 'checked' if tag.privacy_radius_meters.present? %>>
       </label>
       <label class="label">
-        <span class="label-text-alt">Hide map data around places with this tag</span>
+        <span class="label-text-alt"><%= t('.hide_map_data_around_places_with_this_tag') %></span>
       </label>
     </div>
 
     <div class="form-control <%= 'hidden' unless tag.privacy_radius_meters.present? %>"
          data-privacy-radius-target="radiusInput">
-      <%= f.label :privacy_radius_meters, "Privacy Radius", class: "label" %>
+      <%= f.label :privacy_radius_meters, t('.privacy_radius'), class: "label" %>
       <div class="flex flex-col gap-2">
         <input type="range"
                min="50"
@@ -128,18 +128,18 @@
                data-privacy-radius-target="slider"
                data-action="input->privacy-radius#updateFromSlider">
         <div class="flex justify-between text-xs px-2">
-          <span>50m</span>
+          <span><%= t('units.meters_compact', value: 50) %></span>
           <span class="font-semibold" data-privacy-radius-target="label">
             <%= tag.privacy_radius_meters || 1000 %>m
           </span>
-          <span>5000m</span>
+          <span><%= t('units.meters_compact', value: 5000) %></span>
         </div>
         <%= f.hidden_field :privacy_radius_meters,
             value: tag.privacy_radius_meters,
             data: { privacy_radius_target: "field" } %>
       </div>
       <label class="label">
-        <span class="label-text-alt">Data within this radius will be hidden from the map</span>
+        <span class="label-text-alt"><%= t('.data_within_this_radius_will_be_hidden_from_the_map') %></span>
       </label>
     </div>
   </div>
@@ -147,7 +147,7 @@
   <div class="form-control mt-6">
     <div class="flex gap-2">
       <%= f.submit class: "btn btn-primary" %>
-      <%= link_to "Cancel", tags_path, class: "btn btn-ghost" %>
+      <%= link_to t('.cancel'), tags_path, class: "btn btn-ghost" %>
     </div>
   </div>
 <% end %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
   <div class="mb-6">
-    <h1 class="text-3xl font-bold">Edit Tag</h1>
-    <p class="text-gray-600 mt-2">Update your tag details</p>
+    <h1 class="text-3xl font-bold"><%= t('.edit_tag') %></h1>
+    <p class="text-gray-600 mt-2"><%= t('.update_your_tag_details') %></p>
   </div>
 
   <div class="card bg-base-100 shadow-xl">

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full my-5">
-  <%= render layout: 'shared/page_header', locals: { title: 'Tags' } do %>
+  <%= render layout: 'shared/page_header', locals: { title: t('.tags') } do %>
     <%= link_to new_tag_path, class: "btn btn-primary btn-sm" do %>
-      <%= icon 'circle-plus', class: 'w-4 h-4' %> New Tag
+      <%= icon 'circle-plus', class: 'w-4 h-4' %> <%= t('.new_tag') %>
     <% end %>
   <% end %>
 
@@ -10,11 +10,11 @@
       <table class="table table-sm w-full">
         <thead class="bg-base-200">
           <tr>
-            <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-16">Icon</th>
-            <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50">Name</th>
-            <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50">Color</th>
-            <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 text-right">Places</th>
-            <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 text-right">Actions</th>
+            <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 w-16"><%= t('.icon') %></th>
+            <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50"><%= t('.name') %></th>
+            <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50"><%= t('.color') %></th>
+            <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 text-right"><%= t('.places') %></th>
+            <th class="px-4 py-3 text-xs uppercase tracking-wider text-base-content/50 text-right"><%= t('.actions') %></th>
           </tr>
         </thead>
         <tbody>
@@ -44,14 +44,14 @@
               <td class="px-4 py-3 text-right tabular-nums"><%= tag.places.size %></td>
               <td class="px-4 py-3 text-right">
                 <div class="flex gap-1 justify-end">
-                  <div class="tooltip" data-tip="Edit tag">
+                  <div class="tooltip" data-tip="<%= t('.edit_tag') %>">
                     <%= link_to edit_tag_path(tag), class: "btn btn-ghost btn-xs" do %>
                       <%= icon 'square-pen', class: 'w-4 h-4' %>
                     <% end %>
                   </div>
-                  <div class="tooltip tooltip-left" data-tip="Delete tag">
+                  <div class="tooltip tooltip-left" data-tip="<%= t('.delete_tag') %>">
                     <%= button_to tag_path(tag), method: :delete,
-                        data: { turbo_confirm: "Are you sure?", turbo_method: :delete },
+                        data: { turbo_confirm: t('.are_you_sure'), turbo_method: :delete },
                         class: "btn btn-ghost btn-xs text-error hover:bg-error/10" do %>
                       <%= icon 'trash-2', class: 'w-4 h-4' %>
                     <% end %>
@@ -65,12 +65,12 @@
     </div>
   <% else %>
     <div class="text-center py-16 px-8 bg-base-200 rounded-xl border-2 border-dashed border-base-300">
-      <h3 class="text-xl font-bold mb-3">No tags yet</h3>
+      <h3 class="text-xl font-bold mb-3"><%= t('.no_tags_yet') %></h3>
       <p class="text-base-content/50 mb-6 max-w-sm mx-auto">
-        Create tags to organize your places and add privacy zones.
+        <%= t('.create_tags_to_organize_your_places_and_add_privacy_zones') %>
       </p>
       <%= link_to new_tag_path, class: 'btn btn-primary' do %>
-        <%= icon 'circle-plus', class: 'w-4 h-4' %> Create your first tag
+        <%= icon 'circle-plus', class: 'w-4 h-4' %> <%= t('.create_your_first_tag') %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/tags/new.html.erb
+++ b/app/views/tags/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
   <div class="mb-6">
-    <h1 class="text-3xl font-bold">New Tag</h1>
-    <p class="text-gray-600 mt-2">Create a new tag to organize your places</p>
+    <h1 class="text-3xl font-bold"><%= t('.new_tag') %></h1>
+    <p class="text-gray-600 mt-2"><%= t('.create_a_new_tag_to_organize_your_places') %></p>
   </div>
 
   <div class="card bg-base-100 shadow-xl">

--- a/app/views/tracks/segments/_segment_row.html.erb
+++ b/app/views/tracks/segments/_segment_row.html.erb
@@ -21,13 +21,13 @@
                   font-medium underline decoration-dotted underline-offset-4
                   decoration-base-content/25 hover:decoration-base-content/70
                   focus-within:decoration-base-content/70 transition-colors">
-      <span><%= segment.transportation_mode.titleize %></span>
+      <span><%= t("transportation_modes.#{segment.transportation_mode}") %></span>
       <span class="text-base-content/40 text-[10px] leading-none mt-px" aria-hidden="true">▾</span>
       <%= f.select :transportation_mode,
                    modes_for_segment(segment, current_user),
                    { selected: segment.transportation_mode },
                    class: "absolute inset-0 w-full h-full opacity-0 cursor-pointer",
-                   "aria-label": "Transportation mode (currently #{segment.transportation_mode.titleize})",
+                   "aria-label": t('.transportation_mode_currently', mode: t("transportation_modes.#{segment.transportation_mode}")),
                    data: {
                      action: "change->segment-mode-editor#submit",
                      testid: "segment-mode-select-#{segment.id}"
@@ -36,8 +36,8 @@
 
     <% if segment.manually_corrected? %>
       <span class="shrink-0 text-info/80 leading-none"
-            title="Edited <%= time_ago_in_words(segment.corrected_at) %> ago"
-            aria-label="Manually corrected">
+            title="<%= t('.edited_ago', time: time_ago_in_words(segment.corrected_at)) %>"
+            aria-label="<%= t('.manually_corrected') %>">
         <%= icon 'square-pen', class: 'w-3 h-3' %>
       </span>
     <% end %>
@@ -52,8 +52,8 @@
       <%= f.button name: "reset", value: "true",
                    type: "submit",
                    class: "btn btn-ghost btn-xs btn-square shrink-0 ml-auto opacity-60 hover:opacity-100",
-                   title: "Restore auto-detection",
-                   "aria-label": "Reset to auto-detected mode",
+                   title: t('.restore_auto_detection'),
+                   "aria-label": t('.reset_to_auto_detected_mode'),
                    data: { testid: "segment-reset-#{segment.id}" } do %>
         <%= icon 'rotate-ccw', class: 'w-3.5 h-3.5' %>
       <% end %>

--- a/app/views/tracks/segments/index.html.erb
+++ b/app/views/tracks/segments/index.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "track-#{@track.id}-segments", class: "track-segments-list" do %>
   <% if @segments.empty? %>
-    <p class="text-sm text-base-content/60">No segments for this track yet.</p>
+    <p class="text-sm text-base-content/60"><%= t('.no_segments_for_this_track_yet') %></p>
   <% else %>
     <% @segments.each do |segment| %>
       <%= render partial: "tracks/segments/segment_row", locals: { segment: segment } %>

--- a/app/views/tracks/share_links/new.html.erb
+++ b/app/views/tracks/share_links/new.html.erb
@@ -1,8 +1,8 @@
 <%= render 'shared_links/modal',
            resource: @track,
            share: @share,
-           title: "Share #{track_share_label(@track, current_user.safe_settings.distance_unit)}",
-           subtitle: "This track is shared via a public link.",
+           title: t('.share_track', track: track_share_label(@track, current_user.safe_settings.distance_unit)),
+           subtitle: t('.this_track_is_shared_via_a_public_link'),
            close_path: map_v2_path,
            paths: {
              create:            track_share_link_path(@track),

--- a/app/views/trial/resume/show.html.erb
+++ b/app/views/trial/resume/show.html.erb
@@ -1,19 +1,17 @@
 <div class="hero min-h-[70vh] bg-base-200 rounded-box">
   <div class="hero-content text-center">
     <div class="max-w-lg">
-      <h1 class="text-4xl font-bold">Finish setting up your account</h1>
+      <h1 class="text-4xl font-bold"><%= t('.finish_setting_up_your_account') %></h1>
       <p class="py-6">
-        Your account is almost ready. To start tracking your location data, please
-        complete your subscription checkout. You won't be charged during the
-        7-day free trial — cancel anytime before it ends and you won't be billed.
+        <%= t('.your_account_is_almost_ready_to_start_tracking_your_location') %>
       </p>
-      <%= link_to 'Resume checkout', @checkout_url,
+      <%= link_to t('.resume_checkout'), @checkout_url,
             class: 'btn btn-primary btn-lg',
             data: { turbo: false } %>
       <div class="mt-6 text-sm">
-        <%= link_to 'Or delete my account',
+        <%= link_to t('.or_delete_my_account'),
               user_registration_path,
-              data: { turbo_method: :delete, turbo_confirm: 'Are you sure? This cannot be undone.' },
+              data: { turbo_method: :delete, turbo_confirm: t('.are_you_sure_this_cannot_be_undone') },
               class: 'link link-hover text-base-content/60' %>
       </div>
     </div>

--- a/app/views/trips/_countries.html.erb
+++ b/app/views/trips/_countries.html.erb
@@ -1,13 +1,13 @@
 <div class="mb-4">
   <p class="text-base-content/60 text-sm">
     <%= trip.distance_in_unit(distance_unit).round %> <%= distance_unit %>
-    &middot;
+    <%= t('.middot').html_safe %>
     <%= trip_duration(trip) %>
-    &middot;
+    <%= t('.middot').html_safe %>
     <% if trip.visited_countries.any? %>
-      <%= pluralize(trip.visited_countries.count, 'country', 'countries') %>
+      <%= t('.country_count', count: trip.visited_countries.count) %>
     <% else %>
-      <span class="text-base-content/40">&mdash;</span>
+      <span class="text-base-content/40"><%= t('.mdash').html_safe %></span>
     <% end %>
   </p>
   <% if trip.visited_countries.any? %>

--- a/app/views/trips/_distance.html.erb
+++ b/app/views/trips/_distance.html.erb
@@ -1,6 +1,6 @@
 <% if trip.distance.present? %>
   <span class="text-md"><%= trip.distance_in_unit(distance_unit).round %> <%= distance_unit %></span>
 <% else %>
-  <span class="text-md">Calculating...</span>
+  <span class="text-md"><%= t('.calculating') %></span>
   <span class="loading loading-dots loading-sm"></span>
 <% end %>

--- a/app/views/trips/_form.html.erb
+++ b/app/views/trips/_form.html.erb
@@ -2,7 +2,7 @@
 <%= form_with(model: trip, class: "contents") do |form| %>
   <% if trip.errors.any? %>
     <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
-      <h2><%= pluralize(trip.errors.count, "error") %> prohibited this trip from being saved:</h2>
+      <h2><%= t('.errors_prohibited_save', count: trip.errors.count) %></h2>
 
       <ul>
         <% trip.errors.each do |error| %>

--- a/app/views/trips/_recalculate_button.html.erb
+++ b/app/views/trips/_recalculate_button.html.erb
@@ -1,17 +1,17 @@
 <%= turbo_frame_tag "trip_recalculate_frame" do %>
   <% if trip.recalculating? %>
     <button class="btn btn-outline btn-sm" disabled>
-      <span class="loading loading-spinner loading-xs"></span> Recalculating&hellip;
+      <span class="loading loading-spinner loading-xs"></span> <%= t('.recalculating_hellip') %>
     </button>
   <% else %>
     <%= button_to recalculate_trip_path(trip),
         method: :post,
-        form: { data: { turbo_confirm: "Recalculate this trip's path, distance, and countries from your latest points?" } },
+        form: { data: { turbo_confirm: t('.recalculate_this_trip_s_path_distance_and_countries_from_your') } },
         class: "btn btn-outline btn-sm" do %>
-      <%= icon 'refresh-ccw', class: 'w-4 h-4' %> Recalculate
+      <%= icon 'refresh-ccw', class: 'w-4 h-4' %> <%= t('.recalculate') %>
     <% end %>
     <% if local_assigns[:error] %>
-      <span class="text-error text-xs ml-2">Recalculation failed — try again.</span>
+      <span class="text-error text-xs ml-2"><%= t('.recalculation_failed_try_again') %></span>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/trips/_trip.html.erb
+++ b/app/views/trips/_trip.html.erb
@@ -13,13 +13,13 @@
       </div>
     <% elsif trip.distance.present? %>
       <div style="width: 100%; aspect-ratio: 16/10;" class="flex items-center justify-center bg-base-200">
-        <p class="text-base-content/40 text-sm">No points found</p>
+        <p class="text-base-content/40 text-sm"><%= t('.no_points_found') %></p>
       </div>
     <% else %>
       <div style="width: 100%; aspect-ratio: 16/10;" class="flex items-center justify-center bg-base-200">
         <div class="text-center">
           <div class="loading loading-spinner loading-sm"></div>
-          <p class="text-base-content/40 text-xs mt-1">Calculating...</p>
+          <p class="text-base-content/40 text-xs mt-1"><%= t('.calculating') %></p>
         </div>
       </div>
     <% end %>
@@ -28,7 +28,7 @@
     <div class="px-4 py-3">
       <h3 class="font-semibold text-base group-hover:text-primary transition-colors truncate"><%= trip.name %></h3>
       <p class="text-xs text-base-content/50 mt-0.5">
-        <%= human_date(trip.started_at) %> &ndash; <%= human_date(trip.ended_at) %>
+        <%= human_date(trip.started_at) %> <%= t('.ndash') %> <%= human_date(trip.ended_at) %>
       </p>
 
       <div class="flex items-center justify-between mt-3">
@@ -42,7 +42,7 @@
             </span>
           <% end %>
           <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-primary/10 text-primary">
-            <%= pluralize([((trip.ended_at - trip.started_at) / 1.day).ceil, 1].max, 'day') %>
+            <%= t('.day_count', count: [((trip.ended_at - trip.started_at) / 1.day).ceil, 1].max) %>
           </span>
         </div>
       </div>

--- a/app/views/trips/edit.html.erb
+++ b/app/views/trips/edit.html.erb
@@ -1,14 +1,14 @@
 <div class="mx-auto md:w-2/3 w-full my-5">
-  <%= render 'shared/page_header', title: 'Editing trip' %>
+  <%= render 'shared/page_header', title: t('.editing_trip') %>
 
   <%= render "form", trip: @trip %>
 
   <!-- Action Buttons Section -->
   <div class="bg-base-100 items-center mt-8 mb-4">
     <div class="flex flex-wrap gap-2 justify-center">
-      <%= link_to "Show this trip", @trip, class: "btn" %>
+      <%= link_to t('.show_this_trip'), @trip, class: "btn" %>
       <%= link_to trips_path, class: "btn btn-sm btn-ghost gap-1" do %>
-        <%= icon 'arrow-left', class: 'w-4 h-4' %> Back to trips
+        <%= icon 'arrow-left', class: 'w-4 h-4' %> <%= t('.back_to_trips') %>
       <% end %>
     </div>
   </div>

--- a/app/views/trips/index.html.erb
+++ b/app/views/trips/index.html.erb
@@ -1,21 +1,21 @@
-<% content_for :title, 'Trips' %>
+<% content_for :title, t('.trips') %>
 
 <div class="w-full my-5">
   <div id="trips" class="min-w-full">
-    <%= render layout: 'shared/page_header', locals: { title: 'Trips' } do %>
+    <%= render layout: 'shared/page_header', locals: { title: t('.trips') } do %>
       <%= link_to new_trip_path, class: 'btn btn-primary btn-sm' do %>
-        <%= icon 'circle-plus', class: 'w-4 h-4' %> New trip
+        <%= icon 'circle-plus', class: 'w-4 h-4' %> <%= t('.new_trip') %>
       <% end %>
     <% end %>
 
     <% if @trips.empty? %>
       <div class="text-center py-16 px-8 bg-base-200 rounded-xl border-2 border-dashed border-base-300">
-        <h3 class="text-xl font-bold mb-3">No trips yet</h3>
+        <h3 class="text-xl font-bold mb-3"><%= t('.no_trips_yet') %></h3>
         <p class="text-base-content/50 mb-6 max-w-sm mx-auto">
-          Create your first trip to see your journeys visualized with maps, photos, and stats.
+          <%= t('.create_your_first_trip_to_see_your_journeys_visualized_with') %>
         </p>
         <%= link_to new_trip_path, class: 'btn btn-primary' do %>
-          <%= icon 'circle-plus', class: 'w-4 h-4' %> Create your first trip
+          <%= icon 'circle-plus', class: 'w-4 h-4' %> <%= t('.create_your_first_trip') %>
         <% end %>
       </div>
     <% else %>

--- a/app/views/trips/new.html.erb
+++ b/app/views/trips/new.html.erb
@@ -1,11 +1,11 @@
-<% content_for :title, 'New trip' %>
+<% content_for :title, t('.new_trip') %>
 
 <div class="mx-auto md:w-2/3 w-full my-5">
-  <%= render 'shared/page_header', title: 'New trip' %>
+  <%= render 'shared/page_header', title: t('.new_trip') %>
 
   <%= render "form", trip: @trip %>
 
   <%= link_to trips_path, class: "btn btn-sm btn-ghost gap-1" do %>
-    <%= icon 'arrow-left', class: 'w-4 h-4' %> Back to trips
+    <%= icon 'arrow-left', class: 'w-4 h-4' %> <%= t('.back_to_trips') %>
   <% end %>
 </div>

--- a/app/views/trips/notes/_empty.html.erb
+++ b/app/views/trips/notes/_empty.html.erb
@@ -3,7 +3,7 @@
     <button class="btn btn-sm btn-ghost"
             data-action="click->trip-maplibre#showNoteForm"
             data-date="<%= date %>">
-      + Add note
+      <%= t('.add_note') %>
     </button>
   </div>
 
@@ -14,13 +14,13 @@
         <textarea name="note[body]"
                   class="textarea textarea-bordered w-full min-h-[100px]"
                   maxlength="10000"
-                  placeholder="Write your notes for this day..."></textarea>
+                  placeholder="<%= t('.write_your_notes_for_this_day') %>"></textarea>
       </div>
       <div class="flex gap-2">
-        <button type="submit" class="btn btn-primary btn-sm">Save note</button>
+        <button type="submit" class="btn btn-primary btn-sm"><%= t('.save_note') %></button>
         <button type="button" class="btn btn-ghost btn-sm"
                 data-action="click->trip-maplibre#hideNoteForm"
-                data-date="<%= date %>">Cancel</button>
+                data-date="<%= date %>"><%= t('.cancel') %></button>
       </div>
     <% end %>
   </div>

--- a/app/views/trips/notes/_form.html.erb
+++ b/app/views/trips/notes/_form.html.erb
@@ -16,17 +16,17 @@
       <textarea name="note[body]"
                 class="textarea textarea-bordered w-full min-h-[100px]"
                 maxlength="10000"
-                placeholder="Write your notes for this day..."><%= note.body %></textarea>
+                placeholder="<%= t('.write_your_notes_for_this_day') %>"><%= note.body %></textarea>
     </div>
 
     <div class="flex gap-2">
-      <%= form.submit note.persisted? ? "Update note" : "Save note",
+      <%= form.submit t(note.persisted? ? '.update_note' : '.save_note'),
           class: "btn btn-primary btn-sm" %>
       <button type="button"
               class="btn btn-ghost btn-sm"
               data-action="click->trip-maplibre#hideNoteForm"
               data-date="<%= note.date %>">
-        Cancel
+        <%= t('.cancel') %>
       </button>
     </div>
   <% end %>

--- a/app/views/trips/notes/_note.html.erb
+++ b/app/views/trips/notes/_note.html.erb
@@ -7,13 +7,13 @@
       <button class="btn btn-xs btn-ghost"
               data-action="click->trip-maplibre#showNoteForm"
               data-date="<%= note.date %>">
-        Edit
+        <%= t('.edit') %>
       </button>
-      <%= button_to "Delete",
+      <%= button_to t('.delete'),
           trip_note_path(trip, note),
           method: :delete,
           class: "btn btn-xs btn-ghost text-error",
-          data: { turbo_confirm: "Delete this note?" } %>
+          data: { turbo_confirm: t('.delete_this_note') } %>
     </div>
   </div>
 
@@ -36,14 +36,14 @@
         <textarea name="note[body]"
                   class="textarea textarea-bordered w-full min-h-[100px]"
                   maxlength="10000"
-                  placeholder="Write your notes for this day..."><%= note.body %></textarea>
+                  placeholder="<%= t('.write_your_notes_for_this_day') %>"><%= note.body %></textarea>
       </div>
 
       <div class="flex gap-2">
-        <%= form.submit "Update note", class: "btn btn-primary btn-sm" %>
+        <%= form.submit t('.update_note'), class: "btn btn-primary btn-sm" %>
         <button type="button" class="btn btn-ghost btn-sm"
                 data-action="click->trip-maplibre#hideNoteForm"
-                data-date="<%= note.date %>">Cancel</button>
+                data-date="<%= note.date %>"><%= t('.cancel') %></button>
       </div>
     <% end %>
   </div>

--- a/app/views/trips/share_links/new.html.erb
+++ b/app/views/trips/share_links/new.html.erb
@@ -1,8 +1,8 @@
 <%= render 'shared_links/modal',
            resource: @trip,
            share: @share,
-           title: "Share #{@trip.name}",
-           subtitle: "#{@trip.name} is shared via a public link.",
+           title: t('.share_trip', trip: @trip.name),
+           subtitle: t('.trip_is_shared_via_a_public_link', trip: @trip.name),
            close_path: trip_path(@trip),
            paths: {
              create:            trip_share_link_path(@trip),

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -22,14 +22,14 @@
           <div data-trip-maplibre-target="loadingIndicator"
                class="absolute bottom-4 left-4 z-10 bg-base-100/80 backdrop-blur-sm rounded-lg px-3 py-2 flex items-center gap-2 hidden">
             <span class="loading loading-spinner loading-sm"></span>
-            <span class="text-sm">Loading route data...</span>
+            <span class="text-sm"><%= t('.loading_route_data') %></span>
           </div>
           <%= render "shared/replay_panel", stimulus: "trip-maplibre", show_day_nav: true %>
         </div>
       <% else %>
         <div class="flex items-center justify-center h-full rounded-lg bg-base-200">
           <div class="text-center">
-            <p class="text-base-content/60">Trip path is being calculated...</p>
+            <p class="text-base-content/60"><%= t('.trip_path_is_being_calculated') %></p>
             <div class="loading loading-spinner loading-lg mt-4"></div>
           </div>
         </div>
@@ -44,17 +44,17 @@
           <h1 class="text-3xl font-bold leading-tight"><%= @trip.name %></h1>
           <div class="flex items-center gap-1 shrink-0">
             <div class="dropdown dropdown-end">
-              <label tabindex="0" class="btn btn-sm btn-ghost" title="Download trip">
+              <label tabindex="0" class="btn btn-sm btn-ghost" title="<%= t('.download_trip') %>">
                 <%= icon 'download', class: 'w-4 h-4' %>
               </label>
               <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-44 z-10">
                 <li>
-                  <%= link_to 'GPX',
+                  <%= link_to t('.gpx'),
                               export_trip_path(@trip, file_format: 'gpx'),
                               data: { turbo_method: :post } %>
                 </li>
                 <li>
-                  <%= link_to 'GeoJSON',
+                  <%= link_to t('.geojson'),
                               export_trip_path(@trip, file_format: 'json'),
                               data: { turbo_method: :post } %>
                 </li>
@@ -62,30 +62,30 @@
             </div>
             <%= link_to edit_trip_path(@trip),
                 class: "btn btn-sm btn-ghost",
-                title: "Edit trip" do %>
+                title: t('.edit_trip') do %>
               <%= icon 'square-pen', class: 'w-4 h-4' %>
             <% end %>
             <% trip_share = @trip.shared_links.active.first %>
             <%= link_to new_trip_share_link_path(@trip),
                 class: "btn btn-sm btn-ghost relative",
-                title: "Share trip",
+                title: t('.share_trip'),
                 data: { turbo_frame: "share-link-modal" } do %>
               <%= icon 'share', class: 'w-4 h-4' %>
               <% if trip_share %>
-                <span class="badge badge-success badge-xs" aria-label="Currently shared">Public</span>
+                <span class="badge badge-success badge-xs" aria-label="<%= t('.currently_shared') %>"><%= t('.public') %></span>
               <% end %>
             <% end %>
             <%= button_to trip_path(@trip),
                 method: :delete,
-                form: { data: { turbo_confirm: "Delete this trip? This cannot be undone." } },
+                form: { data: { turbo_confirm: t('.delete_this_trip_this_cannot_be_undone') } },
                 class: "btn btn-sm btn-ghost text-error",
-                title: "Delete trip" do %>
+                title: t('.delete_trip') do %>
               <%= icon 'trash-2', class: 'w-4 h-4' %>
             <% end %>
           </div>
         </div>
         <p class="text-md text-base-content/60 mb-4">
-          <%= human_date(@trip.started_at) %> &ndash; <%= human_date(@trip.ended_at) %>
+          <%= human_date(@trip.started_at) %> <%= t('.ndash') %> <%= human_date(@trip.ended_at) %>
         </p>
 
         <%= render "trips/countries", trip: @trip, current_user: current_user, distance_unit: current_user.safe_settings.distance_unit %>
@@ -99,9 +99,9 @@
                   class="btn btn-sm btn-outline gap-1"
                   data-trip-maplibre-target="photosToggleBtn"
                   data-action="click->trip-maplibre#togglePhotos"
-                  title="Toggle photo markers on map">
+                  title="<%= t('.toggle_photo_markers_on_map') %>">
             <%= icon 'camera', class: 'w-4 h-4' %>
-            <span class="hidden sm:inline">Photos</span>
+            <span class="hidden sm:inline"><%= t('.photos') %></span>
           </button>
         <% end %>
 
@@ -110,9 +110,9 @@
                   class="btn btn-sm btn-outline gap-1"
                   data-trip-maplibre-target="flightsToggleBtn"
                   data-action="click->trip-maplibre#toggleFlights"
-                  title="Toggle AirTrail flights on map">
+                  title="<%= t('.toggle_airtrail_flights_on_map') %>">
             <%= icon 'plane', class: 'w-4 h-4' %>
-            <span class="hidden sm:inline">Flights</span>
+            <span class="hidden sm:inline"><%= t('.flights') %></span>
           </button>
         <% end %>
 
@@ -120,9 +120,9 @@
                 class="btn btn-sm btn-outline gap-1"
                 data-trip-maplibre-target="replayToggleBtn"
                 data-action="click->trip-maplibre#toggleReplay"
-                title="Replay the trip">
+                title="<%= t('.replay_the_trip') %>">
           <%= icon 'play', class: 'w-4 h-4' %>
-          <span class="hidden sm:inline">Replay</span>
+          <span class="hidden sm:inline"><%= t('.replay') %></span>
         </button>
 
         <button type="button"
@@ -130,17 +130,17 @@
                 data-trip-maplibre-target="expandAllBtn"
                 data-action="click->trip-maplibre#expandAllDays">
           <%= icon 'chevron-down', class: 'w-4 h-4' %>
-          <span class="hidden sm:inline">Show all days</span>
+          <span class="hidden sm:inline"><%= t('.show_all_days') %></span>
         </button>
 
         <button type="button"
                 class="btn btn-sm btn-outline gap-1"
                 data-trip-maplibre-target="posterBtn"
                 data-action="click->trip-maplibre#openPosterStudio"
-                title="<%= @trip.path.blank? ? 'Available once the trip route is calculated' : 'Create a poster of this trip' %>"
+                title="<%= t(@trip.path.blank? ? '.poster_unavailable' : '.create_poster') %>"
                 <% if @trip.path.blank? %>disabled<% end %>>
           <%= icon 'image', class: 'w-4 h-4' %>
-          <span class="hidden sm:inline">Poster</span>
+          <span class="hidden sm:inline"><%= t('.poster') %></span>
         </button>
 
         <%= render "trips/recalculate_button", trip: @trip %>
@@ -159,22 +159,22 @@
                      data-trip-maplibre-day-key-param="<%= day_key %>">
               <span class="inline-block w-3 h-3 rounded-full flex-shrink-0 bg-base-content/30"
                     data-day-dot="<%= day_key %>"></span>
-              <span><%= date.strftime('%b %-d, %A') %></span>
+              <span><%= l(date, format: :short_month_day_weekday) %></span>
               <% if stats %>
                 <span class="text-base-content/50 text-xs">
-                  <%= stats[:first_time].strftime('%H:%M') %> – <%= stats[:last_time].strftime('%H:%M') %>
+                  <%= l(stats[:first_time], format: :hour_minute) %> – <%= l(stats[:last_time], format: :hour_minute) %>
                 </span>
                 <span class="text-base-content/50 ml-auto mr-6 text-xs">
-                  &middot;
+                  <%= t('.middot') %>
                   <% day_distance = Trip.convert_distance(stats[:distance_m], @distance_unit) %>
                   <% if day_distance < 1 %>
-                    &lt; 1 <%= @distance_unit %>
+                    <%= t('.text') %> <%= @distance_unit %>
                   <% else %>
                     <%= number_with_precision(day_distance, precision: 1) %> <%= @distance_unit %>
                   <% end %>
                 </span>
               <% else %>
-                <span class="text-base-content/50 ml-auto mr-6 text-xs">No data</span>
+                <span class="text-base-content/50 ml-auto mr-6 text-xs"><%= t('.no_data') %></span>
               <% end %>
             </summary>
             <div class="collapse-content">
@@ -205,7 +205,7 @@
       <%# Trip description %>
       <% if @trip.description.body.present? %>
         <div class="mb-6">
-          <h3 class="text-lg font-semibold mb-2">Trip Notes</h3>
+          <h3 class="text-lg font-semibold mb-2"><%= t('.trip_notes') %></h3>
           <div class="prose max-w-none">
             <%= @trip.description.body %>
           </div>
@@ -221,7 +221,7 @@
                   class: "btn btn-sm btn-outline gap-1",
                   target: "_blank",
                   rel: "noopener" do %>
-                <%= icon 'camera', class: 'w-4 h-4' %> More on <%= source.to_s.titleize %>
+                <%= icon 'camera', class: 'w-4 h-4' %> <%= t('.more_on_source', source: t("photo_sources.#{source}")) %>
               <% end %>
             <% end %>
           </div>
@@ -231,7 +231,7 @@
       <%# Back link %>
       <div class="mb-6">
         <%= link_to trips_path, class: "btn btn-sm btn-ghost gap-1" do %>
-          <%= icon 'arrow-left', class: 'w-4 h-4' %> Back to trips
+          <%= icon 'arrow-left', class: 'w-4 h-4' %> <%= t('.back_to_trips') %>
         <% end %>
       </div>
     </div>

--- a/app/views/users/digests/index.html.erb
+++ b/app/views/users/digests/index.html.erb
@@ -1,15 +1,15 @@
-<% content_for :title, 'Year-End Digests' %>
+<% content_for :title, t('.year_end_digests') %>
 
 <div class="max-w-screen-2xl mx-auto my-5 px-4">
   <div class="flex justify-between items-center mb-6 gap-8">
     <h1 class="text-3xl font-bold flex items-center gap-2">
-      <%= icon 'earth' %> Year-End Digests
+      <%= icon 'earth' %> <%= t('.year_end_digests') %>
     </h1>
 
     <% if @available_years.any? && current_user.active? %>
       <div class="dropdown dropdown-end">
         <label tabindex="0" class="btn btn-primary">
-          <%= icon 'calendar-plus-2' %> Generate Digest
+          <%= icon 'calendar-plus-2' %> <%= t('.generate_digest') %>
         </label>
         <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
           <% @available_years.each do |year| %>
@@ -28,12 +28,12 @@
     <div class="card bg-base-200 shadow-xl">
       <div class="card-body text-center py-12">
         <h2 class="text-xl font-semibold mb-2 flex items-center justify-center gap-2">
-          <%= icon 'earth' %>No Year-End Digests Yet
+          <%= icon 'earth' %><%= t('.no_year_end_digests_yet') %>
         </h2>
         <p class="text-gray-500 mb-4">
-          Year-end digests are automatically generated on January 1st each year.
+          <%= t('.year_end_digests_are_automatically_generated_on_january_1st_each') %>
           <% if @available_years.any? && current_user.active? %>
-            <br>Or you can manually generate one for a previous year.
+            <br><%= t('.or_you_can_manually_generate_one_for_a_previous_year') %>
           <% end %>
         </p>
       </div>
@@ -46,13 +46,13 @@
             <h2 class="card-title text-2xl justify-between">
               <%= link_to digest.year, users_digest_path(year: digest.year), class: 'hover:text-primary' %>
               <% if digest.sharing_enabled? %>
-                <span class="badge badge-success badge-sm">Shared</span>
+                <span class="badge badge-success badge-sm"><%= t('.shared') %></span>
               <% end %>
             </h2>
 
             <div class="stats stats-vertical shadow bg-base-100 mt-4 text-center">
               <div class="stat">
-                <div class="stat-title">Distance</div>
+                <div class="stat-title"><%= t('.distance') %></div>
                 <div class="stat-value text-primary text-lg">
                   <%= distance_with_unit(digest.distance, current_user.safe_settings.distance_unit) %>
                 </div>
@@ -60,20 +60,20 @@
 
               <div class="stat">
                 <div class="stat-value text-secondary text-lg"><%= digest.countries_count %></div>
-                <div class="stat-title">Countries</div>
+                <div class="stat-title"><%= t('.countries') %></div>
                 <% if digest.first_time_countries.any? %>
                   <div class="stat-desc text-success flex items-center gap-1 justify-center">
-                    <%= icon 'star' %> <%= digest.first_time_countries.count %> new
+                    <%= icon 'star' %> <%= digest.first_time_countries.count %> <%= t('.new') %>
                   </div>
                 <% end %>
               </div>
 
               <div class="stat">
                 <div class="stat-value text-accent text-lg"><%= digest.cities_count %></div>
-                <div class="stat-title">Cities</div>
+                <div class="stat-title"><%= t('.cities') %></div>
                 <% if digest.first_time_cities.any? %>
                   <div class="stat-desc text-success flex items-center gap-1 justify-center">
-                    <%= icon 'star' %> <%= digest.first_time_cities.count %> new
+                    <%= icon 'star' %> <%= digest.first_time_cities.count %> <%= t('.new') %>
                   </div>
                 <% end %>
               </div>
@@ -81,7 +81,7 @@
 
             <div class="card-actions justify-end mt-4">
               <%= link_to users_digest_path(year: digest.year), class: 'btn btn-primary btn-sm' do %>
-                View Details
+                <%= t('.view_details') %>
               <% end %>
             </div>
           </div>

--- a/app/views/users/digests/public_year.html.erb
+++ b/app/views/users/digests/public_year.html.erb
@@ -5,8 +5,8 @@
   <div class="hero text-white rounded-lg shadow-lg mb-8" style="background: linear-gradient(135deg, #0f766e, #0284c7);">
     <div class="hero-content text-center py-12">
       <div class="max-w-lg">
-        <h1 class="text-4xl font-bold"><%= @digest.year %> Year in Review</h1>
-        <p class="py-4">Your journey, by the numbers</p>
+        <h1 class="text-4xl font-bold"><%= @digest.year %> <%= t('.year_in_review') %></h1>
+        <p class="py-4"><%= t('.your_journey_by_the_numbers') %></p>
       </div>
     </div>
   </div>
@@ -14,24 +14,24 @@
   <!-- Distance Card -->
   <div class="stats shadow mx-auto mb-8 w-full">
     <div class="stat place-items-center text-center">
-      <div class="stat-title">Distance traveled</div>
+      <div class="stat-title"><%= t('.distance_traveled') %></div>
       <div class="stat-value"><%= distance_with_unit(@digest.distance, @distance_unit) %></div>
       <div class="stat-desc"><%= distance_comparison_text(@digest.distance) %></div>
     </div>
 
     <div class="stat place-items-center text-center">
-      <div class="stat-title">Countries visited</div>
+      <div class="stat-title"><%= t('.countries_visited') %></div>
       <div class="stat-value text-secondary"><%= @digest.countries_count %></div>
       <div class="stat-desc <%= @digest.first_time_countries.any? ? 'text-success' : 'invisible' %>">
-        <%= @digest.first_time_countries.any? ? "#{@digest.first_time_countries.count} first time" : '0 first time' %>
+        <%= t('.first_time_count', count: @digest.first_time_countries.count) %>
       </div>
     </div>
 
     <div class="stat place-items-center text-center">
-      <div class="stat-title">Cities explored</div>
+      <div class="stat-title"><%= t('.cities_explored') %></div>
       <div class="stat-value text-accent"><%= @digest.cities_count %></div>
       <div class="stat-desc <%= @digest.first_time_cities.any? ? 'text-success' : 'invisible' %>">
-        <%= @digest.first_time_cities.any? ? "#{@digest.first_time_cities.count} first time" : '0 first time' %>
+        <%= t('.first_time_count', count: @digest.first_time_cities.count) %>
       </div>
     </div>
   </div>
@@ -42,12 +42,12 @@
       <div class="card bg-base-100 shadow-xl mb-8">
         <div class="card-body text-center items-center">
           <h2 class="card-title">
-            <%= icon 'star' %> First Time Visits
+            <%= icon 'star' %> <%= t('.first_time_visits') %>
           </h2>
 
           <% if @digest.first_time_countries.any? %>
             <div class="mb-4">
-              <h3 class="font-semibold mb-2">New Countries</h3>
+              <h3 class="font-semibold mb-2"><%= t('.new_countries') %></h3>
               <div class="flex flex-wrap gap-2 justify-center">
                 <% @digest.first_time_countries.each do |country| %>
                   <span class="badge badge-success badge-lg"><%= country %></span>
@@ -58,13 +58,13 @@
 
           <% if @digest.first_time_cities.any? %>
             <div>
-              <h3 class="font-semibold mb-2">New Cities</h3>
+              <h3 class="font-semibold mb-2"><%= t('.new_cities') %></h3>
               <div class="flex flex-wrap gap-2 justify-center">
                 <% @digest.first_time_cities.take(5).each do |city| %>
                   <span class="badge badge-outline"><%= city %></span>
                 <% end %>
                 <% if @digest.first_time_cities.count > 5 %>
-                  <span class="badge badge-ghost">+<%= @digest.first_time_cities.count - 5 %> more</span>
+                  <span class="badge badge-ghost">+<%= @digest.first_time_cities.count - 5 %> <%= t('.more') %></span>
                 <% end %>
               </div>
             </div>
@@ -78,7 +78,7 @@
       <div class="card bg-base-100 shadow-xl mb-8">
         <div class="card-body text-center items-center">
           <h2 class="card-title">
-            <%= icon 'activity' %> Year by Month
+            <%= icon 'activity' %> <%= t('.year_by_month') %>
           </h2>
           <div class="w-full h-48 bg-base-200 rounded-lg p-4 relative">
             <%= column_chart(
@@ -87,8 +87,8 @@
               },
               height: '200px',
               suffix: " #{@distance_unit}",
-              xtitle: 'Month',
-              ytitle: 'Distance',
+              xtitle: t('.month'),
+              ytitle: t('.distance'),
               colors: [
                 '#397bb5', '#5A4E9D', '#3B945E',
                 '#7BC96F', '#FFD54F', '#FFA94D',
@@ -106,7 +106,7 @@
       <div class="card bg-base-100 shadow-xl mb-8">
         <div class="card-body text-center items-center">
           <h2 class="card-title">
-            <%= icon 'map-pin' %> Where They Spent the Most Time
+            <%= icon 'map-pin' %> <%= t('.where_they_spent_the_most_time') %>
           </h2>
           <ul class="space-y-2 w-full">
             <% @digest.top_countries_by_time.take(3).each do |country| %>
@@ -127,7 +127,7 @@
     <div class="card bg-base-100 shadow-xl mb-8">
       <div class="card-body text-center items-center">
         <h2 class="card-title">
-          <%= icon 'earth' %> Countries & Cities
+          <%= icon 'earth' %> <%= t('.countries_cities') %>
         </h2>
         <div class="space-y-4 w-full">
           <% @digest.toponyms&.each_with_index do |country, index| %>
@@ -137,7 +137,7 @@
                   <span class="mr-1"><%= country_flag(country['country']) %></span>
                   <%= country['country'] %>
                 </span>
-                <span class="text-sm"><%= country['cities']&.length || 0 %> cities</span>
+                <span class="text-sm"><%= country['cities']&.length || 0 %> <%= t('.cities') %></span>
               </div>
               <progress class="progress progress-primary w-full" value="<%= 100 - (index * 15) %>" max="100"></progress>
             </div>
@@ -147,13 +147,13 @@
         <div class="divider"></div>
 
         <div class="flex flex-wrap gap-2 justify-center w-full">
-          <span class="text-sm font-medium">Cities visited:</span>
+          <span class="text-sm font-medium"><%= t('.cities_visited') %></span>
           <% @digest.toponyms&.each do |country| %>
             <% country['cities']&.take(5)&.each do |city| %>
               <div class="badge badge-outline"><%= city['city'] %></div>
             <% end %>
             <% if country['cities']&.length.to_i > 5 %>
-              <div class="badge badge-ghost">+<%= country['cities'].length - 5 %> more</div>
+              <div class="badge badge-ghost">+<%= country['cities'].length - 5 %> <%= t('.more') %></div>
             <% end %>
           <% end %>
         </div>
@@ -164,20 +164,20 @@
     <div class="card bg-slate-800 text-white shadow-xl mb-8">
       <div class="card-body text-center items-center">
         <h2 class="card-title text-white">
-          <%= icon 'trophy' %> All-Time Stats
+          <%= icon 'trophy' %> <%= t('.all_time_stats') %>
         </h2>
         <div class="grid grid-cols-2 gap-4 mt-4">
           <div class="stat place-items-center">
-            <div class="stat-title text-gray-400">Countries visited</div>
+            <div class="stat-title text-gray-400"><%= t('.countries_visited') %></div>
             <div class="stat-value text-white"><%= @digest.total_countries_all_time %></div>
           </div>
           <div class="stat place-items-center">
-            <div class="stat-title text-gray-400">Cities explored</div>
+            <div class="stat-title text-gray-400"><%= t('.cities_explored') %></div>
             <div class="stat-value text-white"><%= @digest.total_cities_all_time %></div>
           </div>
         </div>
         <div class="stat place-items-center mt-2">
-          <div class="stat-title text-gray-400">Total distance</div>
+          <div class="stat-title text-gray-400"><%= t('.total_distance') %></div>
           <div class="stat-value text-white"><%= distance_with_unit(@digest.total_distance_all_time, @distance_unit) %></div>
         </div>
       </div>
@@ -187,7 +187,7 @@
   <!-- Footer with referral hook -->
   <div class="text-center py-8">
     <div class="text-sm text-gray-500">
-      Track your own adventures with <a href="https://dawarich.app?utm_source=shared_digest&utm_medium=referral&utm_campaign=year_in_review" class="link link-primary" target="_blank">Dawarich</a> &#8212; your personal memories mapper.
+      <%= t('.track_your_own_adventures_with') %> <a href="https://dawarich.app?utm_source=shared_digest&utm_medium=referral&utm_campaign=year_in_review" class="link link-primary" target="_blank"><%= t('.dawarich') %></a> <%= t('.your_personal_memories_mapper') %>
     </div>
   </div>
 </div>

--- a/app/views/users/digests/show.html.erb
+++ b/app/views/users/digests/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{@digest.year} Year in Review" %>
+<% content_for :title, t('.year_year_in_review', year: @digest.year) %>
 <%= render 'shared/chartkick_scripts' %>
 
 <div class="max-w-xl mx-auto my-5">
@@ -6,11 +6,11 @@
   <div class="hero text-white rounded-lg shadow-lg mb-8" style="background: linear-gradient(135deg, #0f766e, #0284c7);">
     <div class="hero-content text-center py-12 relative w-full">
       <div class="max-w-lg">
-        <h1 class="text-4xl font-bold"><%= @digest.year %> Year in Review</h1>
-        <p class="py-4">Your journey, by the numbers</p>
+        <h1 class="text-4xl font-bold"><%= @digest.year %> <%= t('.year_in_review') %></h1>
+        <p class="py-4"><%= t('.your_journey_by_the_numbers') %></p>
         <button class="btn btn-outline btn-sm text-neutral border-neutral hover:bg-white hover:text-primary"
                 onclick="sharing_modal.showModal()">
-          <%= icon 'share' %> Share
+          <%= icon 'share' %> <%= t('.share') %>
         </button>
       </div>
     </div>
@@ -20,7 +20,7 @@
   <div class="card bg-base-200 shadow-xl mb-8">
     <div class="card-body text-center items-center">
       <div class="stat-title flex items-center gap-2">
-        <%= icon 'map' %> Distance Traveled
+        <%= icon 'map' %> <%= t('.distance_traveled') %>
       </div>
       <div class="stat-value text-primary text-4xl my-4">
         <%= distance_with_unit(@digest.distance, @distance_unit) %>
@@ -28,7 +28,7 @@
       <p class="text-gray-600"><%= distance_comparison_text(@digest.distance) %></p>
       <% if @digest.yoy_distance_change %>
         <p class="mt-2 font-semibold <%= yoy_change_class(@digest.yoy_distance_change) %>">
-          <%= yoy_change_text(@digest.yoy_distance_change) %> compared to <%= @digest.previous_year %>
+          <%= yoy_change_text(@digest.yoy_distance_change) %> <%= t('.compared_to') %> <%= @digest.previous_year %>
         </p>
       <% end %>
     </div>
@@ -38,21 +38,21 @@
   <div class="stats shadow w-full mb-8 bg-base-200">
     <div class="stat place-items-center">
       <div class="stat-title flex items-center gap-1">
-        <%= icon 'globe' %> Countries
+        <%= icon 'globe' %> <%= t('.countries') %>
       </div>
       <div class="stat-value text-secondary"><%= @digest.countries_count %></div>
       <div class="stat-desc font-medium flex items-center gap-1 <%= @digest.first_time_countries.any? ? 'text-success' : 'invisible' %>">
-        <%= icon 'star' %> <%= @digest.first_time_countries.any? ? "#{@digest.first_time_countries.count} first time" : '0 first time' %>
+        <%= icon 'star' %> <%= t('.first_time_count', count: @digest.first_time_countries.count) %>
       </div>
     </div>
 
     <div class="stat place-items-center">
       <div class="stat-title flex items-center gap-1">
-        <%= icon 'building' %> Cities
+        <%= icon 'building' %> <%= t('.cities') %>
       </div>
       <div class="stat-value text-accent"><%= @digest.cities_count %></div>
       <div class="stat-desc font-medium flex items-center gap-1 <%= @digest.first_time_cities.any? ? 'text-success' : 'invisible' %>">
-        <%= icon 'star' %> <%= @digest.first_time_cities.any? ? "#{@digest.first_time_cities.count} first time" : '0 first time' %>
+        <%= icon 'star' %> <%= t('.first_time_count', count: @digest.first_time_cities.count) %>
       </div>
     </div>
   </div>
@@ -63,12 +63,12 @@
       <div class="card bg-base-200 shadow-xl mb-8">
         <div class="card-body text-center items-center">
           <h2 class="card-title">
-            <%= icon 'star' %> First Time Visits
+            <%= icon 'star' %> <%= t('.first_time_visits') %>
           </h2>
 
           <% if @digest.first_time_countries.any? %>
             <div class="mb-4">
-              <h3 class="font-semibold mb-2">New Countries</h3>
+              <h3 class="font-semibold mb-2"><%= t('.new_countries') %></h3>
               <div class="flex flex-wrap gap-2 justify-center">
                 <% @digest.first_time_countries.each do |country| %>
                   <span class="badge badge-success badge-lg"><%= country %></span>
@@ -79,13 +79,13 @@
 
           <% if @digest.first_time_cities.any? %>
             <div>
-              <h3 class="font-semibold mb-2">New Cities</h3>
+              <h3 class="font-semibold mb-2"><%= t('.new_cities') %></h3>
               <div class="flex flex-wrap gap-2 justify-center">
                 <% @digest.first_time_cities.take(10).each do |city| %>
                   <span class="badge badge-outline"><%= city %></span>
                 <% end %>
                 <% if @digest.first_time_cities.count > 10 %>
-                  <span class="badge badge-ghost">+<%= @digest.first_time_cities.count - 10 %> more</span>
+                  <span class="badge badge-ghost">+<%= @digest.first_time_cities.count - 10 %> <%= t('.more') %></span>
                 <% end %>
               </div>
             </div>
@@ -99,7 +99,7 @@
       <div class="card bg-base-200 shadow-xl mb-8">
         <div class="card-body text-center items-center">
           <h2 class="card-title">
-            <%= icon 'activity' %> Your Year, Month by Month
+            <%= icon 'activity' %> <%= t('.your_year_month_by_month') %>
           </h2>
           <div class="w-full h-64 bg-base-100 rounded-lg p-4">
             <%= column_chart(
@@ -108,8 +108,8 @@
               },
               height: '250px',
               suffix: " #{@distance_unit}",
-              xtitle: 'Month',
-              ytitle: 'Distance',
+              xtitle: t('.month'),
+              ytitle: t('.distance'),
               colors: [
                 '#397bb5', '#5A4E9D', '#3B945E',
                 '#7BC96F', '#FFD54F', '#FFA94D',
@@ -127,7 +127,7 @@
       <div class="card bg-base-200 shadow-xl mb-8">
         <div class="card-body text-center items-center">
           <h2 class="card-title">
-            <%= icon 'map-pin' %> Where You Spent the Most Time
+            <%= icon 'map-pin' %> <%= t('.where_you_spent_the_most_time') %>
           </h2>
           <div class="space-y-4 w-full">
             <% @digest.top_countries_by_time.take(5).each_with_index do |country, index| %>
@@ -149,12 +149,12 @@
               <div class="flex justify-between items-center p-3 bg-base-100 rounded-lg border-2 border-dashed border-gray-200">
                 <div class="flex items-center gap-3">
                   <span class="badge badge-lg badge-ghost">?</span>
-                  <span class="text-gray-500 italic">No tracking data</span>
+                  <span class="text-gray-500 italic"><%= t('.no_tracking_data') %></span>
                 </div>
-                <span class="text-gray-500"><%= pluralize(@digest.untracked_days.round, 'day') %></span>
+                <span class="text-gray-500"><%= t('.day_count', count: @digest.untracked_days.round) %></span>
               </div>
               <p class="text-sm text-gray-500 mt-2 flex items-center justify-center gap-2">
-                <%= icon 'lightbulb' %> Track more in <%= @digest.year + 1 %> to see a fuller picture of your travels!
+                <%= icon 'lightbulb' %> <%= t('.track_more_in') %> <%= @digest.year + 1 %> <%= t('.to_see_a_fuller_picture_of_your_travels') %>
               </p>
             <% end %>
           </div>
@@ -166,7 +166,7 @@
     <div class="card bg-base-200 shadow-xl mb-8">
       <div class="card-body text-center items-center">
         <h2 class="card-title">
-          <%= icon 'earth' %> Countries & Cities
+          <%= icon 'earth' %> <%= t('.countries_cities') %>
         </h2>
         <div class="space-y-4 w-full">
           <% if @digest.toponyms.present? %>
@@ -178,14 +178,14 @@
                     <%= country['country'] %>
                   </span>
                   <span class="text-sm">
-                    <%= pluralize(country['cities']&.length || 0, 'city') %>
+                    <%= t('.city_count', count: country['cities']&.length || 0) %>
                   </span>
                 </div>
                 <progress class="progress <%= progress_color_for_index(index) %> w-full" value="<%= city_progress_value(country['cities']&.length || 0, max_cities_count(@digest.toponyms)) %>" max="100"></progress>
               </div>
             <% end %>
           <% else %>
-            <p class="text-gray-500">No location data available</p>
+            <p class="text-gray-500"><%= t('.no_location_data_available') %></p>
           <% end %>
         </div>
       </div>
@@ -195,20 +195,20 @@
     <div class="card bg-slate-800 text-white shadow-xl mb-8">
       <div class="card-body text-center items-center">
         <h2 class="card-title text-white">
-          <%= icon 'trophy' %> All-Time Stats
+          <%= icon 'trophy' %> <%= t('.all_time_stats') %>
         </h2>
         <div class="grid grid-cols-2 gap-4 mt-4">
           <div class="stat place-items-center">
-            <div class="stat-title text-gray-400">Countries visited</div>
+            <div class="stat-title text-gray-400"><%= t('.countries_visited') %></div>
             <div class="stat-value text-white"><%= @digest.total_countries_all_time %></div>
           </div>
           <div class="stat place-items-center">
-            <div class="stat-title text-gray-400">Cities explored</div>
+            <div class="stat-title text-gray-400"><%= t('.cities_explored') %></div>
             <div class="stat-value text-white"><%= @digest.total_cities_all_time %></div>
           </div>
         </div>
         <div class="stat place-items-center mt-2">
-          <div class="stat-title text-gray-400">Total distance</div>
+          <div class="stat-title text-gray-400"><%= t('.total_distance') %></div>
           <div class="stat-value text-white"><%= distance_with_unit(@digest.total_distance_all_time, @distance_unit) %></div>
         </div>
       </div>
@@ -218,15 +218,14 @@
     <div class="card bg-base-200 shadow-xl mb-8 border border-primary/20">
       <div class="card-body text-center items-center">
         <h2 class="card-title">
-          <%= icon 'sparkles' %> Want more insights?
+          <%= icon 'sparkles' %> <%= t('.want_more_insights') %>
         </h2>
         <p class="text-gray-600 mb-4">
-          Upgrade to Pro to see your full year-in-review with monthly breakdowns,
-          detailed city and country rankings, transportation analysis, and all-time stats.
+          <%= t('.upgrade_to_pro_to_see_your_full_year_in_review') %>
         </p>
         <a href="<%= upgrade_url(utm_medium: 'digest', utm_content: 'year_in_review') %>"
            class="btn btn-primary">
-          Upgrade to Pro
+          <%= t('.upgrade_to_pro') %>
         </a>
       </div>
     </div>
@@ -235,16 +234,16 @@
   <!-- Action Buttons -->
   <div class="flex flex-wrap gap-4 justify-center">
     <%= link_to users_digests_path, class: 'btn btn-outline' do %>
-      Back to All Digests
+      <%= t('.back_to_all_digests') %>
     <% end %>
     <button class="btn btn-outline" onclick="sharing_modal.showModal()">
-      <%= icon 'share' %> Share
+      <%= icon 'share' %> <%= t('.share') %>
     </button>
     <%= button_to users_digest_path(year: @digest.year),
                   method: :delete,
                   class: 'btn btn-outline btn-error',
-                  data: { turbo_confirm: "Are you sure you want to delete the #{@digest.year} digest? This cannot be undone." } do %>
-      <%= icon 'trash-2' %> Delete
+                  data: { turbo_confirm: t('.are_you_sure_you_want_to_delete_the_year_digest', year: @digest.year) } do %>
+      <%= icon 'trash-2' %> <%= t('.delete') %>
     <% end %>
   </div>
 </div>
@@ -257,7 +256,7 @@
     </form>
 
     <h3 class="font-bold text-lg mb-4 flex items-center gap-2">
-      <%= icon 'link' %> Sharing Settings
+      <%= icon 'link' %> <%= t('.sharing_settings') %>
     </h3>
 
     <div data-controller="sharing-modal">
@@ -267,7 +266,7 @@
         <%# Enable/Disable Sharing Toggle %>
         <div class="form-control mb-4">
           <label class="label cursor-pointer">
-            <span class="label-text font-medium">Enable public access</span>
+            <span class="label-text font-medium"><%= t('.enable_public_access') %></span>
             <input type="checkbox"
                    name="enabled"
                    value="1"
@@ -277,7 +276,7 @@
                    data-sharing-modal-target="enableToggle" />
           </label>
           <div class="label">
-            <span class="label-text-alt text-gray-500">Allow others to view this year-end digest • Auto-saves on change</span>
+            <span class="label-text-alt text-gray-500"><%= t('.allow_others_to_view_this_year_end_digest_auto_saves') %></span>
           </div>
         </div>
 
@@ -287,7 +286,7 @@
 
           <div class="form-control mb-4">
             <label class="label">
-              <span class="label-text font-medium">Link expiration</span>
+              <span class="label-text font-medium"><%= t('.link_expiration') %></span>
             </label>
             <select name="expiration"
                     class="select select-bordered w-full"
@@ -314,10 +313,10 @@
       <div class="alert alert-info mb-4">
         <%= icon 'info' %>
         <div>
-          <h3 class="font-bold">Privacy Protection</h3>
+          <h3 class="font-bold"><%= t('.privacy_protection') %></h3>
           <div class="text-sm">
-            • Exact coordinates are hidden<br>
-            • Personal information is not included
+            <%= t('.exact_coordinates_are_hidden') %><br>
+            <%= t('.personal_information_is_not_included') %>
           </div>
         </div>
       </div>
@@ -327,7 +326,7 @@
         <button type="button"
                 class="btn btn-primary"
                 onclick="sharing_modal.close()">
-          Done
+          <%= t('.done') %>
         </button>
       </div>
     </div>

--- a/app/views/users/digests_mailer/monthly_digest.html.erb
+++ b/app/views/users/digests_mailer/monthly_digest.html.erb
@@ -18,18 +18,18 @@
   </style>
 </head>
 <body>
-  <h1>Your <%= Date::MONTHNAMES[@digest.month] %> <%= @digest.year %> in review</h1>
-  <p class="meta">Here's what your location history looked like last month.</p>
+  <h1><%= t('.month_year_in_review', month: l(Date.new(@digest.year, @digest.month, 1), format: :month_name), year: @digest.year) %></h1>
+  <p class="meta"><%= t('.here_s_what_your_location_history_looked_like_last_month') %></p>
 
-  <h2>OVERVIEW</h2>
+  <h2><%= t('.overview') %></h2>
   <pre class="ascii" style="<%= pre_style %>">
-Distance       <%= distance_with_unit(@digest.distance, @distance_unit) %>
-Active days    <%= @active_days %>
-Countries      <%= @digest.time_spent_by_location.to_h['countries'].to_a.size %>
-Cities         <%= @digest.time_spent_by_location.to_h['cities'].to_a.size %>
+<%= t('.distance') %>       <%= distance_with_unit(@digest.distance, @distance_unit) %>
+<%= t('.active_days') %>    <%= @active_days %>
+<%= t('.countries') %>      <%= @digest.time_spent_by_location.to_h['countries'].to_a.size %>
+<%= t('.cities') %>         <%= @digest.time_spent_by_location.to_h['cities'].to_a.size %>
 </pre>
 
-  <h2>WEEKLY PATTERN</h2>
+  <h2><%= t('.weekly_pattern') %></h2>
   <pre class="ascii" style="<%= pre_style %>"><%= ascii_hbar(
       @weekday_totals,
       labels: %w[Mon Tue Wed Thu Fri Sat Sun],
@@ -37,7 +37,7 @@ Cities         <%= @digest.time_spent_by_location.to_h['cities'].to_a.size %>
       suffix: " #{@distance_unit}"
     ) %></pre>
 
-  <h2>DAILY DISTANCE</h2>
+  <h2><%= t('.daily_distance') %></h2>
   <pre class="ascii" style="<%= pre_style %>"><%= ascii_sparkline(
       (1..31).map { |d| @daily_distances[d.to_s].to_f }
              .reject(&:zero?)
@@ -45,35 +45,35 @@ Cities         <%= @digest.time_spent_by_location.to_h['cities'].to_a.size %>
     ) %></pre>
 
   <% if @top_countries.any? %>
-    <h2>TOP COUNTRIES</h2>
+    <h2><%= t('.top_countries') %></h2>
     <pre class="ascii" style="<%= pre_style %>"><%= ascii_ranked_list(@top_countries, value_key: 'minutes', label_key: 'name', width: 20, format: ->(m) { "#{(m.to_f / 60).round}h" }) %></pre>
   <% end %>
 
   <% if @top_cities.any? %>
-    <h2>TOP CITIES</h2>
+    <h2><%= t('.top_cities') %></h2>
     <pre class="ascii" style="<%= pre_style %>"><%= ascii_ranked_list(@top_cities.first(5), value_key: 'minutes', label_key: 'name', width: 20, format: ->(m) { "#{(m.to_f / 60).round}h" }) %></pre>
   <% end %>
 
   <% if @first_countries.any? || @first_cities.any? %>
-    <h2>FIRST VISITS THIS MONTH</h2>
+    <h2><%= t('.first_visits_this_month') %></h2>
     <pre class="ascii" style="<%= pre_style %>"><%
       lines = []
-      @first_countries.first(2).each { |c| lines << "→ #{c}  (new country)" }
-      @first_cities.first(3 - @first_countries.first(2).size).each { |c| lines << "→ #{c}  (new city)" }
+      @first_countries.first(2).each { |country| lines << t('.new_country_line', country: country) }
+      @first_cities.first(3 - @first_countries.first(2).size).each { |city| lines << t('.new_city_line', city: city) }
     %><%= lines.join("\n") %></pre>
   <% end %>
 
   <% if @digest.year_over_year.to_h['distance_change_percent'].present? %>
-    <h2>VS PREVIOUS MONTH</h2>
-    <pre class="ascii" style="<%= pre_style %>">Distance  <%= ascii_trend_from_pct(@digest.distance, @digest.year_over_year['distance_change_percent']) %>
+    <h2><%= t('.vs_previous_month') %></h2>
+    <pre class="ascii" style="<%= pre_style %>"><%= t('.distance') %>  <%= ascii_trend_from_pct(@digest.distance, @digest.year_over_year['distance_change_percent']) %>
 </pre>
   <% end %>
 
-  <p><a href="<%= insights_url(**digest_utm(campaign: 'monthly_digest', content: 'view_insights')) %>">View full insights &rarr;</a></p>
+  <p><a href="<%= insights_url(**digest_utm(campaign: 'monthly_digest', content: 'view_insights')) %>"><%= t('.view_full_insights_rarr') %></a></p>
 
   <div class="footer">
-    You're receiving this because monthly digest emails are on for your account.
-    <a href="<%= settings_general_index_url(anchor: 'email-digests', **digest_utm(campaign: 'monthly_digest', content: 'manage_preferences')) %>">Manage email preferences</a>.
+    <%= t('.you_re_receiving_this_because_monthly_digest_emails_are_on') %>
+    <a href="<%= settings_general_index_url(anchor: 'email-digests', **digest_utm(campaign: 'monthly_digest', content: 'manage_preferences')) %>"><%= t('.manage_email_preferences') %></a>.
   </div>
 </body>
 </html>

--- a/app/views/users/digests_mailer/monthly_digest.text.erb
+++ b/app/views/users/digests_mailer/monthly_digest.text.erb
@@ -1,15 +1,15 @@
-Your <%= Date::MONTHNAMES[@digest.month] %> <%= @digest.year %> in review
+<%= t('.month_year_in_review', month: l(Date.new(@digest.year, @digest.month, 1), format: :month_name), year: @digest.year) %>
 ─────────────────────────
 
-Here's what your location history looked like last month.
+<%= t('.here_s_what_your_location_history_looked_like_last_month') %>
 
-OVERVIEW
-  Distance       <%= distance_with_unit(@digest.distance, @distance_unit) %>
-  Active days    <%= @active_days %>
-  Countries      <%= @digest.time_spent_by_location.to_h['countries'].to_a.size %>
-  Cities         <%= @digest.time_spent_by_location.to_h['cities'].to_a.size %>
+<%= t('.overview') %>
+  <%= t('.distance') %>       <%= distance_with_unit(@digest.distance, @distance_unit) %>
+  <%= t('.active_days') %>    <%= @active_days %>
+  <%= t('.countries') %>      <%= @digest.time_spent_by_location.to_h['countries'].to_a.size %>
+  <%= t('.cities') %>         <%= @digest.time_spent_by_location.to_h['cities'].to_a.size %>
 
-WEEKLY PATTERN
+<%= t('.weekly_pattern') %>
 <%= ascii_hbar(
   @weekday_totals,
   labels: %w[Mon Tue Wed Thu Fri Sat Sun],
@@ -17,7 +17,7 @@ WEEKLY PATTERN
   suffix: " #{@distance_unit}"
 ) %>
 
-DAILY DISTANCE
+<%= t('.daily_distance') %>
 <%= ascii_sparkline(
   (1..31).map { |d| @daily_distances[d.to_s].to_f }
          .reject(&:zero?)
@@ -25,28 +25,28 @@ DAILY DISTANCE
 ) %>
 
 <% if @top_countries.any? %>
-TOP COUNTRIES
+<%= t('.top_countries') %>
 <%= ascii_ranked_list(@top_countries, value_key: 'minutes', label_key: 'name', width: 20, format: ->(m) { "#{(m.to_f / 60).round}h" }) %>
 
 <% end %>
 <% if @top_cities.any? %>
-TOP CITIES
+<%= t('.top_cities') %>
 <%= ascii_ranked_list(@top_cities.first(5), value_key: 'minutes', label_key: 'name', width: 20, format: ->(m) { "#{(m.to_f / 60).round}h" }) %>
 
 <% end %>
 <% if @first_countries.any? || @first_cities.any? %>
-FIRST VISITS THIS MONTH
-<% @first_countries.first(2).each do |c| %>→ <%= c %>  (new country)
-<% end %><% @first_cities.first(3 - @first_countries.first(2).size).each do |c| %>→ <%= c %>  (new city)
+<%= t('.first_visits_this_month') %>
+<% @first_countries.first(2).each do |country| %><%= t('.new_country_line', country: country) %>
+<% end %><% @first_cities.first(3 - @first_countries.first(2).size).each do |city| %><%= t('.new_city_line', city: city) %>
 <% end %>
 <% end %>
 <% if @digest.year_over_year.to_h['distance_change_percent'].present? %>
-VS PREVIOUS MONTH
-  Distance  <%= ascii_trend_from_pct(@digest.distance, @digest.year_over_year['distance_change_percent']) %>
+<%= t('.vs_previous_month') %>
+  <%= t('.distance') %>  <%= ascii_trend_from_pct(@digest.distance, @digest.year_over_year['distance_change_percent']) %>
 
 <% end %>
-→ View full insights: <%= insights_url(**digest_utm(campaign: 'monthly_digest', content: 'view_insights')) %>
+<%= t('.view_full_insights') %> <%= insights_url(**digest_utm(campaign: 'monthly_digest', content: 'view_insights')) %>
 
 ─────────────────────────────────────────
-You're receiving this because monthly digest emails are on.
-Manage email preferences: <%= settings_general_index_url(anchor: 'email-digests', **digest_utm(campaign: 'monthly_digest', content: 'manage_preferences')) %>
+<%= t('.you_re_receiving_this_because_monthly_digest_emails_are_on_3') %>
+<%= t('.manage_email_preferences_2') %> <%= settings_general_index_url(anchor: 'email-digests', **digest_utm(campaign: 'monthly_digest', content: 'manage_preferences')) %>

--- a/app/views/users/digests_mailer/year_end_digest.html.erb
+++ b/app/views/users/digests_mailer/year_end_digest.html.erb
@@ -18,24 +18,24 @@
   </style>
 </head>
 <body>
-  <h1>Your <%= @digest.year %> Year in Review</h1>
-  <p class="meta">Here's your <%= @digest.year %> at a glance.</p>
+  <h1><%= t('.your') %> <%= @digest.year %> <%= t('.year_in_review') %></h1>
+  <p class="meta"><%= t('.here_s_your') %> <%= @digest.year %> <%= t('.at_a_glance') %></p>
 
-  <h2>THE NUMBERS</h2>
+  <h2><%= t('.the_numbers') %></h2>
   <pre class="ascii" style="<%= pre_style %>">
-Distance       <%= distance_with_unit(@digest.distance, @distance_unit) %>
-Countries      <%= @digest.all_time_stats.to_h['total_countries'] %>
-Cities         <%= @digest.all_time_stats.to_h['total_cities'] %>
+<%= t('.distance') %>       <%= distance_with_unit(@digest.distance, @distance_unit) %>
+<%= t('.countries') %>      <%= @digest.all_time_stats.to_h['total_countries'] %>
+<%= t('.cities') %>         <%= @digest.all_time_stats.to_h['total_cities'] %>
 </pre>
 
   <% if @daily_values.any? %>
-    <h2>ACTIVITY HEATMAP</h2>
+    <h2><%= t('.activity_heatmap') %></h2>
     <pre class="ascii" style="<%= pre_style %>"><%= ascii_year_heatmap(@daily_values, start_date: Date.new(@digest.year, 1, 1)) %>
 
-· none   ░ light   ▒ moderate   ▓ high   █ peak</pre>
+<%= t('.none_light_moderate_high_peak') %></pre>
   <% end %>
 
-  <h2>MONTHLY DISTANCE</h2>
+  <h2><%= t('.monthly_distance') %></h2>
   <pre class="ascii" style="<%= pre_style %>"><%= ascii_hbar(
       (1..12).map { |m| @monthly_distances[m.to_s].to_f.round },
       labels: Date::ABBR_MONTHNAMES[1..12],
@@ -44,25 +44,25 @@ Cities         <%= @digest.all_time_stats.to_h['total_cities'] %>
     ) %></pre>
 
   <% if @top_countries.any? %>
-    <h2>TOP COUNTRIES</h2>
+    <h2><%= t('.top_countries') %></h2>
     <pre class="ascii" style="<%= pre_style %>"><%= ascii_ranked_list(@top_countries.first(5), value_key: 'minutes', label_key: 'name', width: 20, format: ->(m) { "#{(m.to_f / 60).round}h" }) %></pre>
   <% end %>
 
   <% if @digest.year_over_year.to_h['distance_change_percent'].present? %>
-    <h2>VS PREVIOUS YEAR</h2>
-    <pre class="ascii" style="<%= pre_style %>">Distance  <%= ascii_trend_from_pct(@digest.distance, @digest.year_over_year['distance_change_percent']) %>
+    <h2><%= t('.vs_previous_year') %></h2>
+    <pre class="ascii" style="<%= pre_style %>"><%= t('.distance') %>  <%= ascii_trend_from_pct(@digest.distance, @digest.year_over_year['distance_change_percent']) %>
 </pre>
   <% end %>
 
-  <p><a href="<%= insights_url %>">View full insights &rarr;</a></p>
+  <p><a href="<%= insights_url %>"><%= t('.view_full_insights_rarr') %></a></p>
 
   <% if @digest.sharing_uuid.present? %>
-    <p><a href="<%= shared_users_digest_url(uuid: @digest.sharing_uuid) %>">Share your year &rarr;</a></p>
+    <p><a href="<%= shared_users_digest_url(uuid: @digest.sharing_uuid) %>"><%= t('.share_your_year_rarr') %></a></p>
   <% end %>
 
   <div class="footer">
-    You're receiving this because yearly digest emails are on for your account.
-    <a href="<%= settings_general_index_url(anchor: 'email-digests') %>">Manage email preferences</a>.
+    <%= t('.you_re_receiving_this_because_yearly_digest_emails_are_on') %>
+    <a href="<%= settings_general_index_url(anchor: 'email-digests') %>"><%= t('.manage_email_preferences') %></a>.
   </div>
 </body>
 </html>

--- a/app/views/users/digests_mailer/year_end_digest.text.erb
+++ b/app/views/users/digests_mailer/year_end_digest.text.erb
@@ -1,21 +1,21 @@
-Your <%= @digest.year %> Year in Review
+<%= t('.your') %> <%= @digest.year %> <%= t('.year_in_review') %>
 ──────────────────────────────
 
-Here's your <%= @digest.year %> at a glance.
+<%= t('.here_s_your') %> <%= @digest.year %> <%= t('.at_a_glance') %>
 
-THE NUMBERS
-  Distance       <%= distance_with_unit(@digest.distance, @distance_unit) %>
-  Countries      <%= @digest.all_time_stats.to_h['total_countries'] %>
-  Cities         <%= @digest.all_time_stats.to_h['total_cities'] %>
+<%= t('.the_numbers') %>
+  <%= t('.distance') %>       <%= distance_with_unit(@digest.distance, @distance_unit) %>
+  <%= t('.countries') %>      <%= @digest.all_time_stats.to_h['total_countries'] %>
+  <%= t('.cities') %>         <%= @digest.all_time_stats.to_h['total_cities'] %>
 
 <% if @daily_values.any? %>
-ACTIVITY HEATMAP
+<%= t('.activity_heatmap') %>
 <%= ascii_year_heatmap(@daily_values, start_date: Date.new(@digest.year, 1, 1)) %>
 
-· none   ░ light   ▒ moderate   ▓ high   █ peak
+<%= t('.none_light_moderate_high_peak') %>
 
 <% end %>
-MONTHLY DISTANCE
+<%= t('.monthly_distance') %>
 <%= ascii_hbar(
   (1..12).map { |m| @monthly_distances[m.to_s].to_f.round },
   labels: Date::ABBR_MONTHNAMES[1..12],
@@ -24,20 +24,20 @@ MONTHLY DISTANCE
 ) %>
 
 <% if @top_countries.any? %>
-TOP COUNTRIES
+<%= t('.top_countries') %>
 <%= ascii_ranked_list(@top_countries.first(5), value_key: 'minutes', label_key: 'name', width: 20, format: ->(m) { "#{(m.to_f / 60).round}h" }) %>
 
 <% end %>
 <% if @digest.year_over_year.to_h['distance_change_percent'].present? %>
-VS PREVIOUS YEAR
-  Distance  <%= ascii_trend_from_pct(@digest.distance, @digest.year_over_year['distance_change_percent']) %>
+<%= t('.vs_previous_year') %>
+  <%= t('.distance') %>  <%= ascii_trend_from_pct(@digest.distance, @digest.year_over_year['distance_change_percent']) %>
 
 <% end %>
--> View full insights: <%= insights_url %>
+<%= t('.view_full_insights') %> <%= insights_url %>
 <% if @digest.sharing_uuid.present? %>
--> Share your year:    <%= shared_users_digest_url(uuid: @digest.sharing_uuid) %>
+<%= t('.share_your_year') %>    <%= shared_users_digest_url(uuid: @digest.sharing_uuid) %>
 <% end %>
 
 ─────────────────────────────────────────
-You're receiving this because yearly digest emails are on.
-Manage email preferences: <%= settings_general_index_url(anchor: 'email-digests') %>
+<%= t('.you_re_receiving_this_because_yearly_digest_emails_are_on_3') %>
+<%= t('.manage_email_preferences_2') %> <%= settings_general_index_url(anchor: 'email-digests') %>

--- a/app/views/users_mailer/account_destroy_confirmation.html.erb
+++ b/app/views/users_mailer/account_destroy_confirmation.html.erb
@@ -14,22 +14,22 @@
 <body>
   <div class="container">
     <div class="header">
-      <h1>Confirm account deletion</h1>
+      <h1><%= t('.confirm_account_deletion') %></h1>
     </div>
     <div class="content">
-      <p>Hi <%= @user.email %>,</p>
+      <p><%= t('.hi') %> <%= @user.email %>,</p>
 
-      <p>We received a request to delete your Dawarich account. <strong>This is your last chance to stop the deletion.</strong> Once confirmed, all your location history, tracks, areas, visits, trips, and family memberships will be permanently removed.</p>
+      <p><%= t('.we_received_a_request_to_delete_your_dawarich_account') %> <strong><%= t('.this_is_your_last_chance_to_stop_the_deletion') %></strong> <%= t('.once_confirmed_all_your_location_history_tracks_areas_visits_trips') %></p>
 
-      <p><a href="<%= @link_url %>" class="cta">Permanently delete my account</a></p>
+      <p><a href="<%= @link_url %>" class="cta"><%= t('.permanently_delete_my_account') %></a></p>
 
       <div class="notice">
-        <p><strong>Didn't request this?</strong> Ignore this email — the link expires in 1 hour and your account remains untouched. If you keep getting these emails, change your password immediately.</p>
+        <p><strong><%= t('.didn_t_request_this') %></strong> <%= t('.ignore_this_email_the_link_expires_in_1_hour_and') %></p>
       </div>
 
-      <p>If you have an active Apple or Google subscription, remember to cancel it in your platform settings to avoid further charges.</p>
+      <p><%= t('.if_you_have_an_active_apple_or_google_subscription_remember') %></p>
 
-      <p style="font-size: 12px; color: #6b7280;">Link: <%= @link_url %></p>
+      <p style="font-size: 12px; color: #6b7280;"><%= t('.link') %> <%= @link_url %></p>
     </div>
   </div>
 </body>

--- a/app/views/users_mailer/account_destroy_confirmation.text.erb
+++ b/app/views/users_mailer/account_destroy_confirmation.text.erb
@@ -1,11 +1,11 @@
-Confirm account deletion
+<%= t('.confirm_account_deletion') %>
 
-Hi <%= @user.email %>,
+<%= t('.hi') %> <%= @user.email %>,
 
-We received a request to delete your Dawarich account. This is your last chance to stop the deletion. Once confirmed, all your location history, tracks, areas, visits, trips, and family memberships will be permanently removed.
+<%= t('.we_received_a_request_to_delete_your_dawarich_account_this_2') %>
 
-Permanently delete my account: <%= @link_url %>
+<%= t('.permanently_delete_my_account_2') %> <%= @link_url %>
 
-Didn't request this? Ignore this email — the link expires in 1 hour and your account remains untouched. If you keep getting these emails, change your password immediately.
+<%= t('.didn_t_request_this_ignore_this_email_the_link_expires_2') %>
 
-If you have an active Apple or Google subscription, remember to cancel it in your platform settings to avoid further charges.
+<%= t('.if_you_have_an_active_apple_or_google_subscription_remember') %>

--- a/app/views/users_mailer/archival_approaching.html.erb
+++ b/app/views/users_mailer/archival_approaching.html.erb
@@ -14,33 +14,33 @@
 <body>
   <div class="container">
     <div class="header">
-      <h1>Your data history is filling up</h1>
+      <h1><%= t('.your_data_history_is_filling_up') %></h1>
     </div>
     <div class="content">
-      <p>Hi <%= @user.email %>, this is Evgenii from Dawarich.</p>
+      <p><%= t('.hi') %> <%= @user.email %><%= t('.this_is_evgenii_from_dawarich') %></p>
 
       <div class="notice">
-        <p><strong>Heads up:</strong> Your oldest location data will be archived in about <strong>2 weeks</strong>.</p>
+        <p><strong><%= t('.heads_up') %></strong> <%= t('.your_oldest_location_data_will_be_archived_in_about') %> <strong><%= t('.weeks') %></strong>.</p>
       </div>
 
-      <p>On the Lite plan, your most recent 12 months of data remain fully searchable and interactive. Older data is archived — it can always be exported, but it won't appear on your map, in search, stats, or timeline replay.</p>
+      <p><%= t('.on_the_lite_plan_your_most_recent_12_months_of') %></p>
 
-      <h3>Upgrade to Pro to keep your full history:</h3>
+      <h3><%= t('.upgrade_to_pro_to_keep_your_full_history') %></h3>
       <ul>
-        <li>Unlimited searchable history — every month, every year</li>
-        <li>Heatmap, Fog of War, and Globe view</li>
-        <li>Full Write API access</li>
-        <li>Immich and PhotoPrism integrations</li>
+        <li><%= t('.unlimited_searchable_history_every_month_every_year') %></li>
+        <li><%= t('.heatmap_fog_of_war_and_globe_view') %></li>
+        <li><%= t('.full_write_api_access') %></li>
+        <li><%= t('.immich_and_photoprism_integrations') %></li>
       </ul>
 
-      <a href="<%= @upgrade_url %>" class="cta">Upgrade to Pro</a>
+      <a href="<%= @upgrade_url %>" class="cta"><%= t('.upgrade_to_pro') %></a>
 
-      <p>Your data is always yours — Pro simply makes all of it searchable and interactive in-app.</p>
+      <p><%= t('.your_data_is_always_yours_pro_simply_makes_all_of') %></p>
 
-      <p>Questions? Drop me a message at hi@dawarich.app or just reply to this email.</p>
+      <p><%= t('.questions_drop_me_a_message_at_hi_dawarich_app_or') %></p>
 
-      <p>Best regards,<br>
-      Evgenii from Dawarich</p>
+      <p><%= t('.best_regards') %><br>
+      <%= t('.evgenii_from_dawarich') %></p>
     </div>
   </div>
 </body>

--- a/app/views/users_mailer/archival_approaching.text.erb
+++ b/app/views/users_mailer/archival_approaching.text.erb
@@ -1,22 +1,22 @@
-Your data history is filling up
+<%= t('.your_data_history_is_filling_up') %>
 
-Hi <%= @user.email %>, this is Evgenii from Dawarich.
+<%= t('.hi') %> <%= @user.email %><%= t('.this_is_evgenii_from_dawarich') %>
 
-Heads up: Your oldest location data will be archived in about 2 weeks.
+<%= t('.heads_up_your_oldest_location_data_will_be_archived_in') %>
 
-On the Lite plan, your most recent 12 months of data remain fully searchable and interactive. Older data is archived — it can always be exported, but it won't appear on your map, in search, stats, or timeline replay.
+<%= t('.on_the_lite_plan_your_most_recent_12_months_of') %>
 
-Upgrade to Pro to keep your full history:
-- Unlimited searchable history — every month, every year
-- Heatmap, Fog of War, and Globe view
-- Full Write API access
-- Immich and PhotoPrism integrations
+<%= t('.upgrade_to_pro_to_keep_your_full_history') %>
+<%= t('.unlimited_searchable_history_every_month_every_year_2') %>
+<%= t('.heatmap_fog_of_war_and_globe_view_2') %>
+<%= t('.full_write_api_access_2') %>
+<%= t('.immich_and_photoprism_integrations_2') %>
 
-Upgrade now: <%= @upgrade_url %>
+<%= t('.upgrade_now') %> <%= @upgrade_url %>
 
-Your data is always yours — Pro simply makes all of it searchable and interactive in-app.
+<%= t('.your_data_is_always_yours_pro_simply_makes_all_of') %>
 
-Questions? Drop me a message at hi@dawarich.app or just reply to this email.
+<%= t('.questions_drop_me_a_message_at_hi_dawarich_app_or') %>
 
-Best regards,
-Evgenii from Dawarich
+<%= t('.best_regards') %>
+<%= t('.evgenii_from_dawarich') %>

--- a/app/views/users_mailer/explore_features.html.erb
+++ b/app/views/users_mailer/explore_features.html.erb
@@ -14,46 +14,46 @@
 <body>
   <div class="container">
     <div class="header">
-      <h1>Explore Dawarich Features</h1>
+      <h1><%= t('.explore_dawarich_features') %></h1>
     </div>
     <div class="content">
-      <p>Hi <%= @user.email %>, this is Evgenii from Dawarich.</p>
+      <p><%= t('.hi') %> <%= @user.email %><%= t('.this_is_evgenii_from_dawarich') %></p>
 
-      <p>You're now 2 days into your Dawarich trial! I hope you're enjoying tracking your location data.</p>
+      <p><%= t('.you_re_now_2_days_into_your_dawarich_trial_i') %></p>
 
-      <p>Here are some powerful features you might want to explore:</p>
+      <p><%= t('.here_are_some_powerful_features_you_might_want_to_explore') %></p>
 
       <div class="feature">
-        <h3>✈️ Reliving your travels</h3>
-        <p>Revisit your past journeys with detailed maps and insights.</p>
+        <h3><%= t('.reliving_your_travels') %></h3>
+        <p><%= t('.revisit_your_past_journeys_with_detailed_maps_and_insights') %></p>
       </div>
 
       <div class="feature">
-        <h3>📊 Statistics & Analytics</h3>
-        <p>View detailed insights about distances traveled and time spent in different locations.</p>
+        <h3><%= t('.statistics_analytics') %></h3>
+        <p><%= t('.view_detailed_insights_about_distances_traveled_and_time_spent_in') %></p>
       </div>
 
       <div class="feature">
-        <h3>🗺️ Interactive Maps</h3>
-        <p>Visualize your tracks on beautiful maps with different layers and styling options.</p>
+        <h3><%= t('.interactive_maps') %></h3>
+        <p><%= t('.visualize_your_tracks_on_beautiful_maps_with_different_layers_and') %></p>
       </div>
 
       <div class="feature">
-        <h3>📍 Places & Visits</h3>
-        <p>Discover the places you've visited and get automatic visit detection for frequently visited locations.</p>
+        <h3><%= t('.places_visits') %></h3>
+        <p><%= t('.discover_the_places_you_ve_visited_and_get_automatic_visit') %></p>
       </div>
 
       <div class="feature">
-        <h3>📤 Data Export</h3>
-        <p>Export your location data in multiple formats (GPX, GeoJSON) for backup or use with other applications.</p>
+        <h3><%= t('.data_export') %></h3>
+        <p><%= t('.export_your_location_data_in_multiple_formats_gpx_geojson_for') %></p>
       </div>
 
-      <a href="https://my.dawarich.app?utm_source=email&utm_medium=email&utm_campaign=explore_features&utm_content=continue_exploring" class="cta">Continue Exploring</a>
+      <a href="https://my.dawarich.app?utm_source=email&utm_medium=email&utm_campaign=explore_features&utm_content=continue_exploring" class="cta"><%= t('.continue_exploring') %></a>
 
-      <p>You have <strong>5 days</strong> left in your trial. Make the most of it!</p>
+      <p><%= t('.you_have') %> <strong><%= t('.days') %></strong> <%= t('.left_in_your_trial_make_the_most_of_it') %></p>
 
-      <p>Best regards,<br>
-      Evgenii from Dawarich</p>
+      <p><%= t('.best_regards') %><br>
+      <%= t('.evgenii_from_dawarich') %></p>
     </div>
   </div>
 </body>

--- a/app/views/users_mailer/explore_features.text.erb
+++ b/app/views/users_mailer/explore_features.text.erb
@@ -1,29 +1,29 @@
-Explore Dawarich Features
+<%= t('.explore_dawarich_features') %>
 
-Hi <%= @user.email %>, this is Evgenii from Dawarich.
+<%= t('.hi') %> <%= @user.email %><%= t('.this_is_evgenii_from_dawarich') %>
 
-You're now 2 days into your Dawarich trial! I hope you're enjoying tracking your location data.
+<%= t('.you_re_now_2_days_into_your_dawarich_trial_i') %>
 
-Here are some powerful features you might want to explore:
+<%= t('.here_are_some_powerful_features_you_might_want_to_explore') %>
 
-✈️ Reliving your travels
-Revisit your past journeys with detailed maps and insights.
+<%= t('.reliving_your_travels') %>
+<%= t('.revisit_your_past_journeys_with_detailed_maps_and_insights') %>
 
-📊 Statistics & Analytics
-View detailed insights about distances traveled and time spent in different locations.
+<%= t('.statistics_analytics') %>
+<%= t('.view_detailed_insights_about_distances_traveled_and_time_spent_in') %>
 
-🗺️ Interactive Maps
-Visualize your tracks on beautiful maps with different layers and styling options.
+<%= t('.interactive_maps') %>
+<%= t('.visualize_your_tracks_on_beautiful_maps_with_different_layers_and') %>
 
-📍 Places & Visits
-Discover the places you've visited and get automatic visit detection for frequently visited locations.
+<%= t('.places_visits') %>
+<%= t('.discover_the_places_you_ve_visited_and_get_automatic_visit') %>
 
-📤 Data Export
-Export your location data in multiple formats (GPX, GeoJSON) for backup or use with other applications.
+<%= t('.data_export') %>
+<%= t('.export_your_location_data_in_multiple_formats_gpx_geojson_for') %>
 
-Continue exploring: https://my.dawarich.app
+<%= t('.continue_exploring_https_my_dawarich_app') %>
 
-You have 5 days left in your trial. Make the most of it!
+<%= t('.you_have_5_days_left_in_your_trial_make_the') %>
 
-Best regards,
-Evgenii from Dawarich
+<%= t('.best_regards') %>
+<%= t('.evgenii_from_dawarich') %>

--- a/app/views/users_mailer/oauth_account_link.html.erb
+++ b/app/views/users_mailer/oauth_account_link.html.erb
@@ -14,20 +14,20 @@
 <body>
   <div class="container">
     <div class="header">
-      <h1>Confirm account link</h1>
+      <h1><%= t('.confirm_account_link') %></h1>
     </div>
     <div class="content">
-      <p>Hi <%= @user.email %>,</p>
+      <p><%= t('.hi') %> <%= @user.email %>,</p>
 
-      <p>Someone — hopefully you — is trying to link <strong><%= @provider_label %></strong> sign-in to your Dawarich account. Clicking the button below will allow that sign-in method to access this account going forward.</p>
+      <p><%= t('.someone_hopefully_you_is_trying_to_link') %> <strong><%= @provider_label %></strong> <%= t('.sign_in_to_your_dawarich_account_clicking_the_button_below') %></p>
 
-      <p><a href="<%= @link_url %>" class="cta">Link <%= @provider_label %></a></p>
+      <p><a href="<%= @link_url %>" class="cta"><%= t('.link') %> <%= @provider_label %></a></p>
 
       <div class="notice">
-        <p><strong>Didn't request this?</strong> Ignore this email — the link expires in 15 minutes and no change will be made to your account. If you keep getting these emails, change your password.</p>
+        <p><strong><%= t('.didn_t_request_this') %></strong> <%= t('.ignore_this_email_the_link_expires_in_15_minutes_and') %></p>
       </div>
 
-      <p style="font-size: 12px; color: #6b7280;">Link: <%= @link_url %></p>
+      <p style="font-size: 12px; color: #6b7280;"><%= t('.link_2') %> <%= @link_url %></p>
     </div>
   </div>
 </body>

--- a/app/views/users_mailer/oauth_account_link.text.erb
+++ b/app/views/users_mailer/oauth_account_link.text.erb
@@ -1,9 +1,9 @@
-Confirm account link
+<%= t('.confirm_account_link') %>
 
-Hi <%= @user.email %>,
+<%= t('.hi') %> <%= @user.email %>,
 
-Someone — hopefully you — is trying to link <%= @provider_label %> sign-in to your Dawarich account. Clicking the link below will allow that sign-in method to access this account going forward.
+<%= t('.someone_hopefully_you_is_trying_to_link') %> <%= @provider_label %> <%= t('.sign_in_to_your_dawarich_account_clicking_the_link_below_2') %>
 
-Link <%= @provider_label %>: <%= @link_url %>
+<%= t('.link') %> <%= @provider_label %>: <%= @link_url %>
 
-Didn't request this? Ignore this email — the link expires in 15 minutes and no change will be made to your account. If you keep getting these emails, change your password.
+<%= t('.didn_t_request_this_ignore_this_email_the_link_expires') %>

--- a/app/views/users_mailer/otp_account_locked.html.erb
+++ b/app/views/users_mailer/otp_account_locked.html.erb
@@ -14,22 +14,22 @@
 <body>
   <div class="container">
     <div class="header">
-      <h1>Account temporarily locked</h1>
+      <h1><%= t('.account_temporarily_locked') %></h1>
     </div>
     <div class="content">
-      <p>Hi <%= @user.email %>,</p>
+      <p><%= t('.hi') %> <%= @user.email %>,</p>
 
-      <p>Your Dawarich account has been <strong>temporarily locked</strong> because 10 consecutive failed two-factor authentication attempts were detected.</p>
+      <p><%= t('.your_dawarich_account_has_been') %> <strong><%= t('.temporarily_locked') %></strong> <%= t('.because_10_consecutive_failed_two_factor_authentication_attempts_were_de') %></p>
 
-      <p>The lock will automatically lift after <strong>30 minutes</strong>. No action is required if this was you.</p>
+      <p><%= t('.the_lock_will_automatically_lift_after') %> <strong><%= t('.minutes') %></strong><%= t('.no_action_is_required_if_this_was_you') %></p>
 
       <div class="notice">
-        <p><strong>Didn't recognise this activity?</strong> Someone may be trying to access your account. We recommend resetting your password immediately.</p>
+        <p><strong><%= t('.didn_t_recognise_this_activity') %></strong> <%= t('.someone_may_be_trying_to_access_your_account_we_recommend') %></p>
       </div>
 
-      <p><a href="<%= new_user_password_url %>" class="cta">Reset your password</a></p>
+      <p><a href="<%= new_user_password_url %>" class="cta"><%= t('.reset_your_password') %></a></p>
 
-      <p>If you need further assistance, contact us at <a href="mailto:security@dawarich.app">security@dawarich.app</a>.</p>
+      <p><%= t('.if_you_need_further_assistance_contact_us_at') %> <a href="mailto:security@dawarich.app"><%= t('.security_dawarich_app') %></a>.</p>
     </div>
   </div>
 </body>

--- a/app/views/users_mailer/otp_account_locked.text.erb
+++ b/app/views/users_mailer/otp_account_locked.text.erb
@@ -1,13 +1,13 @@
-Account temporarily locked
+<%= t('.account_temporarily_locked') %>
 
-Hi <%= @user.email %>,
+<%= t('.hi') %> <%= @user.email %>,
 
-Your Dawarich account has been temporarily locked because 10 consecutive failed two-factor authentication attempts were detected.
+<%= t('.your_dawarich_account_has_been_temporarily_locked_because_10_consecutive_2') %>
 
-The lock will automatically lift after 30 minutes. No action is required if this was you.
+<%= t('.the_lock_will_automatically_lift_after_30_minutes_no_action') %>
 
-Didn't recognise this activity? Someone may be trying to access your account. We recommend resetting your password immediately.
+<%= t('.didn_t_recognise_this_activity_someone_may_be_trying_to') %>
 
-Reset your password: <%= new_user_password_url %>
+<%= t('.reset_your_password_2') %> <%= new_user_password_url %>
 
-If you need further assistance, contact us at security@dawarich.app.
+<%= t('.if_you_need_further_assistance_contact_us_at_security_dawarich') %>

--- a/app/views/users_mailer/welcome.html.erb
+++ b/app/views/users_mailer/welcome.html.erb
@@ -13,27 +13,27 @@
 <body>
   <div class="container">
     <div class="header">
-      <h1>Welcome to Dawarich!</h1>
+      <h1><%= t('.welcome_to_dawarich') %></h1>
     </div>
     <div class="content">
-      <p>Hi <%= @user.email %>, this is Evgenii from Dawarich.</p>
+      <p><%= t('.hi') %> <%= @user.email %><%= t('.this_is_evgenii_from_dawarich') %></p>
 
-      <p>Welcome to Dawarich! I'm excited to have you on board.</p>
+      <p><%= t('.welcome_to_dawarich_i_m_excited_to_have_you_on') %></p>
 
-      <p>Your 7-day free trial has started. During this time, you can:</p>
+      <p><%= t('.your_7_day_free_trial_has_started_during_this_time') %></p>
       <ul>
-        <li>Track your location data</li>
-        <li>View your movement patterns on beautiful maps</li>
-        <li>Analyze your travel statistics</li>
-        <li>Export your data in various formats</li>
+        <li><%= t('.track_your_location_data') %></li>
+        <li><%= t('.view_your_movement_patterns_on_beautiful_maps') %></li>
+        <li><%= t('.analyze_your_travel_statistics') %></li>
+        <li><%= t('.export_your_data_in_various_formats') %></li>
       </ul>
 
-      <a href="https://my.dawarich.app?utm_source=email&utm_medium=email&utm_campaign=welcome&utm_content=start_exploring" class="cta">Start Exploring Dawarich</a>
+      <a href="https://my.dawarich.app?utm_source=email&utm_medium=email&utm_campaign=welcome&utm_content=start_exploring" class="cta"><%= t('.start_exploring_dawarich') %></a>
 
-      <p>If you have any questions, feel free to drop me a message at hi@dawarich.app or just reply to this email.</p>
+      <p><%= t('.if_you_have_any_questions_feel_free_to_drop_me') %></p>
 
-      <p>Happy tracking!<br>
-      Evgenii from Dawarich</p>
+      <p><%= t('.happy_tracking') %><br>
+      <%= t('.evgenii_from_dawarich') %></p>
     </div>
   </div>
 </body>

--- a/app/views/users_mailer/welcome.text.erb
+++ b/app/views/users_mailer/welcome.text.erb
@@ -1,18 +1,18 @@
-Welcome to Dawarich!
+<%= t('.welcome_to_dawarich') %>
 
-Hi <%= @user.email %>, this is Evgenii from Dawarich.
+<%= t('.hi') %> <%= @user.email %><%= t('.this_is_evgenii_from_dawarich') %>
 
-Welcome to Dawarich! I'm excited to have you on board.
+<%= t('.welcome_to_dawarich_i_m_excited_to_have_you_on') %>
 
-Your 7-day free trial has started. During this time, you can:
-- Track your location data
-- View your movement patterns on beautiful maps
-- Analyze your travel statistics
-- Export your data in various formats
+<%= t('.your_7_day_free_trial_has_started_during_this_time') %>
+<%= t('.track_your_location_data_2') %>
+<%= t('.view_your_movement_patterns_on_beautiful_maps_2') %>
+<%= t('.analyze_your_travel_statistics_2') %>
+<%= t('.export_your_data_in_various_formats_2') %>
 
-Start exploring Dawarich: https://my.dawarich.app
+<%= t('.start_exploring_dawarich_https_my_dawarich_app') %>
 
-If you have any questions, feel free to drop me a message at hi@dawarich.app or just reply to this email.
+<%= t('.if_you_have_any_questions_feel_free_to_drop_me') %>
 
-Happy tracking!
-Evgenii from Dawarich
+<%= t('.happy_tracking') %>
+<%= t('.evgenii_from_dawarich') %>

--- a/app/views/visits/_buttons.html.erb
+++ b/app/views/visits/_buttons.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "visit_buttons_#{visit.id}" do %>
   <% if !visit.confirmed? %>
-    <%= link_to 'Confirm', visit_path(visit, 'visit[status]': :confirmed), data: { turbo_method: :patch }, class: 'btn btn-xs btn-success' %>
+    <%= link_to t('.confirm'), visit_path(visit, 'visit[status]': :confirmed), data: { turbo_method: :patch }, class: 'btn btn-xs btn-success' %>
   <% end %>
-  <%= link_to 'Delete', visit_path(visit), data: { turbo_method: :delete, turbo_confirm: 'Delete this visit? Your location points stay.' }, class: 'btn btn-xs btn-error mx-1' %>
+  <%= link_to t('.delete'), visit_path(visit), data: { turbo_method: :delete, turbo_confirm: t('.delete_this_visit_your_location_points_stay') }, class: 'btn btn-xs btn-error mx-1' %>
 <% end %>

--- a/app/views/visits/_name.html.erb
+++ b/app/views/visits/_name.html.erb
@@ -19,12 +19,12 @@
       data-visit-name-target="name"
       data-action="click->visit-name#edit"
       data-testid="visit-rename-trigger"
-      data-tip="Click to rename"
+      data-tip="<%= t('.click_to_rename') %>"
       class="hover:cursor-pointer tooltip">
       <% if resolved_name.present? %>
         <%= resolved_name %>
       <% else %>
-        <span class="text-base-content/40 italic">Unnamed visit</span>
+        <span class="text-base-content/40 italic"><%= t('.unnamed_visit') %></span>
       <% end %>
     </span>
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,6 +7,7 @@ pin_all_from 'app/javascript/maps', under: 'maps'
 pin_all_from 'app/javascript/maps_maplibre', under: 'maps_maplibre'
 
 pin 'application', preload: true
+pin 'i18n', preload: true
 pin '@rails/actioncable', to: 'actioncable.esm.js'
 pin '@rails/activestorage', to: 'activestorage.esm.js'
 pin '@rails/ujs', to: 'rails-ujs.js'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,4189 @@
-
 en:
+  auth:
+    account_links:
+      challenge:
+        link: Link
+        to_your_dawarich_account: to your Dawarich account
+        we_found_an_existing_dawarich_account_for: We found an existing Dawarich account for
+        enter_your_password_to_link_your: ". Enter your password to link your"
+        identity_to_that_account_and_sign_in: identity to that account and sign in.
+        current_password: Current password
+        or: or
+        forgot_your_password: Forgot your password?
+        email_me_a_confirmation_link_instead: Email me a confirmation link instead
+        reset_it: Reset it
+        go_back_to_sign_in: go back to sign in
+        confirm_account_linking: Confirm account linking
+        link_provider_and_sign_in: Link %{provider} and sign in
+  devise:
+    confirmations:
+      new:
+        resend_confirmation: Resend confirmation
+        enter_your_email_address_and_we_ll_resend_the_confirmation: Enter your email address and we'll resend the confirmation instructions.
+        email: Email
+        resend_confirmation_instructions: Resend confirmation instructions
+    mailer:
+      confirmation_instructions:
+        welcome: Welcome
+        you_can_confirm_your_account_email_through_the_link_below: 'You can confirm your account email through the link below:'
+        confirm_my_account: Confirm my account
+      email_changed:
+        hello: Hello
+        we_re_contacting_you_to_notify_you_that_your_email: We're contacting you to notify you that your email is being changed to
+        we_re_contacting_you_to_notify_you_that_your_email_2: We're contacting you to notify you that your email has been changed to
+      password_change:
+        hello: Hello
+        we_re_contacting_you_to_notify_you_that_your_password: We're contacting you to notify you that your password has been changed.
+      reset_password_instructions:
+        hello: Hello
+        someone_has_requested_a_link_to_change_your_password_you: Someone has requested a link to change your password. You can do this through the link below.
+        if_you_didn_t_request_this_please_ignore_this_email: If you didn't request this, please ignore this email.
+        your_password_won_t_change_until_you_access_the_link: Your password won't change until you access the link above and create a new one.
+        change_my_password: Change my password
+      unlock_instructions:
+        hello: Hello
+        your_account_has_been_locked_due_to_an_excessive_number: Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+        click_the_link_below_to_unlock_your_account: 'Click the link below to unlock your account:'
+        unlock_my_account: Unlock my account
+    passwords:
+      edit:
+        change_your_password: Change your password
+        enter_your_new_password_below: Enter your new password below.
+        new_password: New password
+        characters_minimum: characters minimum)
+        confirm_new_password: Confirm new password
+        change_my_password: Change my password
+      new:
+        forgot_your_password: Forgot your password?
+        enter_your_email_address_and_we_ll_send_you_instructions: Enter your email address and we'll send you instructions to reset your password.
+        email: Email
+        send_me_reset_password_instructions: Send me reset password instructions
+    registrations:
+      api_key:
+        current_api_key: Current API key
+        docs: 'Docs:'
+        scan_with_dawarich_app: Scan with Dawarich app
+        usage_examples: Usage examples
+        dawarich_ios_or_android_app: Dawarich iOS or Android app
+        provide_your_instance_url: 'Provide your instance URL:'
+        and_provide_your_api_key: 'And provide your API key:'
+        owntracks: OwnTracks
+        overland: Overland
+        api_documentation: API documentation
+        generate_new_api_key: Generate new API key
+        are_you_sure_this_will_invalidate_the_current_api_key: Are you sure? This will invalidate the current API key.
+      points_usage:
+        you_have_used: You have used
+        points_of: points of
+        available: available.
+      edit:
+        account_settings: Account settings
+        profile: Profile
+        update_your_email_address_and_password_from_one_place: Update your email address and password from one place.
+        connected_with: Connected with
+        email: Email
+        currently_waiting_confirmation_for: 'Currently waiting confirmation for:'
+        new_password: New password
+        leave_blank_to_keep_the_current_one: "(leave blank to keep the current one)"
+        characters_minimum: characters minimum)
+        password_confirmation: Password confirmation
+        current_password: Current password
+        required_to_confirm_your_changes: "(required to confirm your changes)"
+        import_your_data: Import your data
+        upload_a_zip_file_containing_your_exported_dawarich_data_to: Upload a ZIP file containing your exported Dawarich data to restore your points, trips, and settings.
+        select_zip_archive: Select ZIP archive
+        file_will_be_uploaded_directly_to_storage_please_be_patient: File will be uploaded directly to storage. Please be patient during upload.
+        cancel: Cancel
+        close: close
+        trial_status: Trial status
+        your_trial_period_ends_at: Your trial period ends at
+        plan_usage: Plan usage
+        subscription: Subscription
+        your_signup_isn_t_complete_yet_finish_setting_up_your: Your signup isn't complete yet — finish setting up your subscription to start your trial.
+        change_plan_update_your_payment_method_or_cancel_your_subscription: Change plan, update your payment method, or cancel your subscription on Manager.
+        manage_your_subscription_change_plan_or_update_billing_on_manager: Manage your subscription, change plan, or update billing on Manager.
+        api_access: API access
+        use_your_api_key_for_clients_imports_and_external_integrations: Use your API key for clients, imports, and external integrations.
+        data_tools: Data tools
+        export_a_backup_or_restore_a_previous_archive: Export a backup or restore a previous archive.
+        import_my_data: Import my data
+        danger_zone: Danger zone
+        deleting_your_account_is_permanent_and_removes_all_your_data: Deleting your account is permanent and removes all your data.
+        cancel_my_account: Cancel my account
+        delete_your_account: Delete your account
+        this_is_permanent_and_removes_all_your_data_this_cannot: This is permanent and removes all your data. This cannot be undone.
+        this_is_permanent_and_removes_all_your_data_this_cannot_2: This is permanent and removes all your data. This cannot be undone. We'll email you a link to confirm — your account is deleted only after you click it.
+        type_your_email: Type your email (
+        to_confirm: ") to confirm"
+        enter_your_current_password_to_confirm: Enter your current password to confirm
+        save_changes: Save changes
+        import_data: Import data
+        manage_subscription: Manage subscription
+        subscribe: Subscribe
+        export_my_data: Export my data
+        are_you_sure_you_want_to_export_your_data: Are you sure you want to export your data?
+        account: Account
+        importing: Importing...
+        delete_my_account: Delete my account
+        email_me_the_confirmation_link: Email me the confirmation link
+      new:
+        join: Join
+        you_ve_been_invited_by: You've been invited by
+        to_join_their_family_create_your_account_to_accept_the: to join their family. Create your account to accept the invitation and start sharing location data.
+        your_email: Your email (
+        will_be_used_for_this_account: ") will be used for this account"
+        almost_there: Almost there!
+        only_a_few_steps_left_until_you_get_control_over: Only a few steps left until you get control over your location data!
+        create_your_account: 1. Create your account
+        configure_your_mobile_app: 2. Configure your mobile app
+        start_tracking_your_location_data_securely: 3. Start tracking your location data securely
+        you_re_beautiful: 5. You're beautiful!
+        email: Email
+        password: Password
+        characters_minimum: characters minimum)
+        password_confirmation: Password Confirmation
+        how_do_you_plan_to_use_dawarich: How do you plan to use Dawarich?
+        i_m_self_hosting_and_exploring_the_demo: I'm self-hosting and exploring the demo
+        create_account_join_family: Create Account & Join Family
+        sign_up: Sign up
+    sessions:
+      new:
+        sign_in_to_join: Sign in to join
+        you_ve_been_invited_by: You've been invited by
+        to_join_their_family_sign_in_to_your_account_to: to join their family. Sign in to your account to accept the invitation.
+        don_t_have_an_account_yet: Don't have an account yet?
+        login_now: Login now
+        and_take_control_over_your_location_data: and take control over your location data.
+        email: Email
+        password: Password
+        remember_me: Remember me
+        sign_in_using_your_organization_s_identity_provider: Sign in using your organization's identity provider
+        create_one_here: Create one here
+        sign_in_accept_invitation: Sign in & Accept Invitation
+      otp_challenge:
+        two_factor_authentication: Two-Factor Authentication
+        enter_the_6_digit_code_from_your_authenticator_app_to: Enter the 6-digit code from your authenticator app to continue.
+        authentication_code: Authentication code
+        you_can_also_use_a_backup_code: You can also use a backup code.
+        verify: Verify
+        back_to_login: Back to login
+    shared:
+      links:
+        log_in: Log in
+        register: Register
+        forgot_your_password: Forgot your password?
+        didn_t_receive_confirmation_instructions: Didn't receive confirmation instructions?
+        didn_t_receive_unlock_instructions: Didn't receive unlock instructions?
+    unlocks:
+      new:
+        resend_unlock_instructions: Resend unlock instructions
+        enter_your_email_address_and_we_ll_send_you_instructions: Enter your email address and we'll send you instructions to unlock your account.
+        email: Email
+  exports:
+    table_row:
+      middot: "·"
+      download_file: Download file
+      delete_export: Delete export
+      are_you_sure: Are you sure?
+    index:
+      no_exports_yet: No exports yet
+      exports_are_created_from_the: Exports are created from the
+      page_select_a_date_range_and_export_to_geojson_or: page. Select a date range and export to GeoJSON or GPX.
+      go_to_points: Go to Points
+      actions: Actions
+      exports: Exports
+      points: Points
+      name: Name
+      status: Status
+      created: Created
+  families:
+    location_sharing_toggle:
+      live_location: 'Live location:'
+      always: Always
+      hour: 1 hour
+      hours: 6 hours
+      hours_2: 12 hours
+      hours_3: 24 hours
+      expires_in: Expires in
+      location_history: 'Location history:'
+      last_24_hours: Last 24 hours
+      last_7_days: Last 7 days
+      last_30_days: Last 30 days
+      since_sharing_started: Since sharing started
+      a_separate_setting_from_live_location_when_on_family_can: A separate setting from live location. When on, family can view your recent track — not just your current position — on the new map (v2). Only points recorded after you enable this are ever shared.
+      expires_in_time: Expires in %{time}
+    edit:
+      delete_family: Delete Family
+      are_you_sure_you_want_to_delete_this_family_this: Are you sure you want to delete this family? This action cannot be undone.
+      back_to_family: "← Back to Family"
+      members: Members
+      cancel: Cancel
+      editing_family: Editing Family
+      member_count:
+        one: "%{count} member"
+        other: "%{count} members"
+      back: "← Back to Family"
+      created_on: Created on
+      creator: Created by
+      error_title: 'There were problems with your submission:'
+      family_info: Family Information
+      last_updated: Last updated
+      members_count: Members
+      name_help: Choose a name that all family members will recognize.
+      save_changes: Save Changes
+      title: Edit Family
+    lapsed:
+      family_plan_no_longer_active: Family plan no longer active
+      your_family_plan_is_no_longer_active_so_family_features: Your Family plan is no longer active, so family features are paused for everyone. Your family and its members are kept — renewing restores full access.
+      your_family_s_plan_is_no_longer_active_so_family: Your family's plan is no longer active, so family features are paused. They come back when the family owner renews — you don't need a subscription of your own.
+      members: Members
+      remove: Remove
+      your_location_sharing: Your location sharing
+      delete_family: Delete Family
+      leave_family: Leave Family
+      renew_family_plan: Renew Family plan
+      view_pending_invitations: View pending invitations
+      delete_this_family_this_cannot_be_undone: Delete this family? This cannot be undone.
+      are_you_sure_you_want_to_leave_this_family: Are you sure you want to leave this family?
+      family: Family
+      remove_email_from_the_family: Remove %{email} from the family?
+    show:
+      edit: Edit
+      invite: Invite
+      members_middot_created: members · Created
+      no_family_members_are_sharing_their_location: No family members are sharing their location
+      your_sharing: Your Sharing
+      members: Members
+      owner: Owner
+      you: You
+      sharing: Sharing
+      middot: "·"
+      ago: ago
+      not_sharing: Not sharing
+      requested: Requested
+      remove: Remove
+      invitations: Invitations
+      invited: Invited
+      ago_middot_expires: ago · expires
+      family_at_capacity: Family at capacity (
+      members_max: members max)
+      leave_family: Leave Family
+      delete_family: Delete Family
+      request: Request
+      cancel_this_invitation: Cancel this invitation?
+      email_address: Email address
+      are_you_sure_you_want_to_leave_this_family: Are you sure you want to leave this family?
+      delete_this_family_this_cannot_be_undone: Delete this family? This cannot be undone.
+      remove_email_from_the_family: Remove %{email} from the family?
+      members_created:
+        one: "%{count} member · Created %{date}"
+        other: "%{count} members · Created %{date}"
+      invited_ago_expires: Invited %{ago} ago · expires %{date}
+      always: always
+      for_duration: for %{duration}
+      sharing_status: Sharing %{duration}
+    index:
+      have_an_invitation: Have an invitation?
+      if_someone_has_invited_you_to_join_their_family_you: If someone has invited you to join their family, you should have received an email with an invitation link.
+      check_your_email_for_an_invitation_link_that_looks_like: 'Check your email for an invitation link that looks like:'
+      family_management: Family Management
+      create_family: Create Your Family
+      description: Create or join a family to share your location data with loved ones.
+      have_invitation: Have an invitation?
+      invitation_help: 'Check your email for an invitation link that looks like:'
+      invitation_instructions: If someone has invited you to join their family, you should have received an email with an invitation link.
+      title: Family Management
+    new:
+      choose_a_name_that_all_family_members_will_recognize_like: Choose a name that all family members will recognize, like "The Smith Family" or "Our Travel Group".
+      what_happens_next: What happens next?
+      back: "← Back"
+      new_family: New Family
+      create_family: Create Family
+      description: Create a family to share your location data with your loved ones.
+      error_title: 'There were problems with your submission:'
+      name_help: Choose a name that all family members will recognize, like "The Smith Family" or "Our Travel Group".
+      title: Create Your Family
+      upgrade_cta: Upgrade to Family
+      upgrade_description: Creating a family requires the Family plan. Upgrade to invite up to 5 members and share full access.
+      upgrade_title: Family plan required
+      what_happens_1: You will become the family owner
+      what_happens_2: You can invite others to join your family
+      what_happens_3: Family members can view shared location data
+      what_happens_4: You can manage family settings and members
+      what_happens_title: What happens next?
+    navbar_indicator:
+      location_shared: Location is being shared with your family
+      location_not_shared: Location is not being shared with your family
+    form:
+      create: Create Family
+      name: Family Name
+      name_placeholder: Enter your family name
+  family:
+    invitations:
+      show:
+        join: Join
+        you_ve_been_invited_by: You've been invited by
+        to_join_their_family_create_your_account_to_accept_the: to join their family. Create your account to accept the invitation and start sharing location data.
+        your_email: Your email (
+        will_be_used_for_this_account: ") will be used for this account"
+        what_benefits_does_joining_a_family_bring: What benefits does joining a family bring?
+        share_location_data: Share Location Data
+        share_your_location_history_with_family_members_and_see_where: Share your location history with family members and see where they are
+        track_your_location_history: Track your location history
+        access_interactive_maps_and_personal_travel_statistics: Access interactive maps and personal travel statistics
+        stay_connected: Stay Connected
+        keep_track_of_your_loved_ones_travels_and_adventures_in: Keep track of your loved ones' travels and adventures in real-time
+        full_control_privacy: Full Control & Privacy
+        you_control_what_and_how_long_you_share_and_can: You control what and how long you share and can leave the family anytime
+        invitation_details: Invitation Details
+        family: 'Family:'
+        invited_by: 'Invited by:'
+        your_email_2: 'Your email:'
+        expires: 'Expires:'
+        this_family_s_plan_is_currently_inactive_you_can_accept: This family's plan is currently inactive. You can accept the invitation once the family owner renews it.
+        accept_invitation_join_family: "✓ Accept Invitation & Join Family"
+        logged_in_as: Logged in as
+        logout: Logout
+        create_account_join_family: Create Account & Join Family →
+        already_have_an_account: Already have an account?
+        sign_in_to_accept_invitation: Sign in to accept invitation
+        not_interested_you_can_simply_close_this_page: Not interested? You can simply close this page.
+      index:
+        invited: Invited
+        expires: Expires
+        view: View
+        are_you_sure_you_want_to_cancel_this_invitation: Are you sure you want to cancel this invitation?
+        cancel: Cancel
+    location_requests:
+      show:
+        location_request: Location Request
+        requested_by: Requested by
+        requested: Requested
+        ago: ago
+        expires: Expires
+        from_now: from now
+        share_location_for: Share location for
+        hour: 1 hour
+        hours: 6 hours
+        hours_2: 12 hours
+        hours_3: 24 hours
+        permanently: Permanently
+        expired: Expired
+        accepted: Accepted
+        declined: Declined
+        responded: Responded
+        accept_share_location: Accept & Share Location
+        decline: Decline
+        back_to_family: Back to Family
+  family_mailer:
+    invitation:
+      you_ve_been_invited_to_join_a_family: You've been invited to join a family!
+      hi_there: Hi there!
+      has_invited_you_to_join_their_family: has invited you to join their family "
+      on_dawarich: "\" on Dawarich."
+      by_joining_this_family_you_ll_be_able_to: 'By joining this family, you''ll be able to:'
+      share_your_current_location_with_family_members: Share your current location with family members
+      see_the_current_location_of_other_family_members: See the current location of other family members
+      stay_connected_with_your_loved_ones: Stay connected with your loved ones
+      control_your_privacy_with_full_sharing_controls: Control your privacy with full sharing controls
+      important: "⏰ Important:"
+      this_invitation_will_expire_in_7_days: This invitation will expire in 7 days.
+      if_you_don_t_have_a_dawarich_account_yet_you: If you don't have a Dawarich account yet, you'll be able to create one when you accept the invitation.
+      if_you_didn_t_expect_this_invitation_you_can_safely: If you didn't expect this invitation, you can safely ignore this email.
+      best_regards: Best regards,
+      evgenii_from_dawarich: Evgenii from Dawarich
+      you_ve_been_invited_to_join_a_family_hi_there: You've been invited to join a family! Hi there!
+      on_dawarich_by_joining_this_family_you_ll_be_able: "\" on Dawarich. By joining this family, you'll be able to: • Share your current location with family members • See the current location of other family members • Stay connected with your loved ones • Control your privacy with full sharing controls Accept your invitation here:"
+      important_this_invitation_will_expire_in_7_days_if_you: 'IMPORTANT: This invitation will expire in 7 days. If you don''t have a Dawarich account yet, you''ll be able to create one when you accept the invitation. If you didn''t expect this invitation, you can safely ignore this email. Best regards, Evgenii from Dawarich'
+      accept_invitation: Accept Invitation
+      share_your_current_location_with_family_members_2: "• Share your current location with family members"
+      see_the_current_location_of_other_family_members_2: "• See the current location of other family members"
+      stay_connected_with_your_loved_ones_2: "• Stay connected with your loved ones"
+      control_your_privacy_with_full_sharing_controls_2: "• Control your privacy with full sharing controls"
+      accept_your_invitation_here: 'Accept your invitation here:'
+      important_this_invitation_will_expire_in_7_days: 'IMPORTANT: This invitation will expire in 7 days.'
+    location_request:
+      location_request: Location Request
+      hi_there: Hi there!
+      is_requesting_your_location_on_dawarich: is requesting your location on Dawarich.
+      you_can_review_this_request_and_choose_to_accept_or: You can review this request and choose to accept or decline it. If you accept, you can select how long to share your location (1 hour, 6 hours, 12 hours, 24 hours, or permanently).
+      important: "⏰ Important:"
+      this_request_will_expire_in_24_hours_if_not_acted: This request will expire in 24 hours if not acted upon.
+      if_you_don_t_want_to_share_your_location_simply: If you don't want to share your location, simply ignore this request or decline it.
+      best_regards: Best regards,
+      evgenii_from_dawarich: Evgenii from Dawarich
+      location_request_hi_there: Location Request ================ Hi there!
+      is_requesting_your_location_on_dawarich_you_can_review_this: 'is requesting your location on Dawarich. You can review this request and choose to accept or decline it. If you accept, you can select how long to share your location (1 hour, 6 hours, 12 hours, 24 hours, or permanently). View Request:'
+      important_this_request_will_expire_in_24_hours_if_not: "⏰ Important: This request will expire in 24 hours if not acted upon. If you don't want to share your location, simply ignore this request or decline it. Best regards, Evgenii from Dawarich"
+      view_request: View Request
+      you_can_review_this_request_and_choose_to_accept_or_2: You can review this request and choose to accept or decline it.
+      if_you_accept_you_can_select_how_long_to_share: If you accept, you can select how long to share your location (1 hour, 6 hours, 12 hours, 24 hours, or permanently).
+      view_request_2: 'View Request:'
+      important_this_request_will_expire_in_24_hours_if_not_2: "⏰ Important: This request will expire in 24 hours if not acted upon."
+    member_joined:
+      great_news_someone_joined_your_family: "\U0001F389 Great news! Someone joined your family!"
+      hi: Hi
+      we_re_excited_to_let_you_know_that: We're excited to let you know that
+      has_just_joined_your_family: has just joined your family "
+      on_dawarich: "\" on Dawarich!"
+      now_you_can: 'Now you can:'
+      see: See
+      s_current_location_if_they_ve_enabled_sharing: "'s current location (if they've enabled sharing)"
+      stay_connected_with_your_growing_family: Stay connected with your growing family
+      share_your_location_with: Share your location with
+      manage_family_members_and_settings_from_your_family_page: Manage family members and settings from your family page
+      tip: "\U0001F4A1 Tip:"
+      you_can_manage_your_family_members_and_privacy_settings_at: You can manage your family members and privacy settings at any time from your family dashboard.
+      your_family_now_has: Your family now has
+      member: member
+      best_regards: Best regards,
+      evgenii_from_dawarich: Evgenii from Dawarich
+      great_news_someone_joined_your_family_hi: Great news! Someone joined your family! Hi
+      we_re_excited_to_let_you_know_that_2: "! We're excited to let you know that"
+      on_dawarich_now_you_can_see: "\" on Dawarich! Now you can: • See"
+      s_current_location_if_they_ve_enabled_sharing_stay_connected: "'s current location (if they've enabled sharing) • Stay connected with your growing family • Share your location with"
+      manage_family_members_and_settings_from_your_family_page_tip: "• Manage family members and settings from your family page TIP: You can manage your family members and privacy settings at any time from your family dashboard. Your family now has"
+      best_regards_evgenii_from_dawarich: ". Best regards, Evgenii from Dawarich"
+      great_news_someone_joined_your_family_2: Great news! Someone joined your family!
+      see_2: "• See"
+      stay_connected_with_your_growing_family_2: "• Stay connected with your growing family"
+      share_your_location_with_2: "• Share your location with"
+      manage_family_members_and_settings_from_your_family_page_2: "• Manage family members and settings from your family page"
+      tip_you_can_manage_your_family_members_and_privacy_settings: 'TIP: You can manage your family members and privacy settings at any time from your family dashboard.'
+  home:
+    index:
+      dawarich: Dawarich
+      the_only_location_history_tracker_you_ll_ever_need: The only location history tracker you'll ever need.
+      or: or
+      location_history_visualisation: Location history visualisation
+      effortlessly_import_your_location_history_from_google_maps_timeline_and: Effortlessly import your location history from Google Maps Timeline and Owntracks. View your journeys on an interactive map, complete with customizable layers like heatmaps, points, and connecting lines to visualize your travels.
+      comprehensive_travel_statistics: Comprehensive Travel Statistics
+      gain_insights_into_your_travel_patterns_with_detailed_statistics_track: Gain insights into your travel patterns with detailed statistics. Track the number of countries and cities visited and total distance traveled. Split your data by years and months for a clear overview of your journeys.
+      self_hosted_and_private: Self-Hosted and Private
+      maintain_complete_control_over_your_data_with_our_self_hosted: Maintain complete control over your data with our self-hosted solution. Dawarich ensures your location history remains private and secure, giving you peace of mind while enjoying the full functionality of a robust tracking system.
+      find_more_on: Find more on
+      the_website: the website
+      or_check_out_the: ", or check out the"
+      source_code: source code
+      on_github: on GitHub.
+      sign_up: Sign up
+      sign_in: Sign in
+  imports:
+    extraction_card:
+      additional_data: Additional data
+      this_import_format_doesn_t_carry_visits_named_places_or: This import format doesn't carry visits, named places, or transportation modes, so there's nothing additional to extract.
+      extracted: Extracted
+      visits: visits,
+      places: places,
+      tracks: tracks,
+      transportation_mode_segments: transportation-mode segments.
+      re_extract: Re-extract
+      this_extraction_stopped_responding_it_s_safe_to_start_it: This extraction stopped responding. It's safe to start it again.
+      start_over: Start over
+      extraction_failed: 'Extraction failed:'
+      retry_extraction: Retry extraction
+      dawarich_originally_imported_your_file_as_raw_gps_points_click: Dawarich originally imported your file as raw GPS points. Click below to also extract visits, places, tracks, and transportation modes.
+      extract_additional_data: Extract additional data
+      extracting: Extracting…
+      queued: Queued…
+    extraction_dialog:
+      extract_additional_data_from_this_import: Extract additional data from this import
+      dawarich_originally_imported_your_file_as_raw_gps_points_the: 'Dawarich originally imported your file as raw GPS points. The file also contains:'
+      visits: Visits
+      places_where_the_source_app_recorded_you_spending_time_with: "— places where the source app recorded you spending time, with start and end times."
+      tracks: Tracks
+      journeys_identified_between_those_visits_with_their_classified_transport: "— journeys identified between those visits, with their classified transportation mode (driving, walking, cycling, transit, …)."
+      places: Places
+      the_named_places_home_work_frequent_restaurants_the_source_app: "— the named places (home, work, frequent restaurants) the source app associated with your visits."
+      click: Click
+      extract: Extract
+      to_add_this_data_to_your_dawarich_account_existing_points: to add this data to your Dawarich account. Existing points are not modified. Visits and places already detected from your points by Dawarich are kept side-by-side with the imported ones.
+      trust_the_source_app_s_classification: Trust the source app's classification
+      when_checked_transportation_modes_driving_walking_cycling_transit_the_so: When checked, transportation modes (driving, walking, cycling, transit) the source app assigned are kept as-is. When unchecked, Dawarich re-runs its own detector using your settings.
+      cancel: Cancel
+      close: close
+    extraction_remove_button:
+      remove_extracted_data: Remove extracted data
+      remove_the_visits_places_and_tracks_this_extraction_created_your: Remove the visits, places and tracks this extraction created? Your imported GPS points are kept.
+    form:
+      supported_import_formats: Supported Import Formats
+      google_maps: 'Google Maps:'
+      records_json_semantic_history_phone_takeout_json: Records.json, Semantic History, Phone Takeout (.json)
+      google_photos: 'Google Photos:'
+      takeout_metadata_sidecars_json: Takeout metadata sidecars (.json)
+      gpx: 'GPX:'
+      track_files_gpx: Track files (.gpx)
+      geojson: 'GeoJSON:'
+      feature_collections_json_geojson: Feature collections (.json, .geojson)
+      owntracks: 'OwnTracks:'
+      recorder_files_rec: Recorder files (.rec)
+      kml: 'KML:'
+      kml_files_kml_kmz: KML files (.kml, .kmz)
+      fit: 'FIT:'
+      garmin_activity_files_fit: Garmin activity files (.fit)
+      tcx: 'TCX:'
+      training_center_files_tcx: Training Center files (.tcx)
+      csv: 'CSV:'
+      location_data_csv: Location data (.csv)
+      polarsteps: 'Polarsteps:'
+      locations_json_json: locations.json (.json)
+      zip: 'ZIP:'
+      archives_containing_any_of_the_above_zip: Archives containing any of the above (.zip)
+      file_format_is_automatically_detected_during_upload: File format is automatically detected during upload.
+      for_files_larger_than_200mb_consider_compressing_them_into_a: For files larger than 200MB, consider compressing them into a ZIP archive before uploading. This significantly reduces upload time and avoids connection timeouts.
+      trial_limitations_max_5_imports_10mb_per_file: 'Trial limitations: Max 5 imports, 10MB per file.'
+      current_imports: 'Current imports:'
+      select_one_or_multiple_files: Select one or multiple files
+      files_will_be_uploaded_directly_to_storage_please_be_patient: Files will be uploaded directly to storage. Please be patient during upload.
+    import:
+      name: Name
+      imported_points: Imported points
+      created_at: Created at
+      show_this_import: Show this import
+      edit_this_import: Edit this import
+    table_row:
+      demo: Demo
+      points_at_coordinates_and_timestamps_that_already_exist_in_your: Points at coordinates and timestamps that already exist in your timeline were skipped to avoid duplicates.
+      already_imported: already imported
+      deleting: Deleting...
+      deletion_stalled: Deletion stalled
+      retry_deletion: Retry deletion
+      are_you_sure: Are you sure?
+      view_on_map: View on map
+      view_points: View points
+      download_file: Download file
+      delete_import: Delete import
+    edit:
+      editing_import: Editing import
+      back_to_imports: Back to imports
+    index:
+      new_import: New import
+      import_from_immich: Import from Immich
+      import_from_photoprism: Import from Photoprism
+      no_imports_yet: No imports yet
+      import_your_location_data_from_google_maps_timeline_gpx_files: Import your location data from Google Maps Timeline, GPX files, OwnTracks, or other sources to start tracking.
+      create_your_first_import: Create your first import
+      actions: Actions
+      imports: Imports
+      are_you_sure: Are you sure?
+      name: Name
+      points: Points
+      status: Status
+      created: Created
+    new:
+      back_to_imports: Back to imports
+      google_timeline_file_too_large: Google Timeline file too large?
+      your_data_never_leaves_your_browser: "— your data never leaves your browser."
+      new_import: New import
+      split_it_with_our_free_private_tool: Split it with our free private tool
+      new_import_2: New Import
+    show:
+      edit_this_import: Edit this import
+      destroy_this_import: Destroy this import
+      are_you_sure_this_action_will_delete_all_points_imported: Are you sure? This action will delete all points imported with this file
+      back_to_imports: Back to imports
+      import: Import
+  insights:
+    activity_breakdown:
+      activity_breakdown: Activity Breakdown
+      no_activity_data_available_for_this_period: No activity data available for this period
+      driving: Driving
+      walking: Walking
+      stationary: Stationary
+      cycling: Cycling
+      flying: Flying
+      train: Train
+      running: Running
+      bus: Bus
+      boat: Boat
+      motorcycle: Motorcycle
+    activity_heatmap:
+      activity_overview: Activity Overview
+      active_days: active days
+      less: Less
+      more: More
+      mon: Mon
+      wed: Wed
+      fri: Fri
+    activity_streak:
+      activity_streak: Activity Streak
+      current: current
+      longest_streak: Longest Streak
+    header:
+      insights: Insights
+      your_personal_movement_analytics_and_travel_patterns: Your personal movement analytics and travel patterns
+      by_year: By Year
+      overview: Overview
+      all_time: All Time
+    location_clusters:
+      top_visited_locations: Top Visited Locations
+      total_time: total time
+      no_visit_data_available_for_this_period: No visit data available for this period.
+      confirmed_visits_will_appear_here: Confirmed visits will appear here.
+    monthly_digest:
+      total_distance: Total Distance
+      active_days: Active Days
+      countries: Countries
+      cities: Cities
+      weekly_pattern: WEEKLY PATTERN
+      top_locations: TOP LOCATIONS
+      no_location_data: No location data
+      first_visits: FIRST VISITS
+      country: Country
+      city: City
+      no_new_places_this_month: No new places this month
+      vs_previous_month: VS PREVIOUS MONTH
+      distance: distance
+      countries_2: countries
+      monthly_digest: Monthly Digest
+      select_a_month_to_view_its_digest: 'Select a month to view its digest:'
+    movement_wellness:
+      movement_wellness: Movement & Wellness
+      active_time: ACTIVE TIME
+      walking: Walking
+      total: total
+      running: Running
+      cycling: Cycling
+      driving: Driving
+      no_activity_data_available_for_this_period: No activity data available for this period
+      sedentary_vs_active: SEDENTARY VS ACTIVE
+      in_transport: In transport
+      stationary: Stationary
+      active_movement: Active movement
+      ratio: 'Ratio:'
+      active_vs_sedentary: active vs sedentary
+      no_movement_data_available_for_this_period: No movement data available for this period.
+      track_data_with_transportation_modes_will_appear_here: Track data with transportation modes will appear here.
+    pro_locked_card:
+      available_on_pro: Available on Pro
+      upgrade_to_pro: Upgrade to Pro
+    stats_row:
+      total_distance: TOTAL DISTANCE
+      all_tracked_history: All tracked history
+      vs: vs
+      in: in
+      this_year: This year
+      countries: COUNTRIES
+      new_vs: new vs
+      cities: CITIES
+      days_traveling: DAYS TRAVELING
+      active_days_this_year: Active days this year
+      no_stats_data_available: No stats data available
+      stats_are_calculated_from_your_tracked_points: ". Stats are calculated from your tracked points."
+    top_visited_locations:
+      top_visited_locations: Top Visited Locations
+      total_time: total time
+      no_visit_data_available_for_this_period: No visit data available for this period.
+      confirmed_visits_will_appear_here: Confirmed visits will appear here.
+    travel_patterns:
+      when_do_you_travel: When Do You Travel?
+      time_of_day_distribution: TIME OF DAY DISTRIBUTION
+      day_of_week: DAY OF WEEK
+      seasonality: SEASONALITY
+      insight: Insight
+    travel_story:
+      your_travel_story: Your Travel Story
+      summer_2024: Summer 2024
+      june_15_july_20: June 15 - July 20
+      days: 35 Days
+      230_km: 4,230 km
+      the_great_european_road_trip: '"The Great European Road Trip"'
+      you_started_in: You started in
+      berlin: Berlin
+      your_home_base_after_a_week_of_work_you_headed: ", your home base. After a week of work, you headed south through"
+      dresden: Dresden
+      and: and
+      prague: Prague
+      spending_3_days_exploring_the_city_of_a_hundred_spires: ", spending 3 days exploring the city of a hundred spires."
+      the_journey_continued_through: The journey continued through
+      vienna: Vienna
+      where_you_spent_a_weekend_before_crossing_into_italy_you: ", where you spent a weekend before crossing into Italy. You drove through the Alps, stopping at"
+      lake_como: Lake Como
+      for_two_nights_of_swimming_and_pasta: for two nights of swimming and pasta.
+      rome: Rome
+      welcomed_you_for_5_days_of_ancient_history_then_you: welcomed you for 5 days of ancient history, then you traced the coast south to
+      amalfi: Amalfi
+      with_stops_in_naples_and_positano: ", with stops in Naples and Positano."
+      journey_timeline: JOURNEY TIMELINE
+      de: DE
+      home_base: Home base
+      overnight: Overnight
+      cz: CZ
+      days_exploring: 3 days exploring
+      at: AT
+      weekend_stay: Weekend stay
+      it: IT
+      swimming_pasta: Swimming & pasta
+      days_of_history: 5 days of history
+      amalfi_coast: Amalfi Coast
+      positano_naples: Positano, Naples
+      florence: Florence
+      art_coffee: Art & coffee
+      milan: Milan
+      fashion_district: Fashion district
+      munich: Munich
+      beer_gardens: Beer gardens
+      back_home: Back home
+      new_countries: New countries
+      cz_at_it_fr: CZ, AT, IT, FR
+      km: 890 km
+      longest_drive: Longest drive
+      rome_rarr_amalfi: Rome → Amalfi
+      favorites_marked: Favorites marked
+      places: places
+    year_comparison:
+      your_journey: 'Your Journey:'
+      vs: vs
+      distance: DISTANCE
+      countries: COUNTRIES
+      days_traveling: DAYS TRAVELING
+      days: days (
+      days_2: days
+      biggest_month: BIGGEST MONTH
+    details:
+      year_comparison: Year Comparison
+      activity_breakdown: Activity Breakdown
+      location_clusters: Location Clusters
+      monthly_digest: Monthly Digest
+      travel_patterns: Travel Patterns
+      movement_wellness: Movement & Wellness
+    index:
+      geodata_insights_bull_powered_by_your_location_history: Geodata Insights • Powered by your location history
+      activity_heatmap: Activity Heatmap
+      activity_streak: Activity Streak
+      year_comparison: Year Comparison
+      activity_breakdown: Activity Breakdown
+      location_clusters: Location Clusters
+      monthly_digest: Monthly Digest
+      travel_patterns: Travel Patterns
+      movement_wellness: Movement & Wellness
+      insights: Insights
+  kaminari:
+    first_page:
+      laquo: "«"
+    last_page:
+      raquo_raquo: "»»"
+    next_page:
+      raquo: "»"
+    paginator:
+      pager: pager
+    prev_page:
+      laquo: "«"
+  layouts:
+    map:
+      you_re_viewing_demo_data: You're viewing demo data.
+      delete: Delete
+    shared:
+      dawarich: Dawarich
+      try_dawarich_cloud: Try Dawarich Cloud
+      shared_with_dawarich: Shared with Dawarich
+      map_your_own_journeys: Map your own journeys.
+      dawarich_turns_your_own_location_history_into_maps_worth_sharing: Dawarich turns your own location history into maps worth sharing — open-source, self-hostable, and yours to keep.
+      see_how_it_works: See how it works
+      open_source: Open-source
+      self_hostable: Self-hostable
+      managed_cloud_no_setup: Managed Cloud — no setup
+      shared_on_dawarich: Shared on Dawarich
+      dawarich_logo: Dawarich logo
+  map:
+    onboarding_modal:
+      welcome_to_dawarich: Welcome to Dawarich!
+      your_map_starts_with_your_next_step_literally: Your map starts with your next step — literally.
+      start_tracking_now: Start tracking now
+      minutes: 2 minutes
+      get_the_app_scan_a_qr_code_and_watch_your: Get the app, scan a QR code, and watch your first points appear on the map today.
+      i_have_data: I have data
+      import_google_takeout_gpx_kml_geojson_or_owntracks_files: Import Google Takeout, GPX, KML, GeoJSON, or OwnTracks files.
+      explore_with_demo_data: Explore with demo data
+      load_sample_location_data_3_days_in_berlin_to_see: Load sample location data (3 days in Berlin) to see what your map could look like. You can delete it anytime.
+      skip_for_now: Skip for now
+      import_your_data: Import your data
+      supported_formats: Supported formats
+      google_maps: 'Google Maps:'
+      records_json_semantic_history_phone_takeout_json: Records.json, Semantic History, Phone Takeout (.json)
+      gpx: 'GPX:'
+      track_files_gpx: Track files (.gpx)
+      geojson: 'GeoJSON:'
+      feature_collections_json: Feature collections (.json)
+      owntracks: 'OwnTracks:'
+      recorder_files_rec: Recorder files (.rec)
+      kml: 'KML:'
+      kml_files_kml_kmz: KML files (.kml, .kmz)
+      file_format_is_automatically_detected_during_upload: File format is automatically detected during upload.
+      trial_limitations_max_5_imports_10mb_per_file_current_imports: 'Trial limitations: Max 5 imports, 10MB per file. Current imports:'
+      select_one_or_multiple_files: Select one or multiple files
+      files_will_be_uploaded_directly_to_storage_please_be_patient: Files will be uploaded directly to storage. Please be patient during upload.
+      start_tracking: Start tracking
+      download_the_app: Download the app
+      scan_qr_code_to_connect: Scan QR code to connect
+      scan_this_qr_code_with_the_dawarich_app_to_automatically: Scan this QR code with the Dawarich app to automatically configure your connection.
+      or: OR
+      grab_your_api_key_from: Grab your API key from
+      and_follow_the: and follow the
+      have_old_location_history_like_a_google_takeout_tracking_works: Have old location history, like a Google Takeout? Tracking works right away — you can
+      import_your_history_anytime: import your history anytime
+      got_it_let_s_start: Got it, let's start!
+      close: close
+      import_files: Import files
+      settings: Settings
+      setup_guide: setup guide
+    leaflet:
+      settings_modals:
+        route_opacity: Route opacity
+        value_in_percent: Value in percent.
+        this_value_is_the_opacity_of_the_route_on_the: This value is the opacity of the route on the map. The value is in percent, and it can be set from 0 to 100. The default value is 100, which means that the route is fully visible. If you set the value to 0, the route will be invisible.
+        close: Close
+        fog_of_war: Fog of War
+        value_in_meters: Value in meters.
+        here_you_can_set_the_radius_of_the_cleared_area: Here you can set the radius of the "cleared" area around a point when Fog of War mode is enabled. The area around the point will be cleared, and the rest of the map will be covered with fog. The cleared area will be a circle with the point as the center and the radius as the value you set here.
+        fog_of_war_line_threshold: Fog of War Line Threshold
+        value_in_seconds: Value in seconds.
+        points_in_the_fog_are_connected_by_lines_this_value: Points in the fog are connected by lines. This value is the maximum time between two points to be connected by a line. If the time between two points is greater than this value, they will not be connected.
+        meters_between_routes: Meters between routes
+        points_on_the_map_are_connected_by_lines_this_value: Points on the map are connected by lines. This value is the maximum distance between two points to be connected by a line. If the distance between two points is greater than this value, they will not be connected, and the line will not be drawn. This allows to split the route into smaller segments, and to avoid drawing lines between two points that are far from each other.
+        minutes_between_routes: Minutes between routes
+        value_in_minutes: Value in minutes.
+        points_on_the_map_are_connected_by_lines_this_value_2: Points on the map are connected by lines. This value is the maximum time between two points to be connected by a line. If the time between two points is greater than this value, they will not be connected. This allows to split the route into smaller segments, and to avoid drawing lines between two points that are far in time from each other.
+        visit_time_threshold: Visit time threshold
+        this_value_is_the_threshold_based_on_which_a_visit: This value is the threshold, based on which a visit is calculated. If the time between two consequent points is greater than this value, the visit is considered a new visit. If the time between two points is less than this value, the visit is considered as a continuation of the previous visit.
+        for_example_if_you_set_this_value_to_30_minutes: For example, if you set this value to 30 minutes, and you have four points with a time difference of 20 minutes between them, they will be considered as one visit. If the time difference between two first points is 20 minutes, and between third and fourth point is 40 minutes, the visit will be split into two visits.
+        default_value_is_30_minutes: Default value is 30 minutes.
+        merge_threshold: Merge threshold
+        this_value_is_the_threshold_based_on_which_two_visits: This value is the threshold, based on which two visits are merged into one. If the time between two consequent visits is less than this value, the visits are merged into one visit. If the time between two visits is greater than this value, the visits are considered as separate visits.
+        for_example_if_you_set_this_value_to_30_minutes_2: For example, if you set this value to 30 minutes, and you have two visits with a time difference of 20 minutes between them, they will be merged into one visit. If the time difference between two visits is 40 minutes, the visits will be considered as separate visits.
+        default_value_is_15_minutes: Default value is 15 minutes.
+        points_rendering_mode: Points rendering mode
+        to_improve_map_performance_you_can_set_the_rendering_mode: To improve map performance, you can set the rendering mode for points to "Simplified".
+        in_this_mode_the_points_that_are_closer_to_each: In this mode, the points that are closer to each other than 20 seconds or 50 meters are not being rendered. This can significantly improve the performance of the map, especially if you have a lot of points on the map.
+        the_raw_mode_will_render_all_points_on_the_map: The "Raw" mode will render all points on the map, regardless of the distance in space and time between them.
+        speed_colored_routes: Speed-colored routes
+        this_checkbox_will_color_the_routes_based_on_the_speed: This checkbox will color the routes based on the speed of each segment.
+        uncheck_this_checkbox_if_you_want_to_disable_the_speed: Uncheck this checkbox if you want to disable the speed-colored routes.
+        speed_coloring_is_based_on_the_following_color_stops: 'Speed coloring is based on the following color stops:'
+        km_h_green_stationary_or_walking: 0 km/h — green, stationary or walking
+        km_h_cyan_jogging: 15 km/h — cyan, jogging
+        km_h_magenta_cycling: 30 km/h — magenta, cycling
+        km_h_yellow_urban_driving: 50 km/h — yellow, urban driving
+        km_h_orange_red_highway_driving: 100 km/h — orange-red, highway driving
+        live_map: Live map
+        this_checkbox_will_enable_the_live_map: This checkbox will enable the live map.
+        uncheck_this_checkbox_if_you_want_to_disable_the_live: Uncheck this checkbox if you want to disable the live map.
+        when_the_live_map_is_enabled_the_map_will_update: When the live map is enabled, the map will update in real-time with the latest points.
+        speed_color_scale: Speed color scale
+        value_in_format: Value in format
+        speed_kmh_hex_color: speed_kmh:hex_color|...
+        here_you_can_set_a_custom_color_scale_for_speed: Here you can set a custom color scale for speed colored routes. It uses color stops at specified km/h values and creates a gradient from it. The default value is
+        00ff00_15_00ffff_30_ff00ff_50_ffff00_100_ff3300: 0:#00ff00|15:#00ffff|30:#ff00ff|50:#ffff00|100:#ff3300
+        you_can_also_use_the_edit_colors_button_to_edit: You can also use the 'Edit Colors' button to edit it using an UI.
+      sunset_banners:
+        family_location_history_is_only_shown_on_the_new_map: Family location history is only shown on the new map (v2).
+        to_see_where_your_family_has_been: to see where your family has been.
+        dismiss: Dismiss
+        you_re_using_the_classic_map_v1_which_will_be: You're using the classic map (v1), which will be retired in
+        august_2026: August 2026
+        open_the_new_map: Open the new map
+        switch_to_the_new_map: Switch to the new map
+      index:
+        map: Map
+    maplibre:
+      area_creation_modal:
+        create_new_area: Create New Area
+        area_name: Area Name *
+        radius: Radius
+        meters: meters
+        cancel: Cancel
+        e_g_home_office_gym: e.g. Home, Office, Gym...
+        radius_in_meters: Radius in meters
+        create_area: Create Area
+        creating: Creating...
+      button_cluster:
+        map_controls: Map controls
+        timeline: Timeline
+        timeline_t: Timeline (T)
+        layers: Layers
+        layers_l: Layers (L)
+        search: Search
+        search_2: Search (/)
+        create: Create
+        create_c: Create (C)
+        replay: Replay
+        replay_points_for_the_current_date_range_r: Replay points for the current date range (R)
+        poster_studio: Poster Studio
+        settings: Settings
+        settings_s: Settings (S)
+        links: Links
+      residency_modal:
+        days_per_country: Days per Country
+        distinct_days_with_at_least_one_tracked_point_per_country: Distinct days with at least one tracked point per country. Not tax advice.
+      settings_panel:
+        close_panel: Close panel
+        layers: Layers
+        search_for_a_place: Search for a place
+        enter_name_of_a_place: Enter name of a place
+        search_for_a_location_to_find_places_you_visited: Search for a location to find places you visited
+        points: Points
+        show_individual_location_points: Show individual location points
+        edit_points: Edit points
+        allow_dragging_points_to_correct_their_position: Allow dragging points to correct their position.
+        editing_points_is_a_pro_feature_this_stays_on_for: Editing points is a Pro feature — this stays on for the current session only, and moves aren't saved on the Lite plan.
+        allow_dragging_points_to_correct_their_position_remembered_across_sessio: Allow dragging points to correct their position. Remembered across sessions.
+        routes: Routes
+        show_connected_route_lines: Show connected route lines
+        color_by_speed: Color by speed
+        edit_color_gradient: Edit Color Gradient
+        anomalies: Anomalies
+        show_filtered_gps_noise_points: Show filtered GPS noise points
+        tracks: Tracks
+        show_backend_calculated_tracks: Show backend-calculated tracks
+        flights: Flights
+        show_airtrail_flights_as_arcs_hides_overlapping_gps: Show AirTrail flights as arcs (hides overlapping GPS)
+        heatmap: Heatmap
+        show_density_heatmap: Show density heatmap
+        hexagons: Hexagons
+        show_point_density_as_hexagonal_cells: Show point density as hexagonal cells
+        visits: Visits
+        show_detected_area_visits: Show detected area visits
+        filter_by_name: Filter by name...
+        all_visits: All Visits
+        confirmed_only: Confirmed Only
+        suggested_only: Suggested Only
+        places: Places
+        show_your_saved_places: Show your saved places
+        enable_all_tags: Enable All Tags
+        filter_by_tags: Filter by Tags
+        untagged: "\U0001F3F7️ Untagged"
+        click_tags_to_filter_places: Click tags to filter places
+        photos: Photos
+        show_geotagged_photos: Show geotagged photos
+        areas: Areas
+        show_defined_areas: Show defined areas
+        fog_of_war: Fog of War
+        show_explored_areas: Show explored areas
+        per_point: Per point
+        per_hexagon: Per hexagon
+        scratch_map: Scratch Map
+        show_scratched_countries: Show scratched countries
+        family_members: Family Members
+        show_family_member_locations: Show family member locations
+        click_to_center_on_member: Click to center on member
+        appearance: Appearance
+        custom_map_colors_layer_colors_and_vector_tiles_are_pro: Custom map colors, layer colors, and vector tiles are Pro features — you can preview them here, but they won't be saved on the Lite plan.
+        map_style: Map Style
+        light: Light
+        dark: Dark
+        white: White
+        black: Black
+        grayscale: Grayscale
+        custom: Custom
+        color_themes: Color themes
+        customize_colors: Customize colors
+        globe_view: Globe View
+        render_map_as_a_3d_globe_requires_page_reload: Render map as a 3D globe (requires page reload)
+        route_opacity: Route Opacity
+        layer_colors: Layer Colors
+        reset_to_defaults: Reset to defaults
+        distance_unit: Distance Unit
+        kilometers: Kilometers
+        miles: Miles
+        custom_basemap_url: Custom Basemap URL
+        serve_the_base_map_from_your_own_source_accepts_protomaps: Serve the base map from your own source. Accepts Protomaps-schema vector tiles or raster XYZ tiles (both must include {z}, {x}, and {y}), or a full MapLibre style URL. Leave empty for the built-in tiles.
+        base_map_layers: Base Map Layers
+        toggle_base_map_elements_changes_apply_immediately: Toggle base map elements. Changes apply immediately.
+        pro_feature_you_can_preview_changes_here_but_they_won: Pro feature — you can preview changes here, but they won't be saved on the Lite plan.
+        the_custom_style_draws_no_labels_or_points_of_interest: The Custom style draws no labels or points of interest — those toggles are disabled while it's active.
+        points_of_interest: Points of Interest
+        choose_which_poi_categories_appear_on_the_map: Choose which POI categories appear on the map.
+        meters_between_routes: Meters Between Routes
+        distance_threshold_for_route_splitting: Distance threshold for route splitting
+        minutes_between_routes: Minutes Between Routes
+        min: 60min
+        min_2: 1min
+        min_3: 90min
+        min_4: 180min
+        time_threshold_for_route_splitting: Time threshold for route splitting
+        points_rendering_mode: Points Rendering Mode
+        raw_all_points: Raw (all points)
+        simplified_reduced_points: Simplified (reduced points)
+        speed_colored_routes: Speed-Colored Routes
+        color_routes_by_speed: Color routes by speed
+        fog_of_war_radius: Fog of War Radius
+        clear_radius_around_visited_points: Clear radius around visited points
+        fog_of_war_threshold: Fog of War Threshold
+        minimum_points_to_clear_fog: Minimum points to clear fog
+        gps_noise_filtering: GPS Noise Filtering
+        hide_readings_that_cannot_be_a_real_position_impossible_jumps: Hide readings that cannot be a real position — impossible jumps, broken coordinates. Disable to see every raw point.
+        re_evaluate_past_data: Re-evaluate past data
+        clears_existing_anomaly_flags_and_re_runs_the_filter_on: Clears existing anomaly flags and re-runs the filter on all your points with the current settings. Tracks, stats, and digests will be rebuilt afterwards. Runs in the background.
+        recalculate_tracks_stats: Recalculate tracks & stats
+        rebuild_tracks_stats_and_digests_from_your_current_points_without: Rebuild tracks, stats, and digests from your current points without touching anomaly flags. Useful after changing route-splitting thresholds.
+        city_statistics: City Statistics
+        min_minutes_in_city: Min Minutes in City
+        min_5: 60 min
+        min_6: 5min
+        min_7: 120min
+        how_long_you_must_stay_for_a_city_to_count: How long you must stay for a city to count in statistics
+        max_gap_between_points: Max Gap Between Points
+        min_8: 120 min
+        min_9: 30min
+        min_10: 195min
+        min_11: 360min
+        max_gap_between_points_before_assuming_you_left_the_city: Max gap between points before assuming you left the city
+        visit_max_gap: Visit Max Gap
+        min_12: 720min
+        max_time_gap_between_points_within_one_visit_longer_gaps: Max time gap between points within one visit. Longer gaps (e.g. dead battery) split it into separate visits. Default 60.
+        live_mode: Live Mode
+        show_new_points_in_real_time: Show new points in real-time
+        apply_settings: Apply Settings
+        reset_to_defaults_2: Reset to Defaults
+        transportation_mode_detection: Transportation Mode Detection
+        checking_status: Checking status...
+        settings_are_locked_while_recalculation_is_in_progress: Settings are locked while recalculation is in progress.
+        note: 'Note:'
+        changing_these_thresholds_will_trigger_a_recalculation_of_transportation: Changing these thresholds will trigger a recalculation of transportation modes for all your tracks. This may take some time depending on how many tracks you have.
+        detected_modes: Detected modes
+        disabled_modes_won_t_be_detected_existing_tracks_aren_t: Disabled modes won't be detected. Existing tracks aren't affected until you press Re-classify below.
+        expert_mode: Expert Mode
+        show_advanced_detection_thresholds: Show advanced detection thresholds
+        walking_max_speed: Walking max speed
+        km_h: 7 km/h
+        cycling_max_speed: Cycling max speed
+        km_h_2: 45 km/h
+        driving_max_speed: Driving max speed
+        km_h_3: 220 km/h
+        flying_min_speed: Flying min speed
+        km_h_4: 150 km/h
+        speed_thresholds: Speed Thresholds
+        stationary_max_speed: Stationary max speed
+        km_h_5: 1 km/h
+        train_min_speed: Train min speed
+        km_h_6: 80 km/h
+        acceleration_thresholds: Acceleration Thresholds
+        running_vs_cycling_accel: Running vs cycling accel
+        cycling_vs_driving_accel: Cycling vs driving accel
+        segment_detection: Segment Detection
+        min_segment_duration: Min segment duration
+        sec: 60 sec
+        time_gap_threshold: Time gap threshold
+        sec_2: 180 sec
+        min_flight_distance: Min flight distance
+        km: 100 km
+        make_changes_to_enable_the_apply_button: Make changes to enable the Apply button
+        re_runs_auto_classification_across_all_your_tracks_manually_corrected: Re-runs auto-classification across all your tracks. Manually-corrected segments are kept. May take several minutes.
+        loading_calendar: Loading calendar…
+        less: less
+        more: more
+        filter: Filter
+        confirmed: Confirmed
+        suggested: Suggested
+        search_visits_places: Search visits, places…
+        tags: Tags
+        pick_a_day_in_the_calendar_to_see_visits: Pick a day in the calendar to see visits.
+        create_visit: Create Visit
+        create_place: Create Place
+        select_area: Select Area
+        create_area: Create Area
+        replay: Replay
+        days_country: Days / Country
+        enrich_photos: Enrich Photos
+        close: Close
+        match_immich_photos_without_gps_to_your_location_history: Match Immich photos without GPS to your location history.
+        from: From
+        to: To
+        tolerance_minutes: Tolerance (minutes)
+        scan_for_matches: Scan for matches
+        scanning_immich_photos: Scanning Immich photos...
+        all: All
+        back: Back
+        enrich: Enrich
+        start: 'Start:'
+        end: 'End:'
+        duration: 'Duration:'
+        distance: 'Distance:'
+        avg_speed: 'Avg Speed:'
+        points_2: 'Points:'
+        delete_selected_points: Delete Selected Points
+        delete_anomaly_points: Delete Anomaly Points
+        community: Community
+        discord: Discord
+        github: Github
+        mastodon: Mastodon
+        docs: Docs
+        tutorial: Tutorial
+        import_existing_data: Import existing data
+        exporting_data: Exporting data
+        faq: FAQ
+        contact: Contact
+        more_2: More
+        privacy_policy: Privacy policy
+        terms_and_conditions: Terms and Conditions
+        refund_policy: Refund policy
+        impressum: Impressum
+        blog: Blog
+        re_classify_my_history: Re-classify my history
+        manage: Manage
+        manage_tags_in_a_new_tab: Manage tags in a new tab
+        roads: Roads
+        streets_highways_and_paths: Streets, highways, and paths
+        railways: Railways
+        buildings: Buildings
+        building_numbers_visible_at_high_zoom: Building numbers (visible at high zoom)
+        cities_neighborhoods_regions_and_countries: Cities, neighborhoods, regions, and countries
+        ocean_lake_and_river_names: Ocean, lake, and river names
+        water: Water
+        oceans_lakes_rivers_and_streams: Oceans, lakes, rivers, and streams
+        parks_schools_hospitals_airports_etc: Parks, schools, hospitals, airports, etc.
+        boundaries: Boundaries
+        food_drink: Food & Drink
+        restaurants_cafes_bars_bakeries_fast_food: Restaurants, cafes, bars, bakeries, fast food
+        shopping: Shopping
+        supermarkets_clothes_electronics_books_beauty: Supermarkets, clothes, electronics, books, beauty
+        transport: Transport
+        stations_bus_stops_airports_fuel_parking: Stations, bus stops, airports, fuel, parking
+        cycling: Cycling
+        bike_parking_rental_and_repair_stations: Bike parking, rental, and repair stations
+        nature_leisure: Nature & Leisure
+        parks_forests_beaches_playgrounds_stadiums: Parks, forests, beaches, playgrounds, stadiums
+        tourism_culture: Tourism & Culture
+        museums_theatres_attractions_viewpoints_hotels: Museums, theatres, attractions, viewpoints, hotels
+        services_civic: Services & Civic
+        post_offices_libraries_schools_hospitals_police_banks: Post offices, libraries, schools, hospitals, police, banks
+        benches_toilets_drinking_water_fountains_recycling_shelters: Benches, toilets, drinking water, fountains, recycling, shelters
+        theme_aria_label: "%{theme} theme"
+        address_labels: Address Labels
+        background: Background
+        building_footprints: Building footprints
+        country_and_administrative_borders: Country and administrative borders
+        land_use: Land Use
+        master_toggle_for_all_poi_groups_below: Master toggle for all POI groups below
+        motorway_roads: Motorway roads
+        other_roads: Other roads
+        parks: Parks
+        place_names: Place Names
+        primary_roads: Primary roads
+        residential_roads: Residential roads
+        road_labels: Road Labels
+        street_names_and_route_shields: Street names and route shields
+        train_tracks_and_rail_lines: Train tracks and rail lines
+        urban_amenities: Urban Amenities
+        water_labels: Water Labels
+      visit_creation_modal:
+        create_new_visit: Create New Visit
+        visit_name: Visit Name *
+        enter_visit_name: Enter visit name...
+        start_time: Start Time *
+        end_time: End Time *
+        cancel: Cancel
+        create_visit: Create Visit
+      webgl_error:
+        webgl_is_not_available: WebGL is not available
+        map_v2_requires_webgl_to_render_maps_please_enable_hardware: Map v2 requires WebGL to render maps. Please enable hardware acceleration in your browser settings or try a different browser.
+        map_v1_leaflet_is_available_at: Map v1 (Leaflet) is available at
+        but_will_be_deprecated_and_removed_in_one_of_future: but will be deprecated and removed in one of future releases.
+        map_v1: "/map/v1"
+      index:
+        loading: Loading...
+        pick_a_day: Pick a day
+        confirmed: Confirmed
+        suggested: Suggested
+        declined: Declined
+        map: Map
+    residency:
+      show:
+        days: days
+        mon: Mon
+        wed: Wed
+        fri: Fri
+        more: more
+        stay_periods: Stay periods
+        exceeds_183_day_threshold_common_in_many_tax_jurisdictions: Exceeds 183-day threshold common in many tax jurisdictions.
+        no_country_data_for: No country data for
+        points_need_reverse_geocoding_to_detect_countries: Points need reverse geocoding to detect countries.
+    timeline_feeds:
+      calendar:
+        has_suggested_visits: Has suggested visits
+        next_month: Next month
+        previous_month: Previous month
+      day:
+        select: Select
+        visits: Visits
+        tracks: Tracks
+        distance: Distance
+        moving: Moving
+        no_visits_match_the_current_search_or_filter: No visits match the current search or filter.
+        clear_search_filters: Clear search & filters
+        no_visits_tracked_this_day: No visits tracked this day.
+        previous_day: Previous day
+        next_day: Next day
+        visit_count:
+          one: "%{count} visit"
+          other: "%{count} visits"
+      day_banner:
+        waiting: waiting
+        confirm_all: Confirm all
+        delete_all: Delete all
+        delete_all_visits_for_this_day_your_location_points_stay: Delete all %{visits} for this day? Your location points stay.
+        suggestions_waiting:
+          one: "%{count} suggestion waiting"
+          other: "%{count} suggestions waiting"
+        delete_all_suggestions:
+          one: Delete the suggested visit for this day? Your location points stay.
+          other: Delete all %{count} suggested visits for this day? Your location points stay.
+      day_nav:
+        previous_day: Previous day
+        next_day: Next day
+      day_summary:
+        total_distance_traveled_this_day: Total distance traveled this day
+        distinct_places_visited_this_day: Distinct places visited this day
+        places: places
+        moving: moving
+        stationary: stationary
+      feed:
+        no_visits_tracked_this_day: No visits tracked this day.
+        visits_are_auto_detected_daily_from_your_location_data: Visits are auto-detected daily from your location data.
+      journey_entry:
+        continued_from: continued from
+        arrived: ", arrived"
+        middot: "·"
+        continued_from_date_arrived: continued from %{date}, arrived
+      selection_bar:
+        selected: 0 selected
+        cancel: Cancel
+        mark_these_visits_as_confirmed_yes_i_was_there: Mark these visits as confirmed (yes, I was there)
+        confirm: Confirm
+        combine_the_selected_visits_into_one: Combine the selected visits into one
+        merge: Merge
+        remove_the_visit_grouping_your_location_points_stay: Remove the visit grouping (your location points stay)
+        delete: Delete
+      suggested_picker:
+        needs_review: Needs review
+        confirm_this_visit: Confirm this visit?
+        assigned_to: Assigned to
+        use_the_search_button_to_pick_a_different_place: ". Use the search button to pick a different place."
+        no_place_for_this_visit_confirm_to_keep_it_as: No place for this visit. Confirm to keep it as is.
+        confirm: Confirm
+        delete: Delete
+        delete_this_visit_your_location_points_stay: Delete this visit? Your location points stay.
+      track_info:
+        track: 'Track #'
+        dist: Dist
+        avg: Avg
+        show_points: Show points
+        replay: Replay
+        share: Share
+        unknown: Unknown
+      visit_entry:
+        select_visit_for_merge: Select visit for merge
+        all_day: All day
+        pts: pts
+        search_for_a_place: Search for a place
+        delete: Delete
+        delete_this_visit_your_location_points_stay: Delete this visit? Your location points stay.
+  notifications:
+    notification:
+      ago: ago
+      please_when_reporting_a_bug_to: Please, when reporting a bug to
+      github_issues: Github Issues
+      don_t_forget_to_include_logs_from: ", don't forget to include logs from"
+      dawarich_app: dawarich_app
+      and: and
+      dawarich_sidekiq: dawarich_sidekiq
+      docker_containers_thank_you: docker containers. Thank you!
+    index:
+      notifications: Notifications
+      mark_all_as_read: Mark all as read
+      delete_all: Delete all
+      are_you_sure_you_want_to_delete_all_notifications: Are you sure you want to delete all notifications?
+    show:
+      back_to_notifications: Back to notifications
+      destroy_this_notification: Destroy this notification
+      are_you_sure: Are you sure?
+  places:
+    drawer:
+      source: 'Source:'
+      total_hours: total hours
+      avg_dwell: avg dwell
+      no_tags: No tags
+      recent_visits: Recent visits
+      rarr: "→"
+      'on': 'on'
+      no_visits_yet: No visits yet
+      rename: Rename
+      merge: Merge
+      notes: Notes
+      save: Save
+      delete: Delete
+      delete_this_place_this_cannot_be_undone: Delete this place? This cannot be undone.
+      manual_name_title: You named this place, so automatic naming will not change it. Rename it to "%{default_name}" to hand it back to automatic naming.
+      visit_count:
+        one: "%{count} visit"
+        other: "%{count} visits"
+    nearby_places:
+      no_nearby_places_found: No nearby places found
+      load_more_search_up_to_distance_m: Load More (search up to %{distance}m)
+    index:
+      hello_there: Hello there!
+      here_you_ll_find_your_places_created_by_visits_suggestion: Here you'll find your places, created by Visits suggestion process. But now there are none.
+      name: Name
+      created_at: Created at
+      coordinates: Coordinates
+      actions: Actions
+      timeline: Timeline
+      places: Places
+      delete: Delete
+      are_you_sure_deleting_a_place_will_result_in_deleting: Are you sure? Deleting a place will result in deleting all visits for this place.
+  points:
+    address:
+      address: 'Address:'
+    index:
+      export: Export
+      geojson: GeoJSON
+      gpx: GPX
+      address: Address
+      speed: Speed
+      coordinates: Coordinates
+      recorded_at: Recorded at
+      points: Points
+      search: Search
+      export_as_geojson: Export as GeoJSON?
+      export_as_gpx: Export as GPX?
+      delete_selected: Delete Selected
+      are_you_sure: Are you sure?
+      select_all: Select all
+  posters:
+    poster:
+      download_png: Download PNG
+      download_pdf: Download PDF
+      delete: Delete
+      delete_this_poster: Delete this poster?
+    studio:
+      poster_studio: Poster Studio
+      load: Load
+      today: Today
+      last_7_days: Last 7 days
+      last_month: Last month
+      close_studio: Close studio
+      recenter: Recenter
+      drag_to_pan_scroll_to_zoom_the_frame_is_what: Drag to pan, scroll to zoom — the frame is what gets exported.
+      layout: Layout
+      theme: Theme
+      customize_colors: Customize colors
+      text: Text
+      show_text: Show text
+      title: Title
+      berlin: Berlin
+      subtitle: Subtitle
+      germany: Germany
+      coordinates_line: Coordinates line
+      font: Font
+      layers: Layers
+      track_opacity: Track opacity
+      track_width: Track width
+      recent_posters: Recent posters
+      server_rendered_posters_from_save_to_gallery_they_stay_here: Server-rendered posters from "Save to gallery" — they stay here across sessions.
+      export_a_file: Export a file
+      format: Format
+      png: PNG
+      pdf: PDF
+      print_dpi: Print DPI
+      download: Download
+      render_this_area_server_side_as_the_classic_3_4: Render this area server-side as the classic 3:4 print poster and keep it in Recent posters
+      save_to_gallery: Save to gallery
+      order_a_print: Order a print
+      order_a_printed_poster: Order a printed poster
+      free_eu_shipping: Free EU shipping
+      choose_a_print_size: Choose a print size
+      cancel: Cancel
+      pay_via_stripe: "· pay via Stripe"
+      printed_by_gelato_exactly_as_previewed_made_to_order_so: Printed by Gelato, exactly as previewed. Made to order, so the statutory 14-day right of withdrawal does not apply once production starts (§312g Abs. 2 Nr. 1 BGB).
+      order_this_poster: Order this poster
+      back: Back
+      preparing_poster: 1. Preparing poster
+      uploading_poster: 2. Uploading poster
+      continue_to_order: 3. Continue to order
+      continue_to_payment: Continue to payment
+      checkout_not_working_open_your_order_page: Checkout not working? Open your order page
+      close: Close
+      roads: Roads
+      water: Water
+      parks_land_use: Parks & land use
+      buildings: Buildings
+      railways: Railways
+      boundaries: Boundaries
+      theme_aria_label: "%{theme} theme"
+      background: Background
+      motorway_roads: Motorway roads
+      other_roads: Other roads
+      parks: Parks
+      primary_roads: Primary roads
+      residential_roads: Residential roads
+      track: Track
+  settings:
+    navigation:
+      general: General
+      integrations: Integrations
+      map: Map
+      visits: Visits
+      two_factor_authentication: Two-Factor Authentication
+      users: Users
+      background_jobs: Background Jobs
+    background_jobs:
+      index:
+        spamming_many_new_jobs_at_once_is_a_bad_idea: Spamming many new jobs at once is a bad idea. Let them work or clear the queue beforehand.
+        gps_noise_detection_changed_in_this_release_so_your_existing: GPS noise detection changed in this release, so your existing points are queued for a one-time re-check. Your tracks, stats and digests are rebuilt from the result, which can take a while on a large history — some points may appear or disappear on the map when it finishes. No points are deleted, and the pass runs on the lowest-priority queue so everything else stays ahead of it.
+        start_reverse_geocoding: Start Reverse Geocoding
+        this_job_will_re_run_reverse_geocoding_process_for_all: This job will re-run reverse geocoding process for all the points in your database. Might take a few days or even weeks based on the amount of points you have!
+        continue_reverse_geocoding: Continue Reverse Geocoding
+        this_job_will_process_reverse_geocoding_for_all_points_that: This job will process reverse geocoding for all points that don't have geocoding data yet.
+        background_jobs_dashboard: Background Jobs Dashboard
+        this_will_open_the_background_jobs_dashboard_in_a_new: This will open the background jobs dashboard in a new tab.
+        visits_suggestions: Visits suggestions
+        enable_or_disable_visits_suggestions_it_s_a_background_task: Enable or disable visits suggestions. It's a background task that runs every day at midnight. Disabling it might be useful if you don't want to receive visits suggestions or if you're using the Dawarich iOS app, which has its own visits suggestions.
+        background_jobs: Background jobs
+        start_job: Start Job
+        are_you_sure: Are you sure?
+        open_dashboard: Open Dashboard
+        disable: Disable
+        enable: Enable
+    general:
+      changelog_consent:
+        what_s_new_notices: What's New notices
+        a_what_s_new_notice_is_shown_when_a_new: A "What's New" notice is shown when a new Dawarich version ships, including security fixes. It loads a small widget from
+        which_like_any_web_request_sees_your_ip_address_browser: ", which — like any web request — sees your IP address, browser, and the page URL, plus your Dawarich version. It never receives your account, email, or location."
+        get_a_what_s_new_notice_when_a_new_dawarich: Get a "What's New" notice when a new Dawarich version ships, including security fixes. The notice loads a small widget from
+        turn_off_notices: Turn off notices
+        turn_on_notices: Turn on notices
+      supporter_status:
+        supporter_status: Supporter Status
+        thank_you_for_supporting_dawarich: Thank you for supporting Dawarich
+        email_used_for_patreon_github_ko_fi: Email used for Patreon/GitHub/Ko-fi
+        github_username_for_github_sponsors_with_a_private_email: GitHub username (for GitHub Sponsors with a private email)
+        not_found_in_supporter_list_make_sure_you_re_using: Not found in supporter list. Make sure you're using the same email or GitHub username as your donation platform.
+        how_to_support_dawarich: How to support Dawarich
+        dawarich_is_a_free_and_open_source_project_your_support: 'Dawarich is a free and open-source project. Your support helps cover hosting costs, fund development, and keep the project alive. You can support us through any of these platforms:'
+        patreon: Patreon
+        github_sponsors: GitHub Sponsors
+        ko_fi: Ko-fi
+        supporter_benefits: Supporter benefits
+        access_to_reverse_geocoding_api_see_patreon_tier: Access to reverse geocoding API (see Patreon tier)
+        mention_in_github_releases: Mention in Github Releases
+        supporter_badge_displayed_in_the_navbar: Supporter badge displayed in the navbar
+        supporter_example_com: supporter@example.com
+        octocat: octocat
+        verify: Verify
+        supporter_thanks: Thank you for supporting Dawarich%{platform}!
+        supporter_platform: " via %{platform}"
+      index:
+        email_preferences: Email Preferences
+        monthly_digest_emails: Monthly Digest Emails
+        summary_of_your_last_month_sent_on_the_2nd: Summary of your last month, sent on the 2nd.
+        year_end_digest_emails: Year-End Digest Emails
+        receive_an_annual_summary_on_january_2nd_with_your_year: Receive an annual summary on January 2nd with your year in review.
+        news_updates: News & Updates
+        receive_occasional_emails_about_new_features_and_important_updates: Receive occasional emails about new features and important updates
+        timezone: Timezone
+        your_timezone: Your timezone
+        all_dates_and_times_will_be_displayed_in_this_timezone: All dates and times will be displayed in this timezone
+        supporter_badge: Supporter Badge
+        show_supporter_badge_in_navbar: Show supporter badge in navbar
+        display_a_gem_icon_next_to_your_profile_to_show: Display a gem icon next to your profile to show your supporter status
+        general_settings: General settings
+        save_changes: Save changes
+    integrations:
+      index:
+        immich_photoprism_integrations: Immich & Photoprism Integrations
+        connect_your_photo_management_tools_to_see_your_photos_on: Connect your photo management tools to see your photos on the map. Immich and Photoprism integrations are available on the Pro plan.
+        upgrade_to_pro: Upgrade to Pro
+        immich_integration: Immich Integration
+        immich_url: Immich URL
+        the_base_url_of_your_immich_instance: The base URL of your Immich instance
+        immich_api_key: Immich API Key
+        found_in_your_immich_admin_panel_under_api_settings_required: 'Found in your Immich admin panel under API settings. Required permissions:'
+        asset_read: asset.read
+        asset_view: asset.view
+        and: ", and"
+        asset_update: asset.update
+        for_photo_enrichment: "(for photo enrichment)."
+        skip_ssl_certificate_verification_self_signed_certificates: Skip SSL certificate verification (self-signed certificates)
+        security_warning: 'Security Warning:'
+        disabling_ssl_verification_makes_your_connection_vulnerable_to_man_in: Disabling SSL verification makes your connection vulnerable to man-in-the-middle attacks. Only enable this for self-signed certificates you trust on your local network.
+        clears_cached_photo_metadata_and_thumbnails_for_all_integrations: Clears cached photo metadata and thumbnails for all integrations.
+        photoprism_integration: Photoprism Integration
+        photoprism_url: Photoprism URL
+        the_base_url_of_your_photoprism_instance: The base URL of your Photoprism instance
+        photoprism_api_key: Photoprism API Key
+        found_in_your_photoprism_settings_under_library: Found in your Photoprism settings under Library
+        airtrail_integration: AirTrail Integration
+        airtrail_url: AirTrail URL
+        the_base_url_of_your_airtrail_instance_your_flights_are: The base URL of your AirTrail instance. Your flights are shown as arcs on the map.
+        airtrail_api_key: AirTrail API Key
+        create_an_api_key_in_airtrail_under_settings_rarr_security: Create an API key in AirTrail under Settings → Security.
+        last_synced: 'Last synced:'
+        connected_accounts: Connected Accounts
+        you_ve_connected_your_account_using_the_following_oauth_provider: 'You''ve connected your account using the following OAuth provider:'
+        sync_airtrail_flights: Sync AirTrail flights
+        flights_also_sync_automatically_once_a_day: Flights also sync automatically once a day.
+        user_settings: User Settings
+        xxxxxxxxxxxxxx: xxxxxxxxxxxxxx
+        refresh_photo_cache: Refresh photo cache
+        save_test_connection: Save & Test Connection
+        sync_now: Sync now
+        settings: Settings
+    maps:
+      index:
+        map_appearance_colors_layers_and_points_of_interest_for_the: Map appearance, colors, layers, and points of interest for the current map (V2) are configured directly on the
+        open_the_settings_panel_there_this_page_only_covers_the: "— open the settings panel there. This page only covers the legacy V1 (Leaflet) map."
+        general: General
+        preferred_map_version: Preferred Map Version
+        v2_maplibre_is_the_default_v1_leaflet_is_available_for: V2 (MapLibre) is the default. V1 (Leaflet) is available for compatibility.
+        using_a_custom_tile_url_may_result_in_extra_costs: Using a custom tile URL may result in extra costs. Check your map tile provider's terms of service.
+        custom_tiles_v1: Custom Tiles (V1)
+        map_name: Map Name
+        a_descriptive_name_for_your_map_configuration: A descriptive name for your map configuration
+        tile_url: Tile URL
+        url_pattern_for_map_tiles_must_include_x_y_and: URL pattern for map tiles. Must include {x}, {y}, and {z} placeholders
+        map_preview: Map Preview
+        map_settings: Map settings
+        map_page: map page
+        v1_leaflet: V1 (Leaflet)
+        v2_maplibre: V2 (MapLibre)
+        example_openstreetmap: 'Example: OpenStreetMap'
+        save_changes: Save changes
+    subscriptions:
+      index:
+        hello_there: Hello there!
+        you_are_currently_subscribed_to_dawarich_hurray: You are currently subscribed to Dawarich, hurray!
+        your_subscription_will_be_valid_for_the_next: Your subscription will be valid for the next
+        you_are_currently_not_subscribed_to_dawarich_how_about_we: You are currently not subscribed to Dawarich. How about we fix that?
+        manage_subscription: Manage subscription
+        subscriptions: Subscriptions
+    two_factor:
+      backup_codes:
+        save_your_backup_codes: Save your backup codes
+        store_these_codes_in_a_safe_place_each_code_can: Store these codes in a safe place. Each code can only be used once. If you lose access to your authenticator app, you can use these codes to sign in.
+        two_factor_authentication_enabled: Two-Factor Authentication Enabled
+        done: Done
+        backup_codes: Backup Codes
+      show:
+        fa_is_enabled: 2FA is enabled
+        your_account_is_protected_with_two_factor_authentication: Your account is protected with two-factor authentication.
+        to_disable_2fa_enter_your_password_and_a_current_authenticator: To disable 2FA, enter your password and a current authenticator code (or backup code).
+        current_password: Current password
+        authenticator_code_or_backup_code: Authenticator code or backup code
+        fa_is_not_enabled: 2FA is not enabled
+        add_an_extra_layer_of_security_to_your_account: Add an extra layer of security to your account.
+        two_factor_authentication_adds_an_extra_layer_of_security_by: Two-factor authentication adds an extra layer of security by requiring a code from your authenticator app (Google Authenticator, Authy, etc.) when you sign in.
+        two_factor_authentication: Two-Factor Authentication
+        disable_2fa: Disable 2FA
+        enable_2fa: Enable 2FA
+      verify:
+        scan_qr_code: Scan QR code
+        scan_this_qr_code_with_your_authenticator_app_google_authenticator: Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.).
+        can_t_scan_enter_the_code_manually: Can't scan? Enter the code manually
+        verify_setup: Verify setup
+        enter_the_6_digit_code_from_your_authenticator_app_to: Enter the 6-digit code from your authenticator app to verify the setup.
+        set_up_two_factor_authentication: Set up Two-Factor Authentication
+        verification_code: Verification code
+        verify_and_enable: Verify and enable
+    users:
+      edit:
+        editing_user: Editing user
+        email: Email
+        password: Password
+        leave_blank_to_keep_current: "(leave blank to keep current)"
+        admin: Admin
+        status: Status
+        update: Update
+      index:
+        user_registration: User registration
+        allow_new_users_to_register_via_email_and_password: Allow new users to register via email and password
+        add_new_user: Add new user
+        search_by_email: Search by email...
+        search: Search
+        email: Email
+        role: Role
+        status: Status
+        points: Points
+        last_sign_in: Last sign in
+        created_at: Created at
+        admin: Admin
+        user: User
+        active: Active
+        inactive: Inactive
+        trial: Trial
+        never: Never
+        delete: Delete
+        create_a_new_user: Create a new user!
+        password: Password
+        close: close
+        delete_user: Delete user
+        are_you_sure_you_want_to_delete: Are you sure you want to delete
+        this_will_permanently_remove_their_account_and_all_associated_data: "? This will permanently remove their account and all associated data. This action cannot be undone."
+        cancel: Cancel
+        users_management: Users management
+        clear: Clear
+        edit: Edit
+        create: Create
+        users: Users
+      show:
+        user_details: User details
+        admin: Admin
+        user: User
+        active: Active
+        inactive: Inactive
+        trial: Trial
+        data_overview: Data overview
+        points: Points
+        tracks: Tracks
+        imports: Imports
+        exports: Exports
+        areas: Areas
+        sign_in_history: Sign-in history
+        total_sign_ins: Total sign-ins
+        last_sign_in: Last sign-in
+        never: Never
+        last_sign_in_ip: Last sign-in IP
+        current_sign_in_ip: Current sign-in IP
+        account_created: Account created
+        api_key: API key
+        copy: Copy
+        actions: Actions
+        edit: Edit
+        back_to_users: Back to users
+        regenerate_api_key: Regenerate API key
+        are_you_sure_this_will_invalidate_the_current_api_key: Are you sure? This will invalidate the current API key.
+        send_password_reset_email: Send password reset email
+        edit_user: Edit user
+        user_email: 'User: %{email}'
+    visits:
+      redetect_panel:
+        re_run_detection_on_full_history: Re-run detection on full history
+        replaces_all_suggested_visits_across_your_entire_history_with_fresh: Replaces all suggested visits across your entire history with fresh detections using the settings above. Confirmed visits and the places you've named are preserved. Small accounts usually finish in a few minutes; multi-year histories can take 30–60 minutes and will temporarily increase server load.
+        on_the_lite_plan_re_detection_covers_your_visible_12: On the Lite plan, re-detection covers your visible 12-month window only.
+        available_again_at: Available again at
+        replace_all_suggested_visits_across_your_full_history_confirmed_visits: Replace all suggested visits across your full history. Confirmed visits stay. Continue?
+      show:
+        tune_how_dawarich_decides_where_you_actually_were: Tune how Dawarich decides where you actually were
+        these_settings_control_how_the_app_groups_your_gps_points: These settings control how the app groups your GPS points into visits to places.
+        points_within_this_radius_are_treated_as_the_same_visit: Points within this radius are treated as the same visit. Default 100.
+        lower_more_visits_suggested_including_brief_stops_default_3: Lower = more visits suggested, including brief stops. Default 3.
+        skip_stops_shorter_than_this_raise_to_ignore_short_drive: Skip stops shorter than this. Raise to ignore short drive-bys; lower to catch brief errands. Default 5.
+        smart_density_fill: Smart density fill
+        better_visits_when_your_tracker_reports_points_unevenly_leave_on: Better visits when your tracker reports points unevenly. Leave on unless you know you want it off.
+        visit_detection: Visit detection
+        visit_radius_meters: Visit radius (meters)
+        minimum_points_to_count_as_a_visit: Minimum points to count as a visit
+        minimum_visit_duration_minutes: Minimum visit duration (minutes)
+        save_settings: Save settings
+  share_links:
+    hubs:
+      body:
+        live_location: Live location
+        time_period: Time period
+        shared: Shared
+        your_live_location_is_shared_via_a_public_link: Your live location is shared via a public link.
+      modal:
+        share: Share
+        close: Close
+      shared_list:
+        copy_link: Copy link
+        open_in_new_tab: Open in new tab
+        revoke_link: Revoke link
+        revoke_this_link_it_will_stop_working_immediately: Revoke this link? It will stop working immediately.
+        revoke: Revoke
+    lives:
+      new:
+        share_your_live_location: Share your live location
+        your_live_location_is_shared_via_a_public_link: Your live location is shared via a public link.
+    timelines:
+      new:
+        share_a_date_range: Share a date range
+  shared:
+    flash_message:
+      close: Close
+    footer:
+      dawarich: Dawarich
+    legal_footer:
+      dawarich: Dawarich
+      made_and_hosted_in_europe: "Made and hosted in \U0001F1EA\U0001F1FA Europe"
+      copyright: Copyright ©
+      zeitflow_ug: ZeitFlow UG
+      community: Community
+      discord: Discord
+      github: Github
+      mastodon: Mastodon
+      docs: Docs
+      tutorial: Tutorial
+      import_existing_data: Import existing data
+      exporting_data: Exporting data
+      faq: FAQ
+      contact: Contact
+      more: More
+      privacy_policy: Privacy policy
+      terms_and_conditions: Terms and Conditions
+      refund_policy: Refund policy
+      impressum: Impressum
+      blog: Blog
+    navbar:
+      family: Family
+      my_data: My data
+      help: Help
+      dawarich: Dawarich
+      get_started: Get started
+      finish_setting_up_your_account: Finish setting up your account
+      finish_signup: Finish signup
+      trial_expired: Trial expired
+      trial_expired_2: "Trial expired \U0001F97A"
+      remaining: remaining
+      changelog_prompt:
+        stay_up_to_date: Stay up to date?
+        get_a_what_s_new_notice_when_a_new_dawarich: Get a "What's New" notice when a new Dawarich version ships, including security fixes. The notice loads a small widget from
+        like_any_web_request_that_host_sees_your_ip_address: ". Like any web request, that host sees your IP address, browser, and the page URL, plus your Dawarich version — never your account, email, or location. You can change this anytime."
+        no_thanks: No thanks
+        yes_notify_me: Yes, notify me
+      help_links:
+        need_help_ping_us: Need help? Ping us!
+        x_twitter: X (Twitter)
+        mastodon: Mastodon
+        email: Email
+        forum: Forum
+        discord: Discord
+      version_indicator:
+        nbsp: " !"
+        new_version_available_check_out_github_releases: New version available! Check out Github releases!
+      map: Map
+      trips: Trips
+      stats: Stats
+      insights_sup_sup_html: Insights<sup>α</sup>
+      family_sup_sup_html: Family<sup>α</sup>
+      points: Points
+      places: Places
+      imports: Imports
+      exports: Exports
+      tags: Tags
+      subscribe: Subscribe
+      account: Account
+      settings: Settings
+      subscription: Subscription
+      logout: Logout
+      see_all: See all
+      you_re_an_admin_harry: You're an admin, Harry!
+      dawarich_supporter: Dawarich Supporter
+      login: Login
+      register: Register
+      trial_ends_in: Your trial will end in %{time}
+      theme_toggle:
+        dark_mode: Dark mode
+        light_mode: Light mode
+      days_remaining:
+        one: "%{count} day remaining"
+        other: "%{count} days remaining"
+    place_creation_modal:
+      create_new_place: Create New Place
+      place_name: Place Name *
+      note: Note
+      optional_add_any_notes_or_details_about_this_place: Optional - Add any notes or details about this place
+      tags: Tags
+      click_tags_to_select_them_for_this_place: Click tags to select them for this place
+      suggested_places: Suggested Places
+      nearby_places: Nearby Places
+      open_modal_to_load_nearby_suggestions: Open modal to load nearby suggestions
+      cancel: Cancel
+      enter_place_name: Enter place name...
+      add_a_personal_note_about_this_place: Add a personal note about this place...
+      create_place: Create Place
+      saving: Saving...
+    plan_data_window_alert:
+      your_lite_plan_includes_the_last_12_months_of_data: Your Lite plan includes the last 12 months of data. Upgrade to Pro to access your full history.
+      upgrade_to_pro: Upgrade to Pro
+      close: Close
+    replay_panel:
+      close_replay: Close replay
+      times: "×"
+      previous_day: Previous day
+      larr: "←"
+      no_data_loaded: No data loaded
+      next_day: Next day
+      rarr: "→"
+      no_data: No data
+      play_pause: Play/Pause
+      play_or_pause_replay: Play or pause replay
+      recenter_follow_marker: Recenter & follow marker
+      recenter_and_follow_the_marker: Recenter and follow the marker
+      replay_speed: Replay speed
+      previous_point: Previous point
+      point_1_of_1: Point 1 of 1
+      next_point: Next point
+      replay_scrubber_time_of_day: Replay scrubber - time of day
+    sharing_link:
+      sharing_link: Sharing link
+      copy: Copy
+      share_this_link_to_allow_others_to_view_your_stats: Share this link to allow others to view your stats
+    sharing_modal:
+      sharing_settings: Sharing Settings
+      share_your_monthly_stats_publicly_with_friends_and_family_public: Share your monthly stats publicly with friends and family. Public stats sharing is available on the Pro plan.
+      upgrade_to_pro: Upgrade to Pro
+      enable_public_access: Enable public access
+      allow_others_to_view_this_monthly_digest_auto_saves_on: Allow others to view this monthly digest • Auto-saves on change
+      link_expiration: Link expiration
+      privacy_protection: Privacy Protection
+      exact_coordinates_are_hidden: "• Exact coordinates are hidden"
+      personal_information_is_not_included: "• Personal information is not included"
+      done: Done
+    links:
+      live:
+        live: "● Live"
+        connecting: Connecting…
+      missing_resource:
+        this_share_is_no_longer_available: This share is no longer available
+        the_original_content_was_removed_by_the_owner: The original content was removed by the owner.
+      timeline:
+        shared_on_dawarich: "· Shared on Dawarich"
+        days_shared_on_dawarich:
+          one: "%{count} day · Shared on Dawarich"
+          other: "%{count} days · Shared on Dawarich"
+      track:
+        distance: Distance
+        duration: Duration
+        avg_speed: Avg speed
+        elevation_gain: Elevation gain
+        elevation_loss: Elevation loss
+      trip:
+        publicly_shared: Publicly shared
+        public: Public
+        ndash: "–"
+        trip_notes: Trip Notes
+        replay: Replay
+      trip_day_header:
+        middot: "·"
+        no_data: No data
+      unsupported:
+        this_share_type_is_no_longer_supported: This share type is no longer supported
+        the_link_may_have_been_created_by_a_newer_or: The link may have been created by a newer or older version of Dawarich.
+      not_found:
+        this_shared_link_is_no_longer_available: This shared link is no longer available
+        the_owner_may_have_revoked_the_link_or_it_may: The owner may have revoked the link or it may have expired.
+        not_found_dawarich: Not found — Dawarich
+      phrase_prompt:
+        enter_the_magic_phrase: Enter the magic phrase
+        this_shared_link_is_protected_ask_the_owner_for_the: This shared link is protected. Ask the owner for the phrase.
+        magic_phrase: magic phrase
+        unlock: Unlock
+        enter_phrase_dawarich: Enter phrase — Dawarich
+      show:
+        name_shared_on_dawarich: "%{name} — Shared on Dawarich"
+        shared_from_dawarich: Shared from Dawarich
+    map:
+      date_navigation:
+        start_date_and_time: Start date and time
+        end_date_and_time: End date and time
+        search: Search
+        today: Today
+        last_7_days: Last 7 days
+        last_month: Last month
+      date_navigation_v2:
+        share: Share
+        start_date_and_time: Start date and time
+        end_date_and_time: End date and time
+        search: Search
+        today: Today
+        last_7_days: Last 7 days
+        last_month: Last month
+      share_indicator:
+        live_location_is_being_shared: Live location is being shared
+      upgrade_banner:
+        your_lite_plan_includes_the_last_12_months_of_data: Your Lite plan includes the last 12 months of data.
+        upgrade_to_pro: Upgrade to Pro
+        dismiss: Dismiss
+  shared_links:
+    expires_field:
+      expires_optional: Expires (optional)
+      stays_active_through_the_end_of_the_day_before_the: Stays active through the end of the day before the selected date.
+      defaults_to_one_week_from_today_leave_blank_for_a: Defaults to one week from today. Leave blank for a link that never expires.
+    modal:
+      anyone_with_the_link_will_be_able_to_view_this: Anyone with the link will be able to view this.
+      close: Close
+    modal_active:
+      sharing: Sharing
+      public: Public
+      public_link: Public link
+      copy_link: Copy link
+      copy_public_link: Copy public link
+      magic_phrase: Magic phrase
+      copy_magic_phrase: Copy magic phrase
+      last_viewed: Last viewed
+      ago: ago
+      not_viewed_yet: Not viewed yet
+      regenerate_url: Regenerate URL
+      regenerate_phrase: Regenerate phrase
+      revoke: Revoke
+      open_in_new_tab: Open in new tab
+      generate_a_new_url_the_current_url_will_stop_working: Generate a new URL? The current URL will stop working.
+      generate_a_new_phrase: Generate a new phrase?
+      revoke_this_link_it_will_stop_working_immediately: Revoke this link? It will stop working immediately.
+      view_count:
+        one: "%{count} view"
+        other: "%{count} views"
+    modal_live_create_form:
+      this_shares_your: This shares your
+      current_location_in_real_time: current location in real time
+      with_anyone_who_has_the_link_until_it_expires_or: with anyone who has the link, until it expires or you revoke it.
+      magic_phrase_optional: Magic phrase (optional)
+      leave_blank_to_share_without_a_phrase_or_use_the: Leave blank to share without a phrase, or use the auto-generated one.
+      share_the_route: Share the route
+      also_show_the_path_travelled_since_this_link_was_created: Also show the path travelled since this link was created.
+      cancel: Cancel
+      create_share_link: Create share link
+    modal_timeline_create_form:
+      start_date: Start date
+      end_date: End date
+      magic_phrase_optional: Magic phrase (optional)
+      leave_blank_to_share_without_a_phrase_or_use_the: Leave blank to share without a phrase, or use the auto-generated one.
+      show_photos: Show photos
+      cancel: Cancel
+      create_share_link: Create share link
+    modal_track_create_form:
+      magic_phrase_optional: Magic phrase (optional)
+      leave_blank_to_share_without_a_phrase_or_use_the: Leave blank to share without a phrase, or use the auto-generated one.
+      show_photos: Show photos
+      show_stats: Show stats
+      cancel: Cancel
+      create_share_link: Create share link
+    modal_trip_create_form:
+      magic_phrase_optional: Magic phrase (optional)
+      leave_blank_to_share_without_a_phrase_or_use_the: Leave blank to share without a phrase, or use the auto-generated one.
+      what_to_include_on_the_public_page: What to include on the public page
+      cancel: Cancel
+      create_share_link: Create share link
+      stats_countries_distance_duration: Stats & countries (distance, duration)
+      day_by_day_breakdown: Day-by-day breakdown
+      per_day_notes: Per-day notes
+      photos_on_map: Photos on map
+      route_map: Route map
+      trip_description: Trip description
+  stats:
+    locked_year_card:
+      available_on_pro: Available on Pro
+      upgrade_to_pro: Upgrade to Pro
+    month:
+      monthly_digest: Monthly Digest
+      share: Share
+      distance_traveled: Distance traveled
+      active_days: Active days
+      countries_visited: Countries visited
+      map_summary: Map Summary
+      heatmap: Heatmap
+      points: Points
+      daily_activity: Daily Activity
+      peak_day: 'Peak day:'
+      quietest_week: "• Quietest week:"
+      countries_cities: Countries & Cities
+      no_location_data_available_for_this_month: No location data available for this month
+      cities_visited: 'Cities visited:'
+      back_to: "← Back to"
+      day: Day
+      distance: Distance
+      month_year_monthly_digest: "%{month} %{year} Monthly Digest"
+      city_count:
+        one: "%{count} city"
+        other: "%{count} cities"
+    reverse_geocoding_stats:
+      reverse_geocoded_points: Reverse geocoded points
+      points_without_data: points without data
+      countries_visited: Countries visited
+      close: close
+      cities_visited: Cities visited
+      points_that_were_reverse_geocoded_but_had_no_data: Points that were reverse geocoded but had no data
+    stat:
+      total_distance: Total distance
+      year_month: "%{year}/%{month}"
+    year:
+      map: "[Map]"
+      days: Days
+      distance: Distance
+    index:
+      year_end_digests: Year-End Digests
+      total_distance: Total distance
+      geopoints_tracked: Geopoints tracked
+      all_stats_data_above_except_for_total_distance_and_number: All stats data above except for total distance and number of geopoints tracked is being updated daily
+      last_update: 'Last update:'
+      countries_and_cities_visited_in: Countries and Cities visited in
+      no_specific_cities_recorded: No specific cities recorded
+      statistics: Statistics
+      update_stats: Update stats
+      map: "[Map]"
+      days: Days
+      distance: Distance
+      countries_count_countries_cities_count_cities: "%{countries_count} countries, %{cities_count} cities"
+    public_month:
+      monthly_digest: Monthly Digest
+      distance_traveled: Distance traveled
+      total_distance_for_this_month: Total distance for this month
+      active_days: Active days
+      days_with_tracked_activity: Days with tracked activity
+      countries_visited: Countries visited
+      different_countries: Different countries
+      location_hexagons: Location Hexagons
+      loading_hexagons: Loading hexagons...
+      daily_activity: Daily Activity
+      peak_day: 'Peak day:'
+      quietest_week: "• Quietest week:"
+      countries_cities: Countries & Cities
+      cities: cities
+      cities_visited: 'Cities visited:'
+      more: more
+      powered_by: Powered by
+      dawarich: Dawarich
+      your_personal_memories_mapper: ", your personal memories mapper."
+      day: Day
+      distance: Distance
+    show:
+      statistics_for_year_year: Statistics for %{year} year
+  tags:
+    form:
+      prohibited_this_tag_from_being_saved: 'prohibited this tag from being saved:'
+      click_to_select_an_emoji: Click to select an emoji
+      custom: 'Custom:'
+      choose_from_swatches_or_pick_a_custom_color: Choose from swatches or pick a custom color
+      privacy_zone: Privacy Zone
+      hide_map_data_around_places_with_this_tag: Hide map data around places with this tag
+      data_within_this_radius_will_be_hidden_from_the_map: Data within this radius will be hidden from the map
+      home_work_restaurant: Home, Work, Restaurant...
+      privacy_radius: Privacy Radius
+      cancel: Cancel
+      errors_prohibited_save:
+        one: "%{count} error prohibited this tag from being saved:"
+        other: "%{count} errors prohibited this tag from being saved:"
+    edit:
+      edit_tag: Edit Tag
+      update_your_tag_details: Update your tag details
+    index:
+      new_tag: New Tag
+      icon: Icon
+      name: Name
+      color: Color
+      places: Places
+      actions: Actions
+      no_tags_yet: No tags yet
+      create_tags_to_organize_your_places_and_add_privacy_zones: Create tags to organize your places and add privacy zones.
+      create_your_first_tag: Create your first tag
+      tags: Tags
+      edit_tag: Edit tag
+      delete_tag: Delete tag
+      are_you_sure: Are you sure?
+    new:
+      new_tag: New Tag
+      create_a_new_tag_to_organize_your_places: Create a new tag to organize your places
+  tracks:
+    segments:
+      segment_row:
+        manually_corrected: Manually corrected
+        restore_auto_detection: Restore auto-detection
+        transportation_mode_currently: Transportation mode (currently %{mode})
+        reset_to_auto_detected_mode: Reset to auto-detected mode
+        edited_ago: Edited %{time} ago
+      index:
+        no_segments_for_this_track_yet: No segments for this track yet.
+    share_links:
+      new:
+        this_track_is_shared_via_a_public_link: This track is shared via a public link.
+        share_track: Share %{track}
+  trial:
+    resume:
+      show:
+        finish_setting_up_your_account: Finish setting up your account
+        your_account_is_almost_ready_to_start_tracking_your_location: Your account is almost ready. To start tracking your location data, please complete your subscription checkout. You won't be charged during the 7-day free trial — cancel anytime before it ends and you won't be billed.
+        resume_checkout: Resume checkout
+        or_delete_my_account: Or delete my account
+        are_you_sure_this_cannot_be_undone: Are you sure? This cannot be undone.
+  trips:
+    countries:
+      middot: "·"
+      mdash: "&mdash;"
+      country_count:
+        one: "%{count} country"
+        other: "%{count} countries"
+    distance:
+      calculating: Calculating...
+    form:
+      prohibited_this_trip_from_being_saved: 'prohibited this trip from being saved:'
+      errors_prohibited_save:
+        one: "%{count} error prohibited this trip from being saved:"
+        other: "%{count} errors prohibited this trip from being saved:"
+    recalculate_button:
+      recalculating_hellip: Recalculating…
+      recalculate: Recalculate
+      recalculation_failed_try_again: Recalculation failed — try again.
+      recalculate_this_trip_s_path_distance_and_countries_from_your: Recalculate this trip's path, distance, and countries from your latest points?
+    trip:
+      no_points_found: No points found
+      calculating: Calculating...
+      ndash: "–"
+      day_count:
+        one: "%{count} day"
+        other: "%{count} days"
+    edit:
+      back_to_trips: Back to trips
+      editing_trip: Editing trip
+      show_this_trip: Show this trip
+    index:
+      new_trip: New trip
+      no_trips_yet: No trips yet
+      create_your_first_trip_to_see_your_journeys_visualized_with: Create your first trip to see your journeys visualized with maps, photos, and stats.
+      create_your_first_trip: Create your first trip
+      trips: Trips
+    new:
+      back_to_trips: Back to trips
+      new_trip: New trip
+    notes:
+      empty:
+        add_note: "+ Add note"
+        write_your_notes_for_this_day: Write your notes for this day...
+        save_note: Save note
+        cancel: Cancel
+      form:
+        write_your_notes_for_this_day: Write your notes for this day...
+        cancel: Cancel
+        update_note: Update note
+        save_note: Save note
+      note:
+        edit: Edit
+        write_your_notes_for_this_day: Write your notes for this day...
+        cancel: Cancel
+        delete: Delete
+        delete_this_note: Delete this note?
+        update_note: Update note
+    show:
+      loading_route_data: Loading route data...
+      trip_path_is_being_calculated: Trip path is being calculated...
+      download_trip: Download trip
+      currently_shared: Currently shared
+      public: Public
+      ndash: "–"
+      toggle_photo_markers_on_map: Toggle photo markers on map
+      photos: Photos
+      toggle_airtrail_flights_on_map: Toggle AirTrail flights on map
+      flights: Flights
+      replay_the_trip: Replay the trip
+      replay: Replay
+      show_all_days: Show all days
+      poster: Poster
+      middot: "·"
+      text: "< 1"
+      no_data: No data
+      trip_notes: Trip Notes
+      more_on: More on
+      back_to_trips: Back to trips
+      gpx: GPX
+      geojson: GeoJSON
+      edit_trip: Edit trip
+      share_trip: Share trip
+      delete_this_trip_this_cannot_be_undone: Delete this trip? This cannot be undone.
+      delete_trip: Delete trip
+      poster_unavailable: Available once the trip route is calculated
+      create_poster: Create a poster of this trip
+      more_on_source: More on %{source}
+    share_links:
+      new:
+        share_trip: Share %{trip}
+        trip_is_shared_via_a_public_link: "%{trip} is shared via a public link."
+  users:
+    digests:
+      index:
+        year_end_digests: Year-End Digests
+        generate_digest: Generate Digest
+        no_year_end_digests_yet: No Year-End Digests Yet
+        year_end_digests_are_automatically_generated_on_january_1st_each: Year-end digests are automatically generated on January 1st each year.
+        or_you_can_manually_generate_one_for_a_previous_year: Or you can manually generate one for a previous year.
+        shared: Shared
+        distance: Distance
+        countries: Countries
+        new: new
+        cities: Cities
+        view_details: View Details
+      public_year:
+        year_in_review: Year in Review
+        your_journey_by_the_numbers: Your journey, by the numbers
+        distance_traveled: Distance traveled
+        countries_visited: Countries visited
+        cities_explored: Cities explored
+        first_time_visits: First Time Visits
+        new_countries: New Countries
+        new_cities: New Cities
+        more: more
+        year_by_month: Year by Month
+        where_they_spent_the_most_time: Where They Spent the Most Time
+        countries_cities: Countries & Cities
+        cities: cities
+        cities_visited: 'Cities visited:'
+        all_time_stats: All-Time Stats
+        total_distance: Total distance
+        track_your_own_adventures_with: Track your own adventures with
+        dawarich: Dawarich
+        your_personal_memories_mapper: "— your personal memories mapper."
+        month: Month
+        distance: Distance
+        first_time_count:
+          one: "%{count} first time"
+          other: "%{count} first time"
+      show:
+        year_in_review: Year in Review
+        your_journey_by_the_numbers: Your journey, by the numbers
+        share: Share
+        distance_traveled: Distance Traveled
+        compared_to: compared to
+        countries: Countries
+        cities: Cities
+        first_time_visits: First Time Visits
+        new_countries: New Countries
+        new_cities: New Cities
+        more: more
+        your_year_month_by_month: Your Year, Month by Month
+        where_you_spent_the_most_time: Where You Spent the Most Time
+        no_tracking_data: No tracking data
+        track_more_in: Track more in
+        to_see_a_fuller_picture_of_your_travels: to see a fuller picture of your travels!
+        countries_cities: Countries & Cities
+        no_location_data_available: No location data available
+        all_time_stats: All-Time Stats
+        countries_visited: Countries visited
+        cities_explored: Cities explored
+        total_distance: Total distance
+        want_more_insights: Want more insights?
+        upgrade_to_pro_to_see_your_full_year_in_review: Upgrade to Pro to see your full year-in-review with monthly breakdowns, detailed city and country rankings, transportation analysis, and all-time stats.
+        upgrade_to_pro: Upgrade to Pro
+        back_to_all_digests: Back to All Digests
+        delete: Delete
+        sharing_settings: Sharing Settings
+        enable_public_access: Enable public access
+        allow_others_to_view_this_year_end_digest_auto_saves: Allow others to view this year-end digest • Auto-saves on change
+        link_expiration: Link expiration
+        privacy_protection: Privacy Protection
+        exact_coordinates_are_hidden: "• Exact coordinates are hidden"
+        personal_information_is_not_included: "• Personal information is not included"
+        done: Done
+        month: Month
+        distance: Distance
+        year_year_in_review: "%{year} Year in Review"
+        are_you_sure_you_want_to_delete_the_year_digest: Are you sure you want to delete the %{year} digest? This cannot be undone.
+        first_time_count:
+          one: "%{count} first time"
+          other: "%{count} first time"
+        day_count:
+          one: "%{count} day"
+          other: "%{count} days"
+        city_count:
+          one: "%{count} city"
+          other: "%{count} cities"
+    digests_mailer:
+      monthly_digest:
+        your: Your
+        in_review: in review
+        here_s_what_your_location_history_looked_like_last_month: Here's what your location history looked like last month.
+        overview: OVERVIEW
+        distance: Distance
+        active_days: Active days
+        countries: Countries
+        cities: Cities
+        weekly_pattern: WEEKLY PATTERN
+        daily_distance: DAILY DISTANCE
+        top_countries: TOP COUNTRIES
+        top_cities: TOP CITIES
+        first_visits_this_month: FIRST VISITS THIS MONTH
+        vs_previous_month: VS PREVIOUS MONTH
+        view_full_insights_rarr: View full insights →
+        you_re_receiving_this_because_monthly_digest_emails_are_on: You're receiving this because monthly digest emails are on for your account.
+        manage_email_preferences: Manage email preferences
+        in_review_here_s_what_your_location_history_looked_like: in review ───────────────────────── Here's what your location history looked like last month. OVERVIEW Distance
+        new_country: "(new country)"
+        new_city: "(new city)"
+        vs_previous_month_distance: VS PREVIOUS MONTH Distance
+        view_full_insights: "→ View full insights:"
+        you_re_receiving_this_because_monthly_digest_emails_are_on_2: "───────────────────────────────────────── You're receiving this because monthly digest emails are on. Manage email preferences:"
+        weekday_totals: "@weekday_totals,"
+        labels_w_mon_tue_wed_thu_fri_sat_sun: 'labels: %w[Mon Tue Wed Thu Fri Sat Sun],'
+        width_20: 'width: 20,'
+        suffix_distance_unit: 'suffix: " #{@distance_unit}"'
+        31_map_d_daily_distances_d_to_s_to: "(1..31).map { |d| @daily_distances[d.to_s].to_f }"
+        reject_zero: ".reject(&:zero?)"
+        presence_0: ".presence || [0]"
+        you_re_receiving_this_because_monthly_digest_emails_are_on_3: You're receiving this because monthly digest emails are on.
+        manage_email_preferences_2: 'Manage email preferences:'
+        month_year_in_review: Your %{month} %{year} in review
+        new_country_line: "→ %{country}  (new country)"
+        new_city_line: "→ %{city}  (new city)"
+      year_end_digest:
+        your: Your
+        year_in_review: Year in Review
+        here_s_your: Here's your
+        at_a_glance: at a glance.
+        the_numbers: THE NUMBERS
+        distance: Distance
+        countries: Countries
+        cities: Cities
+        activity_heatmap: ACTIVITY HEATMAP
+        none_light_moderate_high_peak: "· none ░ light ▒ moderate ▓ high █ peak"
+        monthly_distance: MONTHLY DISTANCE
+        top_countries: TOP COUNTRIES
+        vs_previous_year: VS PREVIOUS YEAR
+        view_full_insights_rarr: View full insights →
+        share_your_year_rarr: Share your year →
+        you_re_receiving_this_because_yearly_digest_emails_are_on: You're receiving this because yearly digest emails are on for your account.
+        manage_email_preferences: Manage email preferences
+        year_in_review_here_s_your: Year in Review ────────────────────────────── Here's your
+        at_a_glance_the_numbers_distance: at a glance. THE NUMBERS Distance
+        vs_previous_year_distance: VS PREVIOUS YEAR Distance
+        view_full_insights: "-> View full insights:"
+        share_your_year: "-> Share your year:"
+        you_re_receiving_this_because_yearly_digest_emails_are_on_2: "───────────────────────────────────────── You're receiving this because yearly digest emails are on. Manage email preferences:"
+        12_map_m_monthly_distances_m_to_s_to: "(1..12).map { |m| @monthly_distances[m.to_s].to_f.round },"
+        labels_date_abbr_monthnames_1_12: 'labels: Date::ABBR_MONTHNAMES[1..12],'
+        width_24: 'width: 24,'
+        suffix_distance_unit: 'suffix: " #{@distance_unit}"'
+        you_re_receiving_this_because_yearly_digest_emails_are_on_3: You're receiving this because yearly digest emails are on.
+        manage_email_preferences_2: 'Manage email preferences:'
+  users_mailer:
+    account_destroy_confirmation:
+      confirm_account_deletion: Confirm account deletion
+      hi: Hi
+      we_received_a_request_to_delete_your_dawarich_account: We received a request to delete your Dawarich account.
+      this_is_your_last_chance_to_stop_the_deletion: This is your last chance to stop the deletion.
+      once_confirmed_all_your_location_history_tracks_areas_visits_trips: Once confirmed, all your location history, tracks, areas, visits, trips, and family memberships will be permanently removed.
+      permanently_delete_my_account: Permanently delete my account
+      didn_t_request_this: Didn't request this?
+      ignore_this_email_the_link_expires_in_1_hour_and: Ignore this email — the link expires in 1 hour and your account remains untouched. If you keep getting these emails, change your password immediately.
+      if_you_have_an_active_apple_or_google_subscription_remember: If you have an active Apple or Google subscription, remember to cancel it in your platform settings to avoid further charges.
+      link: 'Link:'
+      confirm_account_deletion_hi: Confirm account deletion Hi
+      we_received_a_request_to_delete_your_dawarich_account_this: ", We received a request to delete your Dawarich account. This is your last chance to stop the deletion. Once confirmed, all your location history, tracks, areas, visits, trips, and family memberships will be permanently removed. Permanently delete my account:"
+      didn_t_request_this_ignore_this_email_the_link_expires: Didn't request this? Ignore this email — the link expires in 1 hour and your account remains untouched. If you keep getting these emails, change your password immediately. If you have an active Apple or Google subscription, remember to cancel it in your platform settings to avoid further charges.
+      we_received_a_request_to_delete_your_dawarich_account_this_2: We received a request to delete your Dawarich account. This is your last chance to stop the deletion. Once confirmed, all your location history, tracks, areas, visits, trips, and family memberships will be permanently removed.
+      permanently_delete_my_account_2: 'Permanently delete my account:'
+      didn_t_request_this_ignore_this_email_the_link_expires_2: Didn't request this? Ignore this email — the link expires in 1 hour and your account remains untouched. If you keep getting these emails, change your password immediately.
+    archival_approaching:
+      your_data_history_is_filling_up: Your data history is filling up
+      hi: Hi
+      this_is_evgenii_from_dawarich: ", this is Evgenii from Dawarich."
+      heads_up: 'Heads up:'
+      your_oldest_location_data_will_be_archived_in_about: Your oldest location data will be archived in about
+      weeks: 2 weeks
+      on_the_lite_plan_your_most_recent_12_months_of: On the Lite plan, your most recent 12 months of data remain fully searchable and interactive. Older data is archived — it can always be exported, but it won't appear on your map, in search, stats, or timeline replay.
+      upgrade_to_pro_to_keep_your_full_history: 'Upgrade to Pro to keep your full history:'
+      unlimited_searchable_history_every_month_every_year: Unlimited searchable history — every month, every year
+      heatmap_fog_of_war_and_globe_view: Heatmap, Fog of War, and Globe view
+      full_write_api_access: Full Write API access
+      immich_and_photoprism_integrations: Immich and PhotoPrism integrations
+      upgrade_to_pro: Upgrade to Pro
+      your_data_is_always_yours_pro_simply_makes_all_of: Your data is always yours — Pro simply makes all of it searchable and interactive in-app.
+      questions_drop_me_a_message_at_hi_dawarich_app_or: Questions? Drop me a message at hi@dawarich.app or just reply to this email.
+      best_regards: Best regards,
+      evgenii_from_dawarich: Evgenii from Dawarich
+      your_data_history_is_filling_up_hi: Your data history is filling up Hi
+      this_is_evgenii_from_dawarich_heads_up_your_oldest_location: ", this is Evgenii from Dawarich. Heads up: Your oldest location data will be archived in about 2 weeks. On the Lite plan, your most recent 12 months of data remain fully searchable and interactive. Older data is archived — it can always be exported, but it won't appear on your map, in search, stats, or timeline replay. Upgrade to Pro to keep your full history: - Unlimited searchable history — every month, every year - Heatmap, Fog of War, and Globe view - Full Write API access - Immich and PhotoPrism integrations Upgrade now:"
+      your_data_is_always_yours_pro_simply_makes_all_of_2: Your data is always yours — Pro simply makes all of it searchable and interactive in-app. Questions? Drop me a message at hi@dawarich.app or just reply to this email. Best regards, Evgenii from Dawarich
+      heads_up_your_oldest_location_data_will_be_archived_in: 'Heads up: Your oldest location data will be archived in about 2 weeks.'
+      unlimited_searchable_history_every_month_every_year_2: "- Unlimited searchable history — every month, every year"
+      heatmap_fog_of_war_and_globe_view_2: "- Heatmap, Fog of War, and Globe view"
+      full_write_api_access_2: "- Full Write API access"
+      immich_and_photoprism_integrations_2: "- Immich and PhotoPrism integrations"
+      upgrade_now: 'Upgrade now:'
+    explore_features:
+      explore_dawarich_features: Explore Dawarich Features
+      hi: Hi
+      this_is_evgenii_from_dawarich: ", this is Evgenii from Dawarich."
+      you_re_now_2_days_into_your_dawarich_trial_i: You're now 2 days into your Dawarich trial! I hope you're enjoying tracking your location data.
+      here_are_some_powerful_features_you_might_want_to_explore: 'Here are some powerful features you might want to explore:'
+      reliving_your_travels: "✈️ Reliving your travels"
+      revisit_your_past_journeys_with_detailed_maps_and_insights: Revisit your past journeys with detailed maps and insights.
+      statistics_analytics: "\U0001F4CA Statistics & Analytics"
+      view_detailed_insights_about_distances_traveled_and_time_spent_in: View detailed insights about distances traveled and time spent in different locations.
+      interactive_maps: "\U0001F5FA️ Interactive Maps"
+      visualize_your_tracks_on_beautiful_maps_with_different_layers_and: Visualize your tracks on beautiful maps with different layers and styling options.
+      places_visits: "\U0001F4CD Places & Visits"
+      discover_the_places_you_ve_visited_and_get_automatic_visit: Discover the places you've visited and get automatic visit detection for frequently visited locations.
+      data_export: "\U0001F4E4 Data Export"
+      export_your_location_data_in_multiple_formats_gpx_geojson_for: Export your location data in multiple formats (GPX, GeoJSON) for backup or use with other applications.
+      continue_exploring: Continue Exploring
+      you_have: You have
+      days: 5 days
+      left_in_your_trial_make_the_most_of_it: left in your trial. Make the most of it!
+      best_regards: Best regards,
+      evgenii_from_dawarich: Evgenii from Dawarich
+      explore_dawarich_features_hi: Explore Dawarich Features Hi
+      this_is_evgenii_from_dawarich_you_re_now_2_days: ", this is Evgenii from Dawarich. You're now 2 days into your Dawarich trial! I hope you're enjoying tracking your location data. Here are some powerful features you might want to explore: ✈️ Reliving your travels Revisit your past journeys with detailed maps and insights. \U0001F4CA Statistics & Analytics View detailed insights about distances traveled and time spent in different locations. \U0001F5FA️ Interactive Maps Visualize your tracks on beautiful maps with different layers and styling options. \U0001F4CD Places & Visits Discover the places you've visited and get automatic visit detection for frequently visited locations. \U0001F4E4 Data Export Export your location data in multiple formats (GPX, GeoJSON) for backup or use with other applications. Continue exploring: https://my.dawarich.app You have 5 days left in your trial. Make the most of it! Best regards, Evgenii from Dawarich"
+      continue_exploring_https_my_dawarich_app: 'Continue exploring: https://my.dawarich.app'
+      you_have_5_days_left_in_your_trial_make_the: You have 5 days left in your trial. Make the most of it!
+    oauth_account_link:
+      confirm_account_link: Confirm account link
+      hi: Hi
+      someone_hopefully_you_is_trying_to_link: Someone — hopefully you — is trying to link
+      sign_in_to_your_dawarich_account_clicking_the_button_below: sign-in to your Dawarich account. Clicking the button below will allow that sign-in method to access this account going forward.
+      link: Link
+      didn_t_request_this: Didn't request this?
+      ignore_this_email_the_link_expires_in_15_minutes_and: Ignore this email — the link expires in 15 minutes and no change will be made to your account. If you keep getting these emails, change your password.
+      link_2: 'Link:'
+      confirm_account_link_hi: Confirm account link Hi
+      someone_hopefully_you_is_trying_to_link_2: ", Someone — hopefully you — is trying to link"
+      sign_in_to_your_dawarich_account_clicking_the_link_below: sign-in to your Dawarich account. Clicking the link below will allow that sign-in method to access this account going forward. Link
+      didn_t_request_this_ignore_this_email_the_link_expires: Didn't request this? Ignore this email — the link expires in 15 minutes and no change will be made to your account. If you keep getting these emails, change your password.
+      sign_in_to_your_dawarich_account_clicking_the_link_below_2: sign-in to your Dawarich account. Clicking the link below will allow that sign-in method to access this account going forward.
+    otp_account_locked:
+      account_temporarily_locked: Account temporarily locked
+      hi: Hi
+      your_dawarich_account_has_been: Your Dawarich account has been
+      temporarily_locked: temporarily locked
+      because_10_consecutive_failed_two_factor_authentication_attempts_were_de: because 10 consecutive failed two-factor authentication attempts were detected.
+      the_lock_will_automatically_lift_after: The lock will automatically lift after
+      minutes: 30 minutes
+      no_action_is_required_if_this_was_you: ". No action is required if this was you."
+      didn_t_recognise_this_activity: Didn't recognise this activity?
+      someone_may_be_trying_to_access_your_account_we_recommend: Someone may be trying to access your account. We recommend resetting your password immediately.
+      reset_your_password: Reset your password
+      if_you_need_further_assistance_contact_us_at: If you need further assistance, contact us at
+      security_dawarich_app: security@dawarich.app
+      account_temporarily_locked_hi: Account temporarily locked Hi
+      your_dawarich_account_has_been_temporarily_locked_because_10_consecutive: ", Your Dawarich account has been temporarily locked because 10 consecutive failed two-factor authentication attempts were detected. The lock will automatically lift after 30 minutes. No action is required if this was you. Didn't recognise this activity? Someone may be trying to access your account. We recommend resetting your password immediately. Reset your password:"
+      if_you_need_further_assistance_contact_us_at_security_dawarich: If you need further assistance, contact us at security@dawarich.app.
+      your_dawarich_account_has_been_temporarily_locked_because_10_consecutive_2: Your Dawarich account has been temporarily locked because 10 consecutive failed two-factor authentication attempts were detected.
+      the_lock_will_automatically_lift_after_30_minutes_no_action: The lock will automatically lift after 30 minutes. No action is required if this was you.
+      didn_t_recognise_this_activity_someone_may_be_trying_to: Didn't recognise this activity? Someone may be trying to access your account. We recommend resetting your password immediately.
+      reset_your_password_2: 'Reset your password:'
+    welcome:
+      welcome_to_dawarich: Welcome to Dawarich!
+      hi: Hi
+      this_is_evgenii_from_dawarich: ", this is Evgenii from Dawarich."
+      welcome_to_dawarich_i_m_excited_to_have_you_on: Welcome to Dawarich! I'm excited to have you on board.
+      your_7_day_free_trial_has_started_during_this_time: 'Your 7-day free trial has started. During this time, you can:'
+      track_your_location_data: Track your location data
+      view_your_movement_patterns_on_beautiful_maps: View your movement patterns on beautiful maps
+      analyze_your_travel_statistics: Analyze your travel statistics
+      export_your_data_in_various_formats: Export your data in various formats
+      start_exploring_dawarich: Start Exploring Dawarich
+      if_you_have_any_questions_feel_free_to_drop_me: If you have any questions, feel free to drop me a message at hi@dawarich.app or just reply to this email.
+      happy_tracking: Happy tracking!
+      evgenii_from_dawarich: Evgenii from Dawarich
+      welcome_to_dawarich_hi: Welcome to Dawarich! Hi
+      this_is_evgenii_from_dawarich_welcome_to_dawarich_i_m: ", this is Evgenii from Dawarich. Welcome to Dawarich! I'm excited to have you on board. Your 7-day free trial has started. During this time, you can: - Track your location data - View your movement patterns on beautiful maps - Analyze your travel statistics - Export your data in various formats Start exploring Dawarich: https://my.dawarich.app If you have any questions, feel free to drop me a message at hi@dawarich.app or just reply to this email. Happy tracking! Evgenii from Dawarich"
+      track_your_location_data_2: "- Track your location data"
+      view_your_movement_patterns_on_beautiful_maps_2: "- View your movement patterns on beautiful maps"
+      analyze_your_travel_statistics_2: "- Analyze your travel statistics"
+      export_your_data_in_various_formats_2: "- Export your data in various formats"
+      start_exploring_dawarich_https_my_dawarich_app: 'Start exploring Dawarich: https://my.dawarich.app'
+  visits:
+    buttons:
+      confirm: Confirm
+      delete: Delete
+      delete_this_visit_your_location_points_stay: Delete this visit? Your location points stay.
+    name:
+      unnamed_visit: Unnamed visit
+      click_to_rename: Click to rename
+  date:
+    formats:
+      month_name: "%B"
+      month_year: "%B %Y"
+      short_month_day: "%b %-d"
+      medium: "%b %-d, %Y"
+      long: "%B %d, %Y"
+      weekday_month_day: "%A, %B %-d"
+      short_month_day_weekday: "%b %-d, %A"
+      short_weekday_month_day: "%a, %b %-d"
+      iso: "%Y-%m-%d"
+      day_month_year: "%-d %B %Y"
+      day_month_year_abbreviated: "%-d %b %Y"
+      month_day: "%B %-d"
+      day_year: "%-d, %Y"
+      abbreviated_month_name: "%b"
+  time:
+    formats:
+      hour_minute: "%H:%M"
+      long_with_time: "%B %-d, %Y at %I:%M %p"
+      human: "%-d %b %Y, %H:%M"
+      human_with_seconds: "%-d %b %Y, %H:%M:%S"
+      short_with_time: "%b %d at %I:%M %p"
+  common:
+    app_name: Dawarich
+    not_available: N/A
+  enums:
+    export:
+      file_type:
+        points: Points
+        user_data: User data
+    import:
+      source:
+        google_semantic_history: Google Semantic History
+        owntracks: OwnTracks
+        google_records: Google Records
+        google_phone_takeout: Google Phone Takeout
+        gpx: GPX
+        immich_api: Immich API
+        geojson: GeoJSON
+        photoprism_api: PhotoPrism API
+        user_data_archive: User data archive
+        kml: KML
+        csv: CSV
+        tcx: TCX
+        fit: FIT
+        polarsteps: Polarsteps
+        google_photos: Google Photos
+    place:
+      source:
+        manual: Manual
+        photon: Photon
+    shared_link:
+      resource_type:
+        trip: Trip
+        track: Track
+        timeline: Timeline
+        live: Live
+  photo_sources:
+    immich: Immich
+    photoprism: PhotoPrism
+  supporter_platforms:
+    github: GitHub
+    patreon: Patreon
+    ko_fi: Ko-fi
+  transportation_modes:
+    unknown: Unknown
+    stationary: Stationary
+    walking: Walking
+    running: Running
+    cycling: Cycling
+    driving: Driving
+    bus: Bus
+    train: Train
+    flying: Flying
+    boat: Boat
+    motorcycle: Motorcycle
+  helpers:
+    application:
+      full_title: "%{page_title} | %{app_name}"
+      expired: Expired
+      days_left:
+        one: "%{count}d left"
+        other: "%{count}d left"
+      finish_signup: Finish signup
+      resume: Resume
+      subscribe: Subscribe
+      pro_preview: Available on Pro — click to preview
+      pro_only: Available on Pro
+      pro_badge: " Pro"
+    timeline:
+      unnamed: Unnamed
+    datetime_formatting:
+      expires_on: Expires on %{date}
+    insights:
+      monthly_digest: Monthly Digest
+      monthly_digest_title: "%{month} %{year} Digest"
+      minute_count:
+        one: "%{count} min"
+        other: "%{count} min"
+      day_count:
+        one: "%{count} day"
+        other: "%{count} days"
+      hour_count:
+        one: "%{count} hour"
+        other: "%{count} hours"
+    users:
+      digests:
+        distance_with_unit: "%{distance} %{unit}"
+        moon_distance: That's %{percentage}% of the distance to the Moon!
+        earth_circumference: That's %{percentage}% of Earth's circumference!
+      digests_mailer:
+        same: "→ same"
+        new: "↑ new"
+    trips:
+      duration:
+        years:
+          one: "%{count} year"
+          other: "%{count} years"
+        months:
+          one: "%{count} month"
+          other: "%{count} months"
+        days:
+          one: "%{count} day"
+          other: "%{count} days"
+        hours:
+          one: "%{count} hour"
+          other: "%{count} hours"
+    stats:
+      countries_and_cities: "%{countries} countries, %{cities} cities"
+      distance: "%{value} %{unit}"
+      peak_day: "%{date} (%{distance})"
+      week_range: "%{start_date} - %{end_date}"
+    stats_comparison:
+      same_as_previous_month: Same as previous month
+      distance:
+        more: "%{percentage}% more than your average this year"
+        less: "%{percentage}% less than your average this year"
+      active_days:
+        more:
+          one: "%{count} day more than previous month"
+          other: "%{count} days more than previous month"
+        less:
+          one: "%{count} day less than previous month"
+          other: "%{count} days less than previous month"
+      countries:
+        more:
+          one: "%{count} country more than previous month"
+          other: "%{count} countries more than previous month"
+        less:
+          one: "%{count} country less than previous month"
+          other: "%{count} countries less than previous month"
+    imports:
+      extraction_status:
+        not_attempted: Not extracted
+        pending: Queued
+        running: Extracting
+        completed: Extracted
+        failed: Failed
+        unsupported: Not available
+    posters:
+      render_phases:
+        fetching_data: Fetching map data…
+        drawing_map: Drawing the map…
+        drawing_route: Drawing your route…
+        saving: Saving the image…
+        queued: Queued…
+    shared_links:
+      date_ranges:
+        same_month: "%{start_date}–%{end_date}"
+        same_year: "%{start_date} – %{end_date}"
+        different_years: "%{start_date} – %{end_date}"
+      timeline_subtitle: "%{range} is shared via a public link."
+      trip_subtitle: "%{trip} is shared via a public link."
+      track: Track
+      track_label: "%{mode} · %{date} · %{distance} %{unit}"
+    tracks:
+      segments:
+        mode_disabled: "%{mode} (disabled in settings)"
+  calendar:
+    weekday_initials:
+    - M
+    - T
+    - W
+    - T
+    - F
+    - S
+    - S
+    abbreviated_weekdays:
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    - Sun
+  oauth_providers:
+    google: Google
+    github: GitHub
+    apple: Apple
+    sign_in_with_google: Sign in with Google
+    sign_in_with_github: Sign in with GitHub
+    sign_in_with_apple: Sign in with Apple
+    sign_in_with_provider: Sign in with %{provider}
+    openid_connect: OpenID Connect
+  statuses:
+    completed: Completed
+    processing: Processing
+    created: Created
+    failed: Failed
+    deleting: Deleting
+    suggested: Suggested
+    confirmed: Confirmed
+    declined: Declined
+  units:
+    meters: "%{value} m"
+    meters_compact: "%{value}m"
+    kilometers: "%{value} km"
+    miles: "%{value} mi"
+    minutes: "%{value} min"
+    hours_minutes_compact: "%{hours}h %{minutes}m"
+    days_hours_compact: "%{days}d %{hours}h"
+    days_compact: "%{value}d"
+    minutes_compact: "%{value}m"
+    minutes_word_compact: "%{value}min"
+    hours_compact: "%{value}h"
+    seconds_compact: "%{value}s"
+    feet: "%{value} ft"
+    meters_per_second_squared: "%{value} m/s²"
+    miles_per_hour: mph
+    kilometers_per_hour: km/h
+    speed_mph: "%{value} mph"
+    speed_kmh: "%{value} km/h"
+    kilometers_suffix: " km"
+  controllers:
+    api:
+      v1:
+        areas:
+          area_was_successfully_deleted: Area was successfully deleted
+        auth:
+          apple:
+            apple_has_not_verified_this_email_sign_in_with_password: Apple has not verified this email. Sign in with password and link from settings.
+            this_email_already_has_a_dawarich_account_we_sent_a: This email already has a Dawarich account. We sent a confirmation link to that address — click it to link your Apple ID.
+            we_couldn_t_find_your_existing_account_and_apple_didn: We couldn't find your existing account, and Apple didn't share your email with us this time. Apple only shares it once. Please go to appleid.apple.com → Sign in with Apple, find Dawarich, choose "Stop using Sign in with Apple", then try signing in again.
+            token_verification_failed: 'Apple token verification failed: %{message}'
+          google:
+            google_has_not_verified_this_email_sign_in_with_password: Google has not verified this email. Sign in with password and link from settings.
+            this_email_already_has_a_dawarich_account_we_sent_a: This email already has a Dawarich account. We sent a confirmation link to that address — click it to link your Google sign-in.
+            token_verification_failed: 'Google token verification failed: %{message}'
+          otp_challenges:
+            invalid_challenge: 'Invalid or expired challenge: %{message}'
+            account_locked: Account temporarily locked due to too many failed 2FA attempts. Use a backup code, wait 30 minutes, or reset your password.
+            invalid_two_factor_code: Invalid two-factor code
+          sessions:
+            invalid_credentials: Invalid email or password
+        digests:
+          invalid_year: Invalid year
+          digest_already_exists: Digest already exists
+          digest_for_year_is_being_generated: Digest for %{year} is being generated
+        families:
+          locations:
+            start_at_and_end_at_are_required: start_at and end_at are required
+            invalid_date_format: Invalid date format
+            user_is_not_part_of_a_family: User is not part of a family
+        imports:
+          pending:
+            an_error_occurred: An error occurred
+            missing_file: Missing file
+            missing_filename: Missing original_filename
+            empty_file: File is empty
+            file_too_large: File exceeds 100MB limit
+            unsupported_file_type: Unsupported file type '%{extension}'
+            storage_capacity_exceeded: Pending import storage capacity exceeded
+          missing_required_parameter_file: 'Missing required parameter: file'
+          an_error_occurred_while_processing_the_import: An error occurred while processing the import
+          unsupported_file_type_ext_allowed_join: 'Unsupported file type ''%{ext}''. Allowed: %{allowed}'
+        locations:
+          coordinates_lat_lon_are_required: Coordinates (lat, lon) are required
+          search_failed_please_try_again: Search failed. Please try again.
+          invalid_coordinates_lat_must_be_90_90_lon_must_be: 'Invalid coordinates: lat must be -90..90, lon must be -180..180'
+          search_query_too_long_max_200_characters: Search query too long (max 200 characters)
+        maps:
+          hexagons:
+            missing_required_parameter_param: 'Missing required parameter: %{parameter}'
+            shared_stats_not_found_or_no_longer_available: Shared stats not found or no longer available
+            invalid_date_format: Invalid date format
+            failed_to_generate_hexagon_grid: Failed to generate hexagon grid
+        notes:
+          note_was_successfully_deleted: Note was successfully deleted
+        overland:
+          batches:
+            batch_creation_failed: Batch creation failed
+        owntracks:
+          points:
+            point_creation_failed: Point creation failed
+        photos:
+          failed_to_fetch_photos: Failed to fetch photos
+          capitalize_integration_not_configured: "%{source} integration not configured"
+          failed_to_fetch_thumbnail: Failed to fetch thumbnail
+        places:
+          latitude_and_longitude_are_required: latitude and longitude are required
+          lat_and_lon_are_required: lat and lon are required
+          invalid_coordinates: Invalid coordinates
+        points:
+          invalid_bounding_box: Invalid bounding box
+          point_creation_failed: Point creation failed
+          point_deleted_successfully: Point deleted successfully
+          no_points_selected: No points selected
+          too_many_points_selected_maximum_is_bulk_destroy_max_per: Too many points selected. Maximum is %{limit} per request.
+          points_were_successfully_destroyed: Points were successfully destroyed
+          anomaly_re_evaluation_already_in_progress: Anomaly re-evaluation already in progress.
+          re_evaluation_queued_existing_anomaly_flags_will_be_cleared_and: Re-evaluation queued. Existing anomaly flags will be cleared and recomputed.
+        recalculations:
+          invalid_year: Invalid year
+          recalculation_already_in_progress_for_this_user: Recalculation already in progress for this user.
+          recalculation_queued_tracks_stats_and_digests_will_be_regenerated_in: Recalculation queued. Tracks, stats, and digests will be regenerated in the background.
+        settings:
+          mobile:
+            settings_updated: Settings updated
+            something_went_wrong: Something went wrong
+          something_went_wrong: Something went wrong
+          settings_updated: Settings updated
+          tile_url_error: Tile URL must include {z}, {x}, and {y} placeholders, or be a MapLibre style URL
+        subscriptions:
+          configuration_error: Configuration error
+          invalid_webhook_secret: Invalid webhook secret
+          missing_event_id: Missing event_id
+          stale_event: Stale event
+          subscription_updated_successfully: Subscription updated successfully
+          failed_to_verify_subscription_update: Failed to verify subscription update.
+          invalid_subscription_data_received: Invalid subscription data received.
+        timeline:
+          start_at_and_end_at_are_required: start_at and end_at are required
+          date_range_cannot_exceed_max_range_days_days: Date range cannot exceed %{max_days} days
+        traccar:
+          points:
+            point_creation_failed: Point creation failed
+        users:
+          destroy:
+            cannot_delete: You own a family with other members. Transfer ownership or remove members before deleting your account.
+            deletion_scheduled: Your account has been scheduled for deletion.
+            request_sent: "%{message} If you have an active Apple or Google subscription, cancel it in your platform settings to avoid further charges."
+          two_factor:
+            disable_2fa_first_to_re_provision_the_secret: Disable 2FA first to re-provision the secret.
+            two_factor_authentication_disabled: Two-factor authentication disabled
+            provide_a_valid_two_factor_code_or_backup_code_to: Provide a valid two-factor code (or backup code) to disable 2FA.
+            provide_your_current_password: Provide your current password.
+          configuration_error: Configuration error
+          invalid_webhook_secret: Invalid webhook secret
+          ids_is_required: ids is required
+        visits:
+          possible_places:
+            visit_not_found: Visit not found
+          select_place:
+            visit_not_found: Visit not found
+          invalid_place: Invalid place
+          invalid_area: Invalid area
+          at_least_2_visits_must_be_selected_for_merging: At least 2 visits must be selected for merging
+          one_or_more_visits_not_found: One or more visits not found
+          count_visits_updated_successfully: "%{count} visits updated successfully"
+          failed_to_delete_visit: Failed to delete visit
+          visit_not_found: Visit not found
+          failed_to_create_visit: Failed to create visit
+      record_not_found: Record not found
+      complete_your_subscription_to_continue: Complete your subscription to continue.
+      this_feature_requires_a_pro_plan: This feature requires a Pro plan.
+      write_api_access_requires_a_pro_plan_your_data_was: Write API access requires a Pro plan. Your data was not modified.
+      user_account_is_not_active_or_has_been_deleted: User account is not active or has been deleted
+      user_account_is_not_active: User account is not active
+      user_subscription_is_not_active: User subscription is not active
+      missing_required_parameters_join: 'Missing required parameters: %{parameters}'
+      points_limit_exceeded: Points limit exceeded
+    application:
+      your_account_is_not_active: Your account is not active.
+      please_sign_in_to_continue: Please sign in to continue.
+      you_need_to_sign_in_first: You need to sign in first.
+      this_feature_requires_a_pro_plan: This feature requires a Pro plan.
+      your_account_has_been_deleted: Your account has been deleted.
+      you_are_not_authorized_to_perform_this_action: You are not authorized to perform this action.
+      family_plan_required: This feature requires a Family plan.
+    areas:
+      created: Area created successfully!
+      updated: Area updated successfully!
+    auth:
+      account_links:
+        this_link_has_already_been_used: This link has already been used.
+        link_invalid_or_expired: Link invalid or expired.
+        provider_is_now_linked_to_your_account: "%{provider} is now linked to your account."
+        no_pending_account_link: No pending account link.
+        account_no_longer_exists: Account no longer exists.
+        too_many_invalid_attempts_start_the_linking_flow_again: Too many invalid attempts. Start the linking flow again.
+        pending_is_now_linked_to_your_account: "%{pending} is now linked to your account."
+        linked_sign_in_with_two_factor: "%{provider} is now linked to your account. Sign in with your password and 2FA code to continue."
+        incorrect_password: Incorrect password.
+        confirmation_link_sent: We sent a confirmation link to %{email}. Click it to link your account.
+        already_linked_to_different_identity: This account is already linked to a different %{provider} identity.
+      ios:
+        authentication_successful_you_can_close_this_window: Authentication successful! You can close this window.
+        ios_authentication_successful: iOS authentication successful
+    concerns:
+      share_links:
+        managable:
+          created: Share link created.
+          deleted: Share link deleted.
+          revoked: Share link revoked.
+          url_regenerated: URL regenerated.
+          magic_phrase_regenerated: Magic phrase regenerated.
+          no_active_share_link: No active share link.
+      account_deletion_confirmable:
+        confirm_with_email: Type your email address to confirm deletion.
+        confirm_with_password: Provide your current password to delete your account.
+      pending_import_claimable:
+        expired: Your import link has expired or already been used. You can re-upload from your dashboard.
+        importing: Importing %{filename}... You'll see it in your dashboard shortly.
+        queue_failed: Your import couldn't be queued. Please upload the file from your dashboard.
+    exports:
+      export_was_successfully_initiated_please_wait_until_it_s_finished: Export was successfully initiated. Please wait until it's finished.
+      export_failed_to_initiate_please_try_again: Export failed to initiate. Please try again.
+      export_was_successfully_destroyed: Export was successfully destroyed.
+    families:
+      family_created_successfully: Family created successfully!
+      family_updated_successfully: Family updated successfully!
+      cannot_delete_family_with_members_remove_all_members_first: Cannot delete family with members. Remove all members first.
+      family_deleted_successfully: Family deleted successfully!
+      you_are_not_in_a_family: You are not in a family
+      failed_to_create_family: Failed to create family
+    family:
+      invitations:
+        this_invitation_has_expired: This invitation has expired.
+        this_invitation_is_no_longer_valid: This invitation is no longer valid.
+        invitation_sent_successfully: Invitation sent successfully!
+        invitation_cancelled: Invitation cancelled
+        failed_to_cancel_invitation_please_try_again: Failed to cancel invitation. Please try again
+        an_unexpected_error_occurred_while_cancelling_the_invitation: An unexpected error occurred while cancelling the invitation
+        you_are_not_in_a_family: You are not in a family
+        failed_to_send_invitation: Failed to send invitation
+      location_requests:
+        user_not_found_in_your_family: User not found in your family
+        location_request_sent_successfully: Location request sent successfully
+        this_request_has_expired_or_already_been_responded_to: This request has expired or already been responded to
+        location_sharing_enabled: Location sharing enabled
+        location_request_declined: Location request declined
+        you_are_not_authorized_to_view_this_request: You are not authorized to view this request
+        you_must_be_part_of_a_family: You must be part of a family
+      location_sharing:
+        user_is_not_part_of_a_family: User is not part of a family
+      memberships:
+        welcome_to_the_family: Welcome to the family!
+        an_unexpected_error_occurred_please_try_again_later: An unexpected error occurred. Please try again later
+        you_have_left_the_family: You have left the family
+        email_has_been_removed_from_the_family: "%{email} has been removed from the family"
+        you_are_not_in_a_family: You are not in a family
+        unable_to_accept_invitation: Unable to accept invitation
+        invitation_expired: This invitation is no longer valid or has expired
+        invitation_processed: This invitation has already been processed
+        invitation_email_mismatch: This invitation is not for your email address
+        not_authorized_to_accept: You are not authorized to accept this invitation
+        failed_to_remove_member: Failed to remove member
+    imports:
+      extractions:
+        extraction_queued: Extraction queued.
+        removing_extracted_data: Removing extracted data…
+      import_was_successfully_updated: Import was successfully updated.
+      no_files_were_selected_for_upload: No files were selected for upload
+      no_valid_file_references_were_found_please_upload_files_using: No valid file references were found. Please upload files using the file selector.
+      size_files_are_queued_to_be_imported_in_background: "%{size} files are queued to be imported in background"
+      import_is_being_deleted: Import is being deleted.
+      points_limit_exceeded: Points limit exceeded
+    insights:
+      all_time: All Time
+      year_overview: "%{year} Overview"
+    notifications:
+      all_notifications_marked_as_read: All notifications marked as read.
+      all_notifications_where_successfully_destroyed: All notifications where successfully destroyed.
+      notification_was_successfully_destroyed: Notification was successfully destroyed.
+    places:
+      place_was_successfully_destroyed: Place was successfully destroyed.
+      created: Place created successfully!
+      updated: Place updated successfully!
+    points:
+      no_points_selected: No points selected.
+      points_were_successfully_destroyed: Points were successfully destroyed.
+    posters:
+      poster_generation_started_this_takes_about_a_minute: Poster generation started. This takes about a minute.
+      failed_to_start_poster_generation: Failed to start poster generation.
+      poster_deleted: Poster deleted.
+      untitled: Untitled poster
+    settings:
+      background_jobs:
+        settings_updated: Settings updated
+        settings_could_not_be_updated: Settings could not be updated
+        job_was_successfully_created: Job was successfully created.
+      general:
+        settings_updated: Settings updated
+        failed_to_update_settings: Failed to update settings
+        please_enter_an_email_address_or_github_username: Please enter an email address or GitHub username
+        verified_thank_you_for_supporting_dawarich_via_platform: Verified! Thank you for supporting Dawarich via %{platform}.
+        not_found_in_supporter_list_make_sure_you_re_using: Not found in supporter list. Make sure you're using the same email or GitHub username as your donation platform.
+      maps:
+        settings_updated: Settings updated
+      onboardings:
+        demo_data_loaded: Demo data loaded.
+        demo_data_is_already_loaded: Demo data is already loaded.
+        something_went_wrong_loading_demo_data: Something went wrong loading demo data.
+        demo_data_removed: Demo data removed.
+        no_demo_data_found: No demo data found.
+        something_went_wrong_removing_demo_data: Something went wrong removing demo data.
+      two_factor:
+        incorrect_password: Incorrect password.
+        provide_a_valid_two_factor_code_or_backup_code_to: Provide a valid two-factor code (or backup code) to disable 2FA.
+        two_factor_authentication_disabled: Two-factor authentication disabled.
+        two_factor_authentication_is_not_configured_on_this_instance: Two-factor authentication is not configured on this instance.
+        invalid_verification_code: Invalid verification code. Please try again.
+      users:
+        user_was_successfully_updated: User was successfully updated.
+        user_could_not_be_updated_to_sentence: 'User could not be updated: %{errors}'
+        user_was_successfully_created: User was successfully created
+        user_could_not_be_created_to_sentence: 'User could not be created: %{errors}'
+        cannot_delete_account_while_being_owner_of_a_family_which: Cannot delete account while being owner of a family which has other members.
+        user_deletion_has_been_initiated_the_account_will_be_fully: User deletion has been initiated. The account will be fully removed shortly.
+        api_key_has_been_regenerated: API key has been regenerated.
+        password_reset_email_has_been_sent: Password reset email has been sent.
+        user_registration_has_been_status: User registration has been %{status}.
+        your_data_is_being_exported_you_will_receive_a_notification: Your data is being exported. You will receive a notification when it is ready.
+        please_select_a_zip_archive_to_import: Please select a ZIP archive to import.
+        your_data_import_has_been_started_you_will_receive_a: Your data import has been started. You will receive a notification when it completes.
+        failed_to_start_import_please_try_again: Failed to start import. Please try again.
+        an_error_occurred_while_starting_the_import_please_try_again: An error occurred while starting the import. Please try again.
+        please_upload_a_valid_zip_file: Please upload a valid ZIP file.
+        cannot_remove_last_admin_role: Cannot remove admin role from the last admin user.
+        cannot_disable_last_admin: Cannot disable the last admin user.
+      visits:
+        visit_detection_settings_updated: Visit detection settings updated
+    share_links:
+      lives:
+        default_name: Live location
+      timelines:
+        default_name: 'Timeline: %{start_date} → %{end_date}'
+    shared:
+      digests:
+        shared_digest_not_found_or_no_longer_available: Shared digest not found or no longer available
+        failed_to_update_sharing_settings: Failed to update sharing settings
+        sharing_enabled: Sharing enabled successfully
+        sharing_disabled: Sharing disabled successfully
+        auto_saved: Auto-saved
+      links:
+        incorrect_phrase: That phrase didn't work. Try again.
+      stats:
+        shared_stats_not_found_or_no_longer_available: Shared stats not found or no longer available
+        failed_to_update_sharing_settings: Failed to update sharing settings
+        sharing_enabled: Sharing enabled successfully
+        sharing_disabled: Sharing disabled successfully
+        auto_saved: Auto-saved
+    stats:
+      stats_for_target_are_being_updated: Stats for %{target} are being updated
+      stats_are_being_updated: Stats are being updated
+    tags:
+      tag_was_successfully_created: Tag was successfully created.
+      tag_was_successfully_updated: Tag was successfully updated.
+      tag_was_successfully_deleted: Tag was successfully deleted.
+    tracks:
+      recalculations:
+        re_classification_already_running: Re-classification already running
+        re_classification_started_your_tracks_will_update_over_the_next: Re-classification started — your tracks will update over the next few minutes
+      segments:
+        segment_updated: Segment updated
+        mode_not_enabled: That mode isn't enabled in your settings
+        update_failed: Could not update segment
+      share_links:
+        not_found: Not found
+    trial:
+      welcome:
+        link_invalid_please_sign_in: Link invalid. Please sign in.
+        another_user_is_already_signed_in: Another user is already signed in.
+        this_welcome_link_has_already_been_used: This welcome link has already been used.
+        link_invalid_or_expired_please_sign_in: Link invalid or expired. Please sign in.
+        account_no_longer_exists_please_sign_up_again: Account no longer exists. Please sign up again.
+        trial_active_until: Welcome to Dawarich — your 7-day free trial is active until %{date}.
+        trial_activating: Welcome to Dawarich — your trial is being activated now.
+    trips:
+      notes:
+        invalid_date: Invalid date
+      share_links:
+        not_found: Not found
+        default_name: 'Trip: %{trip}'
+      trip_was_successfully_created_data_is_being_calculated_in_the: Trip was successfully created. Data is being calculated in the background.
+      trip_was_successfully_updated: Trip was successfully updated.
+      trip_was_successfully_destroyed: Trip was successfully destroyed.
+      already_recalculating_this_page_will_update_when_it_s_done: Already recalculating — this page will update when it's done.
+      recalculating_the_page_will_update_automatically_when_it_s_ready: Recalculating — the page will update automatically when it's ready.
+      unsupported_export_format_choose_gpx_or_geojson: Unsupported export format. Choose GPX or GeoJSON.
+      trip_export_initiated_check_the_exports_page_when_it_s: Trip export initiated. Check the Exports page when it's ready.
+      export_failed_to_initiate_please_try_again: Export failed to initiate. Please try again.
+    users:
+      apple_oauth:
+        sign_in_with_apple_was_cancelled: Sign in with Apple was cancelled.
+        sign_in_failed: 'Apple sign-in failed: %{message}'
+        email_not_verified: Your Apple ID email is not verified. Verify it with Apple, then try again.
+        missing_email: Apple didn't share your email this time and we couldn't find your existing account. Visit appleid.apple.com → Sign in with Apple → Dawarich → Stop using Sign in with Apple, then try again.
+        did_not_complete: Sign in with Apple did not complete. Please try again.
+        state_mismatch: Sign in with Apple state mismatch — please try again.
+      destroy_confirmations:
+        this_deletion_link_has_already_been_used: This deletion link has already been used.
+        deletion_link_invalid_or_expired: Deletion link invalid or expired.
+        cannot_delete_account_while_you_own_a_family_with_other: Cannot delete account while you own a family with other members. Transfer ownership or remove members first.
+        your_account_has_been_scheduled_for_deletion_we_are_sorry: Your account has been scheduled for deletion. We are sorry to see you go.
+      digests:
+        year_end_digest_for_year_is_being_generated_check_back: Year-end digest for %{year} is being generated. Check back soon!
+        invalid_year_selected: Invalid year selected
+        year_end_digest_for_year_has_been_deleted: Year-end digest for %{year} has been deleted
+        digest_not_found: Digest not found
+      omniauth_callbacks:
+        invalid_credentials: Invalid credentials. Please check your username and password.
+        connection_timeout: Connection timeout. Please try again.
+        security_error: Security error detected. Please try again.
+        provider_unavailable: Unable to connect to authentication provider. Please contact your administrator.
+        provider_configuration_error: Authentication provider configuration error. Please contact your administrator.
+        unknown_error: Unknown error
+        authentication_failed: 'Authentication failed: %{detail}'
+        oidc_account_requires_administrator: Your account must be created by an administrator before you can sign in with OIDC. Please contact your administrator.
+        account_creation_failed: Unable to create your account. Please try again or contact support.
+        email_not_verified: Your %{provider} email is not verified. Verify it with the provider, then try again — or sign in with your existing password.
+      otp_challenge:
+        session_expired_please_sign_in_again: Session expired. Please sign in again.
+        signed_in_successfully: Signed in successfully.
+        account_temporarily_locked_due_to_too_many_failed_2fa_attempts: Account temporarily locked due to too many failed 2FA attempts. Use a backup code, wait 30 minutes, or reset your password.
+        too_many_invalid_two_factor_codes_please_sign_in_again: Too many invalid two-factor codes. Please sign in again.
+        invalid_two_factor_code: Invalid two-factor code.
+      registrations:
+        your_account_has_been_scheduled_for_deletion: Your account has been scheduled for deletion.
+        email_password_registration_is_disabled_please_use_oidc_to_sign: Email/password registration is disabled. Please use OIDC to sign in.
+        registration_is_not_available_please_contact_your_administrator_for_acce: Registration is not available. Please contact your administrator for access.
+        welcome_to_name_you_re_now_part_of_the_family: Welcome to %{name}! You're now part of the family.
+        account_created_successfully_but_there_was_an_issue_accepting_the: 'Account created successfully, but there was an issue accepting the invitation: %{error_message}'
+        account_created_successfully_but_there_was_an_issue_accepting_the_2: Account created successfully, but there was an issue accepting the invitation. Please try accepting it again.
+      sessions:
+        email_password_login_is_disabled_please_use_oidc_to_sign: Email/password login is disabled. Please use OIDC to sign in.
+    visits:
+      redetections:
+        re_detect_ran_recently_try_again_in_an_hour: Re-detect ran recently. Try again in an hour.
+        re_detection_queued_we_ll_notify_you_when_it_finishes: Re-detection queued. We'll notify you when it finishes.
+      failed_to_update_visits: Failed to update visits.
+      bulk_updated:
+        one: "%{count} visit %{status}."
+        other: "%{count} visits %{status}."
+      no_matching_visits: No matching visits found.
+      select_visit_to_delete: Select at least one visit to delete.
+      failed_to_delete_visits: Failed to delete visits.
+      invalid_place: Invalid place
+      invalid_area: Invalid area
+      failed_to_update_visit: Failed to update visit.
+      select_visits_to_merge: Select at least 2 visits to merge.
+      visits_must_share_day: Visits must be on the same day.
+      failed_to_merge_visits: Failed to merge visits.
+      unsupported_source_status: Unsupported source status.
+      visit_updated: Visit %{status}.
+      visits_merged: Visits merged.
+      visit_removed: Visit removed. Your location points are still here.
+      too_many_visits: You can update up to %{count} visits at once. Narrow your selection and try again.
+      missing_visits: Some of those visits aren't here anymore — probably edited in another tab. Refresh and try again.
+      plan_window_visits: Some of those visits are outside your Lite plan's 12-month window. Upgrade to Pro to manage older data.
+      bulk_removed:
+        one: "%{count} visit removed. Your location points are still here."
+        other: "%{count} visits removed. Your location points are still here."
+  visit_statuses:
+    suggested: suggested
+    confirmed: confirmed
+    declined: declined
+  mailers:
+    family:
+      invitation:
+        subject: "\U0001F389 You've been invited to join %{family} on Dawarich!"
+      location_request:
+        subject: "\U0001F4CD %{requester} is requesting your location on Dawarich"
+      member_joined:
+        subject: "\U0001F46A %{user} has joined your family %{family} on Dawarich!"
+    users:
+      welcome:
+        subject: Welcome to Dawarich!
+      explore_features:
+        subject: Explore Dawarich features!
+      archival_approaching:
+        subject: Keep your full history — upgrade to Pro
+      oauth_account_link:
+        subject: Confirm linking %{provider} to your Dawarich account
+      account_destroy_confirmation:
+        subject: Confirm Dawarich account deletion
+      otp_account_locked:
+        subject: Dawarich account temporarily locked
+      digests:
+        year_end:
+          subject: Your %{year} Year in Review - Dawarich
+        monthly:
+          subject: Your %{month} %{year} in review — Dawarich
+  models:
+    family:
+      location_request:
+        cannot_request_your_own_location: cannot request your own location
+    import:
+      is_too_large_trial_users_can_only_upload_files_up: is too large. Trial users can only upload files up to 10MB.
+      trial_users_can_only_create_up_to_5_imports_please: Trial users can only create up to 5 imports. Please subscribe to import more files.
+    note:
+      has_already_been_taken: has already been taken
+      must_be_within_the_trip_date_range: must be within the trip date range
+      must_belong_to_the_same_user: must belong to the same user
+    point:
+      already_has_a_point_at_this_location_and_time_for: already has a point at this location and time for this user
+    points:
+      raw_data_archive:
+        must_contain_expected_count_and_actual_count: must contain expected_count and actual_count
+    shared_link:
+      is_required_for_this_resource_type: is required for this resource type
+      must_be_blank_for_this_resource_type: must be blank for this resource type
+      must_be_in_the_future: must be in the future
+      must_include_start_date_and_end_date_for_timeline_shares: must include start_date and end_date for timeline shares
+      start_date_and_end_date_must_be_parseable_as_dates: start_date and end_date must be parseable as dates
+      end_date_must_be_on_or_after_start_date: end_date must be on or after start_date
+    tag:
+      must_be_an_emoji_or_symbol_not_a_letter: must be an emoji or symbol, not a letter
+    track_segment:
+      must_be_greater_than_or_equal_to_start_index: must be greater than or equal to start_index
+    trip:
+      must_be_after_start_date: must be after start date
+  services:
+    air_trail:
+      connection_tester:
+        airtrail_connection_verified: AirTrail connection verified
+        airtrail_url_is_missing: AirTrail URL is missing
+        airtrail_api_key_is_missing: AirTrail API key is missing
+        airtrail_connection_failed_message: 'AirTrail connection failed: %{message}'
+    concerns:
+      url_validatable:
+        invalid_scheme: 'Invalid URL scheme: %{scheme}'
+        host_required: URL must include a host
+        embedded_credentials: URL must not embed credentials (user:pass@host)
+        blocked_address: URL resolves to a blocked address
+        invalid_format: Invalid URL format
+        unresolvable_host: 'Could not resolve hostname: %{host}'
+    csv:
+      detector:
+        required_columns_missing: 'Could not detect required columns: latitude, longitude, timestamp. Found headers must include recognized aliases for all three.'
+    exports:
+      create:
+        export_finished: Export finished
+        export_name_successfully_finished: Export "%{name}" successfully finished.
+        export_failed: Export failed
+        export_name_failed_message_stacktrace_n: 'Export "%{name}" failed: %{message}, stacktrace: %{backtrace}'
+        unsupported_file_format: 'Unsupported file format: %{format}'
+    families:
+      accept_invitation:
+        you_must_leave_your_current_family_before_joining_a_new: You must leave your current family before joining a new one.
+        this_invitation_is_no_longer_valid_or_has_expired: This invitation is no longer valid or has expired.
+        this_invitation_is_not_for_your_email_address: This invitation is not for your email address.
+        this_family_s_plan_is_no_longer_active: This family's plan is no longer active.
+        this_family_has_reached_the_maximum_number_of_members: This family has reached the maximum number of members.
+        welcome_to_family: Welcome to Family!
+        you_ve_joined_the_family_name: You've joined the family '%{name}'
+        new_family_member: New Family Member!
+        email_has_joined_your_family: "%{email} has joined your family"
+        an_unexpected_error_occurred_while_joining_the_family_please_try: An unexpected error occurred while joining the family. Please try again
+        failed_to_join: 'Failed to join family: %{message}'
+      create:
+        family_name_is_required: Family name is required
+        family_name_must_be_50_characters_or_less: Family name must be 50 characters or less
+        you_must_leave_your_current_family_before_creating_a_new: You must leave your current family before creating a new one
+        you_have_already_created_a_family_each_user_can_only: You have already created a family. Each user can only create one family
+        family_feature_requires_an_active_subscription: Family feature requires an active subscription
+        family_created: Family Created
+        you_ve_successfully_created_the_family_name: You've successfully created the family '%{name}'
+        a_family_with_this_name_already_exists_for_your_account: A family with this name already exists for your account
+        an_unexpected_error_occurred_while_creating_the_family_please_try: An unexpected error occurred while creating the family. Please try again
+        failed_to_create_family: 'Failed to create family: %{message}'
+      create_location_request:
+        an_error_occurred: An error occurred
+        location_request: Location Request
+        safe_email_is_requesting_your_location_link: "%{email} is requesting your location. %{link}"
+        users_must_be_in_the_same_family: Users must be in the same family
+        target_user_is_already_sharing_their_location: Target user is already sharing their location
+        request_cooldown_active_please_wait_before_requesting_again: Request cooldown active. Please wait before requesting again.
+        view_request: View Request
+      invite:
+        invitation_sent: Invitation Sent
+        failed_to_send_invitation_email_please_try_again_later: Failed to send invitation email. Please try again later
+        an_unexpected_error_occurred_while_sending_the_invitation_please_try: An unexpected error occurred while sending the invitation. Please try again
+        failed_to_send_invitation: Failed to send invitation
+        owner_required: You must be a family owner to send invitations
+        family_full: Family is full
+        user_already_in_family: User is already in a family
+        invitation_already_sent: Invitation already sent to this email
+        sent_self_hosted: Family invitation sent to %{email} if SMTP is configured properly. If you're not using SMTP, copy the invitation link from the family page and share it manually.
+        sent: Family invitation sent to %{email}
+        failed_to_create: 'Failed to create invitation: %{message}'
+      memberships:
+        destroy:
+          user_is_not_currently_in_a_family: User is not currently in a family.
+          family_owners_cannot_remove_their_own_membership_to_leave_the: Family owners cannot remove their own membership. To leave the family, delete it instead.
+          only_family_owners_can_remove_other_members: Only family owners can remove other members.
+          cannot_remove_members_from_a_different_family: Cannot remove members from a different family.
+          cannot_remove_the_family_owner_the_owner_must_delete_the: Cannot remove the family owner. The owner must delete the family or leave on their own.
+          left_family: Left Family
+          you_ve_left_the_family_family_name: You've left the family "%{family_name}"
+          family_member_left: Family Member Left
+          email_has_left_the_family_family_name: '%{email} has left the family "%{family_name}"'
+          removed_from_family: Removed from Family
+          you_have_been_removed_from_the_family_family_name_by: You have been removed from the family "%{family_name}" by %{email}
+          member_removed: Member Removed
+          email_has_been_removed_from_the_family_family_name: '%{email} has been removed from the family "%{family_name}"'
+          an_unexpected_error_occurred_while_removing_the_membership_please_try: An unexpected error occurred while removing the membership. Please try again
+          failed_to_leave: 'Failed to leave family: %{message}'
+      update_location_sharing:
+        update_failed: Failed to update location sharing setting
+        unexpected_error: An error occurred while updating location sharing
+        disabled: Location sharing disabled
+        enabled: Location sharing enabled
+        enabled_for_hours:
+          one: Location sharing enabled for %{count} hour
+          other: Location sharing enabled for %{count} hours
+    fit:
+      importer:
+        fit_parsing_error_message: 'FIT parsing error: %{message}'
+        no_activities_found_in_fit_file: No activities found in FIT file
+    google_maps:
+      semantic_history_importer:
+        google_maps_timeline_import_error: Google Maps Timeline Import Error
+        batch_failed: 'Failed to process location batch: %{message}'
+    immich:
+      connection_tester:
+        immich_connection_verified: Immich connection verified
+        immich_url_is_missing: Immich URL is missing
+        immich_api_key_is_missing: Immich API key is missing
+        immich_connection_failed_message: 'Immich connection failed: %{message}'
+        immich_connection_failed_code: 'Immich connection failed: %{code}'
+        immich_api_key_missing_permission_asset_view: 'Immich API key missing permission: asset.view'
+        immich_thumbnail_check_failed_code: 'Immich thumbnail check failed: %{code}'
+      enrich_photos:
+        http_code_message: 'HTTP %{code}: %{message}'
+      enrich_scan:
+        failed_to_fetch_photos_from_immich: Failed to fetch photos from Immich
+      import_geodata:
+        import_was_not_created: Import was not created
+        import_with_the_same_name_import_name_already_exists_if: Import with the same name (%{import_name}) already exists. If you want to proceed, delete the existing import and try again.
+      response_validator:
+        request_failed_code: 'Request failed: %{code}'
+        expected_json_got_content_type: Expected JSON, got %{content_type}
+        invalid_json_response: Invalid JSON response
+        invalid_json: Invalid JSON
+      configuration:
+        api_key_missing: Immich API key is missing
+        url_missing: Immich URL is missing
+      response_analyzer:
+        permission_missing: 'Immich API key missing permission: asset.view'
+        thumbnail_failed: Failed to fetch thumbnail
+    imports:
+      bulk_insertable:
+        importer_name_import_error: "%{importer_name} Import Error"
+      create:
+        import_post_processing_incomplete: Import post-processing incomplete
+        import_completed_with_no_new_points: Import completed with no new points
+        import_completed_with_no_points: Import completed with no points
+        import_failed: Import failed
+        your_import_name_finished_and_all_points_were_saved_but: Your import "%{name}" finished and all points were saved, but the %{step} step failed. Statistics, tracks or visit suggestions may be missing or outdated. You can trigger a recalculation from Settings.
+        your_file_name_contained_raw_points_points_all_of_which: Your file %{name} contained %{raw_points} points, all of which already exist in your timeline at the same coordinates and timestamps. Nothing was imported. If this was unexpected, delete the existing points for that date range and re-import.
+        source_missing: Import source cannot be nil
+        unsupported_source: 'Unsupported source: %{source}'
+        zip_unclassified: Could not classify zip contents -- file may be corrupted
+      source_detector:
+        amazon_order: This is an Amazon order export, not location data. Dawarich imports location history from Google Takeout, OwnTracks, GPX, and similar sources.
+        apple_plist: Apple binary plist (.plist) files are not supported.
+        ds_store: This is a macOS Finder metadata file (.DS_Store), not a data file. Please upload your actual location export.
+        empty_file: The uploaded file is empty (0 bytes).
+        empty_json: The uploaded file contains no data (empty JSON object or array).
+        encrypted_timeline: Your Google Timeline data is encrypted. Open the Google Maps app, turn off Timeline encryption in your settings, then re-export your data.
+        google_settings: This file contains your Google Maps settings, not location data. Look for "Records.json" or files inside "Timeline/" in your Google Takeout.
+        gzip: Gzip-compressed files (.gz) are not auto-decompressed. Please decompress the file and re-upload the contents.
+        heic: HEIC image files are not supported. Photos do not contain a location history; connect your photo library via the Immich or PhotoPrism integration to import photo locations.
+        html_page: This is an HTML page (likely "archive_browser.html" from your Google Takeout), not the data file. Open the Takeout archive and look for the .json or .kml inside.
+        jpeg: JPEG image files are not supported. Photos do not contain a location history; connect your photo library via the Immich or PhotoPrism integration to import photo locations.
+        json_fragment: The uploaded file appears to be a truncated or corrupted fragment of a JSON file (it does not start with "{" or "["). Please re-export and upload the original complete file.
+        my_activity: This is a Google "My Activity" log (search and Maps activity), not your location history. Look for "Records.json" or files inside "Timeline/" in your Google Takeout.
+        office_document: Microsoft Office documents (Word/Excel) are not supported. Please upload your location data file.
+        pdf: PDF files are not supported. Open the PDF and find your actual location data file.
+        place_feedback: This is a Google Maps place-feedback file (Maps Q&A answers like "Was this place open?"), not your location history. Look for "Records.json" or files inside "Timeline/" in your Google Takeout.
+        png: PNG image files are not supported. Please upload your location data file (.json, .gpx, .kml, etc).
+        rar: RAR archives are not supported. Please extract the archive and upload the data files inside.
+        saved_places: This is a Google saved-places / geocodes file, not your location history. Look for "Records.json" or files inside "Timeline/" in your Google Takeout.
+        snapchat_export: This appears to be a Snapchat data export, not location data. Dawarich imports location history from Google Takeout, OwnTracks, GPX, and similar sources.
+        timeline_edits: Google Timeline Edits format is not yet supported. Please upload Records.json or the files inside the Timeline/ folder of your Google Takeout instead.
+        unknown_format: Unable to detect file format
+      watcher:
+        unsupported_source: 'Unsupported source: %{source}'
+        unsupported_source_without_name: Unsupported source
+    maps:
+      bounds_calculator:
+        no_data_found_for_the_specified_date_range: No data found for the specified date range
+        invalid_date: 'Invalid date format: %{value}'
+        no_date_range: No date range specified
+        no_user: No user found
+    photoprism:
+      connection_tester:
+        photoprism_connection_verified: Photoprism connection verified
+        photoprism_url_is_missing: Photoprism URL is missing
+        photoprism_api_key_is_missing: Photoprism API key is missing
+        photoprism_connection_failed_message: 'Photoprism connection failed: %{message}'
+        photoprism_connection_failed_code: 'Photoprism connection failed: %{code}'
+      import_geodata:
+        import_was_not_created: Import was not created
+        import_with_the_same_name_import_name_already_exists_if: Import with the same name (%{import_name}) already exists. If you want to proceed, delete the existing import and try again.
+      response_validator:
+        request_failed_code: 'Request failed: %{code}'
+        expected_json_got_content_type: Expected JSON, got %{content_type}
+        invalid_json_response: Invalid JSON response
+      configuration:
+        api_key_missing: Photoprism API key is missing
+        url_missing: Photoprism URL is missing
+    points:
+      raw_data:
+        verifier:
+          file_not_attached: File not attached
+          file_download_failed_message: 'File download failed: %{message}'
+          file_is_empty: File is empty
+          decryption_failed_message: 'Decryption failed: %{message}'
+          content_checksum_mismatch: Content checksum mismatch
+          point_count_mismatch_expected_point_count_found_count: 'Point count mismatch: expected %{point_count}, found %{count}'
+          point_ids_checksum_mismatch: Point IDs checksum mismatch
+          decompression_parsing_failed_message: 'Decompression/parsing failed: %{message}'
+          raw_data_mismatch_detected_in_count_point_s_first_mismatch: 'Raw data mismatch detected in %{count} point(s). First mismatch: Point %{point_id}'
+    settings:
+      update:
+        not_allowed: "%{setting} is not allowed: %{message}"
+        failed: Settings could not be updated
+        updated: Settings updated
+        photo_cache_refreshed: Photo cache refreshed
+    stats:
+      calculate_month:
+        stats_update_failed: Stats update failed
+        message_stacktrace_n: "%{message}, stacktrace: %{backtrace}"
+    users:
+      destroy:
+        cannot_delete_user_who_owns_a_family_with_other_members: Cannot delete user who owns a family with other members
+      export_data:
+        export_completed: Export completed
+        your_data_export_has_been_processed_successfully_summary_you_can: Your data export has been processed successfully (%{summary}). You can download it from the exports page.
+      import_data:
+        data_import_completed: Data import completed
+        your_data_has_been_imported_successfully_summary: Your data has been imported successfully (%{summary}).
+        data_import_failed: Data import failed
+        your_data_import_failed_with_error_message_please_check_the: 'Your data import failed with error: %{message}. Please check the archive format and try again.'
+        unknown_export_format: 'Unknown export format: neither manifest.json nor data.json found'
+        unsupported_format_version: 'Unsupported export format version: %{version}'
+        v1_handler:
+          data_file_missing: 'Data file not found in archive: data.json'
+          invalid_json: 'Invalid JSON format in data file: %{message}'
+          read_failed: 'Failed to read JSON data: %{message}'
+        v2_handler:
+          manifest_missing: 'Manifest file not found in archive: manifest.json'
+      transportation_thresholds_updater:
+        enable_at_least_one_transportation_mode: Enable at least one transportation mode
+        recalculation_in_progress: Transportation mode recalculation is in progress. Please wait until it completes.
+    visits:
+      suggest:
+        error_suggesting_visits_message: 'Error suggesting visits: %{message}'
+        new_visits_suggested: New visits suggested
+      merge_service:
+        minimum_visits: At least 2 visits must be selected for merging
+      bulk_destroy:
+        database_error: 'Database error: please try again.'
+        none_found: No matching visits found
+        none_selected: No visits selected
+        too_many_selected: Too many visits selected (max %{max})
+      bulk_update:
+        invalid_status: Invalid status
+        none_found: No matching visits found
+        none_selected: No visits selected
+    posters:
+      generate:
+        failed: Poster generation failed. Please try again later.
+        no_location_data: No location data found for the selected period.
+        track_outside_area: Your track does not pass through the selected map area. Recenter the map or adjust the dates.
+    gpx:
+      track_importer:
+        parse_error: 'GPX parse error: %{message}'
+    insights:
+      travel_insight_generator:
+        active_day: "%{day}s are your most active travel day"
+        days:
+          friday: Friday
+          monday: Monday
+          saturday: Saturday
+          sunday: Sunday
+          thursday: Thursday
+          tuesday: Tuesday
+          wednesday: Wednesday
+        early_start_suggestion: Early starts seem to work well for you!
+        peak_season: "%{season} is your peak travel season"
+        peak_time: You travel most %{period}
+        seasons:
+          fall: Fall
+          spring: Spring
+          summer: Summer
+          winter: Winter
+        sentence: "%{insights}."
+        sunset_suggestion: Consider a sunset drive for your next adventure.
+        time_periods:
+          afternoon: in the afternoon (12pm-6pm)
+          evening: in the evening (6pm-12am)
+          morning: in the morning (6am-12pm)
+          night: at night (12am-6am)
+        weekend_suggestion: Your weekends are made for exploring!
+        weekday_preference: You travel more on weekdays than weekends
+        with_suggestion: "%{insight} %{suggestion}"
+  jobs:
+    air_trail:
+      import_flights_job:
+        airtrail_sync_failed: AirTrail sync failed
+        your_airtrail_flight_sync_failed_with_error_message_check_your: 'Your AirTrail flight sync failed with error: %{message}. Check your AirTrail settings and try again.'
+    data_migrations:
+      recalculate_anomalies_user_job:
+        gps_noise_re_check_finished: GPS noise re-check finished
+        rules_recheck_finished: Your points were re-checked against the noise rules introduced in this release, and your tracks, stats and digests were rebuilt from the result. Some points may appear or disappear on the map. No points were deleted.
+    lite:
+      archival_warning_job:
+        your_oldest_data_will_archive_in_30_days: Your oldest data will archive in 30 days
+        your_oldest_month_of_location_data_will_be_archived_soon: Your oldest month of location data will be archived soon. Upgrade to Pro to keep your full history searchable.
+        data_has_been_archived: Data has been archived
+        month_of_location_data_has_been_archived_your_archived: 1 month of location data has been archived. Your archived data can be exported at any time. Upgrade to Pro to make it visible and interactive in-app again.
+    stale_jobs_recovery_job:
+      export_timed_out_after_being_stuck_in_processing: Export timed out after being stuck in processing
+      export_failed: Export failed
+      export_name_was_stuck_in_processing_and_has_been_marked: Export "%{name}" was stuck in processing and has been marked as failed.
+      import_timed_out_after_being_stuck_in_processing: Import timed out after being stuck in processing
+      import_failed: Import failed
+      import_name_was_stuck_in_processing_and_has_been_marked: Import "%{name}" was stuck in processing and has been marked as failed.
+    stats:
+      calculating_job:
+        stats_update_failed: Stats update failed
+        message_stacktrace_n: "%{message}, stacktrace: %{backtrace}"
+    users:
+      digests:
+        monthly:
+          calculating_job:
+            monthly_digest_calculation_failed: Monthly Digest calculation failed
+            message_stacktrace_backtrace: "%{message}, stacktrace: %{backtrace}"
+        yearly:
+          calculating_job:
+            period_label_calculation_failed: "%{period_label} calculation failed"
+            message_stacktrace_backtrace: "%{message}, stacktrace: %{backtrace}"
+      import_data_job:
+        data_import_failed: Data import failed
+        your_data_import_failed_with_error_message_please_check_the: 'Your data import failed with error: %{message}. Please check the archive format and try again.'
+      recalculate_data_job:
+        data_recalculation_busy: Data recalculation busy
+        another_recalculation_is_already_running_please_try_again_in_a: Another recalculation is already running. Please try again in a few minutes.
+        data_recalculation_completed: Data recalculation completed
+        stats_tracks_and_digests_have_been_recalculated_for_year_label: Stats, tracks, and digests have been recalculated for %{year_label}.
+        data_recalculation_failed: Data recalculation failed
+        message_stacktrace_n: "%{message}, stacktrace: %{backtrace}"
+    visits:
+      full_history_redetect_job:
+        visit_re_detection_busy: Visit re-detection busy
+        another_re_detection_is_already_running_try_again_in_a: Another re-detection is already running. Try again in a few minutes.
+        visit_re_detection: Visit re-detection
+        no_points_to_re_detect: No points to re-detect.
+        visit_re_detection_complete: Visit re-detection complete
+        visits_created_visits_across_size_months: "%{visits_created} visits across %{size} months."
+        visit_re_detection_partially_complete: Visit re-detection partially complete
+        visit_re_detection_failed: Visit re-detection failed
+        visits_created_visits_across_ok_months_of_size_months_size: "%{visits_created} visits across %{ok_months} of %{size} months. %{failed_count} month(s) failed; re-run after the cooldown to retry."
+  javascript:
+    messages:
+      click_on_the_map_to_place_a_visit: Click on the map to place a visit
+      end_time_must_be_after_start_time: End time must be after start time
+      network_error_failed_to_create_visit: 'Network error: Failed to create visit'
+      failed_to_copy_please_copy_manually: Failed to copy. Please copy manually.
+      copied_to_clipboard: Copied to clipboard!
+      location_sharing_has_expired: Location sharing has expired
+      invalid_tile_url_reverting_to_openstreetmap: Invalid tile URL. Reverting to OpenStreetMap.
+      please_select_a_date_range: Please select a date range
+      failed_to_scan_photos: Failed to scan photos
+      failed_to_enrich_photos: Failed to enrich photos
+      draw_a_rectangle_on_the_map_to_select_points: Draw a rectangle on the map to select points
+      fetching_data_in_selected_area: Fetching data in selected area...
+      no_data_found_in_selected_area: No data found in selected area
+      failed_to_fetch_data_in_selected_area: Failed to fetch data in selected area
+      visit_confirmed: Visit confirmed
+      failed_to_confirm_visit: Failed to confirm visit
+      visit_deleted: Visit deleted
+      failed_to_delete_visit: Failed to delete visit
+      select_at_least_2_visits_to_merge: Select at least 2 visits to merge
+      merging_visits: Merging visits...
+      visits_merged_successfully: Visits merged successfully
+      failed_to_merge_visits: Failed to merge visits
+      confirming_visits: Confirming visits...
+      failed_to_confirm_visits: Failed to confirm visits
+      deleting_visits: Deleting visits...
+      failed_to_delete_visits: Failed to delete visits
+      selection_cancelled: Selection cancelled
+      no_anomaly_points_in_selection: No anomaly points in selection
+      deleting_anomaly_points: Deleting anomaly points...
+      no_points_selected: No points selected
+      deleting_points: Deleting points...
+      anomaly_point: Anomaly Point
+      failed_to_load_location_data_please_try_again: Failed to load location data. Please try again.
+      click_on_the_map_to_place_a_place: Click on the map to place a place
+      failed_to_reload_routes: Failed to reload routes
+      failed_to_load_scratch_layer: Failed to load scratch layer
+      failed_to_load_photos: Failed to load photos
+      failed_to_load_areas: Failed to load areas
+      failed_to_load_tracks: Failed to load tracks
+      failed_to_load_flights: Failed to load flights
+      failed_to_load_anomalies: Failed to load anomalies
+      reloading_routes: Reloading routes...
+      cannot_update_recalculation_is_already_in_progress: 'Cannot update: recalculation is already in progress'
+      transportation_settings_saved: Transportation settings saved
+      globe_view_will_be_applied_after_page_reload: Globe view will be applied after page reload
+      settings_updated_successfully: Settings updated successfully
+      reloading_map_data_with_new_settings: Reloading map data with new settings...
+      api_key_not_available_please_reload_the_page: API key not available; please reload the page.
+      could_not_queue_re_evaluation_please_try_again: Could not queue re-evaluation. Please try again.
+      could_not_queue_recalculation_please_try_again: Could not queue recalculation. Please try again.
+      click_on_the_map_to_place_a_visit_esc_to: Click on the map to place a visit (Esc to cancel)
+      visit_creation_modal_not_available: Visit creation modal not available
+      visit_creation_controller_not_available: Visit creation controller not available
+      area_drawer_controller_not_available: Area drawer controller not available
+      area_created_successfully: Area created successfully!
+      failed_to_reload_areas: Failed to reload areas
+      family_feature_not_available: Family feature not available
+      failed_to_load_family_members: Failed to load family members
+      centered_on_family_member: Centered on family member
+      failed_to_load_visit_details: Failed to load visit details
+      failed_to_load_area_details: Failed to load area details
+      point_deleted_successfully: Point deleted successfully
+      failed_to_delete_point: Failed to delete point
+      deleting_area: Deleting area...
+      area_deleted_successfully: Area deleted successfully
+      failed_to_delete_area: Failed to delete area
+      failed_to_load_place_details: Failed to load place details
+      connected_to_real_time_updates: Connected to real-time updates
+      disconnected_from_real_time_updates: Disconnected from real-time updates
+      new_location_recorded: New location recorded
+      error_saving_layer_preferences: Error saving layer preferences
+      failed_to_update_settings: Failed to update settings
+      at_least_one_gradient_stop_is_required: At least one gradient stop is required.
+      failed_to_load_demo_data_please_try_again: Failed to load demo data. Please try again.
+      could_not_load_flights_please_try_again: Could not load flights. Please try again.
+      no_flights_found_for_this_trip: No flights found for this trip.
+      please_select_and_upload_files_first: Please select and upload files first
+      please_select_a_valid_zip_file: Please select a valid ZIP file.
+      failed_to_fetch_photos: Failed to fetch photos
+      failed_to_fetch_photos_after_multiple_attempts: Failed to fetch photos after multiple attempts
+      place_deleted_successfully: Place deleted successfully
+      failed_to_delete_place: Failed to delete place
+      failed_to_load_visits_in_selected_area: Failed to load visits in selected area
+      no_valid_point_ids_found: No valid point IDs found
+      failed_to_delete_points_please_try_again: Failed to delete points. Please try again.
+      at_least_2_visits_must_be_selected_for_merging: At least 2 visits must be selected for merging
+      no_visits_selected: No visits selected
+      visit_confirmed_successfully: Visit confirmed successfully
+      visit_declined_successfully: Visit declined successfully
+      failed_to_decline_visit: Failed to decline visit
+      failed_to_load_possible_places: Failed to load possible places
+      please_select_a_valid_location: Please select a valid location
+      visit_updated_successfully: Visit updated successfully
+      failed_to_update_visit: Failed to update visit
+      visit_deleted_successfully: Visit deleted successfully
+      failed_to_update_point_position_please_try_again: Failed to update point position. Please try again.
+      failed_to_load_track_points: Failed to load track points
+      point_updated_track_will_be_recalculated: Point updated. Track will be recalculated.
+      delete: Delete
+      edit: Edit
+      your_lite_plan_includes_the_last_12_months_of_data: Your Lite plan includes the last 12 months of data.
+      globe_view_is_a_pro_feature: Globe View is a Pro feature.
+      map_styles: Map Styles
+      untagged: Untagged
+      suggested: Suggested
+      confirmed: Confirmed
+      layers: Layers
+      points: Points
+      routes: Routes
+      tracks: Tracks
+      heatmap: Heatmap
+      fog_of_war: Fog of War
+      scratch_map: Scratch map
+      areas: Areas
+      photos: Photos
+      visits: Visits
+      places: Places
+      family_members: Family Members
+      food_drink: Food & Drink
+      shopping: Shopping
+      transport: Transport
+      cycling: Cycling
+      nature_leisure: Nature & Leisure
+      tourism_culture: Tourism & Culture
+      services_civic: Services & Civic
+      urban_amenities: Urban Amenities
+    common:
+      add_row: Add Row
+      and: and
+      cancel: Cancel
+      close: Close
+      save: Save
+      confirm: Confirm
+      delete: Delete
+      decline: Decline
+      dismiss: Dismiss
+      close_panel: Close panel
+      name: Name
+      not_available: N/A
+      reset_to_default: Reset to Default
+      settings: Settings
+      unknown: Unknown
+      unknown_error: Unknown error
+      update: Update
+      upgrade_to_pro: Upgrade to Pro
+      expired: Expired
+      loading: Loading...
+      creating: Creating...
+    trip:
+      show_all_days: Show all days
+      collapse_all_days: Collapse all days
+    map:
+      places_layer: Places Layer
+      confirm_delete_point: Are you sure you want to delete this point?
+      confirm_delete_point_permanently: |-
+        Delete this point?
 
+        This action cannot be undone.
+      edit_speed_color_scale: Edit Speed Color Scale
+      failed_to_update_point_position: Failed to update point position. Please try again.
+      display: Display
+      layer_preferences_failed: 'Failed to save layer preferences: %{error}'
+      preferred_layer_updated: 'Preferred map layer updated to: %{layer}'
+      stats_summary:
+        one: "%{distance} %{unit} | %{count} point"
+        other: "%{distance} %{unit} | %{count} points"
+      updating: Updating map...
+    replay:
+      no_data_at_this_time: No data at this time
+      pause: Pause
+      replay: Replay
+      day_count: Day %{current} of %{total}
+      point_count: Point %{current} of %{total}
+      speed: "%{speed} km/h"
+      no_data: No data
+    places:
+      create_new: Create New Place
+      edit: Edit Place
+      confirm_delete: Are you sure you want to delete this place?
+      search_placeholder: Search for a place…
+      confirm_move_visit: This place is ~%{distance} m from the visit. Move the visit here?
+      create_here: + Create "%{name}" here
+      created: Place "%{name}" created successfully!
+      filter_by_tag: FILTER BY TAG
+      no_tags: No tags created yet
+      none_found: No places found
+      open_for_suggestions: Open modal to load nearby suggestions
+      show_all: Show All Places
+      untagged: Untagged Places
+      updated: Place "%{name}" updated successfully!
+      create: Create Place
+      update: Update Place
+      click_map_to_add: Click on the map to add a place
+    demo:
+      removing_data: Removing demo data…
+      already_loaded: Demo data already loaded
+      confirm_delete: |-
+        Delete all demo data?
+
+        This removes the demo points, visits, places, tags, tracks, and the Prague trip.
+
+        Your real data — anything you've imported, edited, confirmed, or created yourself — will NOT be touched.
+      creating: Creating your demo data…
+      creating_help: Seeding a month of Berlin tracking plus a Prague weekend trip. Takes about a second.
+    visits:
+      add_new: Add New Visit
+      create_new: Create New Visit
+      create: Create Visit
+      create_failed: Failed to create visit
+      create_failed_with_error: 'Failed to create visit: %{error}'
+      created: Visit "%{name}" created successfully!
+      created_without_name: Visit created successfully!
+      current_location: Current Location
+      delete: Delete Visit
+      details: Visit Details
+      edit: Edit Visit
+      enable_layers_help: Enable "Suggested Visits" or "Confirmed Visits" layers from the map controls to view visits.
+      end_time: End Time
+      found:
+        one: "%{count} visit found"
+        other: "%{count} visits found"
+      loading: Loading visits...
+      update: Update Visit
+      recent: Recent Visits
+      name: Visit Name
+      no_data_loaded: No visits data loaded
+      none_found: No visits found
+      none_found_for: No visits found for "%{query}"
+      none_in_timeframe: No visits found in selected timeframe
+      selected:
+        one: "%{count} visit selected"
+        other: "%{count} visits selected"
+      start_time: Start Time
+      cancel_selection: Cancel Selection
+      loading_error: Error loading visits
+      merge: Merge
+      enter_name: Enter visit name
+      confirm_delete_keep_points: Delete this visit? Your location points stay.
+      end_after_start: End time must be after start time
+      network_create_error: 'Network error: Failed to create visit'
+      bulk_status_failed: Failed to mark visits %{status}
+      bulk_status_updated: "%{count} visits %{status} successfully"
+      confirm_delete_count_keep_points:
+        one: Delete %{count} visit? Your location points stay.
+        other: Delete %{count} visits? Your location points stay.
+      confirm_delete_permanently: Are you sure you want to delete this visit? This action cannot be undone.
+      confirm_merge:
+        one: Merge %{count} visit into one?
+        other: Merge %{count} visits into one?
+      confirmed_count:
+        one: Confirmed %{count} visit
+        other: Confirmed %{count} visits
+      deleted_count:
+        one: Deleted %{count} visit
+        other: Deleted %{count} visits
+      status_failed: Failed to mark visit %{status}
+      status_updated: Visit marked %{status} successfully
+      unnamed: Unnamed Visit
+    sharing:
+      expires_in: Expires in %{time}
+      hours_minutes_remaining: "%{hours}h %{minutes}m remaining"
+      minutes_remaining: "%{minutes}m remaining"
+      link_copied: Link Copied!
+    areas:
+      edit: Edit Area
+      create_new: Create New Area
+      enter_name: Enter area name
+      confirm_delete: Are you sure you want to delete this area?
+      confirm_delete_named: |-
+        Delete area "%{name}"?
+
+        This action cannot be undone.
+      deleted: Area was successfully deleted!
+      new: New Area
+      save: Save Area
+      update: Update Area
+      create: Create Area
+    search:
+      locations: Search locations
+      locations_placeholder: Search locations...
+      failed: Search Failed
+      finding_suggestions: Finding suggestions...
+      first_last: first %{first}, last %{last}
+      for_query: for "%{query}"
+      locations_found:
+        one: Found %{count} location
+        other: Found %{count} locations
+      no_locations: No locations found
+      results: Results
+      searching: Searching…
+      searching_for: Searching for "%{query}"...
+      searching_for_visits: Searching for visits...
+      searching_visits_to: Searching visits to
+      suggestions: Suggestions
+      suggestions_failed: Failed to fetch suggestions
+      unavailable: Search unavailable
+      unknown_location: Unknown location
+      unnamed_location: Unnamed Location
+      visits_load_failed: Failed to load visits for this location
+      locations_failed: Failed to search locations. Please try again.
+    settings:
+      transportation_recalculation_completed: Transportation mode recalculation completed!
+      confirm_reset: Reset all settings to defaults? This will reload the page.
+      confirm_globe_reload: Globe view requires a page reload to take effect. Reload now?
+      changed_fields: 'Changed: %{fields}'
+      confirm_reapply_anomaly_filter: |-
+        This is destructive and long-running.
+
+        • All existing anomaly flags will be cleared and re-computed with your current settings.
+        • Tracks, stats, and digests will be rebuilt afterwards.
+        • Depending on how many points you have, this can take several minutes (or longer for years of history).
+        • During the rebuild, tracks and stats on the map may temporarily look incomplete.
+
+        Continue?
+      confirm_recalculate_user_data: |-
+        This is long-running and rebuilds derived data.
+
+        • Tracks, stats, and digests will be regenerated from scratch using your current points and settings.
+        • Existing tracks/stats are replaced — anything you tweaked manually on a track will be overwritten.
+        • Depending on your history this can take several minutes; you'll get a notification when it's done.
+
+        Continue?
+      confirm_transportation_recalculation: |-
+        Applying these changes will recalculate transportation modes for ALL your tracks.
+
+        This process may take some time depending on how many tracks you have, and settings will be locked until it completes.
+
+        Do you want to continue?
+      custom_style_load_failed: Custom map style could not be loaded; reverting to the default style.
+      invalid_tile_url: Tile URL must include {z}, {x}, and {y} placeholders, or be a MapLibre style URL
+      layer_unavailable_custom_style: Not available with the Custom map style — it draws no labels or points of interest
+      layer_unavailable_foreign_basemap: Not available with a custom raster or style basemap — these layers come from the built-in vector tiles
+      make_changes_to_apply: Make changes to enable the Apply button
+      re_evaluation_queued: Re-evaluation queued. The map will update once the job finishes.
+      recalculation_queued: Recalculation queued. You'll get a notification when it finishes.
+      transportation_recalculation_failed: 'Recalculation failed: %{error}'
+      transportation_recalculation_progress: Recalculating transportation modes... (%{processed}/%{total} tracks, %{progress}%)
+      transportation_recalculation_started: Settings saved. Recalculating transportation modes for all tracks...
+      unsaved_count:
+        one: "%{count} unsaved"
+        other: "%{count} unsaved"
+      unsaved_transportation_changes: You have unsaved changes. Click Apply to save and recalculate.
+    upload:
+      complete:
+        one: "%{count} file uploaded successfully. Ready to submit."
+        other: "%{count} files uploaded successfully. Ready to submit."
+      compression_failed: Could not compress %{name}, uploading as-is.
+      error: 'Error uploading %{name}: %{error}'
+      file_size_limit: File size limit exceeded. Trial users can only upload files up to 10MB.
+      import_limit: Import limit reached. Trial users can only create up to %{count} imports.
+      none_uploaded: No files were successfully uploaded. Please try again.
+      preparing:
+        one: Preparing %{count} file for upload...
+        other: Preparing %{count} files for upload...
+      progress: Upload Progress
+      unsupported_type: 'Unsupported file type: %{names}. Supported formats: %{accepted}.'
+      uploading:
+        one: Uploading %{count} file, please wait...
+        other: Uploading %{count} files, please wait...
+    immich:
+      confirm_enrich:
+        one: Write GPS coordinates to %{count} photo in Immich? This will update its location metadata.
+        other: Write GPS coordinates to %{count} photos in Immich? This will update their location metadata.
+      enrich_photos:
+        one: Enrich %{count} photo
+        other: Enrich %{count} photos
+      enriched:
+        one: Successfully enriched %{count} photo!
+        other: Successfully enriched %{count} photos!
+      enriching:
+        one: Enriching %{count} photo...
+        other: Enriching %{count} photos...
+      marker_title: "%{filename} (%{delta} delta)"
+      matched_summary: "%{matched} of %{total} matched"
+      minutes_short: "%{count}m"
+      no_matches: No matches found within tolerance
+      open_in_immich: Open in Immich
+      partially_enriched: Enriched %{enriched} photos. %{failed} failed.
+      photos_without_gps:
+        one: "%{count} photo without GPS"
+        other: "%{count} photos without GPS"
+      scanning: Scanning Immich photos...
+      seconds_short: "%{count}s"
+    selection:
+      anomaly_points_deleted:
+        one: Deleted %{count} anomaly point
+        other: Deleted %{count} anomaly points
+      confirm_delete_anomaly_points:
+        one: Are you sure you want to delete %{count} anomaly point? This action cannot be undone.
+        other: Are you sure you want to delete %{count} anomaly points? This action cannot be undone.
+      confirm_delete_points:
+        one: Are you sure you want to permanently delete %{count} point from your location history? This action cannot be undone.
+        other: Are you sure you want to permanently delete %{count} points from your location history? This action cannot be undone.
+      delete_anomaly_points:
+        one: Delete %{count} Anomaly Point
+        other: Delete %{count} Anomaly Points
+      delete_points:
+        one: Delete %{count} Point
+        other: Delete %{count} Points
+      delete_points_failed: Failed to delete points. Please try again.
+      delete_points_label: Delete Points
+      enabled: Selection mode enabled. Click and drag to select an area.
+      map_refresh_failed: Map didn't refresh. Reload the page to see updated points.
+      no_points_deleted: No points were deleted. They may have already been removed.
+      points:
+        one: "%{count} point"
+        other: "%{count} points"
+      points_deleted:
+        one: Successfully deleted %{count} point
+        other: Successfully deleted %{count} points
+      selected: Selected %{items}
+      too_many_points: Too many points (%{requested}). Please draw a smaller area; max %{limit} per delete.
+      too_many_selected_points: Too many points selected (%{requested}). Please draw a smaller area; max %{limit} per delete.
+      visits:
+        one: "%{count} visit"
+        other: "%{count} visits"
+      visits_in_area: Visits in Area (%{count})
+      write_api_requires_pro: Write API requires Pro
+    map_info:
+      altitude: Altitude
+      area: Area
+      average_speed: Avg Speed
+      battery: Battery
+      center: Center
+      coordinates: Coordinates
+      current_speed: Current Speed
+      distance: Distance
+      duration: Duration
+      duration_hours_minutes: "%{hours}h %{minutes}m"
+      duration_minutes: "%{minutes}m"
+      email: Email
+      end: End
+      h3_index: H3 Index
+      id: Id
+      latitude: Latitude
+      location: Location
+      location_coordinates: Location (%{latitude}, %{longitude})
+      location_data: Location Data
+      location_point: Location Point
+      longitude: Longitude
+      meters:
+        one: "%{count} meter"
+        other: "%{count} meters"
+      mode: Mode
+      photo: Photo
+      place: Place
+      points: Points
+      radius: Radius
+      reason: Reason
+      route_information: Route Information
+      routes: Routes
+      selected_point: Selected Point
+      show_points: Show Points
+      show_points_help: Enable to view and drag points to edit track
+      source: Source
+      speed: Speed
+      start: Start
+      status: Status
+      taken: Taken
+      time: Time
+      time_range: Time Range
+      timestamp: Timestamp
+      total_distance: Total Distance
+      track_number: 'Track #%{id}'
+      tracks: Tracks
+      video: Video
+      area_number: Area %{id}
+      place_name_locked: "\U0001F512 You named this place, so automatic naming won’t change it. Rename it to “Suggested place” to hand it back."
+    map_controls:
+      add_visit: Add a visit
+      create_place: Create a place
+      place_marker_mode: Click map to place marker (click to cancel)
+      select_area: Select Area
+      toggle_footer: Toggle footer visibility
+      toggle_panel: Toggle Panel
+      toggle_visits_drawer: Toggle Visits Drawer
+    map_styles:
+      black: Black
+      dark: Dark
+      grayscale: Grayscale
+      light: Light
+      white: White
+    family:
+      loaded_members:
+        one: Loaded %{count} family member
+        other: Loaded %{count} family members
+      member: Family Member
+      none_sharing: No family members sharing location
+      sharing_since:
+        one: Sharing since %{date} (%{count} day of history)
+        other: Sharing since %{date} (%{count} days of history)
+      sharing_disabled: Location is not being shared with your family
+      sharing_enabled: Location is being shared with your family
+      locations_updated:
+        one: Family locations updated (%{count} member)
+        other: Family locations updated (%{count} members)
+      refresh_failed: Failed to refresh family locations
+    hexagons:
+      limit_warning: Showing the first 100,000 points in this range — narrow the date range for denser detail.
+      load_failed: 'Couldn''t load hexagons: %{error}'
+      points: "<strong>%{count}</strong> points"
+    layer_preview:
+      ended: "%{layer} preview ended."
+      remaining: Previewing %{layer} — %{seconds}s remaining.
+      started: Previewing %{layer} for %{seconds} seconds.
+    poster:
+      categories:
+        print: Print
+        social: Social
+        wallpaper: Wallpaper
+      export_failed: 'Poster export failed: %{error}'
+      open_failed: 'Poster studio failed to open: %{error}'
+      order_summary: "%{layout} poster — %{price}"
+      theme_load_failed: 'Failed to load theme: %{error}'
+      theme_preset_failed: 'Failed to load theme preset: %{error}'
+      layouts:
+        print-a5: A5 Portrait
+        print-a4: A4 Portrait
+        print-a3: A3 Portrait
+        print-a2: A2 Portrait
+        print-a1: A1 Portrait
+        print-a0: A0 Portrait
+        print-30x40: 30 × 40 cm
+        print-50x70: 50 × 70 cm
+        print-70x100: 70 × 100 cm
+        print-letter: Letter (US)
+        print-a4-landscape: A4 Landscape
+        print-a3-landscape: A3 Landscape
+        social-ig-square: Instagram Square
+        social-ig-portrait: Instagram Portrait
+        social-story: Story (9:16)
+        social-x-header: X Header
+        social-youtube-thumb: YouTube Thumbnail
+        wallpaper-fhd: Desktop Full HD
+        wallpaper-4k: Desktop 4K
+        wallpaper-ultrawide: Desktop Ultrawide
+        wallpaper-phone: Phone
+        wallpaper-tablet: Tablet
+      frame_too_wide: This view is wider than the largest poster area — the saved poster will be more zoomed in than the preview.
+      load: Load
+      loading: Loading…
+      loading_tracks: Loading tracks for the new range…
+      no_location_data: No location data in this date range — pick a range with tracks in the date bar above.
+      no_tracks_in_frame: No tracks inside the frame — move or zoom the map over your route to save to the gallery.
+      queued: Queued — rendering server-side into Recent posters…
+      rendering: Rendering %{width} × %{height}px…
+      saved: Saved
+      saved_at_dpi: Saved at %{dpi} dpi (device GL limit)
+      untitled: Untitled poster
+      order_errors:
+        connection: Could not reach the order service — check your connection.
+        generic: Order upload failed — try again.
+        not_pdf: The export didn't produce a valid PDF — try again.
+        payment_unavailable: Payment is temporarily unavailable — try again in a minute.
+        too_large: The exported PDF is too large (50 MB max). Lower the DPI cap or zoom out.
+        unknown_sku: This format is not orderable right now.
+        unreadable: The exported PDF couldn't be read — try again.
+        wrong_size: The exported PDF doesn't match the selected format — try again.
+    legacy_settings:
+      edit_colors: Edit Colors
+      fog_radius: Fog of War radius
+      fog_threshold: Fog of War threshold
+      live_map: Live Map
+      merge_threshold: Merge threshold minutes
+      meters_between_routes: Meters between routes
+      minutes_between_routes: Minutes between routes
+      points_rendering_mode: Points rendering mode
+      raw: Raw
+      route_opacity: Route Opacity, %
+      simplified: Simplified
+      speed_color_scale: Speed color scale
+      speed_colored_routes: Speed-colored routes
+      time_threshold: Time threshold minutes
+    calendar_panel:
+      loading_visited_places: Loading visited places...
+      loading_years: Loading years...
+      no_data: No data available
+      no_places_visited: No places visited during this period
+      select_year: Select year
+      visited_cities: Visited cities
+      visited_places_error: Error loading visited places
+      whole_year: Whole year
+      years_error: Error loading years
+    live_share:
+      ended: This live share has ended.
+      last_seen: 'Last seen: %{date} (%{relative})'
+      last_seen_short: Last seen
+      location_hidden: Location hidden.
+      location_unknown: Location unknown — waiting for an update…
+    speed_gradient:
+      add_stop: Add Color Stop
+      color: Color
+      color_stops: Color Stops
+      help: This gradient will be applied to routes based on speed
+      preview: Preview
+      speed: Speed (km/h)
+      title: Edit Speed Color Gradient
+    stats:
+      no_location_data: No location data available for %{date}
+      location_data_load_failed: Failed to load location data
+      map_initialization_failed: Failed to initialize map
+    anomalies:
+      impossible_speed: 'Filtered: impossible speed between neighboring points'
+      low_accuracy: 'Filtered: low accuracy (%{accuracy}m, threshold %{threshold}m)'
+    live_map:
+      disabled: Live mode disabled
+      enabled: Live mode enabled
+    map_panel:
+      layers: Map Layers
+      links: Links
+      search: Search
+      settings: Settings
+      timeline: Timeline
+      tools: Tools
+    activity:
+      no_activity: No activity
+    datetime:
+      start_before_end: Start date must be earlier than end date
+    timeline:
+      action_count: "%{action} %{count}"
+      merge_count: Merge %{count}
+      selected: "%{count} selected"
+      selected_with_max: "%{count} selected (max %{max})"
+    time:
+      days_short: "%{count}d"
+      hours_short: "%{count}h"
+      invalid_date: Invalid Date
+      minutes_short: "%{count}min"
+  battery_statuses:
+    charging: charging
+    full: full
+  family_invitations:
+    index:
+      back_to_family: Back to Family
+      cancel: Cancel
+      cancel_confirm: Are you sure you want to cancel this invitation?
+      copy_link: Copy Link
+      expires_on: Expires
+      invited_on: Invited
+      no_invitations: No pending invitations
+      title: Family Invitations
+      view_invitation: View

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2481,23 +2481,27 @@ en:
       month_name: "%B"
       month_year: "%B %Y"
       short_month_day: "%b %-d"
+      short_month_day_padded: "%b %d"
       medium: "%b %-d, %Y"
+      medium_padded: "%b %d, %Y"
       long: "%B %d, %Y"
       weekday_month_day: "%A, %B %-d"
       short_month_day_weekday: "%b %-d, %A"
       short_weekday_month_day: "%a, %b %-d"
       iso: "%Y-%m-%d"
-      day_month_year: "%-d %B %Y"
+      day_month_year: "%e %B %Y"
       day_month_year_abbreviated: "%-d %b %Y"
       month_day: "%B %-d"
+      month_day_padded: "%B %d"
+      month_day_year: "%B %-d, %Y"
       day_year: "%-d, %Y"
       abbreviated_month_name: "%b"
   time:
     formats:
       hour_minute: "%H:%M"
-      long_with_time: "%B %-d, %Y at %I:%M %p"
-      human: "%-d %b %Y, %H:%M"
-      human_with_seconds: "%-d %b %Y, %H:%M:%S"
+      long_with_time: "%B %d, %Y at %I:%M %p"
+      human: "%e %b %Y, %H:%M"
+      human_with_seconds: "%e %b %Y, %H:%M:%S"
       short_with_time: "%b %d at %I:%M %p"
   common:
     app_name: Dawarich
@@ -4174,8 +4178,12 @@ en:
       invalid_date: Invalid Date
       minutes_short: "%{count}min"
   battery_statuses:
+    unknown: unknown
+    unplugged: unplugged
     charging: charging
     full: full
+    connected_not_charging: not charging
+    discharging: discharging
   family_invitations:
     index:
       back_to_family: Back to Family

--- a/spec/javascript/i18n_test.mjs
+++ b/spec/javascript/i18n_test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const source = await readFile(
+  new URL("../../app/javascript/i18n.js", import.meta.url),
+  "utf8",
+)
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+
+test("translates strings, interpolation, and count-based plural forms", async () => {
+  const payload = {
+    greeting: "Hello %{name}",
+    visits: { one: "%{count} visit", other: "%{count} visits" },
+  }
+  globalThis.document = {
+    getElementById: () => ({ textContent: JSON.stringify(payload) }),
+  }
+
+  try {
+    const { translate } = await import(moduleUrl)
+
+    assert.equal(translate("greeting", { name: "Ada" }), "Hello Ada")
+    assert.equal(translate("visits", { count: 1 }), "1 visit")
+    assert.equal(translate("visits", { count: 2 }), "2 visits")
+    assert.equal(translate("missing.key"), "missing.key")
+  } finally {
+    delete globalThis.document
+  }
+})

--- a/spec/javascript/location_search_date_format_test.mjs
+++ b/spec/javascript/location_search_date_format_test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+// The class imports "i18n" and "./theme_utils", neither of which node can
+// resolve as a bare/relative specifier here. No method runs at definition time,
+// so dropping the imports is enough to reach formatDateShort, which is a pure
+// function of its argument.
+const source = await readFile(
+  new URL("../../app/javascript/maps/location_search.js", import.meta.url),
+  "utf8",
+)
+const stubbed = `${source.replace(/^import .*$/gm, "")}
+export const formatDateShort = LocationSearch.prototype.formatDateShort
+`
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(stubbed).toString("base64")}`
+const { formatDateShort } = await import(moduleUrl)
+
+test("formatDateShort renders day before month", () => {
+  // 3 August, not 8 March. A locale derived from <html lang="en"> resolves to
+  // en-US and silently swaps these two components.
+  assert.equal(formatDateShort("2026-08-03T12:00:00"), "03/08/2026")
+})
+
+test("formatDateShort zero-pads single-digit days and months", () => {
+  assert.equal(formatDateShort("2026-01-09T12:00:00"), "09/01/2026")
+})

--- a/spec/javascript/map_initializer_test.mjs
+++ b/spec/javascript/map_initializer_test.mjs
@@ -23,6 +23,7 @@ async function loadMapInitializer({ getMapStyle, Toast }) {
     const maplibregl = globalThis.__mapInitializerMaplibre
     const getMapStyle = globalThis.__mapInitializerGetMapStyle
     const Toast = globalThis.__mapInitializerToast
+    const translate = (key) => key
     ${basemapUrlSource.replace(/^export /gm, "")}
   `
   globalThis.__mapInitializerGetMapStyle = getMapStyle

--- a/spec/javascript/poster_order_client_test.mjs
+++ b/spec/javascript/poster_order_client_test.mjs
@@ -9,7 +9,18 @@ const source = await readFile(
   ),
   "utf8",
 )
-const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+const translations = {
+  "poster.order_errors.too_large":
+    "The exported PDF is too large (50 MB max). Lower the DPI cap or zoom out.",
+  "poster.order_errors.generic": "Order upload failed — try again.",
+  "poster.order_errors.connection":
+    "Could not reach the order service — check your connection.",
+}
+const localizedSource = source.replace(
+  'import { translate } from "i18n"',
+  `const translate = (key) => (${JSON.stringify(translations)})[key] || key`,
+)
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(localizedSource).toString("base64")}`
 const { submitPrintOrder } = await import(moduleUrl)
 
 class FakeXhr {

--- a/spec/javascript/settings_manager_test.mjs
+++ b/spec/javascript/settings_manager_test.mjs
@@ -47,6 +47,7 @@ async function loadSettingsController(settingsManager, overrides = {}) {
     const LAYER_COLOR_DEFAULTS = ${JSON.stringify(LAYER_COLOR_DEFAULTS)}
     const SettingsManager = globalThis.__settingsManagerTestDouble
     const getMapStyle = globalThis.__settingsManagerGetMapStyle
+    const translate = (key) => key
     ${basemapUrlSource.replace(/^export /gm, "")}
   `
   const url = `data:text/javascript;base64,${Buffer.from(`${dependencies}\n${withoutImports}`).toString("base64")}`

--- a/spec/regressions/i18n_date_format_parity_spec.rb
+++ b/spec/regressions/i18n_date_format_parity_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Locks the rendered output of every named date/time format against the literal
+# strftime patterns the application used before the copy was centralised in
+# config/locales/en.yml. Single-digit days are the only case where zero- and
+# space-padding differ, so every example uses one.
+RSpec.describe 'I18n date and time format parity' do
+  let(:date) { Date.new(2026, 8, 5) }
+  let(:time) { Time.zone.local(2026, 8, 5, 9, 7, 3) }
+
+  describe 'date formats' do
+    {
+      long: '%B %d, %Y',
+      medium: '%b %-d, %Y',
+      medium_padded: '%b %d, %Y',
+      month_day: '%B %-d',
+      month_day_padded: '%B %d',
+      month_day_year: '%B %-d, %Y',
+      short_month_day: '%b %-d',
+      short_month_day_padded: '%b %d',
+      day_month_year: '%e %B %Y',
+      day_month_year_abbreviated: '%-d %b %Y',
+      day_year: '%-d, %Y',
+      iso: '%Y-%m-%d',
+      month_name: '%B',
+      abbreviated_month_name: '%b',
+      month_year: '%B %Y',
+      weekday_month_day: '%A, %B %-d',
+      short_month_day_weekday: '%b %-d, %A',
+      short_weekday_month_day: '%a, %b %-d'
+    }.each do |format, pattern|
+      it "renders :#{format} as #{pattern}" do
+        expect(I18n.l(date, format:)).to eq(date.strftime(pattern))
+      end
+    end
+  end
+
+  describe 'time formats' do
+    {
+      hour_minute: '%H:%M',
+      human: '%e %b %Y, %H:%M',
+      human_with_seconds: '%e %b %Y, %H:%M:%S',
+      long_with_time: '%B %d, %Y at %I:%M %p',
+      short_with_time: '%b %d at %I:%M %p'
+    }.each do |format, pattern|
+      it "renders :#{format} as #{pattern}" do
+        expect(I18n.l(time, format:)).to eq(time.strftime(pattern))
+      end
+    end
+  end
+end

--- a/spec/regressions/i18n_enum_translation_coverage_spec.rb
+++ b/spec/regressions/i18n_enum_translation_coverage_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Several views and Stimulus controllers build translation keys by interpolating
+# an enum value, e.g. t("battery_statuses.#{point.battery_status}"). A value
+# without a matching key renders the raw key or "translation missing" straight
+# into the UI, so every reachable value needs an entry.
+RSpec.describe 'I18n enum translation coverage' do
+  {
+    'battery_statuses' => -> { Point.battery_statuses.keys },
+    'transportation_modes' => -> { Track::TRANSPORTATION_MODES.keys.map(&:to_s) },
+    'visit_statuses' => -> { Visit.statuses.keys },
+    'enums.import.source' => -> { Import.sources.keys },
+    'enums.export.file_type' => -> { Export.file_types.keys },
+    'enums.place.source' => -> { Place.sources.keys },
+    'enums.shared_link.resource_type' => -> { SharedLink.resource_types.keys },
+    'helpers.imports.extraction_status' => -> { Import.additional_data_extraction_statuses.keys }
+  }.each do |scope, values|
+    it "translates every #{scope} value" do
+      missing = values.call.reject { |value| I18n.exists?("#{scope}.#{value}") }
+
+      expect(missing).to be_empty, "missing #{scope} keys: #{missing.join(', ')}"
+    end
+  end
+
+  it 'translates every status reachable through status_badge' do
+    statuses = (Import.statuses.keys + Export.statuses.keys).uniq
+    missing = statuses.reject { |status| I18n.exists?("statuses.#{status}") }
+
+    expect(missing).to be_empty, "missing statuses keys: #{missing.join(', ')}"
+  end
+end


### PR DESCRIPTION
## Summary

- Move user-facing copy from Rails views, controllers, helpers, mailers, models, jobs, and services into `config/locales/en.yml`.
- Add a small browser I18n bridge so Stimulus, map, sharing, and poster JavaScript use the same Rails locale data.
- Add JavaScript coverage for string lookup, interpolation, plural forms, and missing-key fallback.

## Why

The application still contained hardcoded English throughout both the Rails and browser layers. Centralizing the existing copy in Rails I18n establishes an English source locale and makes additional locales possible without changing application code again.

## How to validate

1. Run `asdf exec bundle exec rspec` — 7,504 examples, 0 failures.
2. Run `npm test` — 65 tests, 0 failures.
3. Run RuboCop against the changed Ruby files — 162 files, no offenses.
4. Run Biome against the changed JavaScript files — no errors.
5. Open representative Rails, map, sharing, import, settings, and poster flows and confirm the English copy remains unchanged.

Additional validation performed: all ERB templates compile; changed Ruby files parse with Prism; literal, interpolated, enumerated, and browser translation keys were audited; `git diff --check` passes.

## Screenshots / GIF

Not included: this changes where copy is sourced, with no intentional visual changes.

## Risk / rollout notes

- Broad but mechanical copy extraction; English output and API messages are preserved.
- Browser translations are emitted as escaped JSON and cached by the shared translator module.
- No database migration or rollout coordination is required.
