### PR TITLE
feat: add complete German locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- The interface is now available in German. Pick a language from the navbar; the choice is saved to your account and used for emails and notifications too. Dawarich also follows your browser's preferred language on first visit, so a German-language browser gets a German interface without changing anything — switch back to English from the same menu. API responses stay in English so integrations keep working.
+- The interface is now available in German. Pick a language from the navbar; the choice is saved to your account and used for emails and notifications too. English stays the default and is never changed for you — if your browser prefers German, Dawarich offers the switch in a banner you can dismiss, and takes no as an answer. API responses stay in English so integrations keep working.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- The interface is now available in German. Pick a language from the navbar; the choice is saved to your account and used for emails and notifications too. Dawarich also follows your browser's preferred language on first visit, so a German-language browser gets a German interface without changing anything — switch back to English from the same menu. API responses stay in English so integrations keep working.
+
+### Fixed
+
+- The "someone joined your family" email no longer fails to send.
+
 ## [1.11.0] - 2026-08-02, Berlin
 
 ### Added

--- a/app/controllers/api/v1/shared/base_controller.rb
+++ b/app/controllers/api/v1/shared/base_controller.rb
@@ -18,6 +18,12 @@ module Api
 
         private
 
+        # Matches ApiController: these render JSON for API clients, so the
+        # payload must not follow the caller's Accept-Language.
+        def switch_locale(&block)
+          I18n.with_locale(I18n.default_locale, &block)
+        end
+
         def load_link
           @link = SharedLink.active.find_by(id: params[:id])
           return if @link

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -11,6 +11,13 @@ class ApiController < ApplicationController
 
   private
 
+  # API payloads are a machine contract, not UI copy. Clients send their device
+  # `Accept-Language`, which would otherwise translate every error and message
+  # string and break anyone matching on them.
+  def switch_locale(&block)
+    I18n.with_locale(I18n.default_locale, &block)
+  end
+
   def set_user_time_zone(&block)
     if current_api_user
       timezone = current_api_user.timezone

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -175,14 +175,19 @@ status: :see_other
 
   def switch_locale(&action)
     parameter_locale = supported_locale(params[:locale])
-    session[:locale] = parameter_locale.to_s if parameter_locale
+    remember_locale(parameter_locale) if parameter_locale && !prefetch_request?
     locale = parameter_locale || current_user&.preferred_locale || supported_locale(session[:locale]) ||
              locale_from_accept_language || I18n.default_locale
 
-    I18n.with_locale(locale) do
-      action.call
-      persist_user_locale(locale) if parameter_locale
-    end
+    I18n.with_locale(locale, &action)
+  end
+
+  # A prefetched response is still rendered in the requested language so the
+  # preview matches what a click would show; only the choice is withheld until
+  # the user actually navigates.
+  def remember_locale(locale)
+    session[:locale] = locale.to_s
+    persist_user_locale(locale)
   end
 
   def supported_locale(value)
@@ -220,7 +225,6 @@ status: :see_other
 
   def persist_user_locale(locale)
     return unless current_user
-    return if prefetch_request?
     return if current_user.preferred_locale == locale
 
     current_user.persist_locale!(locale)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   before_action :unread_notifications, :set_self_hosted_status, :store_client_header
 
   helper_method :current_user_safe_settings, :poster_ordering_enabled?, :family_feature_available?,
-                :current_user_features, :family_home_path, :alternate_locale
+                :current_user_features, :family_home_path, :alternate_locale, :locale_switch_path
 
   # Memoized per-request SafeSettings for the current user. Use this instead of
   # `current_user.safe_settings` in partials/helpers that may render many rows
@@ -205,11 +205,34 @@ status: :see_other
     I18n.locale == :de ? :en : :de
   end
 
+  # Built from `request.path` rather than `url_for` so that query parameters
+  # never reach route generation: `?host=`, `?controller=` and `?action=` would
+  # otherwise send the link off-site or raise on every page carrying the navbar.
+  # Non-GET requests fall back to the root path because a re-rendered form sits
+  # on a path that only answers to POST/PATCH.
+  def locale_switch_path
+    return "#{root_path}?#{{ 'locale' => alternate_locale.to_s }.to_query}" unless request.get?
+
+    query = request.query_parameters.merge('locale' => alternate_locale.to_s)
+
+    "#{request.path}?#{query.to_query}"
+  end
+
   def persist_user_locale(locale)
     return unless current_user
+    return if prefetch_request?
     return if current_user.preferred_locale == locale
 
     current_user.persist_locale!(locale)
+  end
+
+  # Turbo Drive prefetches links on hover, so a pointer passing over the switch
+  # link would otherwise save a language the user never chose.
+  def prefetch_request?
+    request.headers['Sec-Purpose'].to_s.include?('prefetch') ||
+      request.headers['X-Sec-Purpose'].to_s.include?('prefetch') ||
+      request.headers['Purpose'].to_s.include?('prefetch') ||
+      request.headers['X-Moz'].to_s.casecmp?('prefetch')
   end
 
   def sign_out_deleted_users

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,13 +5,14 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  around_action :switch_locale
   before_action :sign_out_deleted_users
   before_action :configure_permitted_parameters, if: :devise_controller?
   around_action :set_user_time_zone
   before_action :unread_notifications, :set_self_hosted_status, :store_client_header
 
   helper_method :current_user_safe_settings, :poster_ordering_enabled?, :family_feature_available?,
-                :current_user_features, :family_home_path
+                :current_user_features, :family_home_path, :alternate_locale
 
   # Memoized per-request SafeSettings for the current user. Use this instead of
   # `current_user.safe_settings` in partials/helpers that may render many rows
@@ -171,6 +172,45 @@ status: :see_other
   end
 
   private
+
+  def switch_locale(&action)
+    parameter_locale = supported_locale(params[:locale])
+    session[:locale] = parameter_locale.to_s if parameter_locale
+    locale = parameter_locale || current_user&.preferred_locale || supported_locale(session[:locale]) ||
+             locale_from_accept_language || I18n.default_locale
+
+    I18n.with_locale(locale) do
+      action.call
+      persist_user_locale(locale) if parameter_locale
+    end
+  end
+
+  def supported_locale(value)
+    locale = value.to_s.downcase.to_sym
+    locale if I18n.available_locales.include?(locale)
+  end
+
+  def locale_from_accept_language
+    candidates = request.headers['Accept-Language'].to_s.split(',').each_with_index.filter_map do |language, index|
+      locale_tag, *parameters = language.split(';').map(&:strip)
+      locale = supported_locale(locale_tag.to_s.split('-').first)
+      quality = parameters.find { |parameter| parameter.start_with?('q=') }&.delete_prefix('q=')&.to_f || 1.0
+      [locale, quality, index] if locale && quality.positive?
+    end
+
+    candidates.max_by { |_locale, quality, index| [quality, -index] }&.first
+  end
+
+  def alternate_locale
+    I18n.locale == :de ? :en : :de
+  end
+
+  def persist_user_locale(locale)
+    return unless current_user
+    return if current_user.preferred_locale == locale
+
+    current_user.persist_locale!(locale)
+  end
 
   def sign_out_deleted_users
     return unless current_user&.deleted?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,8 @@ class ApplicationController < ActionController::Base
   before_action :unread_notifications, :set_self_hosted_status, :store_client_header
 
   helper_method :current_user_safe_settings, :poster_ordering_enabled?, :family_feature_available?,
-                :current_user_features, :family_home_path, :alternate_locale, :locale_switch_path
+                :current_user_features, :family_home_path, :alternate_locale, :locale_switch_path,
+                :suggested_locale, :locale_path
 
   # Memoized per-request SafeSettings for the current user. Use this instead of
   # `current_user.safe_settings` in partials/helpers that may render many rows
@@ -173,13 +174,28 @@ status: :see_other
 
   private
 
+  # The browser's language is deliberately absent from this chain: it is only
+  # ever offered through `suggested_locale`, never applied on the reader's
+  # behalf.
   def switch_locale(&action)
     parameter_locale = supported_locale(params[:locale])
     remember_locale(parameter_locale) if parameter_locale && !prefetch_request?
     locale = parameter_locale || current_user&.preferred_locale || supported_locale(session[:locale]) ||
-             locale_from_accept_language || I18n.default_locale
+             I18n.default_locale
 
     I18n.with_locale(locale, &action)
+  end
+
+  # The language the browser asks for, when the reader has not already chosen
+  # one themselves and it differs from what they are being shown.
+  def suggested_locale
+    return if params[:locale].present?
+    return if current_user&.preferred_locale
+    return if session[:locale].present?
+
+    candidate = locale_from_accept_language
+
+    candidate if candidate && candidate != I18n.locale
   end
 
   # A prefetched response is still rendered in the requested language so the
@@ -216,9 +232,13 @@ status: :see_other
   # Non-GET requests fall back to the root path because a re-rendered form sits
   # on a path that only answers to POST/PATCH.
   def locale_switch_path
-    return "#{root_path}?#{{ 'locale' => alternate_locale.to_s }.to_query}" unless request.get?
+    locale_path(alternate_locale)
+  end
 
-    query = request.query_parameters.merge('locale' => alternate_locale.to_s)
+  def locale_path(locale)
+    return "#{root_path}?#{{ 'locale' => locale.to_s }.to_query}" unless request.get?
+
+    query = request.query_parameters.merge('locale' => locale.to_s)
 
     "#{request.path}?#{query.to_query}"
   end

--- a/app/helpers/datetime_formatting_helper.rb
+++ b/app/helpers/datetime_formatting_helper.rb
@@ -44,6 +44,12 @@ module DatetimeFormattingHelper
     )
   end
 
+  def relative_distance_in_words(time)
+    options = I18n.locale == :de ? { scope: 'datetime.distance_in_words.dative' } : {}
+
+    time_ago_in_words(time, **options)
+  end
+
   def format_duration_short(seconds)
     return I18n.t('units.minutes_compact', value: 0) if seconds.nil? || seconds.to_i.zero?
 

--- a/app/jobs/air_trail/import_flights_job.rb
+++ b/app/jobs/air_trail/import_flights_job.rb
@@ -18,15 +18,17 @@ module AirTrail
     private
 
     def notify_sync_failed(user, error)
-      Notifications::Create.new(
-        user: user,
-        title: I18n.t('jobs.air_trail.import_flights_job.airtrail_sync_failed'),
-        content: I18n.t(
-          'jobs.air_trail.import_flights_job.your_airtrail_flight_sync_failed_with_error_message_check_your',
-          message: error.message
-        ),
-        kind: :error
-      ).call
+      I18n.with_locale(user.locale) do
+        Notifications::Create.new(
+          user: user,
+          title: I18n.t('jobs.air_trail.import_flights_job.airtrail_sync_failed'),
+          content: I18n.t(
+            'jobs.air_trail.import_flights_job.your_airtrail_flight_sync_failed_with_error_message_check_your',
+            message: error.message
+          ),
+          kind: :error
+        ).call
+      end
     end
   end
 end

--- a/app/jobs/data_migrations/recalculate_anomalies_user_job.rb
+++ b/app/jobs/data_migrations/recalculate_anomalies_user_job.rb
@@ -130,14 +130,16 @@ class DataMigrations::RecalculateAnomaliesUserJob < ApplicationJob
   # page is self-hosted only, so this is the only signal a Cloud account gets
   # that its map may look different.
   def notify(user)
-    Notifications::Create.new(
-      user: user,
-      kind: :info,
-      title: I18n.t('jobs.data_migrations.recalculate_anomalies_user_job.gps_noise_re_check_finished'),
-      content: I18n.t(
-        'jobs.data_migrations.recalculate_anomalies_user_job.rules_recheck_finished'
-      )
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user: user,
+        kind: :info,
+        title: I18n.t('jobs.data_migrations.recalculate_anomalies_user_job.gps_noise_re_check_finished'),
+        content: I18n.t(
+          'jobs.data_migrations.recalculate_anomalies_user_job.rules_recheck_finished'
+        )
+      ).call
+    end
   end
 
   def recalculated?(user)

--- a/app/jobs/lite/archival_warning_job.rb
+++ b/app/jobs/lite/archival_warning_job.rb
@@ -43,12 +43,14 @@ class Lite::ArchivalWarningJob < ApplicationJob
   end
 
   def notify_approaching(user)
-    Notification.create!(
-      user: user,
-      kind: :warning,
-      title: I18n.t('jobs.lite.archival_warning_job.your_oldest_data_will_archive_in_30_days'),
-      content: I18n.t('jobs.lite.archival_warning_job.your_oldest_month_of_location_data_will_be_archived_soon')
-    )
+    I18n.with_locale(user.locale) do
+      Notification.create!(
+        user: user,
+        kind: :warning,
+        title: I18n.t('jobs.lite.archival_warning_job.your_oldest_data_will_archive_in_30_days'),
+        content: I18n.t('jobs.lite.archival_warning_job.your_oldest_month_of_location_data_will_be_archived_soon')
+      )
+    end
   end
 
   def notify_email(user)
@@ -56,12 +58,14 @@ class Lite::ArchivalWarningJob < ApplicationJob
   end
 
   def notify_archived(user)
-    Notification.create!(
-      user: user,
-      kind: :warning,
-      title: I18n.t('jobs.lite.archival_warning_job.data_has_been_archived'),
-      content: I18n.t('jobs.lite.archival_warning_job.month_of_location_data_has_been_archived_your_archived')
-    )
+    I18n.with_locale(user.locale) do
+      Notification.create!(
+        user: user,
+        kind: :warning,
+        title: I18n.t('jobs.lite.archival_warning_job.data_has_been_archived'),
+        content: I18n.t('jobs.lite.archival_warning_job.month_of_location_data_has_been_archived_your_archived')
+      )
+    end
   end
 
   def mark_warning_sent(user, key)

--- a/app/jobs/lite/archival_warning_job.rb
+++ b/app/jobs/lite/archival_warning_job.rb
@@ -17,7 +17,7 @@ class Lite::ArchivalWarningJob < ApplicationJob
     User.where(plan: :lite).find_each do |user|
       next if user.full_access?
 
-      check_thresholds(user)
+      I18n.with_locale(user.locale) { check_thresholds(user) }
     end
   end
 

--- a/app/jobs/stale_jobs_recovery_job.rb
+++ b/app/jobs/stale_jobs_recovery_job.rb
@@ -19,13 +19,15 @@ class StaleJobsRecoveryJob < ApplicationJob
       error_message = I18n.t('jobs.stale_jobs_recovery_job.export_timed_out_after_being_stuck_in_processing')
       export.update!(status: :failed, error_message: error_message)
 
-      Notifications::Create.new(
-        user: export.user,
-        kind: :error,
-        title: I18n.t('jobs.stale_jobs_recovery_job.export_failed'),
-        content: I18n.t('jobs.stale_jobs_recovery_job.export_name_was_stuck_in_processing_and_has_been_marked',
-                        name: export.name)
-      ).call
+      I18n.with_locale(export.user.locale) do
+        Notifications::Create.new(
+          user: export.user,
+          kind: :error,
+          title: I18n.t('jobs.stale_jobs_recovery_job.export_failed'),
+          content: I18n.t('jobs.stale_jobs_recovery_job.export_name_was_stuck_in_processing_and_has_been_marked',
+                          name: export.name)
+        ).call
+      end
     rescue StandardError => e
       Rails.logger.error("Failed to recover stale export #{export.id}: #{e.message}")
     end
@@ -36,13 +38,15 @@ class StaleJobsRecoveryJob < ApplicationJob
       error_message = I18n.t('jobs.stale_jobs_recovery_job.import_timed_out_after_being_stuck_in_processing')
       import.update!(status: :failed, error_message: error_message)
 
-      Notifications::Create.new(
-        user: import.user,
-        kind: :error,
-        title: I18n.t('jobs.stale_jobs_recovery_job.import_failed'),
-        content: I18n.t('jobs.stale_jobs_recovery_job.import_name_was_stuck_in_processing_and_has_been_marked',
-                        name: import.name)
-      ).call
+      I18n.with_locale(import.user.locale) do
+        Notifications::Create.new(
+          user: import.user,
+          kind: :error,
+          title: I18n.t('jobs.stale_jobs_recovery_job.import_failed'),
+          content: I18n.t('jobs.stale_jobs_recovery_job.import_name_was_stuck_in_processing_and_has_been_marked',
+                          name: import.name)
+        ).call
+      end
     rescue StandardError => e
       Rails.logger.error("Failed to recover stale import #{import.id}: #{e.message}")
     end

--- a/app/jobs/stats/calculating_job.rb
+++ b/app/jobs/stats/calculating_job.rb
@@ -14,12 +14,14 @@ class Stats::CalculatingJob < ApplicationJob
   def create_stats_update_failed_notification(user_id, error)
     user = find_user_or_skip(user_id) || return
 
-    Notifications::Create.new(
-      user:,
-      kind: :error,
-      title: I18n.t('jobs.stats.calculating_job.stats_update_failed'),
-      content: I18n.t('jobs.stats.calculating_job.message_stacktrace_n', message: error.message,
-                      backtrace: error.backtrace.join("\n"))
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user:,
+        kind: :error,
+        title: I18n.t('jobs.stats.calculating_job.stats_update_failed'),
+        content: I18n.t('jobs.stats.calculating_job.message_stacktrace_n', message: error.message,
+                        backtrace: error.backtrace.join("\n"))
+      ).call
+    end
   end
 end

--- a/app/jobs/users/digests/monthly/calculating_job.rb
+++ b/app/jobs/users/digests/monthly/calculating_job.rb
@@ -21,13 +21,15 @@ class Users::Digests::Monthly::CalculatingJob < ApplicationJob
 
     backtrace = error.backtrace&.first(BACKTRACE_LINE_LIMIT)&.join("\n")
 
-    Notifications::Create.new(
-      user:,
-      kind: :error,
-      title: I18n.t('jobs.users.digests.monthly.calculating_job.monthly_digest_calculation_failed'),
-      content: I18n.t('jobs.users.digests.monthly.calculating_job.message_stacktrace_backtrace',
-                      message: error.message, backtrace: backtrace)
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user:,
+        kind: :error,
+        title: I18n.t('jobs.users.digests.monthly.calculating_job.monthly_digest_calculation_failed'),
+        content: I18n.t('jobs.users.digests.monthly.calculating_job.message_stacktrace_backtrace',
+                        message: error.message, backtrace: backtrace)
+      ).call
+    end
   rescue ActiveRecord::RecordNotFound
     nil
   end

--- a/app/jobs/users/digests/yearly/calculating_job.rb
+++ b/app/jobs/users/digests/yearly/calculating_job.rb
@@ -27,14 +27,16 @@ class Users::Digests::Yearly::CalculatingJob < ApplicationJob
 
     backtrace = error.backtrace&.first(BACKTRACE_LINE_LIMIT)&.join("\n")
 
-    Notifications::Create.new(
-      user:,
-      kind: :error,
-      title: I18n.t('jobs.users.digests.yearly.calculating_job.period_label_calculation_failed',
-                    period_label: period_label),
-      content: I18n.t('jobs.users.digests.yearly.calculating_job.message_stacktrace_backtrace', message: error.message,
-backtrace: backtrace)
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user:,
+        kind: :error,
+        title: I18n.t('jobs.users.digests.yearly.calculating_job.period_label_calculation_failed',
+                      period_label: period_label),
+        content: I18n.t('jobs.users.digests.yearly.calculating_job.message_stacktrace_backtrace',
+                        message: error.message, backtrace: backtrace)
+      ).call
+    end
   rescue ActiveRecord::RecordNotFound
     nil
   end

--- a/app/jobs/users/import_data_job.rb
+++ b/app/jobs/users/import_data_job.rb
@@ -63,12 +63,14 @@ class Users::ImportDataJob < ApplicationJob
   end
 
   def create_import_failed_notification(user, error)
-    ::Notifications::Create.new(
-      user: user,
-      title: I18n.t('jobs.users.import_data_job.data_import_failed'),
-      content: I18n.t('jobs.users.import_data_job.your_data_import_failed_with_error_message_please_check_the',
-                      message: error.message),
-      kind: :error
-    ).call
+    I18n.with_locale(user.locale) do
+      ::Notifications::Create.new(
+        user: user,
+        title: I18n.t('jobs.users.import_data_job.data_import_failed'),
+        content: I18n.t('jobs.users.import_data_job.your_data_import_failed_with_error_message_please_check_the',
+                        message: error.message),
+        kind: :error
+      ).call
+    end
   end
 end

--- a/app/jobs/users/recalculate_data_job.rb
+++ b/app/jobs/users/recalculate_data_job.rb
@@ -17,11 +17,15 @@ class Users::RecalculateDataJob < ApplicationJob
     notify = options.is_a?(Hash) ? options.symbolize_keys.fetch(:notify, true) : true
     user = User.find_by(id: user_id) if notify
     if user
-      content = I18n.t('jobs.users.recalculate_data_job.another_recalculation_is_already_running_please_try_again_in_a')
-      Notifications::Create.new(
-        user: user, kind: :warning, title: I18n.t('jobs.users.recalculate_data_job.data_recalculation_busy'),
-        content: content
-      ).call
+      I18n.with_locale(user.locale) do
+        content = I18n.t(
+          'jobs.users.recalculate_data_job.another_recalculation_is_already_running_please_try_again_in_a'
+        )
+        Notifications::Create.new(
+          user: user, kind: :warning, title: I18n.t('jobs.users.recalculate_data_job.data_recalculation_busy'),
+          content: content
+        ).call
+      end
     end
   end
 
@@ -98,9 +102,14 @@ class Users::RecalculateDataJob < ApplicationJob
   end
 
   def create_success_notification(years_to_process)
-    year_label = years_to_process.size == 1 ? years_to_process.first.to_s : "#{years_to_process.size} years"
-
     I18n.with_locale(user.locale) do
+      year_label =
+        if years_to_process.size == 1
+          years_to_process.first.to_s
+        else
+          I18n.t('jobs.users.recalculate_data_job.year_count', count: years_to_process.size)
+        end
+
       Notifications::Create.new(
         user: user,
         kind: :info,

--- a/app/jobs/users/recalculate_data_job.rb
+++ b/app/jobs/users/recalculate_data_job.rb
@@ -100,23 +100,29 @@ class Users::RecalculateDataJob < ApplicationJob
   def create_success_notification(years_to_process)
     year_label = years_to_process.size == 1 ? years_to_process.first.to_s : "#{years_to_process.size} years"
 
-    Notifications::Create.new(
-      user: user,
-      kind: :info,
-      title: I18n.t('jobs.users.recalculate_data_job.data_recalculation_completed'),
-      content: I18n.t('jobs.users.recalculate_data_job.stats_tracks_and_digests_have_been_recalculated_for_year_label',
-                      year_label: year_label)
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user: user,
+        kind: :info,
+        title: I18n.t('jobs.users.recalculate_data_job.data_recalculation_completed'),
+        content: I18n.t(
+          'jobs.users.recalculate_data_job.stats_tracks_and_digests_have_been_recalculated_for_year_label',
+          year_label: year_label
+        )
+      ).call
+    end
   end
 
   def create_failure_notification(error)
-    Notifications::Create.new(
-      user: user,
-      kind: :error,
-      title: I18n.t('jobs.users.recalculate_data_job.data_recalculation_failed'),
-      content: I18n.t('jobs.users.recalculate_data_job.message_stacktrace_n', message: error.message,
-                      backtrace: error.backtrace.first(10).join("\n"))
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user: user,
+        kind: :error,
+        title: I18n.t('jobs.users.recalculate_data_job.data_recalculation_failed'),
+        content: I18n.t('jobs.users.recalculate_data_job.message_stacktrace_n', message: error.message,
+                        backtrace: error.backtrace.first(10).join("\n"))
+      ).call
+    end
   rescue ActiveRecord::RecordNotFound
     nil
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -4,7 +4,19 @@ class ApplicationMailer < ActionMailer::Base
   default from: ENV['SMTP_FROM']
   layout 'mailer'
 
+  around_action :use_recipient_locale
+
   rescue_from ActiveJob::DeserializationError do |exception|
     Rails.logger.info("[ApplicationMailer] discarding delivery for a missing record: #{exception.message}")
+  end
+
+  private
+
+  def use_recipient_locale(&action)
+    I18n.with_locale(params&.[](:user)&.preferred_locale || I18n.locale, &action)
+  end
+
+  def with_user_locale(user, &action)
+    I18n.with_locale(user&.preferred_locale || I18n.locale, &action)
   end
 end

--- a/app/mailers/family_mailer.rb
+++ b/app/mailers/family_mailer.rb
@@ -7,10 +7,12 @@ class FamilyMailer < ApplicationMailer
     @invited_by = invitation.invited_by
     @accept_url = family_invitation_url(@invitation.token)
 
-    mail(
-      to: @invitation.email,
-      subject: I18n.t('mailers.family.invitation.subject', family: @family.name)
-    )
+    with_user_locale(@invited_by) do
+      mail(
+        to: @invitation.email,
+        subject: I18n.t('mailers.family.invitation.subject', family: @family.name)
+      )
+    end
   end
 
   def location_request(request)
@@ -19,19 +21,23 @@ class FamilyMailer < ApplicationMailer
     @target_user = request.target_user
     @request_url = family_location_request_url(request)
 
-    mail(
-      to: @target_user.email,
-      subject: I18n.t('mailers.family.location_request.subject', requester: @requester.email)
-    )
+    with_user_locale(@target_user) do
+      mail(
+        to: @target_user.email,
+        subject: I18n.t('mailers.family.location_request.subject', requester: @requester.email)
+      )
+    end
   end
 
   def member_joined(family, user)
     @family = family
     @user = user
 
-    mail(
-      to: @family.owner.email,
-      subject: I18n.t('mailers.family.member_joined.subject', user: @user.name, family: @family.name)
-    )
+    with_user_locale(@family.owner) do
+      mail(
+        to: @family.owner.email,
+        subject: I18n.t('mailers.family.member_joined.subject', user: @user.email, family: @family.name)
+      )
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -118,6 +118,27 @@ class User < ApplicationRecord
     Users::SafeSettings.new(settings, plan: plan)
   end
 
+  def preferred_locale
+    locale = settings&.fetch('locale', nil).to_s.to_sym
+    locale if I18n.available_locales.include?(locale)
+  end
+
+  def locale
+    preferred_locale || I18n.default_locale
+  end
+
+  def persist_locale!(locale)
+    self.class.where(id: id).update_all(
+      ActiveRecord::Base.sanitize_sql_array(
+        [
+          "settings = COALESCE(settings, '{}'::jsonb) || jsonb_build_object('locale', ?), updated_at = ?",
+          locale.to_s,
+          Time.current
+        ]
+      )
+    )
+  end
+
   # Only accounts the migration actually handed to a rebuild are waiting on one.
   # Deriving this from live state instead would report a permanent "pending" for
   # anyone the dispatcher never picked up — no points at the time, filtering off

--- a/app/services/exports/create.rb
+++ b/app/services/exports/create.rb
@@ -50,22 +50,26 @@ class Exports::Create
   end
 
   def notify_export_finished
-    Notifications::Create.new(
-      user:,
-      kind: :info,
-      title: I18n.t('services.exports.create.export_finished'),
-      content: I18n.t('services.exports.create.export_name_successfully_finished', name: export.name)
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user:,
+        kind: :info,
+        title: I18n.t('services.exports.create.export_finished'),
+        content: I18n.t('services.exports.create.export_name_successfully_finished', name: export.name)
+      ).call
+    end
   end
 
   def notify_export_failed(error)
-    Notifications::Create.new(
-      user:,
-      kind: :error,
-      title: I18n.t('services.exports.create.export_failed'),
-      content: I18n.t('services.exports.create.export_name_failed_message_stacktrace_n', name: export.name,
-                      message: error.message, backtrace: error.backtrace.join("\n"))
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user:,
+        kind: :error,
+        title: I18n.t('services.exports.create.export_failed'),
+        content: I18n.t('services.exports.create.export_name_failed_message_stacktrace_n', name: export.name,
+                        message: error.message, backtrace: error.backtrace.join("\n"))
+      ).call
+    end
   end
 
   def attach_export_file(zipped_tempfile)

--- a/app/services/families/accept_invitation.rb
+++ b/app/services/families/accept_invitation.rb
@@ -99,22 +99,26 @@ module Families
     end
 
     def send_user_notification
-      Notification.create!(
-        user: user,
-        kind: :info,
-        title: I18n.t('services.families.accept_invitation.welcome_to_family'),
-        content: I18n.t('services.families.accept_invitation.you_ve_joined_the_family_name',
-                        name: invitation.family.name)
-      )
+      I18n.with_locale(user.locale) do
+        Notification.create!(
+          user: user,
+          kind: :info,
+          title: I18n.t('services.families.accept_invitation.welcome_to_family'),
+          content: I18n.t('services.families.accept_invitation.you_ve_joined_the_family_name',
+                          name: invitation.family.name)
+        )
+      end
     end
 
     def send_owner_notification
-      Notification.create!(
-        user: invitation.family.creator,
-        kind: :info,
-        title: I18n.t('services.families.accept_invitation.new_family_member'),
-        content: I18n.t('services.families.accept_invitation.email_has_joined_your_family', email: user.email)
-      )
+      I18n.with_locale(invitation.family.creator.locale) do
+        Notification.create!(
+          user: invitation.family.creator,
+          kind: :info,
+          title: I18n.t('services.families.accept_invitation.new_family_member'),
+          content: I18n.t('services.families.accept_invitation.email_has_joined_your_family', email: user.email)
+        )
+      end
     rescue StandardError => e
       ExceptionReporter.call(e, "Unexpected error in Families::AcceptInvitation: #{e.message}")
     end

--- a/app/services/families/create.rb
+++ b/app/services/families/create.rb
@@ -90,12 +90,14 @@ module Families
     end
 
     def send_notification
-      Notification.create!(
-        user: user,
-        kind: :info,
-        title: I18n.t('services.families.create.family_created'),
-        content: I18n.t('services.families.create.you_ve_successfully_created_the_family_name', name: family.name)
-      )
+      I18n.with_locale(user.locale) do
+        Notification.create!(
+          user: user,
+          kind: :info,
+          title: I18n.t('services.families.create.family_created'),
+          content: I18n.t('services.families.create.you_ve_successfully_created_the_family_name', name: family.name)
+        )
+      end
     rescue StandardError => e
       # Don't fail the entire operation if notification fails
       ExceptionReporter.call(e, "Unexpected error in Families::Create: #{e.message}")

--- a/app/services/families/create_location_request.rb
+++ b/app/services/families/create_location_request.rb
@@ -61,13 +61,15 @@ class Families::CreateLocationRequest
       class: 'link link-primary'
     )
 
-    Notification.create!(
-      user: target_user,
-      kind: :info,
-      title: I18n.t('services.families.create_location_request.location_request'),
-      content: I18n.t('services.families.create_location_request.safe_email_is_requesting_your_location_link',
-                      email: safe_email, link: link)
-    )
+    I18n.with_locale(target_user.locale) do
+      Notification.create!(
+        user: target_user,
+        kind: :info,
+        title: I18n.t('services.families.create_location_request.location_request'),
+        content: I18n.t('services.families.create_location_request.safe_email_is_requesting_your_location_link',
+                        email: safe_email, link: link)
+      )
+    end
   rescue StandardError => e
     ExceptionReporter.call(e, "Failed to create notification for location request: #{e.message}")
   end

--- a/app/services/families/invite.rb
+++ b/app/services/families/invite.rb
@@ -94,12 +94,14 @@ module Families
         email:
       )
 
-      Notification.create!(
-        user: invited_by,
-        kind: :info,
-        title: I18n.t('services.families.invite.invitation_sent'),
-        content: content
-      )
+      I18n.with_locale(invited_by.locale) do
+        Notification.create!(
+          user: invited_by,
+          kind: :info,
+          title: I18n.t('services.families.invite.invitation_sent'),
+          content: content
+        )
+      end
     rescue StandardError => e
       # Don't fail the entire operation if notification fails
       ExceptionReporter.call(e, "Unexpected error in Families::Invite: #{e.message}")

--- a/app/services/families/memberships/destroy.rb
+++ b/app/services/families/memberships/destroy.rb
@@ -108,43 +108,53 @@ module Families
       end
 
       def send_self_removal_notifications
-        Notification.create!(
-          user: member_to_remove,
-          kind: :info,
-          title: I18n.t('services.families.memberships.destroy.left_family'),
-          content: I18n.t('services.families.memberships.destroy.you_ve_left_the_family_family_name',
-                          family_name: @family_name)
-        )
+        I18n.with_locale(member_to_remove.locale) do
+          Notification.create!(
+            user: member_to_remove,
+            kind: :info,
+            title: I18n.t('services.families.memberships.destroy.left_family'),
+            content: I18n.t('services.families.memberships.destroy.you_ve_left_the_family_family_name',
+                            family_name: @family_name)
+          )
+        end
 
         return unless @family_owner&.persisted?
 
-        Notification.create!(
-          user: @family_owner,
-          kind: :info,
-          title: I18n.t('services.families.memberships.destroy.family_member_left'),
-          content: I18n.t('services.families.memberships.destroy.email_has_left_the_family_family_name',
-                          email: member_to_remove.email, family_name: @family_name)
-        )
+        I18n.with_locale(@family_owner.locale) do
+          Notification.create!(
+            user: @family_owner,
+            kind: :info,
+            title: I18n.t('services.families.memberships.destroy.family_member_left'),
+            content: I18n.t('services.families.memberships.destroy.email_has_left_the_family_family_name',
+                            email: member_to_remove.email, family_name: @family_name)
+          )
+        end
       end
 
       def send_member_removed_notifications
-        Notification.create!(
-          user: member_to_remove,
-          kind: :info,
-          title: I18n.t('services.families.memberships.destroy.removed_from_family'),
-          content: I18n.t('services.families.memberships.destroy.you_have_been_removed_from_the_family_family_name_by',
-                          family_name: @family_name, email: user.email)
-        )
+        I18n.with_locale(member_to_remove.locale) do
+          Notification.create!(
+            user: member_to_remove,
+            kind: :info,
+            title: I18n.t('services.families.memberships.destroy.removed_from_family'),
+            content: I18n.t(
+              'services.families.memberships.destroy.you_have_been_removed_from_the_family_family_name_by',
+              family_name: @family_name, email: user.email
+            )
+          )
+        end
 
         return unless user != member_to_remove
 
-        Notification.create!(
-          user: user,
-          kind: :info,
-          title: I18n.t('services.families.memberships.destroy.member_removed'),
-          content: I18n.t('services.families.memberships.destroy.email_has_been_removed_from_the_family_family_name',
-                          email: member_to_remove.email, family_name: @family_name)
-        )
+        I18n.with_locale(user.locale) do
+          Notification.create!(
+            user: user,
+            kind: :info,
+            title: I18n.t('services.families.memberships.destroy.member_removed'),
+            content: I18n.t('services.families.memberships.destroy.email_has_been_removed_from_the_family_family_name',
+                            email: member_to_remove.email, family_name: @family_name)
+          )
+        end
       end
 
       def handle_record_invalid_error(error)

--- a/app/services/google_maps/semantic_history_importer.rb
+++ b/app/services/google_maps/semantic_history_importer.rb
@@ -56,12 +56,14 @@ class GoogleMaps::SemanticHistoryImporter
   end
 
   def create_notification(message)
-    Notification.create!(
-      user_id: user_id,
-      title: I18n.t('services.google_maps.semantic_history_importer.google_maps_timeline_import_error'),
-      content: message,
-      kind: :error
-    )
+    I18n.with_locale(User.find_by(id: user_id)&.locale || I18n.locale) do
+      Notification.create!(
+        user_id: user_id,
+        title: I18n.t('services.google_maps.semantic_history_importer.google_maps_timeline_import_error'),
+        content: message,
+        kind: :error
+      )
+    end
   end
 
   def points_data

--- a/app/services/immich/import_geodata.rb
+++ b/app/services/immich/import_geodata.rb
@@ -70,13 +70,15 @@ class Immich::ImportGeodata
   end
 
   def create_import_failed_notification(import_name)
-    Notifications::Create.new(
-      user:,
-      kind: :info,
-      title: I18n.t('services.immich.import_geodata.import_was_not_created'),
-      content: I18n.t('services.immich.import_geodata.import_with_the_same_name_import_name_already_exists_if',
-                      import_name: import_name)
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user:,
+        kind: :info,
+        title: I18n.t('services.immich.import_geodata.import_was_not_created'),
+        content: I18n.t('services.immich.import_geodata.import_with_the_same_name_import_name_already_exists_if',
+                        import_name: import_name)
+      ).call
+    end
   end
 
   def file_name(immich_data_json)

--- a/app/services/imports/bulk_insertable.rb
+++ b/app/services/imports/bulk_insertable.rb
@@ -51,12 +51,14 @@ module Imports
     end
 
     def create_import_error_notification(message)
-      Notification.create!(
-        user_id: import.user_id,
-        title: I18n.t('services.imports.bulk_insertable.importer_name_import_error', importer_name: importer_name),
-        content: message,
-        kind: :error
-      )
+      I18n.with_locale(import.user.locale) do
+        Notification.create!(
+          user_id: import.user_id,
+          title: I18n.t('services.imports.bulk_insertable.importer_name_import_error', importer_name: importer_name),
+          content: message,
+          kind: :error
+        )
+      end
     end
 
     # Override in subclasses to add custom error handling (e.g. ExceptionReporter)

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -74,13 +74,15 @@ class Imports::Create
 
     @post_import_failure_notified = true
 
-    Notifications::Create.new(
-      user:,
-      kind: :warning,
-      title: I18n.t('services.imports.create.import_post_processing_incomplete'),
-      content: I18n.t('services.imports.create.your_import_name_finished_and_all_points_were_saved_but',
-                      name: import.name, step: step.tr('_', ' '))
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user:,
+        kind: :warning,
+        title: I18n.t('services.imports.create.import_post_processing_incomplete'),
+        content: I18n.t('services.imports.create.your_import_name_finished_and_all_points_were_saved_but',
+                        name: import.name, step: step.tr('_', ' '))
+      ).call
+    end
   rescue StandardError => e
     ExceptionReporter.call(e, 'Failed to create post-import failure notification')
   end
@@ -124,20 +126,24 @@ class Imports::Create
     return unless import.points.count.zero?
 
     if import.doubles.to_i.positive?
-      Notification.create!(
-        user_id: import.user_id,
-        title: I18n.t('services.imports.create.import_completed_with_no_new_points'),
-        content: I18n.t('services.imports.create.your_file_name_contained_raw_points_points_all_of_which',
-                        name: import.name, raw_points: import.raw_points),
-        kind: :info
-      )
+      I18n.with_locale(import.user.locale) do
+        Notification.create!(
+          user_id: import.user_id,
+          title: I18n.t('services.imports.create.import_completed_with_no_new_points'),
+          content: I18n.t('services.imports.create.your_file_name_contained_raw_points_points_all_of_which',
+                          name: import.name, raw_points: import.raw_points),
+          kind: :info
+        )
+      end
     else
-      Notification.create!(
-        user_id: import.user_id,
-        title: I18n.t('services.imports.create.import_completed_with_no_points'),
-        content: zero_points_content(import),
-        kind: :warning
-      )
+      I18n.with_locale(import.user.locale) do
+        Notification.create!(
+          user_id: import.user_id,
+          title: I18n.t('services.imports.create.import_completed_with_no_points'),
+          content: zero_points_content(import),
+          kind: :warning
+        )
+      end
     end
   end
 
@@ -204,12 +210,14 @@ class Imports::Create
   def create_import_failed_notification(import, user, error)
     message = import_failed_message(import, error)
 
-    Notifications::Create.new(
-      user:,
-      kind: :error,
-      title: I18n.t('services.imports.create.import_failed'),
-      content: message
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user:,
+        kind: :error,
+        title: I18n.t('services.imports.create.import_failed'),
+        content: message
+      ).call
+    end
   end
 
   def detect_source_from_file(file_path)

--- a/app/services/photoprism/import_geodata.rb
+++ b/app/services/photoprism/import_geodata.rb
@@ -75,13 +75,15 @@ class Photoprism::ImportGeodata
   end
 
   def create_import_failed_notification(import_name)
-    Notifications::Create.new(
-      user:,
-      kind: :info,
-      title: I18n.t('services.photoprism.import_geodata.import_was_not_created'),
-      content: I18n.t('services.photoprism.import_geodata.import_with_the_same_name_import_name_already_exists_if',
-                      import_name: import_name)
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user:,
+        kind: :info,
+        title: I18n.t('services.photoprism.import_geodata.import_was_not_created'),
+        content: I18n.t('services.photoprism.import_geodata.import_with_the_same_name_import_name_already_exists_if',
+                        import_name: import_name)
+      ).call
+    end
   end
 
   def file_name(photoprism_data_json)

--- a/app/services/stats/calculate_month.rb
+++ b/app/services/stats/calculate_month.rb
@@ -81,13 +81,15 @@ class Stats::CalculateMonth
   end
 
   def create_stats_update_failed_notification(user, error)
-    Notifications::Create.new(
-      user:,
-      kind: :error,
-      title: I18n.t('services.stats.calculate_month.stats_update_failed'),
-      content: I18n.t('services.stats.calculate_month.message_stacktrace_n', message: error.message,
-                      backtrace: error.backtrace.join("\n"))
-    ).call
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user:,
+        kind: :error,
+        title: I18n.t('services.stats.calculate_month.stats_update_failed'),
+        content: I18n.t('services.stats.calculate_month.message_stacktrace_n', message: error.message,
+                        backtrace: error.backtrace.join("\n"))
+      ).call
+    end
   end
 
   def reset_month_stats(year, month)

--- a/app/services/users/export_data.rb
+++ b/app/services/users/export_data.rb
@@ -443,12 +443,14 @@ class Users::ExportData
       "#{counts[:digests]} digests, " \
       "#{counts[:notifications]} notifications"
 
-    ::Notifications::Create.new(
-      user: user,
-      title: I18n.t('services.users.export_data.export_completed'),
-      content: I18n.t('services.users.export_data.your_data_export_has_been_processed_successfully_summary_you_can',
-                      summary: summary),
-      kind: :info
-    ).call
+    I18n.with_locale(user.locale) do
+      ::Notifications::Create.new(
+        user: user,
+        title: I18n.t('services.users.export_data.export_completed'),
+        content: I18n.t('services.users.export_data.your_data_export_has_been_processed_successfully_summary_you_can',
+                        summary: summary),
+        kind: :info
+      ).call
+    end
   end
 end

--- a/app/services/users/import_data.rb
+++ b/app/services/users/import_data.rb
@@ -233,22 +233,27 @@ class Users::ImportData
       "#{@import_stats[:files_restored]} files restored, " \
       "#{@import_stats[:notifications_created]} notifications"
 
-    ::Notifications::Create.new(
-      user: user,
-      title: I18n.t('services.users.import_data.data_import_completed'),
-      content: I18n.t('services.users.import_data.your_data_has_been_imported_successfully_summary', summary: summary),
-      kind: :info
-    ).call
+    I18n.with_locale(user.locale) do
+      ::Notifications::Create.new(
+        user: user,
+        title: I18n.t('services.users.import_data.data_import_completed'),
+        content: I18n.t('services.users.import_data.your_data_has_been_imported_successfully_summary',
+                        summary: summary),
+        kind: :info
+      ).call
+    end
   end
 
   def create_failure_notification(error)
-    ::Notifications::Create.new(
-      user: user,
-      title: I18n.t('services.users.import_data.data_import_failed'),
-      content: I18n.t('services.users.import_data.your_data_import_failed_with_error_message_please_check_the',
-                      message: error.message),
-      kind: :error
-    ).call
+    I18n.with_locale(user.locale) do
+      ::Notifications::Create.new(
+        user: user,
+        title: I18n.t('services.users.import_data.data_import_failed'),
+        content: I18n.t('services.users.import_data.your_data_import_failed_with_error_message_please_check_the',
+                        message: error.message),
+        kind: :error
+      ).call
+    end
   end
 
   def validate_import_completeness(expected_counts)

--- a/app/views/devise/registrations/_points_usage.html.erb
+++ b/app/views/devise/registrations/_points_usage.html.erb
@@ -1,6 +1,8 @@
 <div class="space-y-3">
   <p class='text-sm text-base-content/70'>
-    <%= t('.you_have_used') %> <span class="font-medium text-base-content"><%= number_with_delimiter(current_user.points_count.to_i) %></span> <%= t('.points_of') %> <span class="font-medium text-base-content"><%= number_with_delimiter(DawarichSettings::BASIC_PAID_PLAN_LIMIT) %></span> <%= t('.available') %>
+    <%= t('.summary_html',
+          used: content_tag(:span, number_with_delimiter(current_user.points_count.to_i), class: 'font-medium text-base-content'),
+          limit: content_tag(:span, number_with_delimiter(DawarichSettings::BASIC_PAID_PLAN_LIMIT), class: 'font-medium text-base-content')) %>
   </p>
   <progress class="progress progress-primary h-5 w-full" value="<%= current_user.points_count.to_i %>" max="<%= DawarichSettings::BASIC_PAID_PLAN_LIMIT %>"></progress>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -49,7 +49,7 @@
             <% end %>
           </div>
           <div class="form-control mt-6">
-            <%= f.submit (@invitation ? t('.sign_in_accept_invitation') : "Log in"), class: 'btn btn-primary' %>
+            <%= f.submit (@invitation ? t('.sign_in_accept_invitation') : t('.log_in')), class: 'btn btn-primary' %>
           </div>
         <% end %>
 

--- a/app/views/families/_location_sharing_toggle.html.erb
+++ b/app/views/families/_location_sharing_toggle.html.erb
@@ -53,7 +53,7 @@
           <% if member.family_sharing_enabled? && member.family_sharing_expires_at.present? %>
             <span class="text-xs text-base-content/50"
                   data-location-sharing-toggle-target="expirationInfo">
-              <%= t('.expires_in_time', time: time_ago_in_words(member.family_sharing_expires_at)) %>
+              <%= t('.expires_in_time', time: relative_distance_in_words(member.family_sharing_expires_at)) %>
             </span>
           <% else %>
             <span class="text-xs text-base-content/50 hidden"

--- a/app/views/families/show.html.erb
+++ b/app/views/families/show.html.erb
@@ -100,7 +100,7 @@
                       </span>
                       <% if location %>
                         <span class="text-xs text-base-content/40">
-                          <%= t('.middot') %> <%= time_ago_in_words(Time.zone.at(location[:timestamp])) %> <%= t('.ago') %>
+                          <%= t('.middot') %> <%= t('common.time_ago', time: relative_distance_in_words(Time.zone.at(location[:timestamp]))) %>
                         </span>
                       <% end %>
                     <% else %>
@@ -153,7 +153,7 @@
                   <div class="min-w-0 flex-1 mr-2">
                     <div class="text-sm font-medium"><%= invitation.email %></div>
                     <div class="text-xs text-base-content/40">
-                      <%= t('.invited_ago_expires', ago: time_ago_in_words(invitation.created_at), date: l(invitation.expires_at.to_date, format: :short_month_day_padded)) %>
+                      <%= t('.invited_ago_expires', ago: relative_distance_in_words(invitation.created_at), date: l(invitation.expires_at.to_date, format: :short_month_day_padded)) %>
                     </div>
                     <div class="text-xs text-base-content/50 font-mono break-all select-all mt-1">
                       <%= public_invitation_url(invitation.token) %>

--- a/app/views/family/location_requests/show.html.erb
+++ b/app/views/family/location_requests/show.html.erb
@@ -11,13 +11,13 @@
 
         <div>
           <span class="text-sm text-base-content/60"><%= t('.requested') %></span>
-          <p class="text-lg"><%= time_ago_in_words(@request.created_at) %> <%= t('.ago') %></p>
+          <p class="text-lg"><%= t('common.time_ago', time: relative_distance_in_words(@request.created_at)) %></p>
         </div>
 
         <% if @request.pending? && @request.expires_at > Time.current %>
           <div>
             <span class="text-sm text-base-content/60"><%= t('.expires') %></span>
-            <p class="text-lg"><%= time_ago_in_words(@request.expires_at) %> <%= t('.from_now') %></p>
+            <p class="text-lg"><%= t('common.time_from_now', time: relative_distance_in_words(@request.expires_at)) %></p>
           </div>
 
           <%= form_with url: accept_family_location_request_path(@request), method: :patch, class: "space-y-4 mt-6" do |f| %>
@@ -55,7 +55,7 @@
           <% if @request.responded_at.present? %>
             <div>
               <span class="text-sm text-base-content/60"><%= t('.responded') %></span>
-              <p><%= time_ago_in_words(@request.responded_at) %> <%= t('.ago') %></p>
+              <p><%= t('common.time_ago', time: relative_distance_in_words(@request.responded_at)) %></p>
             </div>
           <% end %>
         <% end %>

--- a/app/views/family_mailer/invitation.html.erb
+++ b/app/views/family_mailer/invitation.html.erb
@@ -5,7 +5,7 @@
     <p style="color: #374151; line-height: 1.6;"><%= t('.hi_there') %></p>
 
     <p style="color: #374151; line-height: 1.6;">
-      <strong><%= @invited_by.email %></strong> <%= t('.has_invited_you_to_join_their_family') %><strong><%= @family.name %></strong><%= t('.on_dawarich') %>
+      <%= t('.invited_by_family_html', email: @invited_by.email, family: @family.name) %>
     </p>
 
     <div style="background-color: #f3f4f6; padding: 20px; border-radius: 6px; margin: 20px 0;">

--- a/app/views/family_mailer/invitation.text.erb
+++ b/app/views/family_mailer/invitation.text.erb
@@ -2,7 +2,7 @@
 
 <%= t('.hi_there') %>
 
-<%= @invited_by.email %> <%= t('.has_invited_you_to_join_their_family') %><%= @family.name %><%= t('.on_dawarich') %>
+<%= t('.invited_by_family_text', email: @invited_by.email, family: @family.name) %>
 
 <%= t('.by_joining_this_family_you_ll_be_able_to') %>
 <%= t('.share_your_current_location_with_family_members_2') %>

--- a/app/views/family_mailer/member_joined.html.erb
+++ b/app/views/family_mailer/member_joined.html.erb
@@ -5,15 +5,15 @@
     <p style="color: #374151; line-height: 1.6;"><%= t('.hi') %> <%= @family.owner.email %>!</p>
 
     <p style="color: #374151; line-height: 1.6;">
-      <%= t('.we_re_excited_to_let_you_know_that') %> <strong><%= @user.email %></strong> <%= t('.has_just_joined_your_family') %><strong><%= @family.name %></strong><%= t('.on_dawarich') %>
+      <%= t('.member_joined_family_html', email: @user.email, family: @family.name) %>
     </p>
 
     <div style="background-color: #f3f4f6; padding: 20px; border-radius: 6px; margin: 20px 0;">
       <h3 style="color: #1f2937; margin-bottom: 15px; font-size: 18px;"><%= t('.now_you_can') %></h3>
       <ul style="color: #374151; line-height: 1.6; margin: 0; padding-left: 20px;">
-        <li style="margin-bottom: 8px;"><%= t('.see') %> <%= @user.email %><%= t('.s_current_location_if_they_ve_enabled_sharing') %></li>
+        <li style="margin-bottom: 8px;"><%= t('.see_current_location_html', email: @user.email) %></li>
         <li style="margin-bottom: 8px;"><%= t('.stay_connected_with_your_growing_family') %></li>
-        <li style="margin-bottom: 8px;"><%= t('.share_your_location_with') %> <%= @user.email %></li>
+        <li style="margin-bottom: 8px;"><%= t('.share_location_with_html', email: @user.email) %></li>
         <li><%= t('.manage_family_members_and_settings_from_your_family_page') %></li>
       </ul>
     </div>
@@ -25,7 +25,7 @@
     </div>
 
     <p style="color: #374151; line-height: 1.6;">
-      <%= t('.your_family_now_has') %> <strong><%= @family.member_count %></strong> <%= t('.member') %><%= @family.member_count == 1 ? '' : 's' %>.
+      <%= t('.member_count_html', count: @family.member_count) %>
     </p>
 
     <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 30px 0;">

--- a/app/views/family_mailer/member_joined.text.erb
+++ b/app/views/family_mailer/member_joined.text.erb
@@ -2,17 +2,17 @@
 
 <%= t('.hi') %> <%= @family.owner.email %>!
 
-<%= t('.we_re_excited_to_let_you_know_that') %> <%= @user.email %> <%= t('.has_just_joined_your_family') %><%= @family.name %><%= t('.on_dawarich') %>
+<%= t('.member_joined_family_text', email: @user.email, family: @family.name) %>
 
 <%= t('.now_you_can') %>
-<%= t('.see_2') %> <%= @user.email %><%= t('.s_current_location_if_they_ve_enabled_sharing') %>
+<%= t('.see_current_location_text', email: @user.email) %>
 <%= t('.stay_connected_with_your_growing_family_2') %>
-<%= t('.share_your_location_with_2') %> <%= @user.email %>
+<%= t('.share_location_with_text', email: @user.email) %>
 <%= t('.manage_family_members_and_settings_from_your_family_page_2') %>
 
 <%= t('.tip_you_can_manage_your_family_members_and_privacy_settings') %>
 
-<%= t('.your_family_now_has') %> <%= @family.member_count %> <%= t('.member') %><%= @family.member_count == 1 ? '' : 's' %>.
+<%= t('.member_count', count: @family.member_count) %>
 
 <%= t('.best_regards') %>
 <%= t('.evgenii_from_dawarich') %>

--- a/app/views/imports/_extraction_dialog.html.erb
+++ b/app/views/imports/_extraction_dialog.html.erb
@@ -12,7 +12,7 @@
         <li><strong><%= t('.places') %></strong> <%= t('.the_named_places_home_work_frequent_restaurants_the_source_app') %></li>
       </ul>
       <p>
-        <%= t('.click') %> <strong><%= t('.extract') %></strong> <%= t('.to_add_this_data_to_your_dawarich_account_existing_points') %>
+        <%= t('.extract_to_add_html') %>
       </p>
     </div>
 

--- a/app/views/insights/_travel_patterns.html.erb
+++ b/app/views/insights/_travel_patterns.html.erb
@@ -27,7 +27,7 @@
       <div>
         <div class="text-sm font-medium mb-2"><%= t('.day_of_week') %></div>
         <div class="flex gap-1">
-          <% days = %w[Mon Tue Wed Thu Fri Sat Sun] %>
+          <% days = t('date.abbr_day_names').rotate %>
           <% max_distance = @day_of_week.max.to_f %>
           <% distance_unit = current_user.safe_settings.distance_unit %>
           <% @day_of_week.each_with_index do |distance_meters, idx| %>

--- a/app/views/insights/details.html.erb
+++ b/app/views/insights/details.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/chartkick_scripts' %>
 
-<% insights_cache_key = [current_user.id, "insights", @selected_year, @year_stats&.maximum(:updated_at), current_user.safe_settings.distance_unit] %>
+<% insights_cache_key = [current_user.id, "insights", I18n.locale, @selected_year, @year_stats&.maximum(:updated_at), current_user.safe_settings.distance_unit] %>
 
 <%= turbo_frame_tag "insights_details" do %>
   <!-- Two Column Layout -->

--- a/app/views/insights/index.html.erb
+++ b/app/views/insights/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('.insights') %>
 <%= render 'shared/chartkick_scripts' %>
 
-<% insights_cache_key = [current_user.id, "insights", @selected_year, @year_stats&.maximum(:updated_at), current_user.safe_settings.distance_unit] %>
+<% insights_cache_key = [current_user.id, "insights", I18n.locale, @selected_year, @year_stats&.maximum(:updated_at), current_user.safe_settings.distance_unit] %>
 
 <div class="w-full my-5">
   <%= render 'header' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,6 +54,7 @@
   <body class='min-h-screen flex flex-col'>
     <div class='container mx-auto flex flex-col flex-1'>
       <%= render 'shared/navbar' %>
+      <%= render 'shared/locale_suggestion' %>
       <%= render 'shared/flash' %>
       <div class="w-full px-4 sm:px-5 flex-1">
         <div class="flex w-full min-w-0 gap-5">

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -3,7 +3,7 @@
     <h3 class="font-bold text-xl">
       <%= link_to notification.title, notification, class: "link hover:no-underline #{notification_link_color(notification)}" %>
     </h3>
-    <div class="text-sm text-gray-500"><%= time_ago_in_words notification.created_at %> <%= t('.ago') %></div>
+    <div class="text-sm text-gray-500"><%= t('common.time_ago', time: relative_distance_in_words(notification.created_at)) %></div>
 
     <% if params[:action] == 'show' %>
       <div class="mt-2">

--- a/app/views/shared/_locale_suggestion.html.erb
+++ b/app/views/shared/_locale_suggestion.html.erb
@@ -1,0 +1,19 @@
+<% if suggested_locale %>
+  <div class="alert alert-info rounded-none py-2 px-4 text-sm flex items-start gap-2"
+       data-testid="locale-suggestion"
+       data-controller="dismissible"
+       data-dismissible-key-value="locale_suggestion_<%= suggested_locale %>"
+       lang="<%= suggested_locale %>">
+    <span class="flex-1">
+      <%= t('shared.locale_suggestion.message', locale: suggested_locale) %>
+      <%= link_to t('shared.locale_suggestion.switch', locale: suggested_locale),
+                  locale_path(suggested_locale),
+                  lang: suggested_locale,
+                  class: 'link link-primary font-medium' %>
+    </span>
+    <button type="button"
+            class="btn btn-ghost btn-xs btn-circle"
+            data-action="dismissible#dismiss"
+            aria-label="<%= t('shared.locale_suggestion.dismiss', locale: suggested_locale) %>">✕</button>
+  </div>
+<% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -41,6 +41,7 @@
         <% if user_signed_in? %>
           <div class="divider my-1"></div>
           <li><%= render 'shared/navbar/theme_toggle', show_label: true, css_class: 'flex items-center gap-2' %></li>
+          <li><%= render 'shared/navbar/locale_switch' %></li>
           <li>
             <details>
               <summary><%= icon 'message-circle-question-mark' %> <%= t('.help') %></summary>
@@ -157,8 +158,8 @@
                 <% else %>
                   <% days_left = [(expiry.to_date - Time.zone.today).to_i, 0].max %>
                   <span class="tooltip tooltip-bottom"
-                        data-tip="<%= t('.trial_ends_in', time: distance_of_time_in_words(expiry, Time.current)) %>"
-                        title="<%= t('.trial_ends_in', time: distance_of_time_in_words(expiry, Time.current)) %>">
+                        data-tip="<%= t('.trial_ends_in', time: relative_distance_in_words(expiry)) %>"
+                        title="<%= t('.trial_ends_in', time: relative_distance_in_words(expiry)) %>">
                     <%= t('.days_remaining', count: days_left) %>
                   </span>
                 <% end %>
@@ -216,6 +217,7 @@
             <ul class="p-2 bg-base-100 rounded-t-none z-[50]">
               <li><%= link_to t('.account'), edit_user_registration_path %></li>
               <li><%= link_to t('.settings'), settings_general_index_path %></li>
+              <li><%= render 'shared/navbar/locale_switch' %></li>
               <% if !DawarichSettings.self_hosted? %>
                 <li><%= link_to t('.subscription'), "#{MANAGER_URL}/auth/dawarich?token=#{current_user.generate_subscription_token}" %></li>
               <% end %>
@@ -236,6 +238,7 @@
       </div>
     <% else %>
       <ul class="menu menu-horizontal bg-base-100 rounded-box px-1">
+        <li><%= render 'shared/navbar/locale_switch' %></li>
         <li><%= link_to t('.login'), new_user_session_path %></li>
         <% if !SELF_HOSTED && defined?(devise_mapping) && devise_mapping&.registerable? %>
           <li><%= link_to t('.register'), new_user_registration_path %></li>

--- a/app/views/shared/navbar/_locale_switch.html.erb
+++ b/app/views/shared/navbar/_locale_switch.html.erb
@@ -1,0 +1,6 @@
+<%= link_to url_for(request.query_parameters.merge(locale: alternate_locale)),
+            lang: alternate_locale,
+            hreflang: alternate_locale,
+            aria: { label: t('shared.navbar.switch_language_aria_label') } do %>
+  <%= t('shared.navbar.switch_language') %>
+<% end %>

--- a/app/views/shared/navbar/_locale_switch.html.erb
+++ b/app/views/shared/navbar/_locale_switch.html.erb
@@ -1,4 +1,4 @@
-<%= link_to url_for(request.query_parameters.merge(locale: alternate_locale)),
+<%= link_to locale_switch_path,
             lang: alternate_locale,
             hreflang: alternate_locale,
             aria: { label: t('shared.navbar.switch_language_aria_label') } do %>

--- a/app/views/shared_links/_modal_active.html.erb
+++ b/app/views/shared_links/_modal_active.html.erb
@@ -55,7 +55,7 @@
     <span class="flex items-center gap-1.5">
       <%= icon 'clock', class: 'w-4 h-4' %>
       <% if share.last_accessed_at %>
-        <%= t('.last_viewed') %> <%= time_ago_in_words(share.last_accessed_at) %> <%= t('.ago') %>
+        <%= t('.last_viewed') %> <%= t('common.time_ago', time: relative_distance_in_words(share.last_accessed_at)) %>
       <% else %>
         <%= t('.not_viewed_yet') %>
       <% end %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -12,7 +12,7 @@
 
   <%= render 'shared/plan_data_window_alert', utm_content: 'stats_index' %>
 
-  <% cache [current_user.id, "stats_summary", current_user.stats.maximum(:updated_at), @points_total, current_user.safe_settings.distance_unit, DawarichSettings.reverse_geocoding_enabled?], expires_in: 24.hours do %>
+  <% cache [current_user.id, "stats_summary", I18n.locale, current_user.stats.maximum(:updated_at), @points_total, current_user.safe_settings.distance_unit, DawarichSettings.reverse_geocoding_enabled?], expires_in: 24.hours do %>
     <div class="stats stats-vertical lg:stats-horizontal shadow w-full bg-base-200 relative">
       <div class="stat text-center">
         <div class="stat-value text-primary">
@@ -45,7 +45,7 @@
 
   <div class="mt-6 grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-6">
     <% @stats.each do |year, stats| %>
-      <% cache [current_user.id, "stats_year_card", year, stats.map(&:updated_at).max, current_user.safe_settings.distance_unit, DawarichSettings.reverse_geocoding_enabled?], expires_in: 24.hours do %>
+      <% cache [current_user.id, "stats_year_card", I18n.locale, year, stats.map(&:updated_at).max, current_user.safe_settings.distance_unit, DawarichSettings.reverse_geocoding_enabled?], expires_in: 24.hours do %>
       <div class="card w-full bg-base-200 shadow-xl">
         <div class="card-body">
           <h2 class="card-title justify-between text-<%= header_colors[year % header_colors.size] %>">

--- a/app/views/tracks/segments/_segment_row.html.erb
+++ b/app/views/tracks/segments/_segment_row.html.erb
@@ -36,7 +36,7 @@
 
     <% if segment.manually_corrected? %>
       <span class="shrink-0 text-info/80 leading-none"
-            title="<%= t('.edited_ago', time: time_ago_in_words(segment.corrected_at)) %>"
+            title="<%= t('.edited_ago', time: relative_distance_in_words(segment.corrected_at)) %>"
             aria-label="<%= t('.manually_corrected') %>">
         <%= icon 'square-pen', class: 'w-3 h-3' %>
       </span>

--- a/app/views/users/digests/public_year.html.erb
+++ b/app/views/users/digests/public_year.html.erb
@@ -83,7 +83,7 @@
           <div class="w-full h-48 bg-base-200 rounded-lg p-4 relative">
             <%= column_chart(
               @digest.monthly_distances.sort_by { |month, _| month.to_i }.map { |month, distance_meters|
-                [Date::ABBR_MONTHNAMES[month.to_i], Users::Digest.convert_distance(distance_meters.to_i, @distance_unit).round]
+                [I18n.t('date.abbr_month_names')[month.to_i], Users::Digest.convert_distance(distance_meters.to_i, @distance_unit).round]
               },
               height: '200px',
               suffix: " #{@distance_unit}",

--- a/app/views/users/digests/show.html.erb
+++ b/app/views/users/digests/show.html.erb
@@ -104,7 +104,7 @@
           <div class="w-full h-64 bg-base-100 rounded-lg p-4">
             <%= column_chart(
               @digest.monthly_distances.sort_by { |month, _| month.to_i }.map { |month, distance_meters|
-                [Date::ABBR_MONTHNAMES[month.to_i], Users::Digest.convert_distance(distance_meters.to_i, @distance_unit).round]
+                [I18n.t('date.abbr_month_names')[month.to_i], Users::Digest.convert_distance(distance_meters.to_i, @distance_unit).round]
               },
               height: '250px',
               suffix: " #{@distance_unit}",

--- a/app/views/users/digests_mailer/monthly_digest.html.erb
+++ b/app/views/users/digests_mailer/monthly_digest.html.erb
@@ -32,7 +32,7 @@
   <h2><%= t('.weekly_pattern') %></h2>
   <pre class="ascii" style="<%= pre_style %>"><%= ascii_hbar(
       @weekday_totals,
-      labels: %w[Mon Tue Wed Thu Fri Sat Sun],
+      labels: I18n.t('date.abbr_day_names').rotate,
       width: 20,
       suffix: " #{@distance_unit}"
     ) %></pre>

--- a/app/views/users/digests_mailer/monthly_digest.text.erb
+++ b/app/views/users/digests_mailer/monthly_digest.text.erb
@@ -12,7 +12,7 @@
 <%= t('.weekly_pattern') %>
 <%= ascii_hbar(
   @weekday_totals,
-  labels: %w[Mon Tue Wed Thu Fri Sat Sun],
+  labels: I18n.t('date.abbr_day_names').rotate,
   width: 20,
   suffix: " #{@distance_unit}"
 ) %>

--- a/app/views/users/digests_mailer/year_end_digest.html.erb
+++ b/app/views/users/digests_mailer/year_end_digest.html.erb
@@ -18,8 +18,8 @@
   </style>
 </head>
 <body>
-  <h1><%= t('.your') %> <%= @digest.year %> <%= t('.year_in_review') %></h1>
-  <p class="meta"><%= t('.here_s_your') %> <%= @digest.year %> <%= t('.at_a_glance') %></p>
+  <h1><%= t('.year_in_review_title', year: @digest.year) %></h1>
+  <p class="meta"><%= t('.year_at_a_glance', year: @digest.year) %></p>
 
   <h2><%= t('.the_numbers') %></h2>
   <pre class="ascii" style="<%= pre_style %>">
@@ -38,7 +38,7 @@
   <h2><%= t('.monthly_distance') %></h2>
   <pre class="ascii" style="<%= pre_style %>"><%= ascii_hbar(
       (1..12).map { |m| @monthly_distances[m.to_s].to_f.round },
-      labels: Date::ABBR_MONTHNAMES[1..12],
+      labels: I18n.t('date.abbr_month_names').compact,
       width: 24,
       suffix: " #{@distance_unit}"
     ) %></pre>

--- a/app/views/users/digests_mailer/year_end_digest.text.erb
+++ b/app/views/users/digests_mailer/year_end_digest.text.erb
@@ -1,7 +1,7 @@
-<%= t('.your') %> <%= @digest.year %> <%= t('.year_in_review') %>
+<%= t('.year_in_review_title', year: @digest.year) %>
 ──────────────────────────────
 
-<%= t('.here_s_your') %> <%= @digest.year %> <%= t('.at_a_glance') %>
+<%= t('.year_at_a_glance', year: @digest.year) %>
 
 <%= t('.the_numbers') %>
   <%= t('.distance') %>       <%= distance_with_unit(@digest.distance, @distance_unit) %>
@@ -18,7 +18,7 @@
 <%= t('.monthly_distance') %>
 <%= ascii_hbar(
   (1..12).map { |m| @monthly_distances[m.to_s].to_f.round },
-  labels: Date::ABBR_MONTHNAMES[1..12],
+  labels: I18n.t('date.abbr_month_names').compact,
   width: 24,
   suffix: " #{@distance_unit}"
 ) %>

--- a/app/views/users_mailer/oauth_account_link.html.erb
+++ b/app/views/users_mailer/oauth_account_link.html.erb
@@ -19,7 +19,7 @@
     <div class="content">
       <p><%= t('.hi') %> <%= @user.email %>,</p>
 
-      <p><%= t('.someone_hopefully_you_is_trying_to_link') %> <strong><%= @provider_label %></strong> <%= t('.sign_in_to_your_dawarich_account_clicking_the_button_below') %></p>
+      <p><%= t('.account_link_request_html', provider: @provider_label) %></p>
 
       <p><a href="<%= @link_url %>" class="cta"><%= t('.link') %> <%= @provider_label %></a></p>
 

--- a/app/views/users_mailer/oauth_account_link.text.erb
+++ b/app/views/users_mailer/oauth_account_link.text.erb
@@ -2,7 +2,7 @@
 
 <%= t('.hi') %> <%= @user.email %>,
 
-<%= t('.someone_hopefully_you_is_trying_to_link') %> <%= @provider_label %> <%= t('.sign_in_to_your_dawarich_account_clicking_the_link_below_2') %>
+<%= t('.account_link_request_text', provider: @provider_label) %>
 
 <%= t('.link') %> <%= @provider_label %>: <%= @link_url %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,8 @@ module Dawarich
     # in config/environments, which are processed later.
     #
     config.time_zone = ENV.fetch('TIME_ZONE', 'Europe/Berlin')
+    config.i18n.available_locales = %i[en de]
+    config.i18n.default_locale = :en
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,4252 @@
+de:
+  auth:
+    account_links:
+      challenge:
+        link: Verknüpfen
+        to_your_dawarich_account: zu deinem Dawarich-Konto
+        we_found_an_existing_dawarich_account_for: Wir haben ein bestehendes Dawarich-Konto für
+        enter_your_password_to_link_your: ". Gib dein Passwort ein, um deine"
+        identity_to_that_account_and_sign_in: Identität mit diesem Konto zu verknüpfen und dich anzumelden.
+        current_password: Aktuelles Passwort
+        or: oder
+        forgot_your_password: Passwort vergessen?
+        email_me_a_confirmation_link_instead: Sende mir stattdessen einen Bestätigungslink per E-Mail
+        reset_it: Zurücksetzen
+        go_back_to_sign_in: Zurück zur Anmeldung
+        confirm_account_linking: Kontoverknüpfung bestätigen
+        link_provider_and_sign_in: Verknüpfe %{provider} und melde dich an
+  devise:
+    confirmations:
+      new:
+        resend_confirmation: Bestätigungslink erneut senden
+        enter_your_email_address_and_we_ll_resend_the_confirmation: Gib deine E-Mail-Adresse ein, und wir senden dir die Bestätigungsanweisungen erneut.
+        email: E-Mail
+        resend_confirmation_instructions: Bestätigungsanweisungen erneut senden
+    mailer:
+      confirmation_instructions:
+        welcome: Willkommen
+        you_can_confirm_your_account_email_through_the_link_below: 'Du kannst deine E-Mail-Adresse für das Konto über den Link unten bestätigen:'
+        confirm_my_account: Mein Konto bestätigen
+      email_changed:
+        hello: Hallo
+        we_re_contacting_you_to_notify_you_that_your_email: 'Wir informieren dich über die Änderung deiner E-Mail-Adresse. Neue Adresse:'
+        we_re_contacting_you_to_notify_you_that_your_email_2: 'Deine E-Mail-Adresse wurde geändert. Neue Adresse:'
+      password_change:
+        hello: Hallo
+        we_re_contacting_you_to_notify_you_that_your_password: Wir kontaktieren dich, um dich zu benachrichtigen, dass dein Passwort geändert wurde.
+      reset_password_instructions:
+        hello: Hallo
+        someone_has_requested_a_link_to_change_your_password_you: Jemand hat einen Link angefordert, um dein Passwort zu ändern. Du kannst dies über den Link unten tun.
+        if_you_didn_t_request_this_please_ignore_this_email: Wenn du diesen Link nicht angefordert hast, ignoriere bitte diese E-Mail.
+        your_password_won_t_change_until_you_access_the_link: Dein Passwort wird nicht geändert, bis du den Link oben öffnest und ein neues erstellst.
+        change_my_password: Passwort ändern
+      unlock_instructions:
+        hello: Hallo
+        your_account_has_been_locked_due_to_an_excessive_number: Dein Konto wurde aufgrund einer zu hohen Anzahl fehlgeschlagener Anmeldeversuche gesperrt.
+        click_the_link_below_to_unlock_your_account: 'Klicke den Link unten, um dein Konto zu entsperren:'
+        unlock_my_account: Konto entsperren
+    passwords:
+      edit:
+        change_your_password: Passwort ändern
+        enter_your_new_password_below: Gib dein neues Passwort unten ein.
+        new_password: Neues Passwort
+        characters_minimum: Zeichen mindestens)
+        confirm_new_password: Neues Passwort bestätigen
+        change_my_password: Passwort ändern
+      new:
+        forgot_your_password: Passwort vergessen?
+        enter_your_email_address_and_we_ll_send_you_instructions: Gib deine E-Mail-Adresse ein und wir senden dir Anweisungen zum Zurücksetzen deines Passworts.
+        email: E-Mail
+        send_me_reset_password_instructions: Reset-Anweisungen senden
+    registrations:
+      api_key:
+        current_api_key: Aktueller API-Schlüssel
+        docs: 'Dokumentation:'
+        scan_with_dawarich_app: Mit Dawarich-App scannen
+        usage_examples: Anwendungsbeispiele
+        dawarich_ios_or_android_app: Dawarich iOS oder Android-App
+        provide_your_instance_url: 'Gib deine Instanz-URL an:'
+        and_provide_your_api_key: 'Gib deinen API-Schlüssel an:'
+        owntracks: OwnTracks
+        overland: Overland
+        api_documentation: API-Dokumentation
+        generate_new_api_key: Neuen API-Schlüssel generieren
+        are_you_sure_this_will_invalidate_the_current_api_key: Bist du sicher? Dies wird den aktuellen API-Schlüssel ungültig machen.
+      points_usage:
+        you_have_used: Du hast verwendet
+        points_of: Punkte von
+        available: verfügbar.
+      edit:
+        account_settings: Kontoeinstellungen
+        profile: Profil
+        update_your_email_address_and_password_from_one_place: Aktualisiere deine E-Mail-Adresse und dein Passwort an einem Ort.
+        connected_with: Verbunden mit
+        email: E-Mail
+        currently_waiting_confirmation_for: 'Bestätigung ausstehend für:'
+        new_password: Neues Passwort
+        leave_blank_to_keep_the_current_one: "(leer lassen, um das aktuelle zu behalten)"
+        characters_minimum: Zeichen mindestens)
+        password_confirmation: Passwortbestätigung
+        current_password: Aktuelles Passwort
+        required_to_confirm_your_changes: "(erforderlich, um deine Änderungen zu bestätigen)"
+        import_your_data: Daten importieren
+        upload_a_zip_file_containing_your_exported_dawarich_data_to: Lade eine ZIP-Datei mit deinen exportierten Dawarich-Daten hoch, um deine Punkte, Reisen und Einstellungen wiederherzustellen.
+        select_zip_archive: ZIP-Archiv auswählen
+        file_will_be_uploaded_directly_to_storage_please_be_patient: Die Datei wird direkt in den Speicher hochgeladen. Bitte habe während des Uploads etwas Geduld.
+        cancel: Abbrechen
+        close: schließen
+        trial_status: Teststatus
+        your_trial_period_ends_at: Dein Testzeitraum endet am
+        plan_usage: Plan-Nutzung
+        subscription: Abonnement
+        your_signup_isn_t_complete_yet_finish_setting_up_your: Deine Registrierung ist noch nicht abgeschlossen — vervollständige die Einrichtung deines Abonnements, um deinen Testzeitraum zu starten.
+        change_plan_update_your_payment_method_or_cancel_your_subscription: Ändere deinen Tarif, aktualisiere deine Zahlungsmethode oder kündige dein Abonnement im Manager.
+        manage_your_subscription_change_plan_or_update_billing_on_manager: Verwalte dein Abonnement, ändere deinen Tarif oder aktualisiere deine Abrechnung im Manager.
+        api_access: API-Zugriff
+        use_your_api_key_for_clients_imports_and_external_integrations: Verwende deinen API-Schlüssel für Clients, Importe und externe Integrationen.
+        data_tools: Daten-Tools
+        export_a_backup_or_restore_a_previous_archive: Exportiere eine Sicherung oder stelle ein vorheriges Archiv wieder her.
+        import_my_data: Meine Daten importieren
+        danger_zone: Gefahrenzone
+        deleting_your_account_is_permanent_and_removes_all_your_data: Das Löschen deines Kontos ist endgültig und entfernt alle deine Daten.
+        cancel_my_account: Mein Konto kündigen
+        delete_your_account: Dein Konto löschen
+        this_is_permanent_and_removes_all_your_data_this_cannot: Dies ist endgültig und entfernt alle deine Daten. Dies kann nicht rückgängig gemacht werden.
+        this_is_permanent_and_removes_all_your_data_this_cannot_2: Dies ist endgültig und entfernt alle deine Daten. Dies kann nicht rückgängig gemacht werden. Wir senden dir eine E-Mail mit einem Link zur Bestätigung — dein Konto wird nur gelöscht, nachdem du den Link anklickst.
+        type_your_email: Gib deine E-Mail-Adresse ein (
+        to_confirm: ") zur Bestätigung"
+        enter_your_current_password_to_confirm: Gib dein aktuelles Passwort ein, um zu bestätigen
+        save_changes: Änderungen speichern
+        import_data: Daten importieren
+        manage_subscription: Abonnement verwalten
+        subscribe: Abonnieren
+        export_my_data: Meine Daten exportieren
+        are_you_sure_you_want_to_export_your_data: Bist du sicher, dass du deine Daten exportieren möchtest?
+        account: Konto
+        importing: Importiere...
+        delete_my_account: Mein Konto löschen
+        email_me_the_confirmation_link: Sende mir den Bestätigungslink per E-Mail
+      new:
+        join: Beitreten
+        you_ve_been_invited_by: Du wurdest von
+        to_join_their_family_create_your_account_to_accept_the: eingeladen, der Familie beizutreten. Erstelle dein Konto, um die Einladung anzunehmen und Standortdaten zu teilen.
+        your_email: Deine E-Mail (
+        will_be_used_for_this_account: ") wird für dieses Konto verwendet"
+        almost_there: Fast fertig!
+        only_a_few_steps_left_until_you_get_control_over: Nur noch wenige Schritte, bis du Kontrolle über deine Standortdaten hast!
+        create_your_account: 1. Erstelle dein Konto
+        configure_your_mobile_app: 2. Konfiguriere deine mobile App
+        start_tracking_your_location_data_securely: 3. Beginne mit der sicheren Aufzeichnung deiner Standortdaten
+        you_re_beautiful: 5. Du bist wunderschön!
+        email: E-Mail
+        password: Passwort
+        characters_minimum: Zeichen mindestens)
+        password_confirmation: Passwortbestätigung
+        how_do_you_plan_to_use_dawarich: Wie planst du, Dawarich zu nutzen?
+        i_m_self_hosting_and_exploring_the_demo: Ich hoste selbst und erkunde die Demo
+        create_account_join_family: Konto erstellen & Familie beitreten
+        sign_up: Registrieren
+    sessions:
+      new:
+        sign_in_to_join: Anmelden, um beizutreten
+        you_ve_been_invited_by: Du wurdest von
+        to_join_their_family_sign_in_to_your_account_to: eingeladen, der Familie beizutreten. Melde dich mit deinem Konto an, um die Einladung anzunehmen.
+        don_t_have_an_account_yet: Du hast noch kein Konto?
+        login_now: Jetzt anmelden
+        and_take_control_over_your_location_data: und übernimm die Kontrolle über deine Standortdaten.
+        email: E-Mail
+        password: Passwort
+        remember_me: Mich erinnern
+        sign_in_using_your_organization_s_identity_provider: Mit dem Identitätsanbieter deiner Organisation anmelden
+        create_one_here: Eines hier erstellen
+        sign_in_accept_invitation: Anmelden & Einladung annehmen
+      otp_challenge:
+        two_factor_authentication: Zwei-Faktor-Authentifizierung
+        enter_the_6_digit_code_from_your_authenticator_app_to: Gib den 6-stelligen Code aus deiner Authenticator-App ein, um fortzufahren.
+        authentication_code: Authentifizierungscode
+        you_can_also_use_a_backup_code: Du kannst auch einen Backup-Code verwenden.
+        verify: Bestätigen
+        back_to_login: Zurück zum Login
+    shared:
+      links:
+        log_in: Anmelden
+        register: Registrieren
+        forgot_your_password: Passwort vergessen?
+        didn_t_receive_confirmation_instructions: Keine Bestätigungsanweisungen erhalten?
+        didn_t_receive_unlock_instructions: Keine Entsperranweisungen erhalten?
+    unlocks:
+      new:
+        resend_unlock_instructions: Entsperranweisungen erneut senden
+        enter_your_email_address_and_we_ll_send_you_instructions: Gib deine E-Mail-Adresse ein, und wir senden dir Anweisungen zur Entsperrung deines Kontos.
+        email: E-Mail
+  exports:
+    table_row:
+      middot: "·"
+      download_file: Datei herunterladen
+      delete_export: Export löschen
+      are_you_sure: Bist du sicher?
+    index:
+      no_exports_yet: Noch keine Exporte
+      exports_are_created_from_the: Exporte werden aus der
+      page_select_a_date_range_and_export_to_geojson_or: Seite erstellt. Wähle einen Zeitraum aus und exportiere zu GeoJSON oder GPX.
+      go_to_points: Zu den Punkten
+      actions: Aktionen
+      exports: Exporte
+      points: Punkte
+      name: Name
+      status: Status
+      created: Erstellt
+  families:
+    location_sharing_toggle:
+      live_location: 'Live-Position:'
+      always: Immer
+      hour: 1 Stunde
+      hours: 6 Stunden
+      hours_2: 12 Stunden
+      hours_3: 24 Stunden
+      expires_in: Verfällt in
+      location_history: 'Standortverlauf:'
+      last_24_hours: Letzte 24 Stunden
+      last_7_days: Letzte 7 Tage
+      last_30_days: Letzte 30 Tage
+      since_sharing_started: Seit Beginn der Freigabe
+      a_separate_setting_from_live_location_when_on_family_can: Diese Einstellung ist von der Live-Position getrennt. Ist sie aktiviert, kann deine Familie auf der neuen Karte (v2) deinen letzten Track sehen — nicht nur deine aktuelle Position. Es werden ausschließlich Punkte geteilt, die nach der Aktivierung aufgezeichnet wurden.
+      expires_in_time: Verfällt in %{time}
+    edit:
+      delete_family: Familie löschen
+      are_you_sure_you_want_to_delete_this_family_this: Bist du sicher, dass du diese Familie löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden.
+      back_to_family: "← Zur Familie"
+      members: Mitglieder
+      cancel: Abbrechen
+      editing_family: Familie bearbeiten
+      member_count:
+        one: "%{count} Mitglied"
+        other: "%{count} Mitglieder"
+      back: "← Zur Familie"
+      created_on: Erstellt am
+      creator: Erstellt von
+      error_title: 'Beim Absenden gab es Probleme:'
+      family_info: Familieninformationen
+      last_updated: Zuletzt geändert
+      members_count: Mitglieder
+      name_help: Wähle einen Namen, den alle Familienmitglieder erkennen werden.
+      save_changes: Änderungen speichern
+      title: Familie bearbeiten
+    lapsed:
+      family_plan_no_longer_active: Family-Tarif ist nicht mehr aktiv
+      your_family_plan_is_no_longer_active_so_family_features: Dein Family-Tarif ist nicht mehr aktiv. Deshalb sind die Familienfunktionen für alle pausiert. Deine Familie und ihre Mitglieder bleiben erhalten — nach der Verlängerung ist der volle Zugriff wieder verfügbar.
+      your_family_s_plan_is_no_longer_active_so_family: Der Family-Tarif ist nicht mehr aktiv. Deshalb sind die Familienfunktionen pausiert. Sie werden wieder freigeschaltet, sobald der Familieninhaber den Tarif verlängert — du benötigst kein eigenes Abonnement.
+      members: Mitglieder
+      remove: Entfernen
+      your_location_sharing: Deine Standortfreigabe
+      delete_family: Familie löschen
+      leave_family: Familie verlassen
+      renew_family_plan: Familienplan erneuern
+      view_pending_invitations: Ausstehende Einladungen ansehen
+      delete_this_family_this_cannot_be_undone: Diese Familie löschen? Dies kann nicht rückgängig gemacht werden.
+      are_you_sure_you_want_to_leave_this_family: Möchtest du diese Familie wirklich verlassen?
+      family: Familie
+      remove_email_from_the_family: "%{email} aus der Familie entfernen?"
+    show:
+      edit: Bearbeiten
+      invite: Einladen
+      members_middot_created: Mitglieder · Erstellt
+      no_family_members_are_sharing_their_location: Keine Familienmitglieder teilen ihren Standort
+      your_sharing: Deine Freigabe
+      members: Mitglieder
+      owner: Inhaber
+      you: Du
+      sharing: Freigabe
+      middot: "·"
+      ago: vor
+      not_sharing: Nicht freigeben
+      requested: Angefordert
+      remove: Entfernen
+      invitations: Einladungen
+      invited: Eingeladen
+      ago_middot_expires: vor · verfällt
+      family_at_capacity: Familie ist voll (
+      members_max: Mitglieder max)
+      leave_family: Von der Familie trennen
+      delete_family: Familie löschen
+      request: Anfordern
+      cancel_this_invitation: Diese Einladung stornieren?
+      email_address: E-Mail-Adresse
+      are_you_sure_you_want_to_leave_this_family: Möchtest du dich wirklich von dieser Familie trennen?
+      delete_this_family_this_cannot_be_undone: Diese Familie löschen? Dies kann nicht rückgängig gemacht werden.
+      remove_email_from_the_family: "%{email} aus der Familie entfernen?"
+      members_created:
+        one: "%{count} Mitglied · Erstellt %{date}"
+        other: "%{count} Mitglieder · Erstellt %{date}"
+      invited_ago_expires: Einladung %{ago} ago · läuft ab %{date}
+      always: immer
+      for_duration: für %{duration}
+      sharing_status: Freigabe %{duration}
+    index:
+      have_an_invitation: Eine Einladung erhalten?
+      if_someone_has_invited_you_to_join_their_family_you: Wenn jemand dich zu seinem Familienkreis eingeladen hat, solltest du eine E-Mail mit einem Einladungslink erhalten haben.
+      check_your_email_for_an_invitation_link_that_looks_like: 'Überprüfe deine E-Mail auf einen Einladungslink, der so aussieht:'
+      family_management: Familienverwaltung
+      create_family: Deine Familie erstellen
+      description: Erstelle oder schließe eine Familie an, um deine Standortdaten mit Lieben zu teilen.
+      have_invitation: Eine Einladung erhalten?
+      invitation_help: 'Überprüfe deine E-Mail auf einen Einladungslink, der so aussieht:'
+      invitation_instructions: Wenn jemand dich zu seinem Familienkreis eingeladen hat, solltest du eine E-Mail mit einem Einladungslink erhalten haben.
+      title: Familienverwaltung
+    new:
+      choose_a_name_that_all_family_members_will_recognize_like: Wähle einen Namen, den alle Familienmitglieder wiedererkennen, zum Beispiel „Familie Schmidt“ oder „Unsere Reisegruppe“.
+      what_happens_next: Was passiert als Nächstes?
+      back: "← Zurück"
+      new_family: Neue Familie
+      create_family: Familie erstellen
+      description: Erstelle eine Familie, um deine Standortdaten mit deinen Lieben zu teilen.
+      error_title: 'Beim Absenden gab es Probleme:'
+      name_help: Wähle einen Namen, den alle Familienmitglieder wiedererkennen, zum Beispiel „Familie Schmidt“ oder „Unsere Reisegruppe“.
+      title: Deine Familie erstellen
+      upgrade_cta: Auf den Family-Tarif upgraden
+      upgrade_description: Zum Erstellen einer Familie ist der Family-Tarif erforderlich. Mit dem Upgrade kannst du bis zu 5 Mitglieder einladen und den vollständigen Zugriff teilen.
+      upgrade_title: Family-Tarif erforderlich
+      what_happens_1: Du wirst Inhaber der Familie
+      what_happens_2: Du kannst andere in deine Familie einladen
+      what_happens_3: Familienmitglieder können freigegebene Standortdaten sehen
+      what_happens_4: Du kannst Familieneinstellungen und Mitglieder verwalten
+      what_happens_title: Was passiert als Nächstes?
+    navbar_indicator:
+      location_shared: Standort wird mit deiner Familie geteilt
+      location_not_shared: Standort wird nicht mit deiner Familie geteilt
+    form:
+      create: Familie erstellen
+      name: Familienname
+      name_placeholder: Gib deinen Familiennamen ein
+  family:
+    invitations:
+      show:
+        join: Beitreten
+        you_ve_been_invited_by: Du wurdest von
+        to_join_their_family_create_your_account_to_accept_the: eingeladen, der Familie beizutreten. Erstelle dein Konto, um die Einladung anzunehmen und Standortdaten zu teilen.
+        your_email: Deine E-Mail (
+        will_be_used_for_this_account: ") wird für dieses Konto verwendet"
+        what_benefits_does_joining_a_family_bring: Welche Vorteile bringt das Beitreten einer Familie mit sich?
+        share_location_data: Standortdaten teilen
+        share_your_location_history_with_family_members_and_see_where: Teile deinen Standortverlauf mit Familienmitgliedern und sieh, wo sie sind
+        track_your_location_history: Verfolge deinen Standortverlauf
+        access_interactive_maps_and_personal_travel_statistics: Zugriff auf interaktive Karten und persönliche Reisestatistiken
+        stay_connected: Immer verbunden bleiben
+        keep_track_of_your_loved_ones_travels_and_adventures_in: Verfolge in Echtzeit die Reisen und Abenteuer deiner Lieben
+        full_control_privacy: Vollständige Kontrolle & Privatsphäre
+        you_control_what_and_how_long_you_share_and_can: Du bestimmst, was und wie lange du teilst, und kannst jederzeit aus der Familie austreten
+        invitation_details: Einladungsdetails
+        family: 'Familie:'
+        invited_by: 'Von:'
+        your_email_2: 'Deine E-Mail-Adresse:'
+        expires: 'Verfällt:'
+        this_family_s_plan_is_currently_inactive_you_can_accept: Der Tarif dieser Familie ist derzeit inaktiv. Du kannst die Einladung annehmen, sobald der Familieninhaber ihn verlängert.
+        accept_invitation_join_family: "✓ Einladung annehmen & Familie beitreten"
+        logged_in_as: Angemeldet als
+        logout: Abmelden
+        create_account_join_family: Konto erstellen & Familie beitreten →
+        already_have_an_account: Bereits ein Konto?
+        sign_in_to_accept_invitation: Anmelden, um Einladung anzunehmen
+        not_interested_you_can_simply_close_this_page: Nicht interessiert? Du kannst diese Seite einfach schließen.
+      index:
+        invited: Eingeladen
+        expires: Verfällt
+        view: Ansehen
+        are_you_sure_you_want_to_cancel_this_invitation: Bist du sicher, dass du diese Einladung abbrechen möchtest?
+        cancel: Abbrechen
+    location_requests:
+      show:
+        location_request: Standortanfrage
+        requested_by: Von
+        requested: Angefordert
+        ago: vor
+        expires: Verfällt
+        from_now: in
+        share_location_for: Standort teilen für
+        hour: 1 Stunde
+        hours: 6 Stunden
+        hours_2: 12 Stunden
+        hours_3: 24 Stunden
+        permanently: Ewig
+        expired: Verfallen
+        accepted: Akzeptiert
+        declined: Abgelehnt
+        responded: Beantwortet
+        accept_share_location: Akzeptieren & Standort teilen
+        decline: Ablehnen
+        back_to_family: Zur Familie
+  family_mailer:
+    invitation:
+      you_ve_been_invited_to_join_a_family: Du hast eine Einladung erhalten, eine Familie beizutreten!
+      hi_there: Hallo!
+      has_invited_you_to_join_their_family: hat dich eingeladen, ihre Familie "
+      on_dawarich: "\" auf Dawarich."
+      by_joining_this_family_you_ll_be_able_to: 'Indem du dieser Familie beitrittst, kannst du:'
+      share_your_current_location_with_family_members: Deinen aktuellen Standort mit Familienmitgliedern teilen
+      see_the_current_location_of_other_family_members: Den aktuellen Standort anderer Familienmitglieder sehen
+      stay_connected_with_your_loved_ones: Mit deinen Lieben in Verbindung bleiben
+      control_your_privacy_with_full_sharing_controls: Deine Privatsphäre mit vollständigen Freigabesteuern kontrollieren
+      important: "⏰ Wichtig:"
+      this_invitation_will_expire_in_7_days: Diese Einladung läuft in 7 Tagen ab.
+      if_you_don_t_have_a_dawarich_account_yet_you: Wenn du noch kein Dawarich-Konto hast, kannst du eines erstellen, sobald du die Einladung annimmst.
+      if_you_didn_t_expect_this_invitation_you_can_safely: Wenn du diese Einladung nicht erwartet hast, kannst du diese E-Mail einfach ignorieren.
+      best_regards: Mit freundlichen Grüßen,
+      evgenii_from_dawarich: Evgenii von Dawarich
+      you_ve_been_invited_to_join_a_family_hi_there: Du wurdest zu einer Familie eingeladen! Hallo da!
+      on_dawarich_by_joining_this_family_you_ll_be_able: "\" auf Dawarich. Durch das Beitreten dieser Familie wirst du in der Lage sein: • Deinen aktuellen Standort mit Familienmitgliedern zu teilen • Den aktuellen Standort anderer Familienmitglieder zu sehen • Mit deinen Lieben in Verbindung zu bleiben • Deine Privatsphäre vollständig zu kontrollieren Akzeptiere die Einladung hier:"
+      important_this_invitation_will_expire_in_7_days_if_you: 'WICHTIG: Diese Einladung läuft in 7 Tagen ab. Wenn du noch kein Dawarich-Konto hast, kannst du eines erstellen, sobald du die Einladung annimmst. Wenn du diese Einladung nicht erwartet hast, kannst du diese E-Mail einfach ignorieren. Mit freundlichen Grüßen, Evgenii von Dawarich'
+      accept_invitation: Einladung annehmen
+      share_your_current_location_with_family_members_2: "• Deinen aktuellen Standort mit Familienmitgliedern teilen"
+      see_the_current_location_of_other_family_members_2: "• Den aktuellen Standort anderer Familienmitglieder sehen"
+      stay_connected_with_your_loved_ones_2: "• Mit deinen Lieben in Verbindung bleiben"
+      control_your_privacy_with_full_sharing_controls_2: "• Deine Privatsphäre vollständig kontrollieren"
+      accept_your_invitation_here: 'Akzeptiere deine Einladung hier:'
+      important_this_invitation_will_expire_in_7_days: 'WICHTIG: Diese Einladung läuft in 7 Tagen ab.'
+    location_request:
+      location_request: Standortanfrage
+      hi_there: Hallo da!
+      is_requesting_your_location_on_dawarich: fragt deinen Standort über Dawarich an.
+      you_can_review_this_request_and_choose_to_accept_or: Du kannst diese Anfrage überprüfen und entscheiden, ob du sie annimmst oder ablehnst. Wenn du annimmst, kannst du auswählen, wie lange du deinen Standort freigibst (1 Stunde, 6 Stunden, 12 Stunden, 24 Stunden oder dauerhaft).
+      important: "⏰ Wichtig:"
+      this_request_will_expire_in_24_hours_if_not_acted: Diese Anfrage läuft in 24 Stunden ab, wenn sie nicht bearbeitet wird.
+      if_you_don_t_want_to_share_your_location_simply: Wenn du deinen Standort nicht freigeben möchtest, ignoriere einfach diese Anfrage oder lehne sie ab.
+      best_regards: Mit freundlichen Grüßen,
+      evgenii_from_dawarich: Evgenii von Dawarich
+      location_request_hi_there: Standortanfrage ================ Hallo!
+      is_requesting_your_location_on_dawarich_you_can_review_this: 'fragt deinen Standort über Dawarich an. Du kannst die Anfrage prüfen und annehmen oder ablehnen. Wenn du sie annimmst, kannst du deinen Standort für 1, 6, 12 oder 24 Stunden oder dauerhaft freigeben. Anfrage ansehen:'
+      important_this_request_will_expire_in_24_hours_if_not: "⏰ Wichtig: Diese Anfrage läuft in 24 Stunden ab, wenn sie nicht bearbeitet wird. Wenn du deinen Standort nicht freigeben möchtest, ignoriere einfach diese Anfrage oder lehne sie ab. Mit freundlichen Grüßen, Evgenii von Dawarich"
+      view_request: Anfrage ansehen
+      you_can_review_this_request_and_choose_to_accept_or_2: Du kannst diese Anfrage überprüfen und entscheiden, ob du sie annimmst oder ablehnst.
+      if_you_accept_you_can_select_how_long_to_share: Wenn du annimmst, kannst du auswählen, wie lange du deinen Standort freigibst (1 Stunde, 6 Stunden, 12 Stunden, 24 Stunden oder dauerhaft).
+      view_request_2: 'Anfrage ansehen:'
+      important_this_request_will_expire_in_24_hours_if_not_2: "⏰ Wichtig: Diese Anfrage läuft in 24 Stunden ab, wenn sie nicht bearbeitet wird."
+    member_joined:
+      great_news_someone_joined_your_family: "\U0001F389 Toll! Jemand hat deine Familie betreten!"
+      hi: Hallo
+      we_re_excited_to_let_you_know_that: Wir freuen uns, dir mitzuteilen, dass
+      has_just_joined_your_family: ist gerade deiner Familie „
+      on_dawarich: "\" auf Dawarich!"
+      now_you_can: 'Jetzt kannst du:'
+      see: sehen
+      s_current_location_if_they_ve_enabled_sharing: "'s aktuellen Standort (falls sie Standortfreigabe aktiviert haben)"
+      stay_connected_with_your_growing_family: Mit deiner wachsenden Familie verbunden bleiben
+      share_your_location_with: Deinen Standort mit
+      manage_family_members_and_settings_from_your_family_page: Verwalte Familienmitglieder und Einstellungen auf deiner Familienseite
+      tip: "\U0001F4A1 Tipp:"
+      you_can_manage_your_family_members_and_privacy_settings_at: Du kannst deine Familienmitglieder und Datenschutzeinstellungen jederzeit in der Familienübersicht verwalten.
+      your_family_now_has: Deine Familie hat jetzt
+      member: Mitglied
+      best_regards: Mit freundlichen Grüßen,
+      evgenii_from_dawarich: Evgenii von Dawarich
+      great_news_someone_joined_your_family_hi: Großartige Nachricht! Jemand hat deine Familie betreten! Hallo
+      we_re_excited_to_let_you_know_that_2: "! Wir freuen uns, dir mitzuteilen, dass"
+      on_dawarich_now_you_can_see: "\" auf Dawarich! Jetzt kannst du: • Deinen"
+      s_current_location_if_they_ve_enabled_sharing_stay_connected: "'s aktuellen Standort (falls sie Standortfreigabe aktiviert haben) • Mit deiner wachsenden Familie in Verbindung bleiben • Deinen Standort mit"
+      manage_family_members_and_settings_from_your_family_page_tip: "• Familie und Einstellungen von deiner Familien-Übersicht verwalten TIP: Du kannst deine Familie und Privatsphäre-Einstellungen jederzeit von deiner Familien-Übersicht verwalten. Deine Familie hat jetzt"
+      best_regards_evgenii_from_dawarich: ". Mit freundlichen Grüßen, Evgenii von Dawarich"
+      great_news_someone_joined_your_family_2: Großartige Nachricht! Jemand hat deine Familie betreten!
+      see_2: "• Deinen"
+      stay_connected_with_your_growing_family_2: "• Mit deiner wachsenden Familie in Verbindung bleiben"
+      share_your_location_with_2: "• Deinen Standort mit"
+      manage_family_members_and_settings_from_your_family_page_2: "• Familie und Einstellungen von deiner Familien-Übersicht verwalten"
+      tip_you_can_manage_your_family_members_and_privacy_settings: 'TIP: Du kannst deine Familie und Privatsphäre-Einstellungen jederzeit von deiner Familien-Übersicht verwalten.'
+  home:
+    index:
+      dawarich: Dawarich
+      the_only_location_history_tracker_you_ll_ever_need: Der einzige Standortverlaufstracker, den du je benötigen wirst.
+      or: oder
+      location_history_visualisation: Visualisierung des Standortverlaufs
+      effortlessly_import_your_location_history_from_google_maps_timeline_and: Leicht importiere deine Standortverlauf aus Google Maps Timeline und Owntracks. Sieh deine Reisen auf einer interaktiven Karte an, vollständig mit anpassbaren Schichten wie Heatmaps, Punkten und Verbindungslinien, um deine Reisen zu visualisieren.
+      comprehensive_travel_statistics: Umfassende Reisestatistiken
+      gain_insights_into_your_travel_patterns_with_detailed_statistics_track: Erhalte Einblicke in deine Reisemuster mit detaillierten Statistiken. Verfolge die Anzahl der besuchten Länder und Städte sowie die Gesamtstrecke. Teile deine Daten nach Jahren und Monaten für einen klaren Überblick über deine Reisen.
+      self_hosted_and_private: Selbst gehostet und privat
+      maintain_complete_control_over_your_data_with_our_self_hosted: Erhalte volle Kontrolle über deine Daten mit unserer selbsthosteten Lösung. Dawarich stellt sicher, dass dein Standortverlauf privat und sicher bleibt, wodurch du dir während der Nutzung eines robusten Tracking-Systems Ruhe gönnst.
+      find_more_on: Mehr auf
+      the_website: die Website
+      or_check_out_the: ", oder schaue dir die"
+      source_code: Quellcode
+      on_github: auf GitHub an.
+      sign_up: Melde dich an
+      sign_in: Melde dich an
+  imports:
+    extraction_card:
+      additional_data: Zusätzliche Daten
+      this_import_format_doesn_t_carry_visits_named_places_or: Dieses Importformat enthält keine Aufenthalte, benannten Orte oder Verkehrsmittel, also gibt es nichts zusätzlich zu extrahieren.
+      extracted: Extrahiert
+      visits: Aufenthalte,
+      places: Orte,
+      tracks: Tracks,
+      transportation_mode_segments: Abschnitte nach Fortbewegungsart.
+      re_extract: Nochmal extrahieren
+      this_extraction_stopped_responding_it_s_safe_to_start_it: Diese Extraktion antwortet nicht mehr. Es ist sicher, sie erneut zu starten.
+      start_over: Von vorne anfangen
+      extraction_failed: 'Extraktion fehlgeschlagen:'
+      retry_extraction: Extraktion wiederholen
+      dawarich_originally_imported_your_file_as_raw_gps_points_click: Dawarich hat deine Datei ursprünglich als rohe GPS-Punkte importiert. Klicke unten, um auch Aufenthalte, Orte, Tracks und Fortbewegungsarten zu extrahieren.
+      extract_additional_data: Zusätzliche Daten extrahieren
+      extracting: Extrahiere…
+      queued: In der Warteschlange…
+    extraction_dialog:
+      extract_additional_data_from_this_import: Zusätzliche Daten aus dieser Importdatei extrahieren
+      dawarich_originally_imported_your_file_as_raw_gps_points_the: 'Dawarich hat deine Datei ursprünglich als Roh-GPS-Punkte importiert. Die Datei enthält außerdem:'
+      visits: Aufenthalte
+      places_where_the_source_app_recorded_you_spending_time_with: "— Orte, an denen die Quelle-App festgehalten hat, dass du Zeit verbracht hast, mit Start- und Endzeit."
+      tracks: Tracks
+      journeys_identified_between_those_visits_with_their_classified_transport: "— Reisen, die zwischen diesen Aufenthalten erkannt wurden, mit ihrer klassifizierten Fortbewegungsmethode (Fahren, Gehen, Radfahren, ÖPNV, …)."
+      places: Orte
+      the_named_places_home_work_frequent_restaurants_the_source_app: "— die benannten Orte (Zuhause, Arbeit, häufige Restaurants) die die Quelle-App mit deinen Aufenthalten verknüpft."
+      click: Klick
+      extract: Extrahieren
+      to_add_this_data_to_your_dawarich_account_existing_points: um diese Daten deinem Dawarich-Konto hinzuzufügen. Bestehende Punkte werden nicht verändert. Aufenthalte und Orte, die Dawarich bereits aus deinen Punkten erkannt hat, bleiben parallel zu den importierten Einträgen erhalten.
+      trust_the_source_app_s_classification: Vertraue der Klassifizierung der Quelle-App
+      when_checked_transportation_modes_driving_walking_cycling_transit_the_so: Wenn aktiviert, werden Fortbewegungsmethoden (Fahren, Gehen, Radfahren, ÖPNV) so beibehalten, wie sie die Quelle-App zugeteilt hat. Wenn deaktiviert, führt Dawarich erneut seinen eigenen Erkennungsalgorithmus mit deinen Einstellungen aus.
+      cancel: Abbrechen
+      close: schließe
+    extraction_remove_button:
+      remove_extracted_data: Extrahierte Daten entfernen
+      remove_the_visits_places_and_tracks_this_extraction_created_your: Entferne die Aufenthalte, Orte und Tracks, die diese Extraktion erstellt hat? Deine importierten GPS-Punkte werden beibehalten.
+    form:
+      supported_import_formats: Unterstützte Importformate
+      google_maps: 'Google Maps:'
+      records_json_semantic_history_phone_takeout_json: records.json, Semantic History, Phone Takeout (.json)
+      google_photos: 'Google Fotos:'
+      takeout_metadata_sidecars_json: Takeout-Metadaten-Sidecars (.json)
+      gpx: 'GPX:'
+      track_files_gpx: Track-Dateien (.gpx)
+      geojson: 'GeoJSON:'
+      feature_collections_json_geojson: Feature-Sammlungen (.json, .geojson)
+      owntracks: 'OwnTracks:'
+      recorder_files_rec: Recorder-Dateien (.rec)
+      kml: 'KML:'
+      kml_files_kml_kmz: KML-Dateien (.kml, .kmz)
+      fit: 'FIT:'
+      garmin_activity_files_fit: Garmin-Aktivitätsdateien (.fit)
+      tcx: 'TCX:'
+      training_center_files_tcx: Training Center-Dateien (.tcx)
+      csv: 'CSV:'
+      location_data_csv: Standortdaten (.csv)
+      polarsteps: 'Polarsteps:'
+      locations_json_json: locations.json (.json)
+      zip: 'ZIP:'
+      archives_containing_any_of_the_above_zip: Archive mit einem der oben genannten Formate (.zip)
+      file_format_is_automatically_detected_during_upload: Dateiformat wird während des Uploads automatisch erkannt.
+      for_files_larger_than_200mb_consider_compressing_them_into_a: Für Dateien größer als 200MB solltest du sie vor dem Upload in eine ZIP-Datei komprimieren. Dies reduziert die Uploadzeit deutlich und vermeidet Verbindungsabbrüche.
+      trial_limitations_max_5_imports_10mb_per_file: 'Testlimitierungen: Max. 5 Importe, 10MB pro Datei.'
+      current_imports: 'Aktuelle Importe:'
+      select_one_or_multiple_files: Wähle eine oder mehrere Dateien
+      files_will_be_uploaded_directly_to_storage_please_be_patient: Dateien werden direkt in die Speicherung hochgeladen. Bitte sei während des Uploads geduldig.
+    import:
+      name: Name
+      imported_points: Importierte Punkte
+      created_at: Erstellt am
+      show_this_import: Diesen Import anzeigen
+      edit_this_import: Diesen Import bearbeiten
+    table_row:
+      demo: Demo
+      points_at_coordinates_and_timestamps_that_already_exist_in_your: Standortpunkte mit Koordinaten und Zeitstempeln, die bereits in deiner Zeitleiste existieren, wurden übersprungen, um Duplikate zu vermeiden.
+      already_imported: bereits importiert
+      deleting: Löschen...
+      deletion_stalled: Löschung angehalten
+      retry_deletion: Löschung wiederholen
+      are_you_sure: Bist du sicher?
+      view_on_map: Auf Karte anzeigen
+      view_points: Standortpunkte ansehen
+      download_file: Datei herunterladen
+      delete_import: Import löschen
+    edit:
+      editing_import: Import bearbeiten
+      back_to_imports: Zurück zu Imports
+    index:
+      new_import: Neuer Import
+      import_from_immich: Von Immich importieren
+      import_from_photoprism: Von Photoprism importieren
+      no_imports_yet: Noch keine Imports
+      import_your_location_data_from_google_maps_timeline_gpx_files: Importiere deine Standortdaten aus Google Maps Timeline, GPX-Dateien, OwnTracks oder anderen Quellen, um zu beginnen.
+      create_your_first_import: Erstelle deinen ersten Import
+      actions: Aktionen
+      imports: Importe
+      are_you_sure: Bist du sicher?
+      name: Name
+      points: Punkte
+      status: Status
+      created: Erstellt
+    new:
+      back_to_imports: Zurück zu Imports
+      google_timeline_file_too_large: Google Timeline-Datei zu groß?
+      your_data_never_leaves_your_browser: "— deine Daten verlassen nie deinen Browser."
+      new_import: Neuer Import
+      split_it_with_our_free_private_tool: Teile es mit unserem kostenlosen privaten Tool
+      new_import_2: Neuer Import
+    show:
+      edit_this_import: Diesen Import bearbeiten
+      destroy_this_import: Diesen Import löschen
+      are_you_sure_this_action_will_delete_all_points_imported: Bist du sicher? Diese Aktion wird alle Punkte löschen, die mit dieser Datei importiert wurden
+      back_to_imports: Zurück zu Imports
+      import: Importieren
+  insights:
+    activity_breakdown:
+      activity_breakdown: Aktivitätsauflistung
+      no_activity_data_available_for_this_period: Keine Aktivitätsdaten für diese Periode verfügbar
+      driving: Fahren
+      walking: Gehen
+      stationary: Stationär
+      cycling: Radfahren
+      flying: Fliegen
+      train: Zug
+      running: Laufen
+      bus: Bus
+      boat: Schiff
+      motorcycle: Motorrad
+    activity_heatmap:
+      activity_overview: Aktivitätsübersicht
+      active_days: aktive Tage
+      less: Weniger
+      more: Mehr
+      mon: Mo
+      wed: Mi
+      fri: Fr
+    activity_streak:
+      activity_streak: Aktivitätsstreak
+      current: aktuell
+      longest_streak: Längster Streak
+    header:
+      insights: Einblicke
+      your_personal_movement_analytics_and_travel_patterns: Deine persönlichen Bewegungsanalysen und Reisemuster
+      by_year: Nach Jahr
+      overview: Übersicht
+      all_time: Gesamtzeitraum
+    location_clusters:
+      top_visited_locations: Top besuchte Orte
+      total_time: Gesamtzeit
+      no_visit_data_available_for_this_period: Für diesen Zeitraum sind keine Aufenthaltsdaten verfügbar.
+      confirmed_visits_will_appear_here: Bestätigte Aufenthalte werden hier angezeigt.
+    monthly_digest:
+      total_distance: Gesamtdistanz
+      active_days: Aktive Tage
+      countries: Länder
+      cities: Städte
+      weekly_pattern: WÖCHENTLICHER ABLAUF
+      top_locations: TOP ORTE
+      no_location_data: Keine Standortdaten
+      first_visits: ERSTE AUFENTHALTE
+      country: Land
+      city: Stadt
+      no_new_places_this_month: Keine neuen Orte in diesem Monat
+      vs_previous_month: IM VORHERIGEN MONAT
+      distance: Distanz
+      countries_2: Länder
+      monthly_digest: Monatlicher Überblick
+      select_a_month_to_view_its_digest: 'Wähle einen Monat aus, um seinen Überblick anzuzeigen:'
+    movement_wellness:
+      movement_wellness: Bewegung & Wohlbefinden
+      active_time: AKTIVE ZEIT
+      walking: Gehen
+      total: gesamt
+      running: Laufen
+      cycling: Radfahren
+      driving: Fahren
+      no_activity_data_available_for_this_period: Keine Aktivitätsdaten für diese Periode verfügbar
+      sedentary_vs_active: SITZEND VS AKTIV
+      in_transport: Im Transport
+      stationary: Stationär
+      active_movement: Aktive Bewegung
+      ratio: 'Verhältnis:'
+      active_vs_sedentary: aktiv vs sedentär
+      no_movement_data_available_for_this_period: Keine Bewegungsdaten für diese Periode verfügbar.
+      track_data_with_transportation_modes_will_appear_here: Track-Daten mit Verkehrsmitteln werden hier angezeigt.
+    pro_locked_card:
+      available_on_pro: Verfügbar auf Pro
+      upgrade_to_pro: Auf Pro upgraden
+    stats_row:
+      total_distance: GESAMTSTrecke
+      all_tracked_history: Alle verfolgten Historie
+      vs: vs
+      in: in
+      this_year: Dieses Jahr
+      countries: Länder
+      new_vs: neu vs
+      cities: Städte
+      days_traveling: Reisetage
+      active_days_this_year: Aktive Tage dieses Jahr
+      no_stats_data_available: Keine Statistikdaten verfügbar
+      stats_are_calculated_from_your_tracked_points: ". Die Statistiken werden aus deinen verfolgten Standortpunkten berechnet."
+    top_visited_locations:
+      top_visited_locations: Top besuchte Orte
+      total_time: Gesamtzeit
+      no_visit_data_available_for_this_period: Für diesen Zeitraum sind keine Aufenthaltsdaten verfügbar.
+      confirmed_visits_will_appear_here: Bestätigte Aufenthalte werden hier angezeigt.
+    travel_patterns:
+      when_do_you_travel: Wann reist du?
+      time_of_day_distribution: ZEIT DES TAGES VERTEILUNG
+      day_of_week: TAG DES WOCHENENDES
+      seasonality: SEASONALITÄT
+      insight: Erkenntnis
+    travel_story:
+      your_travel_story: Deine Reiseerzählung
+      summer_2024: Sommer 2024
+      june_15_july_20: 15. Juni - 20. Juli
+      days: 35 Tage
+      230_km: 4.230 km
+      the_great_european_road_trip: "„Der große europäische Roadtrip“"
+      you_started_in: Du begannst in
+      berlin: Berlin
+      your_home_base_after_a_week_of_work_you_headed: ", deiner Heimatstadt. Nach einer Woche Arbeit stachst du südlich durch"
+      dresden: Dresden
+      and: und
+      prague: Prag
+      spending_3_days_exploring_the_city_of_a_hundred_spires: ", um drei Tage die Stadt der hundert Spitzengeschäfte zu erkunden."
+      the_journey_continued_through: Die Reise setzte ihren Weg fort durch
+      vienna: Wien
+      where_you_spent_a_weekend_before_crossing_into_italy_you: ", wo du einen Wochenendeurlaub verbrachte, bevor du in Italien einfiel. Du durchquerte die Alpen, hieltst an"
+      lake_como: See Como
+      for_two_nights_of_swimming_and_pasta: für zwei Nächte Schwimmen und Pasta.
+      rome: Rom
+      welcomed_you_for_5_days_of_ancient_history_then_you: willkommensbereit für 5 Tage antike Geschichte, dann stachst du die Küste südlich zu
+      amalfi: Amalfi
+      with_stops_in_naples_and_positano: ", mit Haltepunkten in Neapel und Positano."
+      journey_timeline: REISEZEITLEISTE
+      de: DE
+      home_base: Heimatbasis
+      overnight: Übernachtung
+      cz: CZ
+      days_exploring: 3 Tage Erkundung
+      at: AT
+      weekend_stay: Weekend-Aufenthalt
+      it: IT
+      swimming_pasta: Schwimmen & Pasta
+      days_of_history: 5 Tage Geschichte
+      amalfi_coast: Amalfi-Küste
+      positano_naples: Positano, Neapel
+      florence: Florenz
+      art_coffee: Kunst & Kaffee
+      milan: Mailand
+      fashion_district: Modeviertel
+      munich: München
+      beer_gardens: Biergärten
+      back_home: Zurück nach Hause
+      new_countries: Neue Länder
+      cz_at_it_fr: CZ, AT, IT, FR
+      km: 890 km
+      longest_drive: Längste Fahrt
+      rome_rarr_amalfi: Rom → Amalfi
+      favorites_marked: Favoriten markiert
+      places: Orte
+    year_comparison:
+      your_journey: 'Deine Reise:'
+      vs: vs
+      distance: STrecke
+      countries: Länder
+      days_traveling: Tagen unterwegs
+      days: Tage (
+      days_2: Tage
+      biggest_month: GRÖSSTER MONAT
+    details:
+      year_comparison: Jahresvergleich
+      activity_breakdown: Aktivitätsübersicht
+      location_clusters: Ortscluster
+      monthly_digest: Monatlicher Überblick
+      travel_patterns: Reisemuster
+      movement_wellness: Bewegung & Wohlbefinden
+    index:
+      geodata_insights_bull_powered_by_your_location_history: Geodaten-Insights • Erlebt durch deinen Standortverlauf
+      activity_heatmap: Aktivitätsheatmap
+      activity_streak: Aktivitätsreihe
+      year_comparison: Jahresvergleich
+      activity_breakdown: Aktivitätsübersicht
+      location_clusters: Ortscluster
+      monthly_digest: Monatlicher Überblick
+      travel_patterns: Reise Muster
+      movement_wellness: Bewegung & Wohlbefinden
+      insights: Einblicke
+  kaminari:
+    first_page:
+      laquo: "«"
+    last_page:
+      raquo_raquo: "»»"
+    next_page:
+      raquo: "»"
+    paginator:
+      pager: Pager
+    prev_page:
+      laquo: "«"
+  layouts:
+    map:
+      you_re_viewing_demo_data: Du siehst Demo-Daten.
+      delete: Löschen
+    shared:
+      dawarich: Dawarich
+      try_dawarich_cloud: Probier Dawarich Cloud aus
+      shared_with_dawarich: Mit Dawarich geteilt
+      map_your_own_journeys: Karte deine eigenen Reisen.
+      dawarich_turns_your_own_location_history_into_maps_worth_sharing: Dawarich verwandelt deine eigene Standortgeschichte in Karten, die sich teilen lohnen — open-source, selbsthostbar und dein Eigentum.
+      see_how_it_works: Sieh dir an, wie es funktioniert
+      open_source: Open Source
+      self_hostable: Selbst hostbar
+      managed_cloud_no_setup: Managed Cloud — kein Setup
+      shared_on_dawarich: Auf Dawarich geteilt
+      dawarich_logo: Dawarich-Logo
+  map:
+    onboarding_modal:
+      welcome_to_dawarich: Willkommen bei Dawarich!
+      your_map_starts_with_your_next_step_literally: Deine Karte beginnt mit deinem nächsten Schritt — wörtlich.
+      start_tracking_now: Jetzt starten
+      minutes: 2 Minuten
+      get_the_app_scan_a_qr_code_and_watch_your: Hol dir die App, scanne einen QR-Code und sieh deine ersten Punkte auf der Karte heute.
+      i_have_data: Ich habe Daten
+      import_google_takeout_gpx_kml_geojson_or_owntracks_files: Importiere Google Takeout-, GPX-, KML-, GeoJSON- oder OwnTracks-Dateien.
+      explore_with_demo_data: Erkunde mit Demo-Daten
+      load_sample_location_data_3_days_in_berlin_to_see: Lade Beispieldaten (3 Tage in Berlin) herunter, um zu sehen, wie deine Karte aussehen könnte. Du kannst sie jederzeit löschen.
+      skip_for_now: Jetzt überspringen
+      import_your_data: Importiere deine Daten
+      supported_formats: Unterstützte Formate
+      google_maps: 'Google Maps:'
+      records_json_semantic_history_phone_takeout_json: Records.json, Semantic History, Phone Takeout (.json)
+      gpx: 'GPX:'
+      track_files_gpx: Track-Dateien (.gpx)
+      geojson: 'GeoJSON:'
+      feature_collections_json: Feature-Sammlungen (.json)
+      owntracks: 'OwnTracks:'
+      recorder_files_rec: Recorder-Dateien (.rec)
+      kml: 'KML:'
+      kml_files_kml_kmz: KML-Dateien (.kml, .kmz)
+      file_format_is_automatically_detected_during_upload: Die Dateiformat wird während des Uploads automatisch erkannt.
+      trial_limitations_max_5_imports_10mb_per_file_current_imports: 'Testzeitraum-Begrenzungen: Maximal 5 Importe, 10 MB pro Datei. Aktuelle Importe:'
+      select_one_or_multiple_files: Wähle eine oder mehrere Dateien
+      files_will_be_uploaded_directly_to_storage_please_be_patient: Dateien werden direkt in die Speicherung hochgeladen. Bitte sei geduldig während des Uploads.
+      start_tracking: Tracking starten
+      download_the_app: Lade die App herunter
+      scan_qr_code_to_connect: Scanne den QR-Code, um zu verbinden
+      scan_this_qr_code_with_the_dawarich_app_to_automatically: Scanne diesen QR-Code mit der Dawarich-App, um die Verbindung automatisch zu konfigurieren.
+      or: ODER
+      grab_your_api_key_from: Hol dir deinen API-Schlüssel von
+      and_follow_the: und folge den
+      have_old_location_history_like_a_google_takeout_tracking_works: Du hast alte Standortdaten, wie bei Google Takeout? Tracking funktioniert sofort – du kannst
+      import_your_history_anytime: deine Geschichte jederzeit importieren
+      got_it_let_s_start: Verstanden, los geht's!
+      close: schließen
+      import_files: Dateien importieren
+      settings: Einstellungen
+      setup_guide: Einrichtungsanleitung
+    leaflet:
+      settings_modals:
+        route_opacity: Route-Opacity
+        value_in_percent: Wert in Prozent.
+        this_value_is_the_opacity_of_the_route_on_the: Dieser Wert ist die Opazität der Route auf der Karte. Der Wert wird in Prozent angegeben und kann zwischen 0 und 100 eingestellt werden. Der Standardwert ist 100, was bedeutet, dass die Route voll sichtbar ist. Wenn du den Wert auf 0 setzt, ist die Route unsichtbar.
+        close: Schließen
+        fog_of_war: Nebel des Krieges
+        value_in_meters: Wert in Metern.
+        here_you_can_set_the_radius_of_the_cleared_area: Hier kannst du den Radius des „geklärten“ Bereichs um einen Punkt festlegen, wenn der Nebel des Krieges-Modus aktiviert ist. Der Bereich um den Punkt wird geclart, und der Rest der Karte wird mit Nebel bedeckt. Der geclarte Bereich wird ein Kreis mit dem Punkt als Mittelpunkt und dem hier festgelegten Radius sein.
+        fog_of_war_line_threshold: Nebel des Krieges Linien-Schwelle
+        value_in_seconds: Wert in Sekunden.
+        points_in_the_fog_are_connected_by_lines_this_value: Punkte im Nebel werden durch Linien verbunden. Dieser Wert ist die maximale Zeit zwischen zwei Punkten, um durch eine Linie verbunden zu werden. Wenn die Zeit zwischen zwei Punkten größer als dieser Wert ist, werden sie nicht verbunden.
+        meters_between_routes: Meter zwischen Routen
+        points_on_the_map_are_connected_by_lines_this_value: Punkte auf der Karte werden durch Linien verbunden. Dieser Wert ist die maximale Distanz zwischen zwei Punkten, um durch eine Linie verbunden zu werden. Wenn die Distanz zwischen zwei Punkten größer als dieser Wert ist, werden sie nicht verbunden und die Linie wird nicht gezeichnet. Dies ermöglicht es, die Route in kleinere Abschnitte zu unterteilen und Linien zwischen Punkten zu vermeiden, die sich weit voneinander entfernt sind.
+        minutes_between_routes: Minuten zwischen Routen
+        value_in_minutes: Wert in Minuten.
+        points_on_the_map_are_connected_by_lines_this_value_2: Punkte auf der Karte werden durch Linien verbunden. Dieser Wert ist die maximale Zeit zwischen zwei Punkten, um durch eine Linie verbunden zu werden. Wenn die Zeit zwischen zwei Punkten größer als dieser Wert ist, werden sie nicht verbunden. Dies ermöglicht es, die Route in kleinere Abschnitte zu unterteilen und Linien zwischen Punkten zu vermeiden, die sich weit voneinander entfernt sind.
+        visit_time_threshold: Schwellenwert für Aufenthaltsdauer
+        this_value_is_the_threshold_based_on_which_a_visit: Dieser Wert bestimmt, wann ein Aufenthalt beginnt. Ist der zeitliche Abstand zwischen zwei aufeinanderfolgenden Punkten größer, beginnt ein neuer Aufenthalt. Ist er kleiner, wird der vorherige Aufenthalt fortgesetzt.
+        for_example_if_you_set_this_value_to_30_minutes: 'Beispiel: Bei einem Wert von 30 Minuten gelten vier Punkte mit jeweils 20 Minuten Abstand als ein Aufenthalt. Liegen zwischen den ersten beiden Punkten 20 Minuten und zwischen dem dritten und vierten Punkt 40 Minuten, wird der Aufenthalt in zwei Aufenthalte aufgeteilt.'
+        default_value_is_30_minutes: Standardwert ist 30 Minuten.
+        merge_threshold: Verschmelzschwellwert
+        this_value_is_the_threshold_based_on_which_two_visits: Dieser Schwellenwert bestimmt, wann zwei Aufenthalte zusammengeführt werden. Ist der zeitliche Abstand kleiner als der Wert, werden sie zu einem Aufenthalt zusammengeführt. Ist er größer, bleiben sie getrennte Aufenthalte.
+        for_example_if_you_set_this_value_to_30_minutes_2: 'Beispiel: Bei einem Wert von 30 Minuten werden zwei Aufenthalte mit 20 Minuten Abstand zusammengeführt. Bei 40 Minuten Abstand bleiben sie getrennt.'
+        default_value_is_15_minutes: Der Standardwert ist 15 Minuten.
+        points_rendering_mode: Darstellungsmodus der Punkte
+        to_improve_map_performance_you_can_set_the_rendering_mode: Um die Kartenleistung zu verbessern, kannst du den Darstellungsmodus der Punkte auf "Vereinfacht" setzen.
+        in_this_mode_the_points_that_are_closer_to_each: In diesem Modus werden Punkte, die näher als 20 Sekunden oder 50 Meter voneinander entfernt sind, nicht dargestellt. Dies kann die Kartenleistung deutlich verbessern, besonders wenn du viele Punkte auf der Karte hast.
+        the_raw_mode_will_render_all_points_on_the_map: Der "Rohmodus" wird alle Punkte auf der Karte darstellen, unabhängig vom Abstand in Raum und Zeit zwischen ihnen.
+        speed_colored_routes: Geschwindigkeitsfarbige Routen
+        this_checkbox_will_color_the_routes_based_on_the_speed: Diese Option färbt die Routen anhand der Geschwindigkeit jedes Abschnitts.
+        uncheck_this_checkbox_if_you_want_to_disable_the_speed: Deaktiviere diese Option, wenn du die geschwindigkeitsfarbigen Routen deaktivieren möchtest.
+        speed_coloring_is_based_on_the_following_color_stops: 'Die Geschwindigkeitsfärbung basiert auf den folgenden Farbstopps:'
+        km_h_green_stationary_or_walking: 0 km/h — grün, stillstehend oder zu Fuß
+        km_h_cyan_jogging: 15 km/h — cyan, Laufen
+        km_h_magenta_cycling: 30 km/h — magenta, Fahrrad fahren
+        km_h_yellow_urban_driving: 50 km/h — gelb, Stadtverkehr
+        km_h_orange_red_highway_driving: 100 km/h — Orangerot, Autobahnfahrt
+        live_map: Live-Karte
+        this_checkbox_will_enable_the_live_map: Diese Checkbox aktiviert die Live-Karte.
+        uncheck_this_checkbox_if_you_want_to_disable_the_live: Deaktiviere diese Checkbox, wenn du die Live-Karte deaktivieren möchtest.
+        when_the_live_map_is_enabled_the_map_will_update: Wenn die Live-Karte aktiviert ist, aktualisiert sich die Karte in Echtzeit mit den neuesten Punkten.
+        speed_color_scale: Farbskala für Geschwindigkeit
+        value_in_format: Wert im Format
+        speed_kmh_hex_color: speed_kmh:hex_color|...
+        here_you_can_set_a_custom_color_scale_for_speed: Hier kannst du eine benutzerdefinierte Farbskala für Geschwindigkeitsfarbverläufe festlegen. Sie verwendet Farbstopps bei angegebenen km/h-Werten und erstellt einen Farbverlauf daraus. Der Standardwert ist
+        00ff00_15_00ffff_30_ff00ff_50_ffff00_100_ff3300: 0:#00ff00|15:#00ffff|30:#ff00ff|50:#ffff00|100:#ff3300
+        you_can_also_use_the_edit_colors_button_to_edit: Du kannst auch den 'Farben bearbeiten'-Button verwenden, um es über eine Oberfläche zu bearbeiten.
+      sunset_banners:
+        family_location_history_is_only_shown_on_the_new_map: Der Standortverlauf deiner Familie wird nur auf der neuen Karte (v2) angezeigt.
+        to_see_where_your_family_has_been: um zu sehen, wo deine Familie gewesen ist.
+        dismiss: Verwerfen
+        you_re_using_the_classic_map_v1_which_will_be: Du verwendest die klassische Karte (v1), die im
+        august_2026: August 2026 auslaufen wird
+        open_the_new_map: Den neuen Kartenansicht öffnen
+        switch_to_the_new_map: Zur neuen Kartenansicht wechseln
+      index:
+        map: Karte
+    maplibre:
+      area_creation_modal:
+        create_new_area: Neues Gebiet erstellen
+        area_name: Gebietsnamen *
+        radius: Radius
+        meters: Meter
+        cancel: Abbrechen
+        e_g_home_office_gym: z. B. Home, Büro, Gym...
+        radius_in_meters: Radius in Metern
+        create_area: Gebiet erstellen
+        creating: Wird erstellt...
+      button_cluster:
+        map_controls: Kartensteuerung
+        timeline: Zeitleiste
+        timeline_t: Zeitleiste (T)
+        layers: Schichten
+        layers_l: Schichten (L)
+        search: Suche
+        search_2: Suche (/)
+        create: Erstellen
+        create_c: Erstellen (C)
+        replay: Wiederholen
+        replay_points_for_the_current_date_range_r: Standortpunkte für den aktuellen Zeitraum wiedergeben (R)
+        poster_studio: Poster-Studio
+        settings: Einstellungen
+        settings_s: Einstellungen (S)
+        links: Links
+      residency_modal:
+        days_per_country: Tage pro Land
+        distinct_days_with_at_least_one_tracked_point_per_country: Klare Tage mit mindestens einem verfolgten Punkt pro Land. Keine Steuerratgeber.
+      settings_panel:
+        close_panel: Fenster schließen
+        layers: Schichten
+        search_for_a_place: Suche nach einem Ort
+        enter_name_of_a_place: Gib den Namen eines Ortes ein
+        search_for_a_location_to_find_places_you_visited: Suche nach einem Ort, um Orte zu finden, die du besucht hast
+        points: Punkte
+        show_individual_location_points: Zeige einzelne Standortpunkte
+        edit_points: Bearbeite Punkte
+        allow_dragging_points_to_correct_their_position: Erlaube das Ziehen von Punkten, um ihre Position zu korrigieren.
+        editing_points_is_a_pro_feature_this_stays_on_for: Die Bearbeitung von Punkten ist eine Pro-Funktion — dies bleibt für die aktuelle Sitzung aktiv, und Bewegungen werden auf dem Lite-Plan nicht gespeichert.
+        allow_dragging_points_to_correct_their_position_remembered_across_sessio: Erlaube das Ziehen von Punkten, um ihre Position zu korrigieren. Wird über Sitzungen hinweg gespeichert.
+        routes: Routen
+        show_connected_route_lines: Zeige verbundene Routenlinien
+        color_by_speed: Farbe nach Geschwindigkeit
+        edit_color_gradient: Farbverlauf bearbeiten
+        anomalies: Anomalien
+        show_filtered_gps_noise_points: Zeige gefilterte GPS-Rauschpunkte
+        tracks: Tracks
+        show_backend_calculated_tracks: Zeige backend-berechnete Tracks
+        flights: Flüge
+        show_airtrail_flights_as_arcs_hides_overlapping_gps: Flüge von AirTrail als Bögen anzeigen (überlappende GPS-Daten verbergen)
+        heatmap: Heatmap
+        show_density_heatmap: Dichtegradienten-Heatmap anzeigen
+        hexagons: Hexagone
+        show_point_density_as_hexagonal_cells: Punktdichte als hexagonale Zellen anzeigen
+        visits: Aufenthalte
+        show_detected_area_visits: Erkannte Aufenthaltsorte anzeigen
+        filter_by_name: Nach Namen filtern...
+        all_visits: Alle Aufenthalte
+        confirmed_only: Nur bestätigte
+        suggested_only: Nur vorgeschlagene
+        places: Orte
+        show_your_saved_places: Deine gespeicherten Orte anzeigen
+        enable_all_tags: Alle Tags aktivieren
+        filter_by_tags: Nach Tags filtern
+        untagged: "\U0001F3F7️ Ungesponsert"
+        click_tags_to_filter_places: Klick auf Tags, um Orte zu filtern
+        photos: Fotos
+        show_geotagged_photos: Geotagte Fotos anzeigen
+        areas: Flächen
+        show_defined_areas: Definierte Flächen anzeigen
+        fog_of_war: Nebel des Krieges
+        show_explored_areas: Erkundete Flächen anzeigen
+        per_point: Pro Punkt
+        per_hexagon: Pro Sechseck
+        scratch_map: Rubbelkarte
+        show_scratched_countries: Rubbelte Länder anzeigen
+        family_members: Familienmitglieder
+        show_family_member_locations: Standorte von Familienmitgliedern anzeigen
+        click_to_center_on_member: Klicke, um auf Mitglied zu zoomen
+        appearance: Erscheinungsbild
+        custom_map_colors_layer_colors_and_vector_tiles_are_pro: Benutzerdefinierte Kartenfarben, Schichtfarben und Vektorfliesen sind Pro-Funktionen – du kannst sie hier vorschauen, aber sie werden im Lite-Plan nicht gespeichert.
+        map_style: Kartenstil
+        light: Hell
+        dark: Dunkel
+        white: Weiß
+        black: Schwarz
+        grayscale: Graustufen
+        custom: Benutzerdefiniert
+        color_themes: Farbthemen
+        customize_colors: Farben anpassen
+        globe_view: Globusansicht
+        render_map_as_a_3d_globe_requires_page_reload: Karte als 3D-Globus rendern (erfordert Neuladen der Seite)
+        route_opacity: Route-Opacity
+        layer_colors: Schichtfarben
+        reset_to_defaults: Zurücksetzen auf Standardwerte
+        distance_unit: Entfernungseinheit
+        kilometers: Kilometer
+        miles: Meilen
+        custom_basemap_url: Benutzerdefinierte Basemap-URL
+        serve_the_base_map_from_your_own_source_accepts_protomaps: Stelle die Basiskarte von deiner eigenen Quelle bereit. Akzeptiert Protomaps-Schema-Vektor-Tiles oder Raster-XYZ-Tiles (beide müssen {z}, {x} und {y} enthalten), oder eine vollständige MapLibre-Stil-URL. Lasse das leer, um die integrierten Tiles zu verwenden.
+        base_map_layers: Basiskarten-Schichten
+        toggle_base_map_elements_changes_apply_immediately: Basiskarten-Elemente ein-/ausschalten. Änderungen werden sofort angewendet.
+        pro_feature_you_can_preview_changes_here_but_they_won: Pro-Funktion — du kannst Änderungen hier vorschauen, aber sie werden auf dem Lite-Plan nicht gespeichert.
+        the_custom_style_draws_no_labels_or_points_of_interest: Der benutzerdefinierte Stil zeichnet keine Beschriftungen oder Sehenswürdigkeiten — diese Schalter sind während der Aktivierung deaktiviert.
+        points_of_interest: Sehenswürdigkeiten
+        choose_which_poi_categories_appear_on_the_map: Wähle aus, welche POI-Kategorien auf der Karte angezeigt werden.
+        meters_between_routes: Meter zwischen Routen
+        distance_threshold_for_route_splitting: Schwellenwert für die Routenunterteilung
+        minutes_between_routes: Minuten zwischen Routen
+        min: 60min
+        min_2: 1min
+        min_3: 90min
+        min_4: 180min
+        time_threshold_for_route_splitting: Zeitgrenze für die Route-Aufteilung
+        points_rendering_mode: Darstellungsmodus der Punkte
+        raw_all_points: Roh (alle Punkte)
+        simplified_reduced_points: Vereinfacht (reduzierte Punkte)
+        speed_colored_routes: Geschwindigkeitsfarbige Routen
+        color_routes_by_speed: Routen nach Geschwindigkeit färben
+        fog_of_war_radius: Radius des Nebels des Krieges
+        clear_radius_around_visited_points: Radius um besuchte Punkte löschen
+        fog_of_war_threshold: Schwellwert des Nebels des Krieges
+        minimum_points_to_clear_fog: Mindestpunkte zum Wegschaffen des Nebels
+        gps_noise_filtering: GPS-Rauschfilterung
+        hide_readings_that_cannot_be_a_real_position_impossible_jumps: Verstecke Lesungen, die keine echte Position sein können — unmögliche Sprünge, beschädigte Koordinaten. Deaktivieren, um alle Rohpunkte anzuzeigen.
+        re_evaluate_past_data: Vorherige Daten neu bewerten
+        clears_existing_anomaly_flags_and_re_runs_the_filter_on: Löscht vorhandene Anomaliefahnen und führt den Filter erneut auf allen deinen Punkten mit den aktuellen Einstellungen aus. Tracks, Statistiken und Zusammenfassungen werden danach neu erstellt. Läuft im Hintergrund.
+        recalculate_tracks_stats: Tracks & Statistiken neu berechnen
+        rebuild_tracks_stats_and_digests_from_your_current_points_without: Tracks, Statistiken und Zusammenfassungen aus deinen aktuellen Punkten neu erstellen, ohne Anomalie-Flaggen zu berühren. Nützlich nach Änderung der Routenteilungsschwellen.
+        city_statistics: Stadtstatistiken
+        min_minutes_in_city: Min. Minuten in der Stadt
+        min_5: 60 min
+        min_6: 5 min
+        min_7: 120 min
+        how_long_you_must_stay_for_a_city_to_count: Wie lange du in einer Stadt bleiben musst, damit sie in den Statistiken gezählt wird
+        max_gap_between_points: Max. Abstand zwischen Punkten
+        min_8: 120 min
+        min_9: 30 min
+        min_10: 195 min
+        min_11: 360 min
+        max_gap_between_points_before_assuming_you_left_the_city: Max. Abstand zwischen Punkten, bevor du als verlassen angesehen wirst
+        visit_max_gap: Max. Abstand für einen Aufenthalt
+        min_12: 720 min
+        max_time_gap_between_points_within_one_visit_longer_gaps: 'Max. Zeitabstand zwischen Punkten innerhalb eines Aufenthalts. Längere Abstände (z. B. leerer Akku) teilen den Aufenthalt in separate Einträge. Standardwert: 60.'
+        live_mode: Live-Modus
+        show_new_points_in_real_time: Neue Punkte in Echtzeit anzeigen
+        apply_settings: Einstellungen anwenden
+        reset_to_defaults_2: Zurücksetzen auf Standardwerte
+        transportation_mode_detection: Verkehrsmittel-Erkennung
+        checking_status: Status prüfen...
+        settings_are_locked_while_recalculation_is_in_progress: Einstellungen werden während der Neuberechnung gesperrt.
+        note: 'Hinweis:'
+        changing_these_thresholds_will_trigger_a_recalculation_of_transportation: Wenn du diese Schwellenwerte änderst, werden die Fortbewegungsarten aller Tracks neu berechnet. Je nach Anzahl der Tracks kann dies einige Zeit dauern.
+        detected_modes: Erkannte Verkehrsmittel
+        disabled_modes_won_t_be_detected_existing_tracks_aren_t: Deaktivierte Fortbewegungsarten werden nicht erkannt. Bestehende Tracks bleiben unverändert, bis du unten auf „Neu klassifizieren“ klickst.
+        expert_mode: Experten-Modus
+        show_advanced_detection_thresholds: Erweiterte Erkennungsschwellwerte anzeigen
+        walking_max_speed: Maximale Gehgeschwindigkeit
+        km_h: 7 km/h
+        cycling_max_speed: Maximale Fahrradgeschwindigkeit
+        km_h_2: 45 km/h
+        driving_max_speed: Maximale Geschwindigkeit im Straßenverkehr
+        km_h_3: 220 km/h
+        flying_min_speed: Minimale Geschwindigkeit im Flug
+        km_h_4: 150 km/h
+        speed_thresholds: Geschwindigkeitsgrenzen
+        stationary_max_speed: Maximale Geschwindigkeit bei Stillstand
+        km_h_5: 1 km/h
+        train_min_speed: Minimale Geschwindigkeit im Zug
+        km_h_6: 80 km/h
+        acceleration_thresholds: Beschleunigungs Grenzen
+        running_vs_cycling_accel: Laufen vs. Fahrradfahren - Beschleunigung
+        cycling_vs_driving_accel: Fahrradfahren vs. Straßenverkehr - Beschleunigung
+        segment_detection: Abschnittserkennung
+        min_segment_duration: Minimale Abschnittsdauer
+        sec: 60 sec
+        time_gap_threshold: Zeitlücke-Schwellwert
+        sec_2: 180 sec
+        min_flight_distance: Minimale Flugdistanz
+        km: 100 km
+        make_changes_to_enable_the_apply_button: Änderungen vornehmen, um den Anwenden-Button zu aktivieren
+        re_runs_auto_classification_across_all_your_tracks_manually_corrected: Auto-Klassifizierung über alle deine Tracks neu durchlaufen. Manuell korrigierte Abschnitte werden beibehalten. Kann mehrere Minuten dauern.
+        loading_calendar: Kalender wird geladen…
+        less: weniger
+        more: mehr
+        filter: Filter
+        confirmed: Bestätigt
+        suggested: Vorgeschlagen
+        search_visits_places: Suche Aufenthalte, Orte…
+        tags: Tags
+        pick_a_day_in_the_calendar_to_see_visits: Wähle einen Tag im Kalender aus, um Aufenthalte zu sehen.
+        create_visit: Aufenthalt erstellen
+        create_place: Ort erstellen
+        select_area: Bereich auswählen
+        create_area: Bereich erstellen
+        replay: Wiederholen
+        days_country: Tage / Land
+        enrich_photos: Fotos bereichern
+        close: Schließen
+        match_immich_photos_without_gps_to_your_location_history: Immich-Fotos ohne GPS mit deinem Standortverlauf abgleichen.
+        from: Von
+        to: Nach
+        tolerance_minutes: Toleranz (Minuten)
+        scan_for_matches: Nach Übereinstimmungen suchen
+        scanning_immich_photos: Scanne Immich-Fotos...
+        all: Alle
+        back: Zurück
+        enrich: Bereichern
+        start: 'Start:'
+        end: 'End:'
+        duration: 'Dauer:'
+        distance: 'Strecke:'
+        avg_speed: 'Durchschn. Geschwindigkeit:'
+        points_2: 'Punkte:'
+        delete_selected_points: Ausgewählte Punkte löschen
+        delete_anomaly_points: Anomaliepunkte löschen
+        community: Community
+        discord: Discord
+        github: Github
+        mastodon: Mastodon
+        docs: Dokumentation
+        tutorial: Tutorial
+        import_existing_data: Daten importieren
+        exporting_data: Daten exportieren
+        faq: FAQ
+        contact: Kontakt
+        more_2: Mehr
+        privacy_policy: Datenschutzrichtlinie
+        terms_and_conditions: Nutzungsbedingungen
+        refund_policy: Rückgabepolitik
+        impressum: Impressum
+        blog: Blog
+        re_classify_my_history: Meinen Standortverlauf neu klassifizieren
+        manage: Verwalten
+        manage_tags_in_a_new_tab: Tags in einem neuen Tab verwalten
+        roads: Straßen
+        streets_highways_and_paths: Straßen, Autobahnen und Wege
+        railways: Schienenverkehr
+        buildings: Gebäude
+        building_numbers_visible_at_high_zoom: Gebäude-nummern (sichtbar bei hohem Zoom)
+        cities_neighborhoods_regions_and_countries: Städte, Viertel, Regionen und Länder
+        ocean_lake_and_river_names: Ozeane, Seen und Flussnamen
+        water: Wasser
+        oceans_lakes_rivers_and_streams: Ozeane, Seen, Flüsse und Flussarme
+        parks_schools_hospitals_airports_etc: Parks, Schulen, Krankenhäuser, Flughäfen, etc.
+        boundaries: Grenzen
+        food_drink: Essen & Trinken
+        restaurants_cafes_bars_bakeries_fast_food: Restaurants, Cafés, Bars, Bäckereien, Fast Food
+        shopping: Einkaufen
+        supermarkets_clothes_electronics_books_beauty: Supermärkte, Kleidung, Elektronik, Bücher, Beauty
+        transport: Verkehr
+        stations_bus_stops_airports_fuel_parking: Haltestellen, Busstopps, Flughäfen, Kraftstoff, Parkplätze
+        cycling: Radfahren
+        bike_parking_rental_and_repair_stations: Radparkplätze, Mietstationen und Reparaturstellen
+        nature_leisure: Natur & Freizeit
+        parks_forests_beaches_playgrounds_stadiums: Parks, Wälder, Strände, Spielplätze, Stadien
+        tourism_culture: Tourismus & Kultur
+        museums_theatres_attractions_viewpoints_hotels: Museen, Theatere, Sehenswürdigkeiten, Aussichtspunkte, Hotels
+        services_civic: Dienstleistungen & Bürgerliche
+        post_offices_libraries_schools_hospitals_police_banks: Postämter, Bibliotheken, Schulen, Krankenhäuser, Polizei, Banken
+        benches_toilets_drinking_water_fountains_recycling_shelters: Bänke, Toiletten, Trinkwasser, Brunnen, Recycling, Schutzstellen
+        theme_aria_label: "%{theme} Thema"
+        address_labels: Adresslabels
+        background: Hintergrund
+        building_footprints: Gebäudekonturen
+        country_and_administrative_borders: Länder und administrative Grenzen
+        land_use: Landnutzung
+        master_toggle_for_all_poi_groups_below: Hauptschalter für alle POI-Gruppen unten
+        motorway_roads: Autobahnstraßen
+        other_roads: Andere Straßen
+        parks: Parks
+        place_names: Ortsnamen
+        primary_roads: Hauptstraßen
+        residential_roads: Wohnstraßen
+        road_labels: Straßenbeschriftung
+        street_names_and_route_shields: Straßennamen und Routenschilder
+        train_tracks_and_rail_lines: Schienen und Bahnlinien
+        urban_amenities: Stadtanlagen
+        water_labels: Wasserbeschriftung
+      visit_creation_modal:
+        create_new_visit: Neuen Aufenthalt erstellen
+        visit_name: Aufenthaltsname *
+        enter_visit_name: Aufenthaltsname eingeben …
+        start_time: Startzeit *
+        end_time: Endzeit *
+        cancel: Abbrechen
+        create_visit: Aufenthalt erstellen
+      webgl_error:
+        webgl_is_not_available: WebGL ist nicht verfügbar
+        map_v2_requires_webgl_to_render_maps_please_enable_hardware: Map v2 benötigt WebGL, um Karten anzuzeigen. Aktiviere die Hardwarebeschleunigung in den Einstellungen deines Browsers oder versuche einen anderen Browser.
+        map_v1_leaflet_is_available_at: Map v1 (Leaflet) ist unter
+        but_will_be_deprecated_and_removed_in_one_of_future: verfügbar, aber wird in einer zukünftigen Version deaktiviert und entfernt.
+        map_v1: "/map/v1"
+      index:
+        loading: Lädt...
+        pick_a_day: Wähle einen Tag aus
+        confirmed: Bestätigt
+        suggested: Vorgeschlagen
+        declined: Abgelehnt
+        map: Karte
+    residency:
+      show:
+        days: Tage
+        mon: Mo
+        wed: Mi
+        fri: Fr
+        more: mehr
+        stay_periods: Aufenthaltsperioden
+        exceeds_183_day_threshold_common_in_many_tax_jurisdictions: Überschreitet die 183-Tage-Grenze, die in vielen Steuerrechtssystemen üblich ist.
+        no_country_data_for: Keine Länderdaten für
+        points_need_reverse_geocoding_to_detect_countries: Punkte benötigen umgekehrte Geokodierung, um Länder zu erkennen.
+    timeline_feeds:
+      calendar:
+        has_suggested_visits: Hat vorgeschlagene Aufenthalte
+        next_month: Nächster Monat
+        previous_month: Vorheriger Monat
+      day:
+        select: Auswählen
+        visits: Aufenthalte
+        tracks: Tracks
+        distance: Entfernung
+        moving: In Bewegung
+        no_visits_match_the_current_search_or_filter: Keine Aufenthalte passen zur aktuellen Suche oder Filter.
+        clear_search_filters: Suche & Filter löschen
+        no_visits_tracked_this_day: Keine Aufenthalte wurden an diesem Tag erfasst.
+        previous_day: Vorheriger Tag
+        next_day: Nächster Tag
+        visit_count:
+          one: "%{count} Aufenthalt"
+          other: "%{count} Aufenthalte"
+      day_banner:
+        waiting: Warte
+        confirm_all: Alle bestätigen
+        delete_all: Alle löschen
+        delete_all_visits_for_this_day_your_location_points_stay: Alle %{visits} für diesen Tag löschen? Deine Standortpunkte bleiben.
+        suggestions_waiting:
+          one: "%{count} Vorschlag wartet"
+          other: "%{count} Vorschläge warten"
+        delete_all_suggestions:
+          one: Den vorgeschlagenen Aufenthalt für diesen Tag löschen? Deine Standortpunkte bleiben.
+          other: Alle %{count} vorgeschlagenen Aufenthalte für diesen Tag löschen? Deine Standortpunkte bleiben.
+      day_nav:
+        previous_day: Vorheriger Tag
+        next_day: Nächster Tag
+      day_summary:
+        total_distance_traveled_this_day: Gesamte Strecke dieses Tages
+        distinct_places_visited_this_day: Unterschiedliche Orte dieses Tages
+        places: Orte
+        moving: in Bewegung
+        stationary: statisch
+      feed:
+        no_visits_tracked_this_day: Keine Aufenthalte dieses Tag verfolgt.
+        visits_are_auto_detected_daily_from_your_location_data: Aufenthalte werden täglich automatisch aus deinen Standortdaten erkannt.
+      journey_entry:
+        continued_from: fortgesetzt von
+        arrived: ", angekommen"
+        middot: "·"
+        continued_from_date_arrived: fortgesetzt von %{date}, angekommen
+      selection_bar:
+        selected: 0 ausgewählt
+        cancel: Abbrechen
+        mark_these_visits_as_confirmed_yes_i_was_there: Diese Aufenthalte als bestätigt markieren (ja, ich war dort)
+        confirm: Bestätigen
+        combine_the_selected_visits_into_one: Die ausgewählten Aufenthalte zu einem kombinieren
+        merge: Zusammenführen
+        remove_the_visit_grouping_your_location_points_stay: Den Aufenthalt gruppiert entfernen (deine Standortpunkte bleiben)
+        delete: Löschen
+      suggested_picker:
+        needs_review: Zur Überprüfung
+        confirm_this_visit: Diesen Aufenthalt bestätigen?
+        assigned_to: Zugeordnet zu
+        use_the_search_button_to_pick_a_different_place: ". Nutze die Suchschaltfläche, um einen anderen Ort auszuwählen."
+        no_place_for_this_visit_confirm_to_keep_it_as: Kein Ort für diesen Aufenthalt. Bestätige, um ihn so zu lassen.
+        confirm: Bestätigen
+        delete: Löschen
+        delete_this_visit_your_location_points_stay: Diesen Aufenthalt löschen? Deine Standortpunkte bleiben.
+      track_info:
+        track: 'Track #'
+        dist: Dist
+        avg: Avg
+        show_points: Punkte anzeigen
+        replay: Wiederholen
+        share: Teilen
+        unknown: Unbekannt
+      visit_entry:
+        select_visit_for_merge: Aufenthalt zum Zusammenführen auswählen
+        all_day: Ganz Tag
+        pts: pts
+        search_for_a_place: Suche nach einem Ort
+        delete: Löschen
+        delete_this_visit_your_location_points_stay: Diesen Aufenthalt löschen? Deine Standortpunkte bleiben.
+  notifications:
+    notification:
+      ago: vor
+      please_when_reporting_a_bug_to: Bitte, wenn du einen Fehler meldest, melde ihn bei
+      github_issues: GitHub-Issues
+      don_t_forget_to_include_logs_from: ", vergiss nicht, Logs von"
+      dawarich_app: dawarich_app
+      and: und
+      dawarich_sidekiq: dawarich_sidekiq
+      docker_containers_thank_you: docker containers. Danke!
+    index:
+      notifications: Benachrichtigungen
+      mark_all_as_read: Alle markieren als gelesen
+      delete_all: Alle löschen
+      are_you_sure_you_want_to_delete_all_notifications: Bist du sicher, dass du alle Benachrichtigungen löschen möchtest?
+    show:
+      back_to_notifications: Zurück zu den Benachrichtigungen
+      destroy_this_notification: Diese Benachrichtigung entfernen
+      are_you_sure: Bist du sicher?
+  places:
+    drawer:
+      source: 'Quelle:'
+      total_hours: Gesamtstunden
+      avg_dwell: Durchschnittlicher Aufenthaltszeitraum
+      no_tags: Keine Tags
+      recent_visits: Letzte Aufenthalte
+      rarr: "→"
+      'on': auf
+      no_visits_yet: Noch keine Aufenthalte
+      rename: Umbenennen
+      merge: Verbinden
+      notes: Notizen
+      save: Speichern
+      delete: Löschen
+      delete_this_place_this_cannot_be_undone: Diesen Ort löschen? Dies kann nicht rückgängig gemacht werden.
+      manual_name_title: Du hast diesen Ort benannt, daher wird der automatische Name nicht geändert. Benenne ihn um zu „%{default_name}“, um ihn wieder der automatischen Namensgebung zu übergeben.
+      visit_count:
+        one: "%{count} Aufenthalt"
+        other: "%{count} Aufenthalte"
+    nearby_places:
+      no_nearby_places_found: Keine nahen Orte gefunden
+      load_more_search_up_to_distance_m: Weitere laden (Suche bis zu %{distance}m)
+    index:
+      hello_there: Hallo da!
+      here_you_ll_find_your_places_created_by_visits_suggestion: Hier findest du deine Orte, die durch den Visits-Vorschlagsprozess erstellt wurden. Aber jetzt gibt es keine.
+      name: Name
+      created_at: Erstellt am
+      coordinates: Koordinaten
+      actions: Aktionen
+      timeline: Zeitleiste
+      places: Orte
+      delete: Löschen
+      are_you_sure_deleting_a_place_will_result_in_deleting: Bist du sicher? Das Löschen eines Ortes wird dazu führen, dass alle Aufenthalte für diesen Ort gelöscht werden.
+  points:
+    address:
+      address: 'Adresse:'
+    index:
+      export: Export
+      geojson: GeoJSON
+      gpx: GPX
+      address: Adresse
+      speed: Geschwindigkeit
+      coordinates: Koordinaten
+      recorded_at: Aufgenommen am
+      points: Punkte
+      search: Suche
+      export_as_geojson: Exportiere als GeoJSON?
+      export_as_gpx: Exportiere als GPX?
+      delete_selected: Ausgewählte löschen
+      are_you_sure: Bist du sicher?
+      select_all: Alles auswählen
+  posters:
+    poster:
+      download_png: PNG herunterladen
+      download_pdf: PDF herunterladen
+      delete: Löschen
+      delete_this_poster: Diesen Poster löschen?
+    studio:
+      poster_studio: Poster-Studio
+      load: Laden
+      today: Heute
+      last_7_days: Letzte 7 Tage
+      last_month: Letzter Monat
+      close_studio: Studio schließen
+      recenter: Zentrieren
+      drag_to_pan_scroll_to_zoom_the_frame_is_what: Ziehen, um zu verschieben, scrollen, um zu zoomen — das Bildfeld ist, was exportiert wird.
+      layout: Layout
+      theme: Thema
+      customize_colors: Farben anpassen
+      text: Text
+      show_text: Text anzeigen
+      title: Titel
+      berlin: Berlin
+      subtitle: Untertitel
+      germany: Deutschland
+      coordinates_line: Koordinatenlinie
+      font: Schriftart
+      layers: Schichten
+      track_opacity: Track-Opacity
+      track_width: Track-Breite
+      recent_posters: Letzte Poster
+      server_rendered_posters_from_save_to_gallery_they_stay_here: Server-renderte Poster von „Speichern in Galerie“ — sie bleiben hier über Sitzungen hinweg.
+      export_a_file: Exportiere eine Datei
+      format: Format
+      png: PNG
+      pdf: PDF
+      print_dpi: Druck-DPI
+      download: Herunterladen
+      render_this_area_server_side_as_the_classic_3_4: Diesen Bereich serverseitig als klassischen 3:4-Druckplakat rendern und in Recent Posters speichern
+      save_to_gallery: In Galerie speichern
+      order_a_print: Druck bestellen
+      order_a_printed_poster: Plakat drucken bestellen
+      free_eu_shipping: Kostenlose EU-Versand
+      choose_a_print_size: Druckgröße auswählen
+      cancel: Abbrechen
+      pay_via_stripe: "· Bezahlung über Stripe"
+      printed_by_gelato_exactly_as_previewed_made_to_order_so: Druck von Gelato, exakt wie vorgesehen. Auf Bestellung gefertigt, so dass das gesetzliche Widerrufsrecht von 14 Tagen nicht mehr gilt, sobald die Produktion startet (§312g Abs. 2 Nr. 1 BGB).
+      order_this_poster: Dieses Plakat bestellen
+      back: Zurück
+      preparing_poster: 1. Plakat vorbereiten
+      uploading_poster: 2. Plakat hochladen
+      continue_to_order: 3. Weiter zur Bestellung
+      continue_to_payment: Weiter zur Bezahlung
+      checkout_not_working_open_your_order_page: Bestellabwicklung nicht funktioniert? Deine Bestellseite öffnen
+      close: Schließen
+      roads: Straßen
+      water: Wasser
+      parks_land_use: Parks & Landnutzung
+      buildings: Gebäude
+      railways: Schienenwege
+      boundaries: Grenzen
+      theme_aria_label: "%{theme} Thema"
+      background: Hintergrund
+      motorway_roads: Autobahnstraßen
+      other_roads: Andere Straßen
+      parks: Parks
+      primary_roads: Hauptstraßen
+      residential_roads: Wohnstraßen
+      track: Track
+  settings:
+    navigation:
+      general: Allgemein
+      integrations: Integrationen
+      map: Karte
+      visits: Aufenthalte
+      two_factor_authentication: Zwei-Faktor-Authentifizierung
+      users: Benutzer
+      background_jobs: Hintergrundaufgaben
+    background_jobs:
+      index:
+        spamming_many_new_jobs_at_once_is_a_bad_idea: Das Erstellen vieler neuer Aufgaben auf einmal ist eine schlechte Idee. Lass sie arbeiten oder leere die Warteschlange zuerst.
+        gps_noise_detection_changed_in_this_release_so_your_existing: Die GPS-Rauschdetektion wurde in dieser Version geändert, weshalb deine vorhandenen Punkte für eine einmalige Überprüfung in die Warteschlange gegeben werden. Deine Tracks, Statistiken und Zusammenfassungen werden aus dem Ergebnis neu erstellt, was bei einem großen Standortverlauf etwas länger dauern kann – einige Punkte können auf der Karte verschwinden oder erscheinen, sobald der Vorgang abgeschlossen ist. Keine Punkte werden gelöscht, und der Vorgang läuft in der niedrigsten Prioritätswarteschlange, sodass alles andere priorisiert wird.
+        start_reverse_geocoding: Reverse Geocoding starten
+        this_job_will_re_run_reverse_geocoding_process_for_all: Diese Aufgabe wird den Reverse Geocoding-Prozess für alle Punkte in deiner Datenbank erneut durchlaufen. Es kann mehrere Tage oder sogar Wochen dauern, abhängig von der Anzahl der Punkte, die du hast!
+        continue_reverse_geocoding: Reverse Geocoding fortsetzen
+        this_job_will_process_reverse_geocoding_for_all_points_that: Diese Aufgabe wird Reverse Geocoding für alle Punkte durchführen, die noch keine Geodaten haben.
+        background_jobs_dashboard: Hintergrundaufgaben-Übersicht
+        this_will_open_the_background_jobs_dashboard_in_a_new: Dies öffnet die Hintergrundaufgaben-Übersicht in einem neuen Tab.
+        visits_suggestions: Aufenthaltsvorschläge
+        enable_or_disable_visits_suggestions_it_s_a_background_task: Aktiviere oder deaktiviere Aufenthaltsvorschläge. Es handelt sich um eine Hintergrundaufgabe, die täglich um Mitternacht läuft. Deaktivieren kann sinnvoll sein, wenn du keine Aufenthaltsvorschläge erhalten möchtest oder wenn du die Dawarich iOS-App verwendest, die ihre eigenen Aufenthaltsvorschläge hat.
+        background_jobs: Hintergrundaufgaben
+        start_job: Aufgabe starten
+        are_you_sure: Bist du sicher?
+        open_dashboard: Dashboard öffnen
+        disable: Deaktivieren
+        enable: Aktivieren
+    general:
+      changelog_consent:
+        what_s_new_notices: Neuigkeiten-Benachrichtigungen
+        a_what_s_new_notice_is_shown_when_a_new: Bei einer neuen Dawarich-Version wird ein Hinweis zu den Neuerungen angezeigt, auch bei Sicherheitsupdates. Dafür wird ein kleines Widget von
+        which_like_any_web_request_sees_your_ip_address_browser: ", das — wie jede Webanfrage — deine IP-Adresse, Browser und die Seite-URL sowie deine Dawarich-Version sieht. Es erhält niemals dein Konto, E-Mail-Adresse oder Standort."
+        get_a_what_s_new_notice_when_a_new_dawarich: Erhalte eine "Neuigkeiten"-Benachrichtigung, wenn eine neue Dawarich-Version veröffentlicht wird, einschließlich Sicherheitsupdates. Die Benachrichtigung lädt ein kleines Widget von
+        turn_off_notices: Benachrichtigungen deaktivieren
+        turn_on_notices: Benachrichtigungen aktivieren
+      supporter_status:
+        supporter_status: Supporter-Status
+        thank_you_for_supporting_dawarich: Danke für deine Unterstützung von Dawarich
+        email_used_for_patreon_github_ko_fi: E-Mail-Adresse, die für Patreon/GitHub/Ko-fi verwendet wird
+        github_username_for_github_sponsors_with_a_private_email: GitHub-Benutzername (für GitHub Sponsors mit privater E-Mail-Adresse)
+        not_found_in_supporter_list_make_sure_you_re_using: Nicht in der Unterstützerliste gefunden. Stelle sicher, dass du dieselbe E-Mail-Adresse oder GitHub-Nutzername verwendest, wie dein Spenden-Portal.
+        how_to_support_dawarich: Wie man Dawarich unterstützt
+        dawarich_is_a_free_and_open_source_project_your_support: 'Dawarich ist ein kostenloses und Open-Source-Projekt. Deine Unterstützung hilft dabei, Hostingkosten zu decken, die Entwicklung zu finanzieren und das Projekt am Laufen zu halten. Du kannst uns über folgende Plattformen unterstützen:'
+        patreon: Patreon
+        github_sponsors: GitHub Sponsors
+        ko_fi: Ko-fi
+        supporter_benefits: Vorteile für Unterstützer
+        access_to_reverse_geocoding_api_see_patreon_tier: Zugang zur umgekehrten Geokodierung-API (siehe Patreon-Tier)
+        mention_in_github_releases: Erwähnung in GitHub Releases
+        supporter_badge_displayed_in_the_navbar: Unterstützer-Abzeichen im Navbar angezeigt
+        supporter_example_com: supporter@example.com
+        octocat: octocat
+        verify: Überprüfen
+        supporter_thanks: Danke für deine Unterstützung von Dawarich%{platform}!
+        supporter_platform: " via %{platform}"
+      index:
+        email_preferences: E-Mail-Präferenzen
+        monthly_digest_emails: Monatlicher Newsletter
+        summary_of_your_last_month_sent_on_the_2nd: Zusammenfassung deines letzten Monats, der am 2. des Monats gesendet wird.
+        year_end_digest_emails: Jahreszusammenfassung per E-Mail
+        receive_an_annual_summary_on_january_2nd_with_your_year: Erhalte eine jährliche Zusammenfassung am 2. Januar mit einem Überblick über dein Jahr.
+        news_updates: Nachrichten & Updates
+        receive_occasional_emails_about_new_features_and_important_updates: Erhalte gelegentliche E-Mails zu neuen Funktionen und wichtigen Updates
+        timezone: Zeitzone
+        your_timezone: Deine Zeitzone
+        all_dates_and_times_will_be_displayed_in_this_timezone: Alle Daten und Uhrzeiten werden in dieser Zeitzone angezeigt
+        supporter_badge: Supporter-Badge
+        show_supporter_badge_in_navbar: Supporter-Badge im Navigationsleiste anzeigen
+        display_a_gem_icon_next_to_your_profile_to_show: Zeige einen Gem-Icon neben deinem Profil an, um deinen Supporter-Status anzuzeigen
+        general_settings: Allgemeine Einstellungen
+        save_changes: Änderungen speichern
+    integrations:
+      index:
+        immich_photoprism_integrations: Immich & Photoprism-Integrationen
+        connect_your_photo_management_tools_to_see_your_photos_on: Verbinde deine Foto-Management-Tools, um deine Fotos auf der Karte anzuzeigen. Immich- und Photoprism-Integrationen sind im Pro-Tarif verfügbar.
+        upgrade_to_pro: Auf升级到Pro
+        immich_integration: Immich-Integration
+        immich_url: Immich-URL
+        the_base_url_of_your_immich_instance: Die Basis-URL deiner Immich-Instanz
+        immich_api_key: Immich-API-Schlüssel
+        found_in_your_immich_admin_panel_under_api_settings_required: 'Finde diesen in deinem Immich-Admin-Panel unter API-Einstellungen. Erforderliche Berechtigungen:'
+        asset_read: asset.read
+        asset_view: asset.view
+        and: ", und"
+        asset_update: asset.update
+        for_photo_enrichment: "(für die Bildverfeinerung)."
+        skip_ssl_certificate_verification_self_signed_certificates: Überspringe die SSL-Zertifikatsprüfung (selbstsignierte Zertifikate)
+        security_warning: 'Sicherheitswarnung:'
+        disabling_ssl_verification_makes_your_connection_vulnerable_to_man_in: Wenn du die SSL-Prüfung deaktivierst, wird deine Verbindung anfällig für Man-in-the-Middle-Angriffe. Aktiviere dies nur bei selbst signierten Zertifikaten, denen du in deinem lokalen Netzwerk vertraust.
+        clears_cached_photo_metadata_and_thumbnails_for_all_integrations: Löscht den zwischengespeicherten Bildmetadaten und Vorschaubildern für alle Integrationen.
+        photoprism_integration: Photoprism-Integration
+        photoprism_url: Photoprism-URL
+        the_base_url_of_your_photoprism_instance: Die Basis-URL deiner Photoprism-Instanz
+        photoprism_api_key: Photoprism-API-Schlüssel
+        found_in_your_photoprism_settings_under_library: Finde den Schlüssel in den Einstellungen deiner Photoprism-Instanz unter Library
+        airtrail_integration: AirTrail-Integration
+        airtrail_url: AirTrail-URL
+        the_base_url_of_your_airtrail_instance_your_flights_are: Die Basis-URL deiner AirTrail-Instanz. Deine Flüge werden als Bögen auf der Karte angezeigt.
+        airtrail_api_key: AirTrail-API-Schlüssel
+        create_an_api_key_in_airtrail_under_settings_rarr_security: Erstelle einen API-Schlüssel in AirTrail unter Einstellungen → Sicherheit.
+        last_synced: 'Letzte Synchronisation:'
+        connected_accounts: Verknüpfte Konten
+        you_ve_connected_your_account_using_the_following_oauth_provider: 'Du hast dein Konto über folgenden OAuth-Anbieter verknüpft:'
+        sync_airtrail_flights: AirTrail-Flüge synchronisieren
+        flights_also_sync_automatically_once_a_day: Flüge synchronisieren sich auch automatisch einmal täglich.
+        user_settings: Benutzer-Einstellungen
+        xxxxxxxxxxxxxx: xxxxxxxxxxxxxx
+        refresh_photo_cache: Foto-Cache aktualisieren
+        save_test_connection: Speichern & Verbindung testen
+        sync_now: Jetzt synchronisieren
+        settings: Einstellungen
+    maps:
+      index:
+        map_appearance_colors_layers_and_points_of_interest_for_the: Kartendarstellung, Farben, Schichten und Punkte von Interesse für die aktuelle Karte (V2) sind direkt in der
+        open_the_settings_panel_there_this_page_only_covers_the: "— öffne das Einstellungspanel dort. Diese Seite beschreibt nur die alte V1 (Leaflet)-Karte."
+        general: Allgemein
+        preferred_map_version: Bevorzugte Kartenversion
+        v2_maplibre_is_the_default_v1_leaflet_is_available_for: V2 (MapLibre) ist die Standardversion. V1 (Leaflet) ist für die Kompatibilität verfügbar.
+        using_a_custom_tile_url_may_result_in_extra_costs: Die Nutzung eines benutzerdefinierten Kachel-URLs kann zusätzliche Kosten verursachen. Prüfe die Nutzungsbedingungen deines Karten-Tile-Anbieters.
+        custom_tiles_v1: Benutzerdefinierte Kacheln (V1)
+        map_name: Kartenname
+        a_descriptive_name_for_your_map_configuration: Ein beschreibender Name für deine Kartenkonfiguration
+        tile_url: Kachel-URL
+        url_pattern_for_map_tiles_must_include_x_y_and: URL-Muster für Kacheln. Muss die Platzhalter {x}, {y} und {z} enthalten
+        map_preview: Kartenvorschau
+        map_settings: Karten-Einstellungen
+        map_page: Kartenseite
+        v1_leaflet: V1 (Leaflet)
+        v2_maplibre: V2 (MapLibre)
+        example_openstreetmap: 'Beispiel: OpenStreetMap'
+        save_changes: Änderungen speichern
+    subscriptions:
+      index:
+        hello_there: Hallo da!
+        you_are_currently_subscribed_to_dawarich_hurray: Du bist derzeit bei Dawarich abonniert, hurra!
+        your_subscription_will_be_valid_for_the_next: Dein Abonnement ist für die nächsten
+        you_are_currently_not_subscribed_to_dawarich_how_about_we: Du bist derzeit nicht bei Dawarich abonniert. Wie wäre es, das zu ändern?
+        manage_subscription: Abonnement verwalten
+        subscriptions: Abonnements
+    two_factor:
+      backup_codes:
+        save_your_backup_codes: Speichere deine Backup-Codes
+        store_these_codes_in_a_safe_place_each_code_can: Speichere diese Codes an einem sicheren Ort. Jeder Code kann nur einmal verwendet werden. Falls du keinen Zugriff auf deine Authenticator-App hast, kannst du diese Codes verwenden, um dich anzumelden.
+        two_factor_authentication_enabled: Zwei-Faktor-Authentifizierung aktiviert
+        done: Fertig
+        backup_codes: Backup-Codes
+      show:
+        fa_is_enabled: 2FA ist aktiviert
+        your_account_is_protected_with_two_factor_authentication: Dein Konto ist mit zwei-Faktor-Authentifizierung geschützt.
+        to_disable_2fa_enter_your_password_and_a_current_authenticator: Um 2FA zu deaktivieren, gib dein Passwort und einen aktuellen Authenticator-Code (oder Backup-Code) ein.
+        current_password: Aktuelles Passwort
+        authenticator_code_or_backup_code: Authenticator-Code oder Backup-Code
+        fa_is_not_enabled: 2FA ist nicht aktiviert
+        add_an_extra_layer_of_security_to_your_account: Füge deinem Konto eine zusätzliche Sicherheitsschicht hinzu.
+        two_factor_authentication_adds_an_extra_layer_of_security_by: Zwei-Faktor-Authentifizierung fügt einer Sicherheitsschicht hinzu, indem sie einen Code von deiner Authenticator-App (Google Authenticator, Authy, etc.) verlangt, wenn du dich anmeldest.
+        two_factor_authentication: Zwei-Faktor-Authentifizierung
+        disable_2fa: 2FA deaktivieren
+        enable_2fa: 2FA aktivieren
+      verify:
+        scan_qr_code: QR-Code scannen
+        scan_this_qr_code_with_your_authenticator_app_google_authenticator: Scanne diesen QR-Code mit deiner Authenticator-App (Google Authenticator, Authy, etc.).
+        can_t_scan_enter_the_code_manually: Kann nicht scannen? Gib den Code manuell ein
+        verify_setup: Setup überprüfen
+        enter_the_6_digit_code_from_your_authenticator_app_to: Gib den 6-stelligen Code aus deiner Authentifizierungs-App ein, um die Einrichtung zu bestätigen.
+        set_up_two_factor_authentication: Zwei-Faktor-Authentifizierung einrichten
+        verification_code: Überprüfungscodes
+        verify_and_enable: Überprüfen und aktivieren
+    users:
+      edit:
+        editing_user: Benutzer bearbeiten
+        email: E-Mail
+        password: Passwort
+        leave_blank_to_keep_current: "(leer lassen, um den aktuellen zu behalten)"
+        admin: Admin
+        status: Status
+        update: Aktualisieren
+      index:
+        user_registration: Benutzerregistrierung
+        allow_new_users_to_register_via_email_and_password: Erlaube neuen Benutzern, sich über E-Mail und Passwort zu registrieren
+        add_new_user: Neuen Benutzer hinzufügen
+        search_by_email: Nach E-Mail suchen...
+        search: Suche
+        email: E-Mail
+        role: Rolle
+        status: Status
+        points: Punkte
+        last_sign_in: Letzte Anmeldung
+        created_at: Erstellt am
+        admin: Admin
+        user: Benutzer
+        active: Aktiv
+        inactive: Inaktiv
+        trial: Testzeitraum
+        never: Nie
+        delete: Löschen
+        create_a_new_user: Neuen Benutzer erstellen!
+        password: Passwort
+        close: schließen
+        delete_user: Benutzer löschen
+        are_you_sure_you_want_to_delete: Bist du sicher, dass du löschen möchtest
+        this_will_permanently_remove_their_account_and_all_associated_data: "? Dadurch werden das Konto und alle zugehörigen Daten dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden."
+        cancel: Abbrechen
+        users_management: Benutzer verwalten
+        clear: Löschen
+        edit: Bearbeiten
+        create: Erstellen
+        users: Benutzer
+      show:
+        user_details: Benutzerdetails
+        admin: Admin
+        user: Benutzer
+        active: Aktiv
+        inactive: Inaktiv
+        trial: Testzeitraum
+        data_overview: Datenübersicht
+        points: Punkte
+        tracks: Tracks
+        imports: Importe
+        exports: Exporte
+        areas: Flächen
+        sign_in_history: Anmeldehistorie
+        total_sign_ins: Gesamtanzahl Anmeldungen
+        last_sign_in: Letzte Anmeldung
+        never: Nie
+        last_sign_in_ip: Letzte Anmelde-IP
+        current_sign_in_ip: Aktuelle Anmelde-IP
+        account_created: Konto erstellt
+        api_key: API-Schlüssel
+        copy: Kopieren
+        actions: Aktionen
+        edit: Bearbeiten
+        back_to_users: Zurück zu den Benutzern
+        regenerate_api_key: API-Schlüssel erneuern
+        are_you_sure_this_will_invalidate_the_current_api_key: Bist du sicher? Dies wird den aktuellen API-Schlüssel ungültig machen.
+        send_password_reset_email: Passwort-zurücksetzen-E-Mail senden
+        edit_user: Benutzer bearbeiten
+        user_email: 'Benutzer: %{email}'
+    visits:
+      redetect_panel:
+        re_run_detection_on_full_history: Erneut Erkennung auf vollständigen Historie ausführen
+        replaces_all_suggested_visits_across_your_entire_history_with_fresh: Ersetzt alle vorgeschlagenen Aufenthalte über deine gesamte Historie mit frischen Erkennungen unter Verwendung der Einstellungen oben. Bestätigte Aufenthalte und die Orte, die du benannt hast, bleiben erhalten. Kleine Konten benötigen normalerweise einige Minuten; mehrjährige Historien können 30–60 Minuten dauern und erhöhen vorübergehend den Serverlast.
+        on_the_lite_plan_re_detection_covers_your_visible_12: Auf dem Lite-Plan umfasst die erneute Erkennung nur deinen sichtbaren 12-Monats-Window.
+        available_again_at: Verfügbar wieder ab
+        replace_all_suggested_visits_across_your_full_history_confirmed_visits: Ersetze alle vorgeschlagenen Aufenthalte über deine gesamte Historie. Bestätigte Aufenthalte bleiben. Fortfahren?
+      show:
+        tune_how_dawarich_decides_where_you_actually_were: Anpassen, wie Dawarich entscheidet, wo du tatsächlich warst
+        these_settings_control_how_the_app_groups_your_gps_points: Diese Einstellungen steuern, wie die App deine GPS-Punkte in Aufenthalte zu Orten gruppieren wird.
+        points_within_this_radius_are_treated_as_the_same_visit: Punkte innerhalb dieses Radius werden als der gleiche Aufenthalt betrachtet. Standard 100.
+        lower_more_visits_suggested_including_brief_stops_default_3: Niedriger = mehr Aufenthalte werden vorgeschlagen, einschließlich kurzer Halte. Standard 3.
+        skip_stops_shorter_than_this_raise_to_ignore_short_drive: Übergehe Halte, die kürzer als dies sind. Erhöhe, um kurze Durchfahrten zu ignorieren; senke, um kurze Einkäufe zu erfassen. Standard 5.
+        smart_density_fill: Intelligente Dichteausfüllung
+        better_visits_when_your_tracker_reports_points_unevenly_leave_on: Bessere Aufenthalte, wenn dein Tracker Punkte ungleichmäßig berichtet. Aktiviert, es sei denn, du weißt, dass du es deaktivieren möchtest.
+        visit_detection: Aufenthaltserkennung
+        visit_radius_meters: Aufenthaltsradius (Meter)
+        minimum_points_to_count_as_a_visit: Mindestanzahl an Punkten für einen Aufenthalt
+        minimum_visit_duration_minutes: Mindestdauer eines Aufenthalts (Minuten)
+        save_settings: Einstellungen speichern
+  share_links:
+    hubs:
+      body:
+        live_location: Live-Position
+        time_period: Zeitraum
+        shared: Geteilt
+        your_live_location_is_shared_via_a_public_link: Deine Live-Position wird über einen öffentlichen Link geteilt.
+      modal:
+        share: Teilen
+        close: Schließen
+      shared_list:
+        copy_link: Link kopieren
+        open_in_new_tab: In neuem Tab öffnen
+        revoke_link: Link widerrufen
+        revoke_this_link_it_will_stop_working_immediately: Diesen Link widerrufen? Er wird sofort nicht mehr funktionieren.
+        revoke: Widerrufen
+    lives:
+      new:
+        share_your_live_location: Live-Ort teilen
+        your_live_location_is_shared_via_a_public_link: Dein Live-Ort wird über einen öffentlichen Link geteilt.
+    timelines:
+      new:
+        share_a_date_range: Ein Datum bereich teilen
+  shared:
+    flash_message:
+      close: Schließen
+    footer:
+      dawarich: Dawarich
+    legal_footer:
+      dawarich: Dawarich
+      made_and_hosted_in_europe: "Gestaltet und gehostet in \U0001F1EA\U0001F1FA Europa"
+      copyright: Copyright ©
+      zeitflow_ug: ZeitFlow UG
+      community: Community
+      discord: Discord
+      github: Github
+      mastodon: Mastodon
+      docs: Dokumentation
+      tutorial: Tutorial
+      import_existing_data: Daten importieren
+      exporting_data: Daten exportieren
+      faq: Häufige Fragen
+      contact: Kontakt
+      more: Mehr
+      privacy_policy: Datenschutzrichtlinie
+      terms_and_conditions: Nutzungsbedingungen
+      refund_policy: Rückgabepolitik
+      impressum: Impressum
+      blog: Blog
+    navbar:
+      family: Familie
+      my_data: Meine Daten
+      help: Hilfe
+      dawarich: Dawarich
+      get_started: Loslegen
+      finish_setting_up_your_account: Konto einrichten abschließen
+      finish_signup: Registrierung abschließen
+      trial_expired: Testzeitraum abgelaufen
+      trial_expired_2: "Testzeitraum abgelaufen \U0001F97A"
+      remaining: verbleibend
+      changelog_prompt:
+        stay_up_to_date: Aktuell bleiben?
+        get_a_what_s_new_notice_when_a_new_dawarich: Erhalte eine "Was Neues"-Benachrichtigung, wenn eine neue Dawarich-Version veröffentlicht wird, einschließlich Sicherheitsupdates. Die Benachrichtigung lädt ein kleines Widget von
+        like_any_web_request_that_host_sees_your_ip_address: ". Wie bei jeder Webanfrage sieht der Host deine IP-Adresse, Browser und die Seite-URL, plus deine Dawarich-Version — niemals dein Konto, deine E-Mail-Adresse oder dein Standort. Du kannst dies jederzeit ändern."
+        no_thanks: Danke, nein
+        yes_notify_me: Ja, benachrichtige mich
+      help_links:
+        need_help_ping_us: Hilfe benötigt? Ping uns!
+        x_twitter: X (Twitter)
+        mastodon: Mastodon
+        email: E-Mail
+        forum: Forum
+        discord: Discord
+      version_indicator:
+        nbsp: " !"
+        new_version_available_check_out_github_releases: Neue Version verfügbar! Schau auf GitHub Releases!
+      map: Karte
+      trips: Reisen
+      stats: Statistiken
+      insights_sup_sup_html: Einblicke<sup>α</sup>
+      family_sup_sup_html: Familie<sup>α</sup>
+      points: Punkte
+      places: Orte
+      imports: Importe
+      exports: Exporte
+      tags: Tags
+      subscribe: Abonnieren
+      account: Konto
+      settings: Einstellungen
+      subscription: Abonnement
+      logout: Abmelden
+      see_all: Alle ansehen
+      you_re_an_admin_harry: Du bist Admin, Harry!
+      dawarich_supporter: Dawarich-Unterstützer
+      login: Anmelden
+      register: Registrieren
+      trial_ends_in: Dein Testzeitraum endet in %{time}
+      theme_toggle:
+        dark_mode: Dunkelmodus
+        light_mode: Hellmodus
+      days_remaining:
+        one: "%{count} Tag verbleibend"
+        other: "%{count} Tage verbleibend"
+    place_creation_modal:
+      create_new_place: Neuer Ort erstellen
+      place_name: Ortsname *
+      note: Notiz
+      optional_add_any_notes_or_details_about_this_place: Optional - Füge hier beliebige Notizen oder Details über diesen Ort hinzu
+      tags: Tags
+      click_tags_to_select_them_for_this_place: Klick auf Tags, um sie für diesen Ort auszuwählen
+      suggested_places: Vorgeschlagene Orte
+      nearby_places: Nahegelegene Orte
+      open_modal_to_load_nearby_suggestions: Modal öffnen, um nahegelegene Vorschläge zu laden
+      cancel: Abbrechen
+      enter_place_name: Ortsname eingeben...
+      add_a_personal_note_about_this_place: Füge eine persönliche Notiz über diesen Ort hinzu...
+      create_place: Ort erstellen
+      saving: Speichern...
+    plan_data_window_alert:
+      your_lite_plan_includes_the_last_12_months_of_data: Dein Lite-Plan beinhaltet die letzten 12 Monate Daten. Upgrade zu Pro, um deinen gesamten Standortverlauf zu sehen.
+      upgrade_to_pro: Auf Pro upgraden
+      close: Schließen
+    replay_panel:
+      close_replay: Wiederholung schließen
+      times: "×"
+      previous_day: Vorheriger Tag
+      larr: "←"
+      no_data_loaded: Keine Daten geladen
+      next_day: Nächster Tag
+      rarr: "→"
+      no_data: Keine Daten
+      play_pause: Wiedergabe/Pausieren
+      play_or_pause_replay: Wiedergabe oder Pausieren
+      recenter_follow_marker: Zentrieren & Marker verfolgen
+      recenter_and_follow_the_marker: Zentrieren und den Marker verfolgen
+      replay_speed: Wiedergabegeschwindigkeit
+      previous_point: Vorheriger Punkt
+      point_1_of_1: Punkt 1 von 1
+      next_point: Nächster Punkt
+      replay_scrubber_time_of_day: Wiedergabeschieber - Uhrzeit
+    sharing_link:
+      sharing_link: Freigabelink
+      copy: Kopieren
+      share_this_link_to_allow_others_to_view_your_stats: Teile diesen Link, damit andere deine Statistiken ansehen können
+    sharing_modal:
+      sharing_settings: Teilen-Einstellungen
+      share_your_monthly_stats_publicly_with_friends_and_family_public: Monatliche Statistiken öffentlich mit Freunden und Familie teilen. Öffentliche Statistik-Teilung ist im Pro-Plan verfügbar.
+      upgrade_to_pro: Auf Pro upgraden
+      enable_public_access: Öffentlichen Zugriff aktivieren
+      allow_others_to_view_this_monthly_digest_auto_saves_on: Andere dürfen diesen monatlichen Überblick einsehen • Automatisch gespeichert bei Änderung
+      link_expiration: Link-Ablauf
+      privacy_protection: Datenschutz
+      exact_coordinates_are_hidden: "• Genauere Koordinaten sind versteckt"
+      personal_information_is_not_included: "• Persönliche Informationen sind nicht enthalten"
+      done: Fertig
+    links:
+      live:
+        live: "● Live"
+        connecting: Verbinden…
+      missing_resource:
+        this_share_is_no_longer_available: Dieser Share ist nicht mehr verfügbar
+        the_original_content_was_removed_by_the_owner: Der ursprüngliche Inhalt wurde vom Besitzer entfernt.
+      timeline:
+        shared_on_dawarich: "· Auf Dawarich geteilt"
+        days_shared_on_dawarich:
+          one: "%{count} Tag · Auf Dawarich geteilt"
+          other: "%{count} Tage · Auf Dawarich geteilt"
+      track:
+        distance: Distanz
+        duration: Dauer
+        avg_speed: Durchschnittsgeschwindigkeit
+        elevation_gain: Höhenmeter
+        elevation_loss: Höhenverlust
+      trip:
+        publicly_shared: Öffentlich geteilt
+        public: Öffentlich
+        ndash: "–"
+        trip_notes: Reisehinweise
+        replay: Wiederholen
+      trip_day_header:
+        middot: "·"
+        no_data: Keine Daten
+      unsupported:
+        this_share_type_is_no_longer_supported: Dieser Teiltyp wird nicht mehr unterstützt
+        the_link_may_have_been_created_by_a_newer_or: Der Link wurde möglicherweise von einer neueren oder älteren Version von Dawarich erstellt.
+      not_found:
+        this_shared_link_is_no_longer_available: Dieser geteilte Link ist nicht mehr verfügbar
+        the_owner_may_have_revoked_the_link_or_it_may: Der Besitzer hat den Link möglicherweise widerrufen oder er ist abgelaufen.
+        not_found_dawarich: Nicht gefunden — Dawarich
+      phrase_prompt:
+        enter_the_magic_phrase: Gib die magische Phrase ein
+        this_shared_link_is_protected_ask_the_owner_for_the: Dieser geteilte Link ist geschützt. Frag den Besitzer nach der Phrase.
+        magic_phrase: magische Phrase
+        unlock: Entsperrung
+        enter_phrase_dawarich: Phrase eingeben — Dawarich
+      show:
+        name_shared_on_dawarich: "%{name} — Geteilt auf Dawarich"
+        shared_from_dawarich: Von Dawarich geteilt
+    map:
+      date_navigation:
+        start_date_and_time: Startdatum und -zeit
+        end_date_and_time: Enddatum und -zeit
+        search: Suche
+        today: Heute
+        last_7_days: Letzte 7 Tage
+        last_month: Letzter Monat
+      date_navigation_v2:
+        share: Teilen
+        start_date_and_time: Startdatum und -zeit
+        end_date_and_time: Enddatum und -zeit
+        search: Suchen
+        today: Heute
+        last_7_days: Letzte 7 Tage
+        last_month: Letzter Monat
+      share_indicator:
+        live_location_is_being_shared: Live-Position wird geteilt
+      upgrade_banner:
+        your_lite_plan_includes_the_last_12_months_of_data: Dein Lite-Plan beinhaltet die letzten 12 Monate Daten.
+        upgrade_to_pro: Auf Pro upgraden
+        dismiss: Verwerfen
+  shared_links:
+    expires_field:
+      expires_optional: Verfällt (optional)
+      stays_active_through_the_end_of_the_day_before_the: Aktiv bis zum Ende des Tages vor dem ausgewählten Datum.
+      defaults_to_one_week_from_today_leave_blank_for_a: Standardmäßig eine Woche ab heute. Lasse das Feld leer, um einen nie verfallenden Link zu erstellen.
+    modal:
+      anyone_with_the_link_will_be_able_to_view_this: Jeder mit dem Link kann dies betrachten.
+      close: Schließen
+    modal_active:
+      sharing: Teilen
+      public: Öffentlich
+      public_link: Öffentlicher Link
+      copy_link: Link kopieren
+      copy_public_link: Öffentlichen Link kopieren
+      magic_phrase: Magische Phrase
+      copy_magic_phrase: Magische Phrase kopieren
+      last_viewed: Zuletzt angesehen
+      ago: vor
+      not_viewed_yet: Noch nicht angesehen
+      regenerate_url: URL erneuern
+      regenerate_phrase: Phrase erneuern
+      revoke: Link widerrufen
+      open_in_new_tab: In neuem Tab öffnen
+      generate_a_new_url_the_current_url_will_stop_working: Neue URL generieren? Die aktuelle URL wird nicht mehr funktionieren.
+      generate_a_new_phrase: Neue Phrase generieren?
+      revoke_this_link_it_will_stop_working_immediately: Diesen Link widerrufen? Er wird sofort nicht mehr funktionieren.
+      view_count:
+        one: "%{count} Ansicht"
+        other: "%{count} Ansichten"
+    modal_live_create_form:
+      this_shares_your: Dies teilt deine
+      current_location_in_real_time: aktuelle Position in Echtzeit
+      with_anyone_who_has_the_link_until_it_expires_or: mit jedem, der den Link hat, bis er abläuft oder du ihn widerrufst.
+      magic_phrase_optional: Magische Phrase (optional)
+      leave_blank_to_share_without_a_phrase_or_use_the: Lass es leer, um ohne Phrase zu teilen, oder verwende die automatisch generierte.
+      share_the_route: Route teilen
+      also_show_the_path_travelled_since_this_link_was_created: Zeige auch den Weg, den du seit der Erstellung dieses Links zurückgelegt hast.
+      cancel: Abbrechen
+      create_share_link: Teilen-Link erstellen
+    modal_timeline_create_form:
+      start_date: Startdatum
+      end_date: Enddatum
+      magic_phrase_optional: Magische Phrase (optional)
+      leave_blank_to_share_without_a_phrase_or_use_the: Lass es leer, um ohne Phrase zu teilen, oder verwende die automatisch generierte.
+      show_photos: Fotos anzeigen
+      cancel: Abbrechen
+      create_share_link: Share-Link erstellen
+    modal_track_create_form:
+      magic_phrase_optional: Magische Phrase (optional)
+      leave_blank_to_share_without_a_phrase_or_use_the: Lass es leer, um ohne Phrase zu teilen, oder verwende die automatisch generierte.
+      show_photos: Fotos anzeigen
+      show_stats: Statistiken anzeigen
+      cancel: Abbrechen
+      create_share_link: Share-Link erstellen
+    modal_trip_create_form:
+      magic_phrase_optional: Magische Phrase (optional)
+      leave_blank_to_share_without_a_phrase_or_use_the: Lass es leer, um ohne Phrase zu teilen, oder verwende die automatisch generierte.
+      what_to_include_on_the_public_page: Was auf der öffentlichen Seite enthalten sein soll
+      cancel: Abbrechen
+      create_share_link: Share-Link erstellen
+      stats_countries_distance_duration: Statistiken & Länder (Entfernung, Dauer)
+      day_by_day_breakdown: Tag-für-Tag-Übersicht
+      per_day_notes: Tägliche Notizen
+      photos_on_map: Fotos auf Karte
+      route_map: Route-Karte
+      trip_description: Reisebeschreibung
+  stats:
+    locked_year_card:
+      available_on_pro: Verfügbar auf Pro
+      upgrade_to_pro: Auf Pro upgraden
+    month:
+      monthly_digest: Monatlicher Digest
+      share: Teilen
+      distance_traveled: Gefahrene Strecke
+      active_days: Aktive Tage
+      countries_visited: Besuchte Länder
+      map_summary: Kartenzusammenfassung
+      heatmap: Heatmap
+      points: Punkte
+      daily_activity: Tägliche Aktivität
+      peak_day: 'Höhepunkt:'
+      quietest_week: "• Ruhestige Woche:"
+      countries_cities: Länder & Städte
+      no_location_data_available_for_this_month: Keine Standortdaten für diesen Monat verfügbar
+      cities_visited: 'Besuchte Städte:'
+      back_to: "← Zurück zu"
+      day: Tag
+      distance: Entfernung
+      month_year_monthly_digest: "%{month} %{year} Monatlicher Überblick"
+      city_count:
+        one: "%{count} Stadt"
+        other: "%{count} Städte"
+    reverse_geocoding_stats:
+      reverse_geocoded_points: Umgekehrte Geokodierungspunkte
+      points_without_data: Punkte ohne Daten
+      countries_visited: Besuchte Länder
+      close: schließen
+      cities_visited: Besuchte Städte
+      points_that_were_reverse_geocoded_but_had_no_data: Punkte, die umgekehrt geokodiert wurden, aber keine Daten hatten
+    stat:
+      total_distance: Gesamte Entfernung
+      year_month: "%{year}/%{month}"
+    year:
+      map: "[Karte]"
+      days: Tage
+      distance: Distanz
+    index:
+      year_end_digests: Jahresende-Zusammenfassung
+      total_distance: Gesamtdistanz
+      geopoints_tracked: Verfolgte Standortpunkte
+      all_stats_data_above_except_for_total_distance_and_number: Alle Statistiken oben, außer Gesamtdistanz und Anzahl der verfolgten Standortpunkte, werden täglich aktualisiert
+      last_update: 'Letzte Aktualisierung:'
+      countries_and_cities_visited_in: Länder und Städte, die in
+      no_specific_cities_recorded: Keine spezifischen Städte erfasst
+      statistics: Statistiken
+      update_stats: Statistiken aktualisieren
+      map: "[Karte]"
+      days: Tage
+      distance: Distanz
+      countries_count_countries_cities_count_cities: "%{countries_count} Länder, %{cities_count} Städte"
+    public_month:
+      monthly_digest: Monatlicher Überblick
+      distance_traveled: Gesamtstrecke
+      total_distance_for_this_month: Gesamtstrecke für diesen Monat
+      active_days: Aktive Tage
+      days_with_tracked_activity: Tage mit verfolgter Aktivität
+      countries_visited: Besuchte Länder
+      different_countries: Verschiedene Länder
+      location_hexagons: Standort-Hexagone
+      loading_hexagons: Hexagone werden geladen...
+      daily_activity: Tägliche Aktivität
+      peak_day: 'Höchstaktiv am:'
+      quietest_week: "• Ruheständige Woche:"
+      countries_cities: Länder & Städte
+      cities: Städte
+      cities_visited: 'Besuchte Städte:'
+      more: mehr
+      powered_by: Bereitgestellt von
+      dawarich: Dawarich
+      your_personal_memories_mapper: ", dein persönlicher Memories Mapper."
+      day: Tag
+      distance: Distanz
+    show:
+      statistics_for_year_year: Statistiken für %{year} Jahr
+  tags:
+    form:
+      prohibited_this_tag_from_being_saved: 'Dieses Tag wurde verweigert, gespeichert zu werden:'
+      click_to_select_an_emoji: Klicke, um ein Emoji auszuwählen
+      custom: 'Benutzerdefiniert:'
+      choose_from_swatches_or_pick_a_custom_color: Wähle aus den Farbkarten oder wähle eine benutzerdefinierte Farbe
+      privacy_zone: Privatsphäre-Zone
+      hide_map_data_around_places_with_this_tag: Karte-Daten um Orte mit diesem Tag verbergen
+      data_within_this_radius_will_be_hidden_from_the_map: Daten innerhalb dieses Radius werden von der Karte versteckt
+      home_work_restaurant: Zuhause, Arbeit, Restaurant...
+      privacy_radius: Privatsphäre-Radius
+      cancel: Abbrechen
+      errors_prohibited_save:
+        one: "%{count} Fehler verhinderten das Speichern dieses Tags:"
+        other: "%{count} Fehler verhinderten das Speichern dieses Tags:"
+    edit:
+      edit_tag: Tag bearbeiten
+      update_your_tag_details: Deine Tag-Einstellungen aktualisieren
+    index:
+      new_tag: Neues Tag
+      icon: Symbol
+      name: Name
+      color: Farbe
+      places: Orte
+      actions: Aktionen
+      no_tags_yet: Noch keine Tags
+      create_tags_to_organize_your_places_and_add_privacy_zones: Tags erstellen, um deine Orte zu organisieren und Privatsphäre-Zonen hinzuzufügen.
+      create_your_first_tag: Erstes Tag erstellen
+      tags: Tags
+      edit_tag: Tag bearbeiten
+      delete_tag: Tag löschen
+      are_you_sure: Bist du sicher?
+    new:
+      new_tag: Neuer Tag
+      create_a_new_tag_to_organize_your_places: Erstelle einen neuen Tag, um deine Orte zu organisieren
+  tracks:
+    segments:
+      segment_row:
+        manually_corrected: Manuell korrigiert
+        restore_auto_detection: Automatische Erkennung wiederherstellen
+        transportation_mode_currently: Verkehrsmittel (derzeit %{mode})
+        reset_to_auto_detected_mode: Zur automatisch erkannten Mode zurücksetzen
+        edited_ago: Bearbeitet vor %{time}
+      index:
+        no_segments_for_this_track_yet: Noch keine Segmente für diesen Track
+    share_links:
+      new:
+        this_track_is_shared_via_a_public_link: Dieser Track wird über eine öffentliche Link geteilt.
+        share_track: Track teilen %{track}
+  trial:
+    resume:
+      show:
+        finish_setting_up_your_account: Konto einrichten abschließen
+        your_account_is_almost_ready_to_start_tracking_your_location: Dein Konto ist fast bereit. Schließe die Einrichtung deines Abonnements ab, um deine Standortdaten aufzuzeichnen. Während des 7-tägigen kostenlosen Testzeitraums fallen keine Kosten an — kündige vor Ablauf, damit dir nichts berechnet wird.
+        resume_checkout: Check-out fortsetzen
+        or_delete_my_account: Oder mein Konto löschen
+        are_you_sure_this_cannot_be_undone: Bist du sicher? Dies kann nicht rückgängig gemacht werden.
+  trips:
+    countries:
+      middot: "·"
+      mdash: "&mdash;"
+      country_count:
+        one: "%{count} Land"
+        other: "%{count} Länder"
+    distance:
+      calculating: Berechnung...
+    form:
+      prohibited_this_trip_from_being_saved: 'verhindert, dass diese Reise gespeichert werden kann:'
+      errors_prohibited_save:
+        one: "%{count} Fehler verhindert, dass diese Reise gespeichert werden kann:"
+        other: "%{count} Fehler verhindern, dass diese Reise gespeichert werden kann:"
+    recalculate_button:
+      recalculating_hellip: Wiederberechnung…
+      recalculate: Wiederberechnen
+      recalculation_failed_try_again: Wiederberechnung fehlgeschlagen — erneut versuchen.
+      recalculate_this_trip_s_path_distance_and_countries_from_your: Diese Reise wiederberechnen und den Weg, die Distanz und die Länder aus deinen neuesten Punkten ermitteln?
+    trip:
+      no_points_found: Keine Punkte gefunden
+      calculating: Berechnung...
+      ndash: "–"
+      day_count:
+        one: "%{count} Tag"
+        other: "%{count} Tage"
+    edit:
+      back_to_trips: Zurück zu Reisen
+      editing_trip: Reise bearbeiten
+      show_this_trip: Diese Reise zeigen
+    index:
+      new_trip: Neue Reise
+      no_trips_yet: Noch keine Reisen
+      create_your_first_trip_to_see_your_journeys_visualized_with: Erstelle deine erste Reise, um deine Reisen mit Karten, Fotos und Statistiken visuell darzustellen.
+      create_your_first_trip: Erstelle deine erste Reise
+      trips: Reisen
+    new:
+      back_to_trips: Zurück zu Reisen
+      new_trip: Neue Reise
+    notes:
+      empty:
+        add_note: "+ Notiz hinzufügen"
+        write_your_notes_for_this_day: Schreibe deine Notizen für diesen Tag...
+        save_note: Notiz speichern
+        cancel: Abbrechen
+      form:
+        write_your_notes_for_this_day: Schreibe deine Notizen für diesen Tag...
+        cancel: Abbrechen
+        update_note: Notiz aktualisieren
+        save_note: Notiz speichern
+      note:
+        edit: Bearbeiten
+        write_your_notes_for_this_day: Schreibe deine Notizen für diesen Tag...
+        cancel: Abbrechen
+        delete: Löschen
+        delete_this_note: Diese Notiz löschen?
+        update_note: Notiz aktualisieren
+    show:
+      loading_route_data: Route-Daten werden geladen...
+      trip_path_is_being_calculated: Reisepfad wird berechnet...
+      download_trip: Reise herunterladen
+      currently_shared: Aktuell geteilt
+      public: Öffentlich
+      ndash: "–"
+      toggle_photo_markers_on_map: Foto-Marker auf Karte ein-/ausschalten
+      photos: Fotos
+      toggle_airtrail_flights_on_map: AirTrail-Flüge auf Karte ein-/ausschalten
+      flights: Flüge
+      replay_the_trip: Reise wiederholen
+      replay: Wiederholen
+      show_all_days: Alle Tage anzeigen
+      poster: Poster
+      middot: "·"
+      text: "< 1"
+      no_data: Keine Daten
+      trip_notes: Reisehinweise
+      more_on: Weitere Informationen zu
+      back_to_trips: Zurück zu Reisen
+      gpx: GPX
+      geojson: GeoJSON
+      edit_trip: Reise bearbeiten
+      share_trip: Reise teilen
+      delete_this_trip_this_cannot_be_undone: Diese Reise löschen? Dies kann nicht rückgängig gemacht werden.
+      delete_trip: Reise löschen
+      poster_unavailable: Verfügbar sobald der Reiseweg berechnet ist
+      create_poster: Poster dieser Reise erstellen
+      more_on_source: Weitere Informationen zu %{source}
+    share_links:
+      new:
+        share_trip: Teile %{trip}
+        trip_is_shared_via_a_public_link: "%{trip} wird über eine öffentliche Link geteilt."
+  users:
+    digests:
+      index:
+        year_end_digests: Jahresende-Zusammenfassungen
+        generate_digest: Zusammenfassung generieren
+        no_year_end_digests_yet: Noch keine Jahresende-Zusammenfassungen
+        year_end_digests_are_automatically_generated_on_january_1st_each: Jahresende-Zusammenfassungen werden automatisch am 1. Januar jedes Jahres generiert.
+        or_you_can_manually_generate_one_for_a_previous_year: Oder du kannst eine manuell für ein vorheriges Jahr erstellen.
+        shared: Geteilt
+        distance: Entfernung
+        countries: Länder
+        new: neu
+        cities: Städte
+        view_details: Details ansehen
+      public_year:
+        year_in_review: Jahr in Überblick
+        your_journey_by_the_numbers: Deine Reise, im Zahlenbild
+        distance_traveled: Gesamtstrecke
+        countries_visited: Besuchte Länder
+        cities_explored: Besuchte Städte
+        first_time_visits: Erstmalige Aufenthalte
+        new_countries: Neue Länder
+        new_cities: Neue Städte
+        more: mehr
+        year_by_month: Monat für Monat
+        where_they_spent_the_most_time: Wo am meisten Zeit verbracht wurde
+        countries_cities: Länder & Städte
+        cities: Städte
+        cities_visited: 'Städte besucht:'
+        all_time_stats: All-Time Statistiken
+        total_distance: Gesamtstrecke
+        track_your_own_adventures_with: Verfolge deine eigenen Abenteuer mit
+        dawarich: Dawarich
+        your_personal_memories_mapper: "— dein persönlicher Erinnerungskartenmapper."
+        month: Monat
+        distance: Strecke
+        first_time_count:
+          one: "%{count} erstmaliger Aufenthalt"
+          other: "%{count} erstmalige Aufenthalte"
+      show:
+        year_in_review: Jahr in Überblick
+        your_journey_by_the_numbers: Deine Reise, im Überblick
+        share: Teilen
+        distance_traveled: Gesamtstrecke
+        compared_to: im Vergleich zu
+        countries: Länder
+        cities: Städte
+        first_time_visits: Erstmalige Aufenthalte
+        new_countries: Neue Länder
+        new_cities: Neue Städte
+        more: mehr
+        your_year_month_by_month: Dein Jahr, Monat für Monat
+        where_you_spent_the_most_time: Wo du am meisten Zeit verbracht hast
+        no_tracking_data: Keine Nachverfolgungsdaten
+        track_more_in: Melde mehr in
+        to_see_a_fuller_picture_of_your_travels: um ein vollständigeres Bild deiner Reisen zu erhalten!
+        countries_cities: Länder & Städte
+        no_location_data_available: Keine Standortdaten verfügbar
+        all_time_stats: Alle Zeit Statistiken
+        countries_visited: Besuchte Länder
+        cities_explored: Erkundete Städte
+        total_distance: Gesamter Weg
+        want_more_insights: Möchtest du mehr Einblicke?
+        upgrade_to_pro_to_see_your_full_year_in_review: Upgrade zu Pro, um dein vollständiges Jahresrückblick mit monatlicher Aufschlüsselung, detaillierten Stadtranglisten, Ländervergleichen, Verkehrsanalyse und allen Zeitrekorde zu sehen.
+        upgrade_to_pro: Upgrade zu Pro
+        back_to_all_digests: Zurück zu allen Rückblicken
+        delete: Löschen
+        sharing_settings: Freigabeeinstellungen
+        enable_public_access: Öffentlichen Zugriff aktivieren
+        allow_others_to_view_this_year_end_digest_auto_saves: Erlaube anderen, diesen Jahresrückblick zu sehen • Automatisches Speichern bei Änderung
+        link_expiration: Link-Ablaufdatum
+        privacy_protection: Datenschutz
+        exact_coordinates_are_hidden: "• Genauere Koordinaten sind versteckt"
+        personal_information_is_not_included: "• Persönliche Informationen sind nicht enthalten"
+        done: Fertig
+        month: Monat
+        distance: Entfernung
+        year_year_in_review: "%{year} Jahr im Überblick"
+        are_you_sure_you_want_to_delete_the_year_digest: Bist du sicher, dass du den %{year} Digest löschen möchtest? Dies kann nicht rückgängig gemacht werden.
+        first_time_count:
+          one: "%{count} erste Zeit"
+          other: "%{count} erste Zeit"
+        day_count:
+          one: "%{count} Tag"
+          other: "%{count} Tage"
+        city_count:
+          one: "%{count} Stadt"
+          other: "%{count} Städte"
+    digests_mailer:
+      monthly_digest:
+        your: Dein
+        in_review: in Überblick
+        here_s_what_your_location_history_looked_like_last_month: Hier ist ein Überblick, wie dein Standortverlauf im letzten Monat aussah.
+        overview: ÜBERBLICK
+        distance: Entfernung
+        active_days: Aktive Tage
+        countries: Länder
+        cities: Städte
+        weekly_pattern: Wöchentlicher Muster
+        daily_distance: Tägliche Distanz
+        top_countries: Top Länder
+        top_cities: Top Städte
+        first_visits_this_month: ERSTMALIGE AUFENTHALTE IN DIESEM MONAT
+        vs_previous_month: Im Vergleich zum Vormonat
+        view_full_insights_rarr: Vollständige Einblicke ansehen →
+        you_re_receiving_this_because_monthly_digest_emails_are_on: Du erhältst dies, weil monatliche Zusammenfassung-E-Mails für dein Konto aktiviert sind.
+        manage_email_preferences: E-Mail-Voreinstellungen verwalten
+        in_review_here_s_what_your_location_history_looked_like: in Revisionsmodus ───────────────────────── Hier ist ein Überblick, wie dein Standortverlauf im letzten Monat aussah. Distanz
+        new_country: "(neues Land)"
+        new_city: "(ne Stadt)"
+        vs_previous_month_distance: Im Vergleich zum Vormonat Distanz
+        view_full_insights: "→ Vollständige Einblicke:"
+        you_re_receiving_this_because_monthly_digest_emails_are_on_2: "───────────────────────────────────────── Du erhältst dies, weil monatliche Zusammenfassung-E-Mails aktiviert sind. E-Mail-Voreinstellungen verwalten:"
+        weekday_totals: "@weekday_totals,"
+        labels_w_mon_tue_wed_thu_fri_sat_sun: 'labels: %w[Montag Dienstag Mittwoch Donnerstag Freitag Samstag Sonntag],'
+        width_20: 'width: 20,'
+        suffix_distance_unit: 'suffix: " #{@distance_unit}"'
+        31_map_d_daily_distances_d_to_s_to: "(1..31).map { |d| @daily_distances[d.to_s].to_f }"
+        reject_zero: ".reject(&:zero?)"
+        presence_0: ".presence || [0]"
+        you_re_receiving_this_because_monthly_digest_emails_are_on_3: Du erhältst diese E-Mail, weil monatliche Zusammenfassungsemails aktiviert sind.
+        manage_email_preferences_2: 'E-Mail-Einstellungen verwalten:'
+        month_year_in_review: Dein %{month} %{year} im Überblick
+        new_country_line: "→ %{country}  (neuer Land)"
+        new_city_line: "→ %{city}  (neue Stadt)"
+      year_end_digest:
+        your: Dein
+        year_in_review: Jahr im Überblick
+        here_s_your: Hier ist dein
+        at_a_glance: in Kürze.
+        the_numbers: DIE ZAHLEN
+        distance: Entfernung
+        countries: Länder
+        cities: Städte
+        activity_heatmap: AKTIVITÄTSGEWINN
+        none_light_moderate_high_peak: "· keine ░ gering ▒ mittel ▓ hoch █ Spitze"
+        monthly_distance: MONATLICHE ENTFERNUNG
+        top_countries: TOP LÄNDER
+        vs_previous_year: IM VORHERIGEN JAHR
+        view_full_insights_rarr: Vollständige Einblicke →
+        share_your_year_rarr: Dein Jahr teilen →
+        you_re_receiving_this_because_yearly_digest_emails_are_on: Du erhältst dies, weil jährliche Zusammenfassungsmails für dein Konto aktiviert sind.
+        manage_email_preferences: E-Mail-Einstellungen verwalten
+        year_in_review_here_s_your: Jahr in der Übersicht ────────────────────────────── Hier ist dein
+        at_a_glance_the_numbers_distance: im Überblick. DIE ZAHLEN Entfernung
+        vs_previous_year_distance: IM VORHERIGEN JAHR Entfernung
+        view_full_insights: "-> Vollständige Einblicke:"
+        share_your_year: "-> Dein Jahr teilen:"
+        you_re_receiving_this_because_yearly_digest_emails_are_on_2: "───────────────────────────────────────── Du erhältst diese E-Mail, weil jährliche Zusammenfassungsmails aktiviert sind. E-Mail-Einstellungen verwalten:"
+        12_map_m_monthly_distances_m_to_s_to: "(1..12).map { |m| @monthly_distances[m.to_s].to_f.round },"
+        labels_date_abbr_monthnames_1_12: 'labels: Date::ABBR_MONTHNAMES[1..12],'
+        width_24: 'width: 24,'
+        suffix_distance_unit: 'suffix: " #{@distance_unit}"'
+        you_re_receiving_this_because_yearly_digest_emails_are_on_3: Du erhältst diese E-Mail, weil jährliche Zusammenfassungsmails aktiviert sind.
+        manage_email_preferences_2: 'E-Mail-Einstellungen verwalten:'
+  users_mailer:
+    account_destroy_confirmation:
+      confirm_account_deletion: Konto löschen bestätigen
+      hi: Hallo
+      we_received_a_request_to_delete_your_dawarich_account: Wir haben eine Anfrage erhalten, dein Dawarich-Konto zu löschen.
+      this_is_your_last_chance_to_stop_the_deletion: Dies ist deine letzte Chance, die Löschung zu stoppen.
+      once_confirmed_all_your_location_history_tracks_areas_visits_trips: Sobald bestätigt, werden alle deine Standortverläufe, Tracks, Gebiete, Aufenthalte, Reisen und Familienmitgliedschaften dauerhaft gelöscht.
+      permanently_delete_my_account: Mein Konto dauerhaft löschen
+      didn_t_request_this: Dies war keine Anfrage von dir?
+      ignore_this_email_the_link_expires_in_1_hour_and: Ignoriere diese E-Mail — der Link läuft in 1 Stunde ab und dein Konto bleibt unangetastet. Wenn du diese E-Mails weiterhin erhältst, ändere dein Passwort sofort.
+      if_you_have_an_active_apple_or_google_subscription_remember: Wenn du ein aktives Apple- oder Google-Abonnement hast, vergiss nicht, es in den Einstellungen deiner Plattform zu kündigen, um weitere Gebühren zu vermeiden.
+      link: 'Link:'
+      confirm_account_deletion_hi: Konto löschen bestätigen Hi
+      we_received_a_request_to_delete_your_dawarich_account_this: ", Wir haben eine Anfrage erhalten, dein Dawarich-Konto zu löschen. Dies ist dein letzter Versuch, die Löschung zu stoppen. Sobald bestätigt, werden alle deine Standortverläufe, Tracks, Gebiete, Aufenthalte, Reisen und Familienmitgliedschaften dauerhaft entfernt. Dauerhaftes Konto löschen:"
+      didn_t_request_this_ignore_this_email_the_link_expires: Du hast das nicht angefordert? Ignoriere diese E-Mail — der Link läuft in 1 Stunde ab und dein Konto bleibt unangetastet. Wenn du weiterhin diese E-Mails erhältst, ändere dein Passwort sofort. Wenn du ein aktives Apple- oder Google-Abonnement hast, vergiss nicht, es in den Einstellungen deiner Plattform zu kündigen, um weitere Gebühren zu vermeiden.
+      we_received_a_request_to_delete_your_dawarich_account_this_2: Wir haben eine Anfrage erhalten, dein Dawarich-Konto zu löschen. Dies ist dein letzter Versuch, die Löschung zu stoppen. Sobald bestätigt, werden alle deine Standortverläufe, Tracks, Gebiete, Aufenthalte, Reisen und Familienmitgliedschaften dauerhaft entfernt.
+      permanently_delete_my_account_2: 'Dauerhaftes Konto löschen:'
+      didn_t_request_this_ignore_this_email_the_link_expires_2: Du hast das nicht angefordert? Ignoriere diese E-Mail — der Link läuft in 1 Stunde ab und dein Konto bleibt unangetastet. Wenn du weiterhin diese E-Mails erhältst, ändere dein Passwort sofort.
+    archival_approaching:
+      your_data_history_is_filling_up: Deine Datenhistorie füllt sich auf
+      hi: Hallo
+      this_is_evgenii_from_dawarich: ", das ist Evgenii von Dawarich."
+      heads_up: 'Achtung:'
+      your_oldest_location_data_will_be_archived_in_about: Deine ältesten Standortdaten werden in etwa
+      weeks: 2 Wochen
+      on_the_lite_plan_your_most_recent_12_months_of: Auf dem Lite-Plan bleiben deine letzten 12 Monate Daten vollständig suchbar und interaktiv. Ältere Daten werden archiviert — sie können immer exportiert werden, erscheinen aber nicht auf deiner Karte, in der Suche, den Statistiken oder der Zeitleistenwiedergabe.
+      upgrade_to_pro_to_keep_your_full_history: 'Aufstieg zum Pro-Plan, um deine vollständige Historie zu behalten:'
+      unlimited_searchable_history_every_month_every_year: Unbegrenzter Suchverlauf — monatlich, jährlich
+      heatmap_fog_of_war_and_globe_view: Heatmap, Nebel des Krieges und Globusansicht
+      full_write_api_access: Vollständiger Schreibzugriff über die API
+      immich_and_photoprism_integrations: Integrationen mit Immich und PhotoPrism
+      upgrade_to_pro: Auf Pro upgraden
+      your_data_is_always_yours_pro_simply_makes_all_of: Deine Daten sind immer dein Eigentum — Pro macht einfach alles suchbar und interaktiv in der App.
+      questions_drop_me_a_message_at_hi_dawarich_app_or: Fragen? Schreib mir eine Nachricht an hi@dawarich.app oder antworte einfach auf diese E-Mail.
+      best_regards: Mit freundlichen Grüßen,
+      evgenii_from_dawarich: Evgenii von Dawarich
+      your_data_history_is_filling_up_hi: Deine Datenhistorie füllt sich auf Hi
+      this_is_evgenii_from_dawarich_heads_up_your_oldest_location: ", das ist Evgenii von Dawarich. Achtung: Deine ältesten Standortdaten werden in etwa zwei Wochen archiviert. Auf dem Lite-Plan bleiben deine letzten 12 Monate Daten vollständig suchbar und interaktiv. Ältere Daten sind archiviert — sie können immer exportiert werden, erscheinen aber nicht auf deiner Karte, in der Suche, den Statistiken oder in der Zeitleistenwiedergabe. Auf Pro upgraden, um deinen gesamten Verlauf zu behalten: - Unbegrenzter Suchverlauf — monatlich, jährlich - Heatmap, Nebel des Krieges und Globusansicht - Vollständiger Schreibzugriff über die API - Integrationen mit Immich und PhotoPrism Jetzt upgraden:"
+      your_data_is_always_yours_pro_simply_makes_all_of_2: Deine Daten sind immer dein Eigentum — Pro macht einfach alles suchbar und interaktiv in der App. Fragen? Schreib mir eine Nachricht an hi@dawarich.app oder antworte einfach auf diese E-Mail. Mit freundlichen Grüßen, Evgenii von Dawarich
+      heads_up_your_oldest_location_data_will_be_archived_in: 'Achtung: Deine ältesten Standortdaten werden in etwa zwei Wochen archiviert.'
+      unlimited_searchable_history_every_month_every_year_2: "- Unbegrenzter Suchverlauf — monatlich, jährlich"
+      heatmap_fog_of_war_and_globe_view_2: "- Heatmap, Nebel des Krieges und Globusansicht"
+      full_write_api_access_2: "- Vollständiger Schreibzugriff über die API"
+      immich_and_photoprism_integrations_2: "- Immich und PhotoPrism-Integrationen"
+      upgrade_now: 'Jetzt upgraden:'
+    explore_features:
+      explore_dawarich_features: Dawarich-Funktionen erkunden
+      hi: Hallo
+      this_is_evgenii_from_dawarich: ", das ist Evgenii von Dawarich."
+      you_re_now_2_days_into_your_dawarich_trial_i: Du bist jetzt 2 Tage in deinem Dawarich-Testzeitraum! Ich hoffe, du genießt es, deinen Standortdaten zu folgen.
+      here_are_some_powerful_features_you_might_want_to_explore: 'Hier sind einige leistungsstarke Funktionen, die du vielleicht erkunden möchtest:'
+      reliving_your_travels: "✈️ Deine Reisen wiederbeleben"
+      revisit_your_past_journeys_with_detailed_maps_and_insights: Erlebe deine vergangenen Reisen mit detaillierten Karten und Einblicken erneut.
+      statistics_analytics: "\U0001F4CA Statistiken & Analysen"
+      view_detailed_insights_about_distances_traveled_and_time_spent_in: Betrachte detaillierte Einblicke zu zurückgelegten Entfernungen und verbrachten Zeiten in verschiedenen Orten.
+      interactive_maps: "\U0001F5FA️ Interaktive Karten"
+      visualize_your_tracks_on_beautiful_maps_with_different_layers_and: Visualisiere deine Tracks auf schönen Karten mit verschiedenen Schichten und Stiloptionen.
+      places_visits: "\U0001F4CD Orte & Aufenthalte"
+      discover_the_places_you_ve_visited_and_get_automatic_visit: Entdecke die Orte, die du besucht hast, und nutze die automatische Aufenthaltserkennung für häufig besuchte Orte.
+      data_export: "\U0001F4E4 Datenexport"
+      export_your_location_data_in_multiple_formats_gpx_geojson_for: Exportiere deine Standortdaten in verschiedenen Formaten (GPX, GeoJSON) zum Backup oder zur Nutzung mit anderen Anwendungen.
+      continue_exploring: Weiter erkunden
+      you_have: Du hast
+      days: 5 Tage
+      left_in_your_trial_make_the_most_of_it: noch in deinem Testzeitraum. Nutze ihn sinnvoll!
+      best_regards: Mit freundlichen Grüßen,
+      evgenii_from_dawarich: Evgenii von Dawarich
+      explore_dawarich_features_hi: Dawarich-Funktionen erkunden Hi
+      this_is_evgenii_from_dawarich_you_re_now_2_days: ", hier ist Evgenii von Dawarich. Du nutzt deinen Dawarich-Testzeitraum nun seit 2 Tagen! Ich hoffe, dir gefällt die Aufzeichnung deiner Standortdaten. Diese leistungsstarken Funktionen kannst du ausprobieren: ✈️ Reisen wiedererleben Erkunde vergangene Reisen mit detaillierten Karten und Einblicken. \U0001F4CA Statistiken & Analysen Erhalte detaillierte Einblicke in zurückgelegte Strecken und die an verschiedenen Orten verbrachte Zeit. \U0001F5FA️ Interaktive Karten Visualisiere deine Tracks auf ansprechenden Karten mit unterschiedlichen Ebenen und Darstellungen. \U0001F4CD Orte & Aufenthalte Entdecke besuchte Orte und nutze die automatische Aufenthaltserkennung für häufig besuchte Orte. \U0001F4E4 Datenexport Exportiere deine Standortdaten zur Sicherung oder Verwendung in anderen Anwendungen in mehreren Formaten (GPX, GeoJSON). Weiter erkunden: https://my.dawarich.app Dein Testzeitraum läuft noch 5 Tage. Nutze sie voll aus! Viele Grüße, Evgenii von Dawarich"
+      continue_exploring_https_my_dawarich_app: 'Weiter erkunden: https://my.dawarich.app'
+      you_have_5_days_left_in_your_trial_make_the: Du hast 5 Tage noch in deinem Testzeitraum. Nutze ihn sinnvoll!
+    oauth_account_link:
+      confirm_account_link: Kontoverknüpfung bestätigen
+      hi: Hallo
+      someone_hopefully_you_is_trying_to_link: Jemand – hoffentlich du – versucht, eine Verknüpfung herzustellen
+      sign_in_to_your_dawarich_account_clicking_the_button_below: Anmeldung bei deinem Dawarich-Konto zu verknüpfen. Klicke auf die Schaltfläche unten, damit diese Anmeldemethode künftig auf das Konto zugreifen kann.
+      link: Verknüpfen
+      didn_t_request_this: Dies hat keinen Anspruch?
+      ignore_this_email_the_link_expires_in_15_minutes_and: Ignoriere diese E-Mail — der Link läuft in 15 Minuten ab und wird keine Änderungen an deinem Konto vornehmen. Wenn du diese E-Mails weiterhin erhältst, ändere dein Passwort.
+      link_2: 'Link:'
+      confirm_account_link_hi: Bestätige die Kontoverknüpfung Hi
+      someone_hopefully_you_is_trying_to_link_2: ", Jemand — hoffentlich du — versucht, sich"
+      sign_in_to_your_dawarich_account_clicking_the_link_below: Anmeldung bei deinem Dawarich-Konto zu verknüpfen. Klicke auf den Link unten, damit diese Anmeldemethode künftig auf das Konto zugreifen kann. Link
+      didn_t_request_this_ignore_this_email_the_link_expires: Dies hat keinen Anspruch? Ignoriere diese E-Mail — der Link läuft in 15 Minuten ab und wird keine Änderungen an deinem Konto vornehmen. Wenn du diese E-Mails weiterhin erhältst, ändere dein Passwort.
+      sign_in_to_your_dawarich_account_clicking_the_link_below_2: Anmeldung bei deinem Dawarich-Konto zu verknüpfen. Klicke auf den Link unten, damit diese Anmeldemethode künftig auf das Konto zugreifen kann.
+    otp_account_locked:
+      account_temporarily_locked: Konto vorübergehend gesperrt
+      hi: Hallo
+      your_dawarich_account_has_been: Dein Dawarich-Konto wurde
+      temporarily_locked: vorübergehend gesperrt
+      because_10_consecutive_failed_two_factor_authentication_attempts_were_de: weil 10 aufeinanderfolgende fehlgeschlagene zweistufige Authentifizierungsversuche erkannt wurden.
+      the_lock_will_automatically_lift_after: Die Sperrung wird automatisch nach
+      minutes: 30 Minuten aufheben
+      no_action_is_required_if_this_was_you: ". Keine Aktion ist erforderlich, wenn dies dich betrifft."
+      didn_t_recognise_this_activity: Erkannt dieser Aktivität nicht?
+      someone_may_be_trying_to_access_your_account_we_recommend: Jemand könnte versuchen, dein Konto zu accessieren. Wir empfehlen, dein Passwort sofort zu ändern.
+      reset_your_password: Passwort ändern
+      if_you_need_further_assistance_contact_us_at: Wenn du weitere Hilfe benötigst, kontaktiere uns unter
+      security_dawarich_app: security@dawarich.app
+      account_temporarily_locked_hi: Konto temporär gesperrt Hi
+      your_dawarich_account_has_been_temporarily_locked_because_10_consecutive: ", Dein Dawarich-Konto wurde temporär gesperrt, weil 10 aufeinanderfolgende fehlgeschlagene Zwei-Faktor-Authentifizierungsversuche erkannt wurden. Die Sperrung wird automatisch nach 30 Minuten aufgehoben. Keine Aktion ist erforderlich, wenn dies du warst. Erkannt dieser Aktivität nicht? Jemand könnte versuchen, dein Konto zu accessieren. Wir empfehlen, dein Passwort sofort zu ändern. Passwort ändern:"
+      if_you_need_further_assistance_contact_us_at_security_dawarich: Wenn du weitere Hilfe benötigst, kontaktiere uns unter security@dawarich.app.
+      your_dawarich_account_has_been_temporarily_locked_because_10_consecutive_2: Dein Dawarich-Konto wurde temporär gesperrt, weil 10 aufeinanderfolgende fehlgeschlagene Zwei-Faktor-Authentifizierungsversuche erkannt wurden.
+      the_lock_will_automatically_lift_after_30_minutes_no_action: Die Sperrung wird automatisch nach 30 Minuten aufgehoben. Keine Aktion ist erforderlich, wenn dies du warst.
+      didn_t_recognise_this_activity_someone_may_be_trying_to: Erkannt dieser Aktivität nicht? Jemand könnte versuchen, dein Konto zu accessieren. Wir empfehlen, dein Passwort sofort zu ändern.
+      reset_your_password_2: 'Passwort ändern:'
+    welcome:
+      welcome_to_dawarich: Willkommen bei Dawarich!
+      hi: Hallo
+      this_is_evgenii_from_dawarich: ", das ist Evgenii von Dawarich."
+      welcome_to_dawarich_i_m_excited_to_have_you_on: Willkommen bei Dawarich! Ich freue mich, dich an Bord zu haben.
+      your_7_day_free_trial_has_started_during_this_time: 'Dein 7-tägiger kostenloses Testzeitraum hat begonnen. Während dieser Zeit kannst du:'
+      track_your_location_data: Deine Standortdaten verfolgen
+      view_your_movement_patterns_on_beautiful_maps: Deine Bewegungsmuster auf schönen Karten ansehen
+      analyze_your_travel_statistics: Deine Reise statistiken analysieren
+      export_your_data_in_various_formats: Deine Daten in verschiedenen Formaten exportieren
+      start_exploring_dawarich: Mit der Erkundung von Dawarich beginnen
+      if_you_have_any_questions_feel_free_to_drop_me: Falls du Fragen hast, melde dich einfach bei mir per E-Mail an hi@dawarich.app oder antworte einfach auf diese E-Mail.
+      happy_tracking: Freue dich auf die Verfolgung!
+      evgenii_from_dawarich: Evgenii von Dawarich
+      welcome_to_dawarich_hi: Willkommen bei Dawarich! Hallo
+      this_is_evgenii_from_dawarich_welcome_to_dawarich_i_m: ", das bin ich, Evgenii von Dawarich. Willkommen bei Dawarich! Ich freue mich, dich an Bord zu haben. Dein 7-tägiger kostenloses Testzeitraum hat begonnen. Während dieser Zeit kannst du: - Deine Standortdaten verfolgen - Deine Bewegungsmuster auf schönen Karten ansehen - Deine Reise statistiken analysieren - Deine Daten in verschiedenen Formaten exportieren Mit der Erkundung von Dawarich beginnen: https://my.dawarich.app Falls du Fragen hast, melde dich einfach bei mir per E-Mail an hi@dawarich.app oder antworte einfach auf diese E-Mail. Freue dich auf die Verfolgung! Evgenii von Dawarich"
+      track_your_location_data_2: "- Deine Standortdaten verfolgen"
+      view_your_movement_patterns_on_beautiful_maps_2: "- Deine Bewegungsmuster auf schönen Karten ansehen"
+      analyze_your_travel_statistics_2: "- Deine Reise statistiken analysieren"
+      export_your_data_in_various_formats_2: "- Deine Daten in verschiedenen Formaten exportieren"
+      start_exploring_dawarich_https_my_dawarich_app: 'Mit der Erkundung von Dawarich beginnen: https://my.dawarich.app'
+  visits:
+    buttons:
+      confirm: Bestätigen
+      delete: Löschen
+      delete_this_visit_your_location_points_stay: Diesen Aufenthalt löschen? Deine Standortpunkte bleiben.
+    name:
+      unnamed_visit: Unbenannter Aufenthalt
+      click_to_rename: Klicken, um umzubenennen
+  date:
+    formats:
+      month_name: "%B"
+      month_year: "%B %Y"
+      short_month_day: "%-d. %b"
+      short_month_day_padded: "%d. %b"
+      medium: "%-d. %b %Y"
+      medium_padded: "%d. %b %Y"
+      long: "%-d. %B %Y"
+      weekday_month_day: "%A, %-d. %B"
+      short_month_day_weekday: "%-d. %b, %A"
+      short_weekday_month_day: "%a, %-d. %b"
+      iso: "%Y-%m-%d"
+      day_month_year: "%-d. %B %Y"
+      day_month_year_abbreviated: "%-d. %b %Y"
+      month_day: "%-d. %B"
+      month_day_padded: "%d. %B"
+      month_day_year: "%-d. %B %Y"
+      day_year: "%-d. %Y"
+      abbreviated_month_name: "%b"
+      default: "%d.%m.%Y"
+      short: "%d.%m."
+    day_names:
+    - Sonntag
+    - Montag
+    - Dienstag
+    - Mittwoch
+    - Donnerstag
+    - Freitag
+    - Samstag
+    abbr_day_names:
+    - So
+    - Mo
+    - Di
+    - Mi
+    - Do
+    - Fr
+    - Sa
+    month_names:
+    -
+    - Januar
+    - Februar
+    - März
+    - April
+    - Mai
+    - Juni
+    - Juli
+    - August
+    - September
+    - Oktober
+    - November
+    - Dezember
+    abbr_month_names:
+    -
+    - Jan
+    - Feb
+    - Mär
+    - Apr
+    - Mai
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Okt
+    - Nov
+    - Dez
+    order:
+    - day
+    - month
+    - year
+  time:
+    formats:
+      hour_minute: "%H:%M"
+      long_with_time: "%-d. %B %Y um %H:%M Uhr"
+      human: "%-d. %b %Y, %H:%M"
+      human_with_seconds: "%-d. %b %Y, %H:%M:%S"
+      short_with_time: "%-d. %b um %H:%M Uhr"
+      default: "%A, %-d. %B %Y, %H:%M Uhr"
+      short: "%-d. %b, %H:%M Uhr"
+      long: "%A, %-d. %B %Y, %H:%M Uhr"
+    am: vormittags
+    pm: nachmittags
+  common:
+    app_name: Dawarich
+    not_available: N/A
+  enums:
+    export:
+      file_type:
+        points: Punkte
+        user_data: Benutzerdaten
+    import:
+      source:
+        google_semantic_history: Google Semantic History
+        owntracks: OwnTracks
+        google_records: Google Records
+        google_phone_takeout: Google Phone Takeout
+        gpx: GPX
+        immich_api: Immich API
+        geojson: GeoJSON
+        photoprism_api: PhotoPrism API
+        user_data_archive: Benutzerdatenarchiv
+        kml: KML
+        csv: CSV
+        tcx: TCX
+        fit: FIT
+        polarsteps: Polarsteps
+        google_photos: Google Photos
+    place:
+      source:
+        manual: Manuell
+        photon: Photon
+    shared_link:
+      resource_type:
+        trip: Reise
+        track: Track
+        timeline: Zeitleiste
+        live: Live
+  photo_sources:
+    immich: Immich
+    photoprism: PhotoPrism
+  supporter_platforms:
+    github: GitHub
+    patreon: Patreon
+    ko_fi: Ko-fi
+  transportation_modes:
+    unknown: Unbekannt
+    stationary: Stationär
+    walking: Gehen
+    running: Laufen
+    cycling: Radfahren
+    driving: Fahren
+    bus: Bus
+    train: Zug
+    flying: Fliegen
+    boat: Schiff
+    motorcycle: Motorrad
+  helpers:
+    application:
+      full_title: "%{page_title} | %{app_name}"
+      expired: Abgelaufen
+      days_left:
+        one: "%{count} Tag übrig"
+        other: "%{count} Tage übrig"
+      finish_signup: Registrierung abschließen
+      resume: Fortsetzen
+      subscribe: Abonnieren
+      pro_preview: Auf Pro verfügbar — klicken, um Vorschau zu zeigen
+      pro_only: Auf Pro verfügbar
+      pro_badge: " Pro"
+    timeline:
+      unnamed: Unbenannt
+    datetime_formatting:
+      expires_on: Verfällt am %{date}
+    insights:
+      monthly_digest: Monatlicher Newsletter
+      monthly_digest_title: "%{month} %{year} Newsletter"
+      minute_count:
+        one: "%{count} min"
+        other: "%{count} min"
+      day_count:
+        one: "%{count} Tag"
+        other: "%{count} Tage"
+      hour_count:
+        one: "%{count} Stunde"
+        other: "%{count} Stunden"
+    users:
+      digests:
+        distance_with_unit: "%{distance} %{unit}"
+        moon_distance: Das sind %{percentage}% der Entfernung zur Mond!
+        earth_circumference: Das sind %{percentage}% der Erdumfang!
+      digests_mailer:
+        same: "→ gleiche"
+        new: "↑ neue"
+    trips:
+      duration:
+        years:
+          one: "%{count} Jahr"
+          other: "%{count} Jahre"
+        months:
+          one: "%{count} Monat"
+          other: "%{count} Monate"
+        days:
+          one: "%{count} Tag"
+          other: "%{count} Tage"
+        hours:
+          one: "%{count} Stunde"
+          other: "%{count} Stunden"
+    stats:
+      countries_and_cities: "%{countries} Länder, %{cities} Städte"
+      distance: "%{value} %{unit}"
+      peak_day: "%{date} (%{distance})"
+      week_range: "%{start_date} - %{end_date}"
+    stats_comparison:
+      same_as_previous_month: Gleich wie im Vormonat
+      distance:
+        more: "%{percentage}% mehr als dein Durchschnitt dieses Jahr"
+        less: "%{percentage}% weniger als dein Durchschnitt dieses Jahr"
+      active_days:
+        more:
+          one: "%{count} Tag mehr als im Vormonat"
+          other: "%{count} Tage mehr als im Vormonat"
+        less:
+          one: "%{count} Tag weniger als im Vormonat"
+          other: "%{count} Tage weniger als im Vormonat"
+      countries:
+        more:
+          one: "%{count} Land mehr als im Vormonat"
+          other: "%{count} Länder mehr als im Vormonat"
+        less:
+          one: "%{count} Land weniger als im Vormonat"
+          other: "%{count} Länder weniger als im Vormonat"
+    imports:
+      extraction_status:
+        not_attempted: Nicht extrahiert
+        pending: In der Warteschlange
+        running: Wird extrahiert
+        completed: Extrahiert
+        failed: Fehlerhaft
+        unsupported: Nicht verfügbar
+    posters:
+      render_phases:
+        fetching_data: Kartendaten werden geladen…
+        drawing_map: Karte wird gezeichnet…
+        drawing_route: Dein Weg wird gezeichnet…
+        saving: Bild wird gespeichert…
+        queued: In der Warteschlange…
+    shared_links:
+      date_ranges:
+        same_month: "%{start_date} – %{end_date}"
+        same_year: "%{start_date} – %{end_date}"
+        different_years: "%{start_date} – %{end_date}"
+      timeline_subtitle: "%{range} wird über einen öffentlichen Link geteilt."
+      trip_subtitle: "%{trip} wird über einen öffentlichen Link geteilt."
+      track: Track
+      track_label: "%{mode} · %{date} · %{distance} %{unit}"
+    tracks:
+      segments:
+        mode_disabled: "%{mode} (deaktiviert in den Einstellungen)"
+  calendar:
+    weekday_initials:
+    - M
+    - D
+    - M
+    - D
+    - F
+    - S
+    - S
+    abbreviated_weekdays:
+    - Montag
+    - Di
+    - Mi
+    - Do
+    - Fr
+    - Sa
+    - So
+  oauth_providers:
+    google: Google
+    github: GitHub
+    apple: Apple
+    sign_in_with_google: Mit Google anmelden
+    sign_in_with_github: Mit GitHub anmelden
+    sign_in_with_apple: Mit Apple anmelden
+    sign_in_with_provider: Mit %{provider} anmelden
+    openid_connect: OpenID Connect
+  statuses:
+    completed: Abgeschlossen
+    processing: Wird verarbeitet
+    created: Erstellt
+    failed: Fehlgeschlagen
+    deleting: Löschen
+    suggested: Vorgeschlagen
+    confirmed: Bestätigt
+    declined: Abgelehnt
+  units:
+    meters: "%{value} m"
+    meters_compact: "%{value}m"
+    kilometers: "%{value} km"
+    miles: "%{value} mi"
+    minutes: "%{value} min"
+    hours_minutes_compact: "%{hours}h %{minutes}m"
+    days_hours_compact: "%{days}d %{hours}h"
+    days_compact: "%{value}d"
+    minutes_compact: "%{value}m"
+    minutes_word_compact: "%{value}min"
+    hours_compact: "%{value}h"
+    seconds_compact: "%{value}s"
+    feet: "%{value} ft"
+    meters_per_second_squared: "%{value} m/s²"
+    miles_per_hour: mph
+    kilometers_per_hour: km/h
+    speed_mph: "%{value} mph"
+    speed_kmh: "%{value} km/h"
+    kilometers_suffix: " km"
+  controllers:
+    api:
+      v1:
+        areas:
+          area_was_successfully_deleted: Der Bereich wurde erfolgreich gelöscht
+        auth:
+          apple:
+            apple_has_not_verified_this_email_sign_in_with_password: Apple hat diese E-Mail nicht verifiziert. Melde dich mit Passwort an und verknüpfe sie in den Einstellungen.
+            this_email_already_has_a_dawarich_account_we_sent_a: Diese E-Mail hat bereits ein Dawarich-Konto. Wir haben einen Bestätigungslink an diese Adresse gesendet — klicke darauf, um deinen Apple-ID zu verknüpfen.
+            we_couldn_t_find_your_existing_account_and_apple_didn: Wir konnten dein bestehendes Konto nicht finden, und Apple hat dieses Mal deine E-Mail nicht mit uns geteilt. Apple teilt die E-Mail nur einmal. Gehe zu appleid.apple.com → Anmeldung mit Apple, finde Dawarich, wähle "Nicht mehr mit Apple anmelden" und versuche es erneut.
+            token_verification_failed: 'Apple-Token-Überprüfung fehlgeschlagen: %{message}'
+          google:
+            google_has_not_verified_this_email_sign_in_with_password: Google hat diese E-Mail nicht verifiziert. Melde dich mit Passwort an und verknüpfe sie in den Einstellungen.
+            this_email_already_has_a_dawarich_account_we_sent_a: Diese E-Mail hat bereits ein Dawarich-Konto. Wir haben einen Bestätigungslink an diese Adresse gesendet — klicke darauf, um deine Google-Anmeldung zu verknüpfen.
+            token_verification_failed: 'Google-Token-Überprüfung fehlgeschlagen: %{message}'
+          otp_challenges:
+            invalid_challenge: 'Ungültiger oder abgelaufener Challenge: %{message}'
+            account_locked: Konto vorübergehend gesperrt aufgrund zu vieler fehlgeschlagener 2FA-Versuche. Nutze einen Backup-Code, warte 30 Minuten oder setze dein Passwort zurück.
+            invalid_two_factor_code: Ungültiger zweistufiger Authentifizierungscode
+          sessions:
+            invalid_credentials: Ungültige E-Mail-Adresse oder Passwort
+        digests:
+          invalid_year: Ungültiges Jahr
+          digest_already_exists: Digest existiert bereits
+          digest_for_year_is_being_generated: Digest für %{year} wird generiert
+        families:
+          locations:
+            start_at_and_end_at_are_required: start_at und end_at sind erforderlich
+            invalid_date_format: Ungültiges Datum im Format
+            user_is_not_part_of_a_family: Benutzer ist nicht Teil einer Familie
+        imports:
+          pending:
+            an_error_occurred: Ein Fehler ist aufgetreten
+            missing_file: Datei fehlt
+            missing_filename: Originaldateiname fehlt
+            empty_file: Datei ist leer
+            file_too_large: Datei überschreitet die 100MB-Grenze
+            unsupported_file_type: Nicht unterstützter Dateityp '%{extension}'
+            storage_capacity_exceeded: Speicherplatz für ausstehende Importe ist aufgebraucht
+          missing_required_parameter_file: 'Fehlender erforderlicher Parameter: file'
+          an_error_occurred_while_processing_the_import: Fehler beim Verarbeiten des Imports
+          unsupported_file_type_ext_allowed_join: 'Nicht unterstützter Dateityp ''%{ext}''. Erlaubt: %{allowed}'
+        locations:
+          coordinates_lat_lon_are_required: Koordinaten (lat, lon) sind erforderlich
+          search_failed_please_try_again: Suche fehlgeschlagen. Bitte versuche es erneut.
+          invalid_coordinates_lat_must_be_90_90_lon_must_be: 'Ungültige Koordinaten: lat muss -90..90 sein, lon muss -180..180 sein'
+          search_query_too_long_max_200_characters: Suchabfrage zu lang (max. 200 Zeichen)
+        maps:
+          hexagons:
+            missing_required_parameter_param: 'Fehlender erforderlicher Parameter: %{parameter}'
+            shared_stats_not_found_or_no_longer_available: Gemeinsame Statistiken nicht gefunden oder nicht mehr verfügbar
+            invalid_date_format: Ungültiges Datum im Format
+            failed_to_generate_hexagon_grid: Erzeugung der Hexagon-Grid fehlgeschlagen
+        notes:
+          note_was_successfully_deleted: Notiz wurde erfolgreich gelöscht
+        overland:
+          batches:
+            batch_creation_failed: Batch-Erstellung fehlgeschlagen
+        owntracks:
+          points:
+            point_creation_failed: Punkterstellung fehlgeschlagen
+        photos:
+          failed_to_fetch_photos: Fotos konnten nicht abgerufen werden
+          capitalize_integration_not_configured: "%{source} Integration nicht konfiguriert"
+          failed_to_fetch_thumbnail: Thumbnail konnte nicht abgerufen werden
+        places:
+          latitude_and_longitude_are_required: Latitude und Longitude sind erforderlich
+          lat_and_lon_are_required: Lat und Lon sind erforderlich
+          invalid_coordinates: Ungültige Koordinaten
+        points:
+          invalid_bounding_box: Ungültiger Begrenzungsrahmen
+          point_creation_failed: Erstellung des Punktes fehlgeschlagen
+          point_deleted_successfully: Punkt erfolgreich gelöscht
+          no_points_selected: Keine Punkte ausgewählt
+          too_many_points_selected_maximum_is_bulk_destroy_max_per: Zu viele Punkte ausgewählt. Maximal ist %{limit} pro Anfrage.
+          points_were_successfully_destroyed: Punkte wurden erfolgreich gelöscht
+          anomaly_re_evaluation_already_in_progress: Anomalie-Neubewertung läuft bereits.
+          re_evaluation_queued_existing_anomaly_flags_will_be_cleared_and: Neubewertung in der Warteschlange. Bestehende Anomaliefahnen werden gelöscht und neu berechnet.
+        recalculations:
+          invalid_year: Ungültiges Jahr
+          recalculation_already_in_progress_for_this_user: Neuberechnung läuft bereits für diesen Benutzer.
+          recalculation_queued_tracks_stats_and_digests_will_be_regenerated_in: Wiederaufbereitung ist im Warteschlange. Tracks, Statistiken und Digests werden im Hintergrund neu erstellt.
+        settings:
+          mobile:
+            settings_updated: Einstellungen aktualisiert
+            something_went_wrong: Etwas ist schiefgelaufen
+          something_went_wrong: Etwas ist schiefgelaufen
+          settings_updated: Einstellungen aktualisiert
+          tile_url_error: Tile-URL muss {z}, {x} und {y} Platzhalter enthalten oder eine MapLibre-Stil-URL sein
+        subscriptions:
+          configuration_error: Konfigurationsfehler
+          invalid_webhook_secret: Ungültiges Webhook-Secret
+          missing_event_id: Fehlender event_id
+          stale_event: Veraltete Ereignis
+          subscription_updated_successfully: Abonnement erfolgreich aktualisiert
+          failed_to_verify_subscription_update: Überprüfung der Abonnementaktualisierung fehlgeschlagen.
+          invalid_subscription_data_received: Ungültige Abonnementdaten erhalten.
+        timeline:
+          start_at_and_end_at_are_required: start_at und end_at sind erforderlich
+          date_range_cannot_exceed_max_range_days_days: Datumsbereich darf nicht mehr als %{max_days} Tage umfassen
+        traccar:
+          points:
+            point_creation_failed: Erstellung des Punktes fehlgeschlagen
+        users:
+          destroy:
+            cannot_delete: Du hast eine Familie mit anderen Mitgliedern. Übertrage die Verantwortung oder entferne Mitglieder, bevor du dein Konto löscht.
+            deletion_scheduled: Dein Konto wurde zur Löschung geplant.
+            request_sent: "%{message} Wenn du ein aktives Apple- oder Google-Abonnement hast, kündige es in den Einstellungen deiner Plattform, um weitere Gebühren zu vermeiden."
+          two_factor:
+            disable_2fa_first_to_re_provision_the_secret: Deaktiviere zuerst 2FA, um den Geheimcode neu bereitzustellen.
+            two_factor_authentication_disabled: Zwei-Faktor-Authentifizierung deaktiviert
+            provide_a_valid_two_factor_code_or_backup_code_to: Gib einen gültigen Zwei-Faktor-Code (oder Sicherheitscode) ein, um 2FA zu deaktivieren.
+            provide_your_current_password: Gib dein aktuelles Passwort ein.
+          configuration_error: Konfigurationsfehler
+          invalid_webhook_secret: Ungültiger Webhook-Geheimcode
+          ids_is_required: ids ist erforderlich
+        visits:
+          possible_places:
+            visit_not_found: Aufenthalt nicht gefunden
+          select_place:
+            visit_not_found: Aufenthalt nicht gefunden
+          invalid_place: Ungültiger Ort
+          invalid_area: Ungültiger Bereich
+          at_least_2_visits_must_be_selected_for_merging: Mindestens 2 Aufenthalte müssen ausgewählt werden, um sie zu verbinden
+          one_or_more_visits_not_found: Ein oder mehrere Aufenthalte wurden nicht gefunden
+          count_visits_updated_successfully: "%{count} Aufenthalte wurden erfolgreich aktualisiert"
+          failed_to_delete_visit: Aufenthalt konnte nicht gelöscht werden
+          visit_not_found: Aufenthalt nicht gefunden
+          failed_to_create_visit: Aufenthalt konnte nicht erstellt werden
+      record_not_found: Datensatz nicht gefunden
+      complete_your_subscription_to_continue: Fertige dein Abonnement ab, um fortzufahren.
+      this_feature_requires_a_pro_plan: Diese Funktion erfordert ein Pro-Abonnement.
+      write_api_access_requires_a_pro_plan_your_data_was: Write-API-Zugriff erfordert ein Pro-Abonnement. Deine Daten wurden nicht geändert.
+      user_account_is_not_active_or_has_been_deleted: Benutzerkonto ist nicht aktiv oder wurde gelöscht
+      user_account_is_not_active: Benutzerkonto ist nicht aktiv
+      user_subscription_is_not_active: Benutzersubscription ist nicht aktiv
+      missing_required_parameters_join: 'Fehlende erforderliche Parameter: %{parameters}'
+      points_limit_exceeded: Punktegrenze überschritten
+    application:
+      your_account_is_not_active: Dein Konto ist nicht aktiv.
+      please_sign_in_to_continue: Melde dich an, um fortzufahren.
+      you_need_to_sign_in_first: Du musst dich zuerst anmelden.
+      this_feature_requires_a_pro_plan: Diese Funktion benötigt einen Pro-Plan.
+      your_account_has_been_deleted: Dein Konto wurde gelöscht.
+      you_are_not_authorized_to_perform_this_action: Du bist nicht berechtigt, diese Aktion auszuführen.
+      family_plan_required: Für diese Funktion ist der Family-Tarif erforderlich.
+    areas:
+      created: Bereich erfolgreich erstellt!
+      updated: Bereich erfolgreich aktualisiert!
+    auth:
+      account_links:
+        this_link_has_already_been_used: Dieser Link wurde bereits verwendet.
+        link_invalid_or_expired: Link ungültig oder abgelaufen.
+        provider_is_now_linked_to_your_account: "%{provider} ist jetzt mit deinem Konto verbunden."
+        no_pending_account_link: Keine ausstehende Kontoverknüpfung.
+        account_no_longer_exists: Konto existiert nicht mehr.
+        too_many_invalid_attempts_start_the_linking_flow_again: Zu viele ungültige Versuche. Starte den Verknüpfungsprozess erneut.
+        pending_is_now_linked_to_your_account: "%{pending} ist jetzt mit deinem Konto verbunden."
+        linked_sign_in_with_two_factor: "%{provider} ist jetzt mit deinem Konto verbunden. Melde dich mit deinem Passwort und dem 2FA-Code an, um fortzufahren."
+        incorrect_password: Falsches Passwort.
+        confirmation_link_sent: Wir haben einen Bestätigungslink an %{email} gesendet. Klicke darauf, um dein Konto zu verknüpfen.
+        already_linked_to_different_identity: Dieses Konto ist bereits mit einer anderen %{provider}-Identität verknüpft.
+      ios:
+        authentication_successful_you_can_close_this_window: Authentifizierung erfolgreich! Du kannst dieses Fenster schließen.
+        ios_authentication_successful: iOS-Authentifizierung erfolgreich
+    concerns:
+      share_links:
+        managable:
+          created: Teilen-Link erstellt.
+          deleted: Teilen-Link gelöscht.
+          revoked: Teilen-Link widerrufen.
+          url_regenerated: URL erneuert.
+          magic_phrase_regenerated: Magische Phrase erneuert.
+          no_active_share_link: Kein aktiver Teilen-Link.
+      account_deletion_confirmable:
+        confirm_with_email: Gib deine E-Mail-Adresse ein, um die Löschung zu bestätigen.
+        confirm_with_password: Gib dein aktuelles Passwort ein, um dein Konto zu löschen.
+      pending_import_claimable:
+        expired: Dein Import-Link ist abgelaufen oder wurde bereits verwendet. Du kannst die Datei von deinem Dashboard aus hochladen.
+        importing: Importiere %{filename}... Du wirst es bald in deinem Dashboard sehen.
+        queue_failed: Dein Import konnte nicht in die Warteschlange gegeben werden. Bitte hochlade die Datei von deinem Dashboard aus.
+    exports:
+      export_was_successfully_initiated_please_wait_until_it_s_finished: Export wurde erfolgreich gestartet. Bitte warte, bis es fertig ist.
+      export_failed_to_initiate_please_try_again: Export konnte nicht gestartet werden. Bitte versuche es erneut.
+      export_was_successfully_destroyed: Export wurde erfolgreich zerstört.
+    families:
+      family_created_successfully: Familie erfolgreich erstellt!
+      family_updated_successfully: Familie erfolgreich aktualisiert!
+      cannot_delete_family_with_members_remove_all_members_first: Familie mit Mitgliedern kann nicht gelöscht werden. Entferne zuerst alle Mitglieder.
+      family_deleted_successfully: Familie erfolgreich gelöscht!
+      you_are_not_in_a_family: Du bist nicht in einer Familie
+      failed_to_create_family: Familie konnte nicht erstellt werden
+    family:
+      invitations:
+        this_invitation_has_expired: Diese Einladung ist abgelaufen.
+        this_invitation_is_no_longer_valid: Diese Einladung ist nicht mehr gültig.
+        invitation_sent_successfully: Einladung erfolgreich gesendet!
+        invitation_cancelled: Einladung abgebrochen
+        failed_to_cancel_invitation_please_try_again: Einladung konnte nicht abgebrochen werden. Versuche es erneut
+        an_unexpected_error_occurred_while_cancelling_the_invitation: Unerwartter Fehler beim Abbrechen der Einladung
+        you_are_not_in_a_family: Du bist nicht in einer Familie
+        failed_to_send_invitation: Einladung konnte nicht gesendet werden
+      location_requests:
+        user_not_found_in_your_family: Benutzer wurde in deiner Familie nicht gefunden
+        location_request_sent_successfully: Standortanfrage erfolgreich gesendet
+        this_request_has_expired_or_already_been_responded_to: Diese Anfrage ist abgelaufen oder wurde bereits beantwortet
+        location_sharing_enabled: Standortfreigabe aktiviert
+        location_request_declined: Standortanfrage abgelehnt
+        you_are_not_authorized_to_view_this_request: Du bist nicht berechtigt, diese Anfrage anzuzeigen
+        you_must_be_part_of_a_family: Du musst Teil einer Familie sein
+      location_sharing:
+        user_is_not_part_of_a_family: Benutzer ist nicht Teil einer Familie
+      memberships:
+        welcome_to_the_family: Willkommen in der Familie!
+        an_unexpected_error_occurred_please_try_again_later: Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es später erneut
+        you_have_left_the_family: Du hast die Familie verlassen
+        email_has_been_removed_from_the_family: "%{email} wurde aus der Familie entfernt"
+        you_are_not_in_a_family: Du bist nicht Teil einer Familie
+        unable_to_accept_invitation: Einladung kann nicht angenommen werden
+        invitation_expired: Diese Einladung ist nicht mehr gültig oder ist abgelaufen
+        invitation_processed: Diese Einladung wurde bereits verarbeitet
+        invitation_email_mismatch: Diese Einladung gilt nicht für deine E-Mail-Adresse
+        not_authorized_to_accept: Du bist nicht berechtigt, diese Einladung anzunehmen
+        failed_to_remove_member: Mitglied konnte nicht entfernt werden
+    imports:
+      extractions:
+        extraction_queued: Extraktion wurde in die Warteschlange gestellt.
+        removing_extracted_data: Entferne extrahierte Daten…
+      import_was_successfully_updated: Import wurde erfolgreich aktualisiert.
+      no_files_were_selected_for_upload: Keine Dateien wurden zum Upload ausgewählt
+      no_valid_file_references_were_found_please_upload_files_using: Keine gültigen Dateireferenzen gefunden. Bitte Dateien mit dem Dateiauswahlfenster hochladen.
+      size_files_are_queued_to_be_imported_in_background: "%{size} Dateien werden im Hintergrund importiert"
+      import_is_being_deleted: Import wird gelöscht.
+      points_limit_exceeded: Punktegrenze überschritten
+    insights:
+      all_time: Alle Zeit
+      year_overview: "%{year} Übersicht"
+    notifications:
+      all_notifications_marked_as_read: Alle Benachrichtigungen als gelesen markiert.
+      all_notifications_where_successfully_destroyed: Alle Benachrichtigungen wurden erfolgreich gelöscht.
+      notification_was_successfully_destroyed: Benachrichtigung wurde erfolgreich gelöscht.
+    places:
+      place_was_successfully_destroyed: Ort wurde erfolgreich gelöscht.
+      created: Ort erfolgreich erstellt!
+      updated: Ort erfolgreich aktualisiert!
+    points:
+      no_points_selected: Keine Punkte ausgewählt.
+      points_were_successfully_destroyed: Punkte wurden erfolgreich gelöscht.
+    posters:
+      poster_generation_started_this_takes_about_a_minute: Poster-Generierung gestartet. Das dauert etwa eine Minute.
+      failed_to_start_poster_generation: Fehler beim Start der Poster-Generierung.
+      poster_deleted: Poster gelöscht.
+      untitled: Unbenanntes Poster
+    settings:
+      background_jobs:
+        settings_updated: Einstellungen aktualisiert
+        settings_could_not_be_updated: Einstellungen konnten nicht aktualisiert werden
+        job_was_successfully_created: Aufgabe wurde erfolgreich erstellt.
+      general:
+        settings_updated: Einstellungen aktualisiert
+        failed_to_update_settings: Fehler beim Aktualisieren der Einstellungen
+        please_enter_an_email_address_or_github_username: Gib bitte eine E-Mail-Adresse oder GitHub-Nutzername ein
+        verified_thank_you_for_supporting_dawarich_via_platform: Verifiziert! Danke für deine Unterstützung von Dawarich über %{platform}.
+        not_found_in_supporter_list_make_sure_you_re_using: Nicht in der Unterstützerliste gefunden. Stelle sicher, dass du dieselbe E-Mail-Adresse oder GitHub-Nutzername verwendest, wie dein Spenden-Plattform.
+      maps:
+        settings_updated: Einstellungen aktualisiert
+      onboardings:
+        demo_data_loaded: Demo-Daten geladen.
+        demo_data_is_already_loaded: Demo-Daten sind bereits geladen.
+        something_went_wrong_loading_demo_data: Beim Laden der Demo-Daten ist etwas schiefgelaufen.
+        demo_data_removed: Demo-Daten entfernt.
+        no_demo_data_found: Keine Demo-Daten gefunden.
+        something_went_wrong_removing_demo_data: Beim Entfernen der Demo-Daten ist etwas schiefgelaufen.
+      two_factor:
+        incorrect_password: Falsches Passwort.
+        provide_a_valid_two_factor_code_or_backup_code_to: Gib einen gültigen Zwei-Faktor-Code (oder Sicherungscodes) ein, um die Zwei-Faktor-Authentifizierung zu deaktivieren.
+        two_factor_authentication_disabled: Zwei-Faktor-Authentifizierung deaktiviert.
+        two_factor_authentication_is_not_configured_on_this_instance: Zwei-Faktor-Authentifizierung ist auf dieser Instanz nicht konfiguriert.
+        invalid_verification_code: Ungültiger Verifizierungscode. Bitte versuche es erneut.
+      users:
+        user_was_successfully_updated: Benutzer wurde erfolgreich aktualisiert.
+        user_could_not_be_updated_to_sentence: 'Benutzer konnte nicht aktualisiert werden: %{errors}'
+        user_was_successfully_created: Benutzer wurde erfolgreich erstellt
+        user_could_not_be_created_to_sentence: 'Benutzer konnte nicht erstellt werden: %{errors}'
+        cannot_delete_account_while_being_owner_of_a_family_which: Konto kann nicht gelöscht werden, solange du Besitzer einer Familie bist, die andere Mitglieder hat.
+        user_deletion_has_been_initiated_the_account_will_be_fully: Benutzerlöschung wurde initiiert. Das Konto wird bald vollständig entfernt.
+        api_key_has_been_regenerated: API-Schlüssel wurde neu generiert.
+        password_reset_email_has_been_sent: E-Mail zum Passwort zurücksetzen wurde gesendet.
+        user_registration_has_been_status: Benutzerregistrierung wurde %{status}.
+        your_data_is_being_exported_you_will_receive_a_notification: Deine Daten werden exportiert. Du wirst benachrichtigt, sobald der Export fertig ist.
+        please_select_a_zip_archive_to_import: Bitte wähle ein ZIP-Archiv zum Importieren aus.
+        your_data_import_has_been_started_you_will_receive_a: Dein Datenimport wurde gestartet. Du wirst benachrichtigt, sobald er abgeschlossen ist.
+        failed_to_start_import_please_try_again: Importieren konnte nicht gestartet werden. Bitte versuche es erneut.
+        an_error_occurred_while_starting_the_import_please_try_again: Ein Fehler ist beim Starten des Imports aufgetreten. Bitte versuche es erneut.
+        please_upload_a_valid_zip_file: Bitte lade eine gültige ZIP-Datei hoch.
+        cannot_remove_last_admin_role: Der letzte Admin-Benutzer kann nicht von der Admin-Rolle entfernt werden.
+        cannot_disable_last_admin: Der letzte Admin-Benutzer kann nicht deaktiviert werden.
+      visits:
+        visit_detection_settings_updated: Einstellungen für die Aufenthaltserkennung wurden aktualisiert
+    share_links:
+      lives:
+        default_name: Live-Ort
+      timelines:
+        default_name: 'Zeitleiste: %{start_date} → %{end_date}'
+    shared:
+      digests:
+        shared_digest_not_found_or_no_longer_available: Gemeinsamer Digest nicht gefunden oder nicht mehr verfügbar
+        failed_to_update_sharing_settings: Aktualisierung der Freigabestellungen fehlgeschlagen
+        sharing_enabled: Freigabe erfolgreich aktiviert
+        sharing_disabled: Freigabe erfolgreich deaktiviert
+        auto_saved: Automatisch gespeichert
+      links:
+        incorrect_phrase: Dieser Phrase hat nicht funktioniert. Versuche es erneut.
+      stats:
+        shared_stats_not_found_or_no_longer_available: Gemeinsame Statistiken nicht gefunden oder nicht mehr verfügbar
+        failed_to_update_sharing_settings: Aktualisierung der Freigabestellungen fehlgeschlagen
+        sharing_enabled: Freigabe erfolgreich aktiviert
+        sharing_disabled: Freigabe erfolgreich deaktiviert
+        auto_saved: Automatisch gespeichert
+    stats:
+      stats_for_target_are_being_updated: Statistiken für %{target} werden aktualisiert
+      stats_are_being_updated: Statistiken werden aktualisiert
+    tags:
+      tag_was_successfully_created: Tag wurde erfolgreich erstellt.
+      tag_was_successfully_updated: Tag wurde erfolgreich aktualisiert.
+      tag_was_successfully_deleted: Tag wurde erfolgreich gelöscht.
+    tracks:
+      recalculations:
+        re_classification_already_running: Re-Klassifizierung läuft bereits
+        re_classification_started_your_tracks_will_update_over_the_next: Re-Klassifizierung gestartet — deine Tracks werden in den nächsten Minuten aktualisiert
+      segments:
+        segment_updated: Segment aktualisiert
+        mode_not_enabled: Dieser Modus ist in deinen Einstellungen nicht aktiviert
+        update_failed: Segment konnte nicht aktualisiert werden
+      share_links:
+        not_found: Nicht gefunden
+    trial:
+      welcome:
+        link_invalid_please_sign_in: Link ungültig. Bitte melde dich an.
+        another_user_is_already_signed_in: Ein anderer Benutzer ist bereits angemeldet.
+        this_welcome_link_has_already_been_used: Dieser Willkommenslink wurde bereits verwendet.
+        link_invalid_or_expired_please_sign_in: Link ungültig oder abgelaufen. Bitte melde dich an.
+        account_no_longer_exists_please_sign_up_again: Konto existiert nicht mehr. Bitte melde dich erneut an.
+        trial_active_until: Willkommen bei Dawarich — dein 7-tägiger kostenloses Testzeitraum läuft bis %{date}.
+        trial_activating: Willkommen bei Dawarich — dein Testzeitraum wird gerade aktiviert.
+    trips:
+      notes:
+        invalid_date: Ungültiges Datum
+      share_links:
+        not_found: Nicht gefunden
+        default_name: 'Reise: %{trip}'
+      trip_was_successfully_created_data_is_being_calculated_in_the: Reise wurde erfolgreich erstellt. Die Daten werden im Hintergrund berechnet.
+      trip_was_successfully_updated: Reise wurde erfolgreich aktualisiert.
+      trip_was_successfully_destroyed: Reise wurde erfolgreich gelöscht.
+      already_recalculating_this_page_will_update_when_it_s_done: Berechnung läuft — diese Seite wird aktualisiert, sobald sie fertig ist.
+      recalculating_the_page_will_update_automatically_when_it_s_ready: Berechnung läuft — die Seite wird automatisch aktualisiert, sobald sie fertig ist.
+      unsupported_export_format_choose_gpx_or_geojson: Nicht unterstütztes Exportformat. Wähle GPX oder GeoJSON.
+      trip_export_initiated_check_the_exports_page_when_it_s: Der Reiseexport wurde gestartet. Prüfe die Exportseite, sobald er abgeschlossen ist.
+      export_failed_to_initiate_please_try_again: Der Export konnte nicht gestartet werden. Bitte versuche es erneut.
+    users:
+      apple_oauth:
+        sign_in_with_apple_was_cancelled: Anmeldung mit Apple wurde abgebrochen.
+        sign_in_failed: 'Apple-Anmeldung fehlgeschlagen: %{message}'
+        email_not_verified: Die E-Mail-Adresse deiner Apple-ID ist nicht verifiziert. Verifiziere sie bei Apple und versuche es erneut.
+        missing_email: Apple hat deine E-Mail-Adresse diesmal nicht übermittelt und wir konnten dein bestehendes Konto nicht finden. Öffne appleid.apple.com → Mit Apple anmelden → Dawarich → „Mit Apple anmelden“ nicht mehr verwenden und versuche es erneut.
+        did_not_complete: Die Anmeldung mit Apple wurde nicht abgeschlossen. Bitte versuche es erneut.
+        state_mismatch: 'Die Anmeldung mit Apple ist fehlgeschlagen: Der Status stimmt nicht überein. Bitte versuche es erneut.'
+      destroy_confirmations:
+        this_deletion_link_has_already_been_used: Dieser Löschlink wurde bereits verwendet.
+        deletion_link_invalid_or_expired: Löschlink ungültig oder abgelaufen.
+        cannot_delete_account_while_you_own_a_family_with_other: Konto kann nicht gelöscht werden, solange du ein Familienkonto mit anderen Mitgliedern besitzt. Übertrage die Verantwortung oder entferne zuerst die Mitglieder.
+        your_account_has_been_scheduled_for_deletion_we_are_sorry: Dein Konto wurde zum Löschen geplant. Wir sind traurig, dich gehen zu sehen.
+      digests:
+        year_end_digest_for_year_is_being_generated_check_back: Jahresende-Zusammenfassung für %{year} wird erstellt. Schau bald wieder vorbei!
+        invalid_year_selected: Ungültiges Jahr ausgewählt
+        year_end_digest_for_year_has_been_deleted: Jahresende-Zusammenfassung für %{year} wurde gelöscht
+        digest_not_found: Zusammenfassung nicht gefunden
+      omniauth_callbacks:
+        invalid_credentials: Ungültige Anmeldeinformationen. Bitte überprüfe deinen Benutzernamen und dein Passwort.
+        connection_timeout: Verbindungstimeout. Bitte versuche es erneut.
+        security_error: Sicherheitsfehler erkannt. Bitte versuche es erneut.
+        provider_unavailable: Verbindung zum Authentifizierungsanbieter nicht möglich. Bitte kontaktiere deinen Administrator.
+        provider_configuration_error: Konfigurationsfehler beim Authentifizierungsanbieter. Bitte kontaktiere deinen Administrator.
+        unknown_error: Unbekannter Fehler
+        authentication_failed: 'Authentifizierung fehlgeschlagen: %{detail}'
+        oidc_account_requires_administrator: Dein Konto muss von einem Administrator erstellt werden, bevor du dich mit OIDC anmelden kannst. Bitte kontaktiere deinen Administrator.
+        account_creation_failed: Dein Konto kann nicht erstellt werden. Bitte versuche es erneut oder kontaktiere den Support.
+        email_not_verified: Deine %{provider} E-Mail-Adresse ist nicht verifiziert. Bestätige sie über den Anbieter, dann versuche es erneut – oder melde dich mit deinem vorhandenen Passwort an.
+      otp_challenge:
+        session_expired_please_sign_in_again: Session abgelaufen. Bitte melde dich erneut an.
+        signed_in_successfully: Eingeloggt.
+        account_temporarily_locked_due_to_too_many_failed_2fa_attempts: Konto temporär gesperrt aufgrund zu vieler fehlgeschlagener 2FA-Versuche. Nutze einen Backup-Code, warte 30 Minuten oder setze dein Passwort zurück.
+        too_many_invalid_two_factor_codes_please_sign_in_again: Zu viele ungültige Zwei-Faktor-Codes. Bitte melde dich erneut an.
+        invalid_two_factor_code: Ungültiger Zwei-Faktor-Code.
+      registrations:
+        your_account_has_been_scheduled_for_deletion: Dein Konto wurde zur Löschung geplant.
+        email_password_registration_is_disabled_please_use_oidc_to_sign: Registrierung per E-Mail/Passwort ist deaktiviert. Bitte verwende OIDC zum Anmelden.
+        registration_is_not_available_please_contact_your_administrator_for_acce: Registrierung ist nicht verfügbar. Bitte kontaktiere deinen Administrator für Zugriff.
+        welcome_to_name_you_re_now_part_of_the_family: Willkommen bei %{name}! Du bist jetzt Teil der Familie.
+        account_created_successfully_but_there_was_an_issue_accepting_the: 'Konto erfolgreich erstellt, aber es gab ein Problem beim Annahme des Einladungslinks: %{error_message}'
+        account_created_successfully_but_there_was_an_issue_accepting_the_2: Konto erfolgreich erstellt, aber es gab ein Problem beim Annahme der Einladung. Bitte versuche es erneut.
+      sessions:
+        email_password_login_is_disabled_please_use_oidc_to_sign: Anmeldung per E-Mail/Passwort ist deaktiviert. Bitte verwende OIDC zum Anmelden.
+    visits:
+      redetections:
+        re_detect_ran_recently_try_again_in_an_hour: Re-Detect wurde kürzlich ausgeführt. Versuche es in einer Stunde erneut.
+        re_detection_queued_we_ll_notify_you_when_it_finishes: Re-Detection ist in der Warteschlange. Wir benachrichtigen dich, sobald es fertig ist.
+      failed_to_update_visits: Aktualisierung der Aufenthalte fehlgeschlagen.
+      bulk_updated:
+        one: "%{count} Aufenthalt %{status}."
+        other: "%{count} Aufenthalte %{status}."
+      no_matching_visits: Keine passenden Aufenthalte gefunden.
+      select_visit_to_delete: Wähle mindestens einen Aufenthalt zum Löschen.
+      failed_to_delete_visits: Löschen der Aufenthalte fehlgeschlagen.
+      invalid_place: Ungültiger Ort
+      invalid_area: Ungültiger Bereich
+      failed_to_update_visit: Aktualisierung des Aufenthalts fehlgeschlagen.
+      select_visits_to_merge: Wähle mindestens zwei Aufenthalte zum Verbinden.
+      visits_must_share_day: Aufenthalte müssen am selben Tag sein.
+      failed_to_merge_visits: Verbinden der Aufenthalte fehlgeschlagen.
+      unsupported_source_status: Unbekannter Quellstatus.
+      visit_updated: Aufenthalt %{status} aktualisiert.
+      visits_merged: Aufenthalte verbunden.
+      visit_removed: Aufenthalt entfernt. Deine Standortpunkte sind immer noch hier.
+      too_many_visits: Du kannst bis zu %{count} Aufenthalte gleichzeitig aktualisieren. Schränke deine Auswahl ein und versuche es erneut.
+      missing_visits: Einige dieser Aufenthalte sind nicht mehr hier – wahrscheinlich bearbeitet in einem anderen Tab. Aktualisiere und versuche es erneut.
+      plan_window_visits: Einige dieser Aufenthalte liegen außerhalb des 12-Monats-Zeitraums deines Lite-Plans. Upgrade zu Pro, um ältere Daten zu verwalten.
+      bulk_removed:
+        one: "%{count} Aufenthalt entfernt. Deine Standortpunkte sind immer noch hier."
+        other: "%{count} Aufenthalte entfernt. Deine Standortpunkte sind immer noch hier."
+  visit_statuses:
+    suggested: vorgeschlagen
+    confirmed: bestätigt
+    declined: abgelehnt
+  mailers:
+    family:
+      invitation:
+        subject: "\U0001F389 Du wurdest eingeladen, der Familie %{family} auf Dawarich beizutreten!"
+      location_request:
+        subject: "\U0001F4CD %{requester} bittet um deinen Standort auf Dawarich"
+      member_joined:
+        subject: "\U0001F46A %{user} ist deiner Familie %{family} auf Dawarich beigetreten!"
+    users:
+      welcome:
+        subject: Willkommen bei Dawarich!
+      explore_features:
+        subject: Entdecke die Funktionen von Dawarich!
+      archival_approaching:
+        subject: Behalte deinen vollständigen Historie – upgrade zu Pro
+      oauth_account_link:
+        subject: Bestätige die Verknüpfung %{provider} mit deinem Dawarich-Konto
+      account_destroy_confirmation:
+        subject: Bestätige die Löschung deines Dawarich-Kontos
+      otp_account_locked:
+        subject: Dawarich-Konto vorübergehend gesperrt
+      digests:
+        year_end:
+          subject: Dein %{year} Jahresrückblick – Dawarich
+        monthly:
+          subject: Dein %{month} %{year} in Überprüfung — Dawarich
+  models:
+    family:
+      location_request:
+        cannot_request_your_own_location: Kann deine eigene Position nicht anfordern
+    import:
+      is_too_large_trial_users_can_only_upload_files_up: ist zu groß. Testnutzer können nur Dateien bis zu 10MB hochladen.
+      trial_users_can_only_create_up_to_5_imports_please: Testnutzer können nur bis zu 5 Importe erstellen. Bitte abonnieren, um mehr Dateien hochzuladen.
+    note:
+      has_already_been_taken: wurde bereits genommen
+      must_be_within_the_trip_date_range: muss im Zeitraum der Reise liegen
+      must_belong_to_the_same_user: muss demselben Benutzer gehören
+    point:
+      already_has_a_point_at_this_location_and_time_for: hat bereits einen Punkt an diesem Ort und zu dieser Zeit für diesen Benutzer
+    points:
+      raw_data_archive:
+        must_contain_expected_count_and_actual_count: muss erwartete_count und tatsächliche_count enthalten
+    shared_link:
+      is_required_for_this_resource_type: ist für dieses Ressourcentyp erforderlich
+      must_be_blank_for_this_resource_type: muss leer sein für diesen Ressourcentyp
+      must_be_in_the_future: muss in der Zukunft liegen
+      must_include_start_date_and_end_date_for_timeline_shares: muss start_date und end_date enthalten für Zeitleistenteilen
+      start_date_and_end_date_must_be_parseable_as_dates: start_date und end_date müssen als Datum parsierbar sein
+      end_date_must_be_on_or_after_start_date: end_date muss nach oder gleich start_date sein
+    tag:
+      must_be_an_emoji_or_symbol_not_a_letter: muss ein Emoji oder Symbol, nicht ein Buchstabe, sein
+    track_segment:
+      must_be_greater_than_or_equal_to_start_index: muss größer oder gleich start_index sein
+    trip:
+      must_be_after_start_date: muss nach start_date sein
+  services:
+    air_trail:
+      connection_tester:
+        airtrail_connection_verified: AirTrail-Verbindung bestätigt
+        airtrail_url_is_missing: AirTrail-URL fehlt
+        airtrail_api_key_is_missing: AirTrail-API-Schlüssel fehlt
+        airtrail_connection_failed_message: 'AirTrail-Verbindung fehlgeschlagen: %{message}'
+    concerns:
+      url_validatable:
+        invalid_scheme: 'Ungültiger URL-Schema: %{scheme}'
+        host_required: URL muss einen Host enthalten
+        embedded_credentials: URL darf keine Anmeldeinformationen enthalten (user:pass@host)
+        blocked_address: URL führt zu einem blockierten Adressraum
+        invalid_format: Ungültiges URL-Format
+        unresolvable_host: 'Hostname konnte nicht aufgelöst werden: %{host}'
+    csv:
+      detector:
+        required_columns_missing: 'Erforderliche Spalten konnten nicht erkannt werden: Breitengrad, Längengrad, Zeitstempel. Die gefundenen Header müssen erkannte Aliasnamen für alle drei enthalten.'
+    exports:
+      create:
+        export_finished: Export beendet
+        export_name_successfully_finished: Export „%{name}“ wurde erfolgreich beendet.
+        export_failed: Export fehlgeschlagen
+        export_name_failed_message_stacktrace_n: 'Export „%{name}“ fehlgeschlagen: %{message}, Stapelverfolgung: %{backtrace}'
+        unsupported_file_format: 'Nicht unterstütztes Dateiformat: %{format}'
+    families:
+      accept_invitation:
+        you_must_leave_your_current_family_before_joining_a_new: Du musst dein aktuelles Familienmitglied verlassen, bevor du ein neues anschließt.
+        this_invitation_is_no_longer_valid_or_has_expired: Diese Einladung ist nicht mehr gültig oder ist abgelaufen.
+        this_invitation_is_not_for_your_email_address: Diese Einladung gilt nicht für deine E-Mail-Adresse.
+        this_family_s_plan_is_no_longer_active: Das Familienabonnement ist nicht mehr aktiv.
+        this_family_has_reached_the_maximum_number_of_members: Diese Familie hat die maximale Anzahl an Mitgliedern erreicht.
+        welcome_to_family: Willkommen in der Familie!
+        you_ve_joined_the_family_name: Du hast die Familie „%{name}“ beigetreten
+        new_family_member: Neues Familienmitglied!
+        email_has_joined_your_family: "%{email} hat deine Familie beigetreten"
+        an_unexpected_error_occurred_while_joining_the_family_please_try: Beim Beitreten zur Familie ist ein unerwarteter Fehler aufgetreten. Bitte versuche es erneut
+        failed_to_join: 'Beitritt zur Familie fehlgeschlagen: %{message}'
+      create:
+        family_name_is_required: Familienname ist erforderlich
+        family_name_must_be_50_characters_or_less: Familienname muss 50 Zeichen oder weniger sein
+        you_must_leave_your_current_family_before_creating_a_new: Du musst dein aktuelles Familienmitglied verlassen, bevor du eines erstellst
+        you_have_already_created_a_family_each_user_can_only: Du hast bereits eine Familie erstellt. Jeder Benutzer kann nur eine Familie erstellen
+        family_feature_requires_an_active_subscription: Die Familien-Funktion erfordert ein aktives Abonnement
+        family_created: Familie erstellt
+        you_ve_successfully_created_the_family_name: Du hast die Familie '%{name}' erfolgreich erstellt
+        a_family_with_this_name_already_exists_for_your_account: Eine Familie mit diesem Namen existiert bereits für dein Konto
+        an_unexpected_error_occurred_while_creating_the_family_please_try: Beim Erstellen der Familie ist ein unerwarteter Fehler aufgetreten. Bitte versuche es erneut
+        failed_to_create_family: 'Familie nicht erstellen: %{message}'
+      create_location_request:
+        an_error_occurred: Ein Fehler ist aufgetreten
+        location_request: Standortanfrage
+        safe_email_is_requesting_your_location_link: "%{email} fragt nach deinem Standort. %{link}"
+        users_must_be_in_the_same_family: Benutzer müssen in derselben Familie sein
+        target_user_is_already_sharing_their_location: Zielbenutzer teilt bereits seinen Standort
+        request_cooldown_active_please_wait_before_requesting_again: Anfragekühlauf der Aktivität. Bitte warte, bevor du erneut anfragst.
+        view_request: Anfrage ansehen
+      invite:
+        invitation_sent: Einladung gesendet
+        failed_to_send_invitation_email_please_try_again_later: Einladungs-E-Mail konnte nicht gesendet werden. Bitte versuche es später erneut
+        an_unexpected_error_occurred_while_sending_the_invitation_please_try: Ein unerwarteter Fehler ist aufgetreten, während die Einladung gesendet wurde. Bitte versuche es erneut
+        failed_to_send_invitation: Einladung konnte nicht gesendet werden
+        owner_required: Du musst ein Familien-Owner sein, um Einladungen senden zu können
+        family_full: Familie ist voll
+        user_already_in_family: Benutzer ist bereits in einer Familie
+        invitation_already_sent: Einladung wurde bereits an diese E-Mail gesendet
+        sent_self_hosted: Familien-Einladung an %{email} gesendet, wenn SMTP korrekt konfiguriert ist. Wenn du nicht SMTP verwendest, kopiere den Einladungslink von der Familien-Seite und teile ihn manuell.
+        sent: Familien-Einladung an %{email} gesendet
+        failed_to_create: 'Einladung konnte nicht erstellt werden: %{message}'
+      memberships:
+        destroy:
+          user_is_not_currently_in_a_family: Benutzer ist derzeit nicht in einer Familie.
+          family_owners_cannot_remove_their_own_membership_to_leave_the: Familien-Owners können ihre eigene Mitgliedschaft nicht entfernen, um die Familie zu verlassen. Um die Familie zu verlassen, lösche sie stattdessen.
+          only_family_owners_can_remove_other_members: Nur Familien-Owners können andere Mitglieder entfernen.
+          cannot_remove_members_from_a_different_family: Man kann Mitglieder aus einer anderen Familie nicht entfernen.
+          cannot_remove_the_family_owner_the_owner_must_delete_the: Man kann den Familien-Owner nicht entfernen. Der Owner muss die Familie löschen oder selbst verlassen.
+          left_family: Verlassen Familie
+          you_ve_left_the_family_family_name: Du hast die Familie "%{family_name}" verlassen
+          family_member_left: Mitglied verlassen
+          email_has_left_the_family_family_name: '%{email} hat die Familie "%{family_name}" verlassen'
+          removed_from_family: Von der Familie entfernt
+          you_have_been_removed_from_the_family_family_name_by: Du wurdest von der Familie "%{family_name}" von %{email} entfernt
+          member_removed: Mitglied entfernt
+          email_has_been_removed_from_the_family_family_name: '%{email} wurde von der Familie "%{family_name}" entfernt'
+          an_unexpected_error_occurred_while_removing_the_membership_please_try: Beim Entfernen der Mitgliedschaft ist ein unerwarteter Fehler aufgetreten. Bitte versuche es erneut
+          failed_to_leave: 'Verlassen fehlgeschlagen: %{message}'
+      update_location_sharing:
+        update_failed: Aktualisierung der Standortfreigabe fehlgeschlagen
+        unexpected_error: Beim Aktualisieren der Standortfreigabe ist ein Fehler aufgetreten
+        disabled: Standortfreigabe deaktiviert
+        enabled: Standortfreigabe aktiviert
+        enabled_for_hours:
+          one: Standortfreigabe für %{count} Stunde aktiviert
+          other: Standortfreigabe für %{count} Stunden aktiviert
+    fit:
+      importer:
+        fit_parsing_error_message: 'FIT-Parser-Fehler: %{message}'
+        no_activities_found_in_fit_file: Keine Aktivitäten im FIT-Datei gefunden
+    google_maps:
+      semantic_history_importer:
+        google_maps_timeline_import_error: Fehler beim Importieren des Google Maps Timeline-Verlaufs
+        batch_failed: 'Verarbeitung der Standortbatch fehlgeschlagen: %{message}'
+    immich:
+      connection_tester:
+        immich_connection_verified: Immich-Verbindung bestätigt
+        immich_url_is_missing: Immich-URL fehlt
+        immich_api_key_is_missing: Immich-API-Schlüssel fehlt
+        immich_connection_failed_message: 'Immich-Verbindung fehlgeschlagen: %{message}'
+        immich_connection_failed_code: 'Immich-Verbindung fehlgeschlagen: %{code}'
+        immich_api_key_missing_permission_asset_view: 'Immich-API-Schlüssel fehlt Berechtigung: asset.view'
+        immich_thumbnail_check_failed_code: 'Immich-Thumbnail-Prüfung fehlgeschlagen: %{code}'
+      enrich_photos:
+        http_code_message: 'HTTP %{code}: %{message}'
+      enrich_scan:
+        failed_to_fetch_photos_from_immich: Fehler beim Abrufen der Fotos von Immich
+      import_geodata:
+        import_was_not_created: Import wurde nicht erstellt
+        import_with_the_same_name_import_name_already_exists_if: Import mit dem gleichen Namen (%{import_name}) existiert bereits. Wenn du fortfahren möchtest, lösche den vorhandenen Import und versuche es erneut.
+      response_validator:
+        request_failed_code: 'Anfrage fehlgeschlagen: %{code}'
+        expected_json_got_content_type: Erwartete JSON, erhielt %{content_type}
+        invalid_json_response: Ungültige JSON-Antwort
+        invalid_json: Ungültiges JSON
+      configuration:
+        api_key_missing: Immich API-Schlüssel fehlt
+        url_missing: Immich-URL fehlt
+      response_analyzer:
+        permission_missing: 'Immich API-Schlüssel fehlt die Berechtigung: asset.view'
+        thumbnail_failed: Thumbnail konnte nicht abgerufen werden
+    imports:
+      bulk_insertable:
+        importer_name_import_error: "%{importer_name} Importfehler"
+      create:
+        import_post_processing_incomplete: Import-Post-Processing unvollständig
+        import_completed_with_no_new_points: Import abgeschlossen, aber keine neuen Punkte
+        import_completed_with_no_points: Import abgeschlossen, aber keine Punkte
+        import_failed: Import fehlgeschlagen
+        your_import_name_finished_and_all_points_were_saved_but: Dein Import „%{name}“ ist abgeschlossen und alle Punkte wurden gespeichert, aber der Schritt „%{step}“ ist fehlgeschlagen. Statistiken, Tracks oder vorgeschlagene Aufenthalte könnten fehlen oder veraltet sein. Du kannst eine Neuberechnung in den Einstellungen auslösen.
+        your_file_name_contained_raw_points_points_all_of_which: Deine Datei „%{name}“ enthielt „%{raw_points}“ Rohpunkte, alle bereits in deiner Zeitleiste bei gleichen Koordinaten und Zeitstempeln. Nichts wurde importiert. Falls dies unerwartet war, lösche die vorhandenen Punkte für diesen Zeitraum und importiere erneut.
+        source_missing: Importquelle darf nicht null sein
+        unsupported_source: 'Nicht unterstützte Quelle: %{source}'
+        zip_unclassified: Zip-Inhalt konnte nicht klassifiziert werden – Datei könnte beschädigt sein
+      source_detector:
+        amazon_order: Dies ist eine Amazon-Exportdatei, nicht Standortdaten. Dawarich importiert Standortverläufe aus Google Takeout, OwnTracks, GPX und ähnlichen Quellen.
+        apple_plist: Apple binäre plist-Dateien (.plist) werden nicht unterstützt.
+        ds_store: Dies ist eine macOS-Finder-Metadatendatei (.DS_Store), keine Datendatei. Lade stattdessen deine tatsächliche Standort-Exportdatei hoch.
+        empty_file: Die hochgeladene Datei ist leer (0 Bytes).
+        empty_json: Die hochgeladene Datei enthält keine Daten (leeres JSON-Objekt oder -Array).
+        encrypted_timeline: Deine Google Timeline-Daten sind verschlüsselt. Öffne die Google Maps-App, deaktiviere die Timeline-Verschlüsselung in den Einstellungen und exportiere deine Daten erneut.
+        google_settings: Diese Datei enthält deine Google Maps-Einstellungen, keine Standortdaten. Suche nach "Records.json" oder Dateien innerhalb von "Timeline/" in deinem Google Takeout.
+        gzip: Gzip-komprimierte Dateien (.gz) werden nicht automatisch dekomprimiert. Bitte dekomprimiere die Datei und hochlade den Inhalt erneut.
+        heic: HEIC-Bild-Dateien werden nicht unterstützt. Fotos enthalten keine Standortverlauf; verbinde deine Foto-Bibliothek über die Immich- oder PhotoPrism-Integration, um Standortdaten aus Fotos zu importieren.
+        html_page: Dies ist eine HTML-Seite (vermutlich "archive_browser.html" aus deinem Google Takeout), keine Daten-Datei. Öffne das Takeout-Archiv und suche nach der .json oder .kml-Datei darin.
+        jpeg: JPEG-Bild-Dateien werden nicht unterstützt. Fotos enthalten keine Standortverlauf; verbinde deine Foto-Bibliothek über die Immich- oder PhotoPrism-Integration, um Standortdaten aus Fotos zu importieren.
+        json_fragment: Die hochgeladene Datei sieht aus wie ein abgeschnittenes oder beschädigtes JSON-fragment (es beginnt nicht mit "{" oder "["). Bitte exportiere und hochlade die ursprüngliche vollständige Datei erneut.
+        my_activity: Dies ist ein Google "My Activity"-Log (Such- und Kartenaktivitäten), keine Standortverlauf. Suche nach "Records.json" oder Dateien innerhalb von "Timeline/" in deinem Google Takeout.
+        office_document: Microsoft Office-Dokumente (Word/Excel) werden nicht unterstützt. Bitte hochlade deine Standortdaten-Datei.
+        pdf: PDF-Dateien werden nicht unterstützt. Öffne das PDF und finde deine tatsächliche Standortdaten-Datei.
+        place_feedback: Dies ist eine Google Maps-Ort-Feedback-Datei (Maps-Fragen wie "War dieser Ort geöffnet?"), keine Standortverlauf. Suche nach "Records.json" oder Dateien innerhalb von "Timeline/" in deinem Google Takeout.
+        png: PNG-Bild-Dateien werden nicht unterstützt. Bitte hochlade deine Standortdaten-Datei (.json, .gpx, .kml, etc).
+        rar: RAR-Archive werden nicht unterstützt. Extrahiere das Archiv und hochlade die Daten-Dateien darin.
+        saved_places: Dies ist eine Google saved-places / Geocodes-Datei, nicht dein Standortverlauf. Suche nach „Records.json“ oder Dateien innerhalb von „Timeline/“ in deiner Google Takeout-Exportdatei.
+        snapchat_export: Dies sieht aus wie ein Snapchat-Datenexport, nicht Standortdaten. Dawarich importiert Standortverläufe von Google Takeout, OwnTracks, GPX und ähnlichen Quellen.
+        timeline_edits: Der Google Timeline Edits-Format wird nicht unterstützt. Hochlade stattdessen Records.json oder die Dateien innerhalb des Timeline-Ordners deiner Google Takeout-Exportdatei.
+        unknown_format: Dateiformat konnte nicht erkannt werden
+      watcher:
+        unsupported_source: 'Nicht unterstützte Quelle: %{source}'
+        unsupported_source_without_name: Nicht unterstützte Quelle
+    maps:
+      bounds_calculator:
+        no_data_found_for_the_specified_date_range: Keine Daten für den angegebenen Zeitraum gefunden
+        invalid_date: 'Ungültiges Datum: %{value}'
+        no_date_range: Kein Zeitraum angegeben
+        no_user: Kein Benutzer gefunden
+    photoprism:
+      connection_tester:
+        photoprism_connection_verified: Photoprism-Verbindung bestätigt
+        photoprism_url_is_missing: Photoprism-URL fehlt
+        photoprism_api_key_is_missing: Photoprism-API-Schlüssel fehlt
+        photoprism_connection_failed_message: 'Photoprism-Verbindung fehlgeschlagen: %{message}'
+        photoprism_connection_failed_code: 'Photoprism-Verbindung fehlgeschlagen: %{code}'
+      import_geodata:
+        import_was_not_created: Import wurde nicht erstellt
+        import_with_the_same_name_import_name_already_exists_if: Import mit demselben Namen (%{import_name}) existiert bereits. Wenn du fortfahren möchtest, lösche den vorhandenen Import und versuche es erneut.
+      response_validator:
+        request_failed_code: 'Anfrage fehlgeschlagen: %{code}'
+        expected_json_got_content_type: Erwartete JSON, erhielt %{content_type}
+        invalid_json_response: Ungültige JSON-Antwort
+      configuration:
+        api_key_missing: Photoprism API-Schlüssel fehlt
+        url_missing: Photoprism-URL fehlt
+    points:
+      raw_data:
+        verifier:
+          file_not_attached: Datei nicht angehängt
+          file_download_failed_message: 'Dateiherunterladung fehlgeschlagen: %{message}'
+          file_is_empty: Datei ist leer
+          decryption_failed_message: 'Entschlüsselung fehlgeschlagen: %{message}'
+          content_checksum_mismatch: Inhaltssumme stimmt nicht überein
+          point_count_mismatch_expected_point_count_found_count: 'Anzahl der Punkte stimmt nicht überein: erwartet %{point_count}, gefunden %{count}'
+          point_ids_checksum_mismatch: Summe der Punkte-IDs stimmt nicht überein
+          decompression_parsing_failed_message: 'Entpacken/Verarbeiten fehlgeschlagen: %{message}'
+          raw_data_mismatch_detected_in_count_point_s_first_mismatch: 'Ungültige Rohdaten wurden in %{count} Punkten erkannt. Erster Fehler: Punkt %{point_id}'
+    settings:
+      update:
+        not_allowed: "%{setting} ist nicht erlaubt: %{message}"
+        failed: Einstellungen konnten nicht aktualisiert werden
+        updated: Einstellungen aktualisiert
+        photo_cache_refreshed: Foto-Cache aktualisiert
+    stats:
+      calculate_month:
+        stats_update_failed: Statistikaktualisierung fehlgeschlagen
+        message_stacktrace_n: "%{message}, Stacktrace: %{backtrace}"
+    users:
+      destroy:
+        cannot_delete_user_who_owns_a_family_with_other_members: Benutzer kann nicht gelöscht werden, der ein Familienkonto mit anderen Mitgliedern besitzt
+      export_data:
+        export_completed: Export abgeschlossen
+        your_data_export_has_been_processed_successfully_summary_you_can: Deine Datenexport wurde erfolgreich verarbeitet (%{summary}). Du kannst es von der Exportseite herunterladen.
+      import_data:
+        data_import_completed: Datenimport abgeschlossen
+        your_data_has_been_imported_successfully_summary: Deine Daten wurden erfolgreich importiert (%{summary}).
+        data_import_failed: Datenimport fehlgeschlagen
+        your_data_import_failed_with_error_message_please_check_the: 'Dein Datenimport ist fehlgeschlagen mit Fehler: %{message}. Bitte prüfe das Archivformat und versuche es erneut.'
+        unknown_export_format: 'Unbekanntes Exportformat: weder manifest.json noch data.json gefunden'
+        unsupported_format_version: 'Nicht unterstützte Exportformatversion: %{version}'
+        v1_handler:
+          data_file_missing: 'Datenfile nicht im Archiv gefunden: data.json'
+          invalid_json: 'Ungültiges JSON-Format in der Daten-Datei: %{message}'
+          read_failed: 'Fehler beim Lesen der JSON-Daten: %{message}'
+        v2_handler:
+          manifest_missing: 'Manifest-Datei nicht im Archiv gefunden: manifest.json'
+      transportation_thresholds_updater:
+        enable_at_least_one_transportation_mode: Aktiviere mindestens einen Verkehrsmodus
+        recalculation_in_progress: Der Modusberechnung für Verkehrsmittel läuft. Bitte warte, bis sie abgeschlossen ist.
+    visits:
+      suggest:
+        error_suggesting_visits_message: 'Fehler beim Vorschlagen von Aufenthalten: %{message}'
+        new_visits_suggested: Neue Aufenthalte vorgeschlagen
+      merge_service:
+        minimum_visits: Mindestens 2 Aufenthalte müssen ausgewählt werden, um sie zu verbinden
+      bulk_destroy:
+        database_error: 'Datenbankfehler: Bitte versuche es erneut.'
+        none_found: Keine passenden Aufenthalte gefunden
+        none_selected: Keine Aufenthalte ausgewählt
+        too_many_selected: Zu viele Aufenthalte ausgewählt (max %{max})
+      bulk_update:
+        invalid_status: Ungültiger Status
+        none_found: Keine passenden Aufenthalte gefunden
+        none_selected: Keine Aufenthalte ausgewählt
+    posters:
+      generate:
+        failed: Poster-Generierung fehlgeschlagen. Bitte versuche es später erneut.
+        no_location_data: Keine Standortdaten für den ausgewählten Zeitraum gefunden.
+        track_outside_area: Dein Track verläuft nicht durch den ausgewählten Kartenbereich. Zentriere die Karte oder passe die Daten an.
+    gpx:
+      track_importer:
+        parse_error: 'GPX-Parser-Fehler: %{message}'
+    insights:
+      travel_insight_generator:
+        active_day: "%{day} sind deine aktivsten Reisetage"
+        days:
+          friday: Freitag
+          monday: Montag
+          saturday: Samstag
+          sunday: Sonntag
+          thursday: Donnerstag
+          tuesday: Dienstag
+          wednesday: Mittwoch
+        early_start_suggestion: Frühe Starts funktionieren für dich scheinbar gut!
+        peak_season: "%{season} ist deine Hochzeitungsreisezeit"
+        peak_time: Du reist meist %{period}
+        seasons:
+          fall: Herbst
+          spring: Frühling
+          summer: Sommer
+          winter: Winter
+        sentence: "%{insights}."
+        sunset_suggestion: Überlege dir eine Sonnenuntergangsfahrt für deine nächste Reise.
+        time_periods:
+          afternoon: nachmittags (12 Uhr - 18 Uhr)
+          evening: abends (18 Uhr - 0 Uhr)
+          morning: morgens (6 Uhr - 12 Uhr)
+          night: in der Nacht (0 Uhr - 6 Uhr)
+        weekend_suggestion: Deine Wochenenden sind für Entdeckungen gemacht!
+        weekday_preference: Du reist mehr an Werktagen als an Wochenenden
+        with_suggestion: "%{insight} %{suggestion}"
+  jobs:
+    air_trail:
+      import_flights_job:
+        airtrail_sync_failed: AirTrail-Synchronisation fehlgeschlagen
+        your_airtrail_flight_sync_failed_with_error_message_check_your: 'Deine AirTrail-Flugdatensynchronisation ist fehlgeschlagen mit Fehler: %{message}. Prüfe deine AirTrail-Einstellungen und versuche es erneut.'
+    data_migrations:
+      recalculate_anomalies_user_job:
+        gps_noise_re_check_finished: GPS-Rauschprüfung abgeschlossen
+        rules_recheck_finished: Deine Punkte wurden erneut gemäß den Rauschregeln dieser Version überprüft, und deine Tracks, Statistiken und Zusammenfassungen wurden aus den Ergebnissen neu erstellt. Einige Punkte können auf der Karte erscheinen oder verschwinden. Keine Punkte wurden gelöscht.
+    lite:
+      archival_warning_job:
+        your_oldest_data_will_archive_in_30_days: Deine ältesten Daten werden in 30 Tagen archiviert
+        your_oldest_month_of_location_data_will_be_archived_soon: Dein ältestes Monat Standortdaten wird bald archiviert. Upgrade zu Pro, um deinen vollständigen Verlauf suchbar zu halten.
+        data_has_been_archived: Daten wurden archiviert
+        month_of_location_data_has_been_archived_your_archived: 1 Monat Standortdaten wurde archiviert. Deine archivierten Daten können jederzeit exportiert werden. Upgrade zu Pro, um sie wieder in der App sichtbar und interaktiv zu machen.
+    stale_jobs_recovery_job:
+      export_timed_out_after_being_stuck_in_processing: Export ist nach Verhängen in Verarbeitung abgebrochen
+      export_failed: Export fehlgeschlagen
+      export_name_was_stuck_in_processing_and_has_been_marked: Export "%{name}" war in Verarbeitung verhängen und wurde als fehlgeschlagen markiert.
+      import_timed_out_after_being_stuck_in_processing: Import ist nach Verhängen in Verarbeitung abgebrochen
+      import_failed: Import fehlgeschlagen
+      import_name_was_stuck_in_processing_and_has_been_marked: Import "%{name}" war in Verarbeitung verhängen und wurde als fehlgeschlagen markiert.
+    stats:
+      calculating_job:
+        stats_update_failed: Statistikupdate fehlgeschlagen
+        message_stacktrace_n: "%{message}, stacktrace: %{backtrace}"
+    users:
+      digests:
+        monthly:
+          calculating_job:
+            monthly_digest_calculation_failed: Monatlicher Digestberechnung fehlgeschlagen
+            message_stacktrace_backtrace: "%{message}, stacktrace: %{backtrace}"
+        yearly:
+          calculating_job:
+            period_label_calculation_failed: "%{period_label} Berechnung fehlgeschlagen"
+            message_stacktrace_backtrace: "%{message}, stacktrace: %{backtrace}"
+      import_data_job:
+        data_import_failed: Datenimport fehlgeschlagen
+        your_data_import_failed_with_error_message_please_check_the: 'Deine Datenimport ist fehlgeschlagen mit Fehler: %{message}. Bitte prüfe das Archivformat und versuche es erneut.'
+      recalculate_data_job:
+        data_recalculation_busy: Datenberechnung beschäftigt
+        another_recalculation_is_already_running_please_try_again_in_a: Eine andere Berechnung läuft bereits. Bitte versuche es in ein paar Minuten erneut.
+        data_recalculation_completed: Datenberechnung abgeschlossen
+        stats_tracks_and_digests_have_been_recalculated_for_year_label: Statistiken, Tracks und Zusammenfassungen wurden für %{year_label} berechnet.
+        data_recalculation_failed: Datenberechnung fehlgeschlagen
+        message_stacktrace_n: "%{message}, Stacktrace: %{backtrace}"
+    visits:
+      full_history_redetect_job:
+        visit_re_detection_busy: Aufenthalte werden bereits neu erkannt
+        another_re_detection_is_already_running_try_again_in_a: Eine erneute Erkennung läuft bereits. Versuche es in ein paar Minuten erneut.
+        visit_re_detection: Aufenthalte neu erkennen
+        no_points_to_re_detect: Keine Punkte zum erneuten Erkennen.
+        visit_re_detection_complete: Neuerkennung der Aufenthalte abgeschlossen
+        visits_created_visits_across_size_months: "%{visits_created} Aufenthalte in %{size} Monaten."
+        visit_re_detection_partially_complete: Neuerkennung der Aufenthalte teilweise abgeschlossen
+        visit_re_detection_failed: Neuerkennung der Aufenthalte fehlgeschlagen
+        visits_created_visits_across_ok_months_of_size_months_size: "%{visits_created} Aufenthalte in %{ok_months} von %{size} Monaten. %{failed_count} Monat(e) fehlgeschlagen; starte den Vorgang nach der Wartezeit erneut."
+  javascript:
+    messages:
+      click_on_the_map_to_place_a_visit: Klicke auf die Karte, um einen Aufenthalt zu platzieren
+      end_time_must_be_after_start_time: Endezeit muss nach Startzeit sein
+      network_error_failed_to_create_visit: 'Netzwerkfehler: Fehler beim Erstellen eines Aufenthalts'
+      failed_to_copy_please_copy_manually: Kopieren fehlgeschlagen. Bitte kopiere manuell.
+      copied_to_clipboard: In die Zwischenablage kopiert!
+      location_sharing_has_expired: Standortfreigabe ist abgelaufen
+      invalid_tile_url_reverting_to_openstreetmap: Ungültige Kachel-URL. Zurück zur OpenStreetMap.
+      please_select_a_date_range: Bitte wähle einen Datumsbereich aus
+      failed_to_scan_photos: Fotoscannen fehlgeschlagen
+      failed_to_enrich_photos: Fotos nicht bereichert
+      draw_a_rectangle_on_the_map_to_select_points: Zeichne ein Rechteck auf der Karte, um Punkte auszuwählen
+      fetching_data_in_selected_area: Daten im ausgewählten Bereich werden geladen...
+      no_data_found_in_selected_area: Keine Daten im ausgewählten Bereich gefunden
+      failed_to_fetch_data_in_selected_area: Daten im ausgewählten Bereich konnten nicht geladen werden
+      visit_confirmed: Aufenthalt bestätigt
+      failed_to_confirm_visit: Bestätigung des Aufenthalts fehlgeschlagen
+      visit_deleted: Aufenthalt gelöscht
+      failed_to_delete_visit: Aufenthalt konnte nicht gelöscht werden
+      select_at_least_2_visits_to_merge: Wähle mindestens 2 Aufenthalte zum Verbinden
+      merging_visits: Verbinde Aufenthalte...
+      visits_merged_successfully: Aufenthalte wurden erfolgreich verbunden
+      failed_to_merge_visits: Aufenthalte konnten nicht verbunden werden
+      confirming_visits: Bestätige Aufenthalte...
+      failed_to_confirm_visits: Aufenthalte konnten nicht bestätigt werden
+      deleting_visits: Lösche Aufenthalte...
+      failed_to_delete_visits: Aufenthalte konnten nicht gelöscht werden
+      selection_cancelled: Auswahl abgebrochen
+      no_anomaly_points_in_selection: Keine Anomaliepunkte in der Auswahl
+      deleting_anomaly_points: Lösche Anomaliepunkte...
+      no_points_selected: Keine Punkte ausgewählt
+      deleting_points: Lösche Punkte...
+      anomaly_point: Anomaliepunkt
+      failed_to_load_location_data_please_try_again: Daten zum Standort konnten nicht geladen werden. Bitte versuche es erneut.
+      click_on_the_map_to_place_a_place: Klicke auf die Karte, um einen Ort zu platzieren
+      failed_to_reload_routes: Route konnte nicht neu geladen werden
+      failed_to_load_scratch_layer: Scratch-Schicht konnte nicht geladen werden
+      failed_to_load_photos: Fotos konnten nicht geladen werden
+      failed_to_load_areas: Gebiete konnten nicht geladen werden
+      failed_to_load_tracks: Tracks konnten nicht geladen werden
+      failed_to_load_flights: Flüge konnten nicht geladen werden
+      failed_to_load_anomalies: Anomalien konnten nicht geladen werden
+      reloading_routes: Route wird neu geladen...
+      cannot_update_recalculation_is_already_in_progress: 'Aktualisierung nicht möglich: Rechnung ist bereits im Gange'
+      transportation_settings_saved: Transporteinstellungen gespeichert
+      globe_view_will_be_applied_after_page_reload: Globusansicht wird nach Neuladen der Seite angewendet
+      settings_updated_successfully: Einstellungen wurden erfolgreich aktualisiert
+      reloading_map_data_with_new_settings: Kartendaten werden mit den neuen Einstellungen neu geladen...
+      api_key_not_available_please_reload_the_page: API-Schlüssel nicht verfügbar; bitte die Seite neu laden.
+      could_not_queue_re_evaluation_please_try_again: Kann Re-Bewertung nicht in die Warteschlange stecken. Bitte versuche es erneut.
+      could_not_queue_recalculation_please_try_again: Kann Berechnung nicht in die Warteschlange stecken. Bitte versuche es erneut.
+      click_on_the_map_to_place_a_visit_esc_to: Klicke auf die Karte, um einen Aufenthalt zu platzieren (Esc zum Abbrechen)
+      visit_creation_modal_not_available: Modals für Aufenthalt-Erstellung nicht verfügbar
+      visit_creation_controller_not_available: Controller für Aufenthalt-Erstellung nicht verfügbar
+      area_drawer_controller_not_available: Controller für Flächenzeichnung nicht verfügbar
+      area_created_successfully: Fläche erfolgreich erstellt!
+      failed_to_reload_areas: Flächen nicht erneut laden
+      family_feature_not_available: Familienfunktion nicht verfügbar
+      failed_to_load_family_members: Familienmitglieder nicht laden
+      centered_on_family_member: Auf Familienmitglied zentriert
+      failed_to_load_visit_details: Aufenthalt-Details nicht laden
+      failed_to_load_area_details: Flächen-Details nicht laden
+      point_deleted_successfully: Punkt erfolgreich gelöscht
+      failed_to_delete_point: Punkt nicht löschen
+      deleting_area: Fläche löschen...
+      area_deleted_successfully: Bereich erfolgreich gelöscht
+      failed_to_delete_area: Bereich konnte nicht gelöscht werden
+      failed_to_load_place_details: Platzdetails konnten nicht geladen werden
+      connected_to_real_time_updates: Verbunden mit Echtzeit-Updates
+      disconnected_from_real_time_updates: Von Echtzeit-Updates getrennt
+      new_location_recorded: Neuer Standort erfasst
+      error_saving_layer_preferences: Fehler beim Speichern der Layer-Einstellungen
+      failed_to_update_settings: Einstellungen konnten nicht aktualisiert werden
+      at_least_one_gradient_stop_is_required: Mindestens ein Gradientenstopp ist erforderlich.
+      failed_to_load_demo_data_please_try_again: Demo-Daten konnten nicht geladen werden. Bitte versuche es erneut.
+      could_not_load_flights_please_try_again: Flüge konnten nicht geladen werden. Bitte versuche es erneut.
+      no_flights_found_for_this_trip: Für diese Reise wurden keine Flüge gefunden.
+      please_select_and_upload_files_first: Bitte wähle zuerst Dateien aus und lade sie hoch
+      please_select_a_valid_zip_file: Bitte wähle eine gültige ZIP-Datei aus.
+      failed_to_fetch_photos: Fotos konnten nicht geladen werden
+      failed_to_fetch_photos_after_multiple_attempts: Fotos konnten nicht geladen werden, nach mehreren Versuchen
+      place_deleted_successfully: Ort erfolgreich gelöscht
+      failed_to_delete_place: Löschen des Ortes fehlgeschlagen
+      failed_to_load_visits_in_selected_area: Laden der Aufenthalte im ausgewählten Bereich fehlgeschlagen
+      no_valid_point_ids_found: Keine gültigen Punkt-IDs gefunden
+      failed_to_delete_points_please_try_again: Löschen der Punkte fehlgeschlagen. Bitte versuche es erneut.
+      at_least_2_visits_must_be_selected_for_merging: Mindestens 2 Aufenthalte müssen ausgewählt werden, um sie zu verbinden
+      no_visits_selected: Keine Aufenthalte ausgewählt
+      visit_confirmed_successfully: Aufenthalt bestätigt
+      visit_declined_successfully: Aufenthalt abgelehnt
+      failed_to_decline_visit: Abweisung des Aufenthalts fehlgeschlagen
+      failed_to_load_possible_places: Laden der möglichen Orte fehlgeschlagen
+      please_select_a_valid_location: Bitte wähle einen gültigen Ort aus
+      visit_updated_successfully: Aufenthalt aktualisiert
+      failed_to_update_visit: Aktualisierung des Aufenthalts fehlgeschlagen
+      visit_deleted_successfully: Aufenthalt gelöscht
+      failed_to_update_point_position_please_try_again: Aktualisierung der Punktposition fehlgeschlagen. Bitte versuche es erneut.
+      failed_to_load_track_points: Die Track-Punkte konnten nicht geladen werden
+      point_updated_track_will_be_recalculated: Punkt aktualisiert. Der Track wird neu berechnet.
+      delete: Löschen
+      edit: Bearbeiten
+      your_lite_plan_includes_the_last_12_months_of_data: Dein Lite-Plan beinhaltet die letzten 12 Monate Daten.
+      globe_view_is_a_pro_feature: Globe View ist eine Pro-Funktion.
+      map_styles: Kartenstile
+      untagged: Unbeschriftet
+      suggested: Vorgeschlagen
+      confirmed: Bestätigt
+      layers: Schichten
+      points: Punkte
+      routes: Routen
+      tracks: Tracks
+      heatmap: Heatmap
+      fog_of_war: Nebel des Krieges
+      scratch_map: Rubbelkarte
+      areas: Gebiete
+      photos: Fotos
+      visits: Aufenthalte
+      places: Orte
+      family_members: Familienmitglieder
+      food_drink: Essen & Trinken
+      shopping: Einkaufen
+      transport: Verkehr
+      cycling: Radfahren
+      nature_leisure: Natur & Freizeit
+      tourism_culture: Tourismus & Kultur
+      services_civic: Dienstleistungen & Bürgerliches
+      urban_amenities: Stadtentwicklung
+    common:
+      add_row: Zeile hinzufügen
+      and: und
+      cancel: Abbrechen
+      close: Schließen
+      save: Speichern
+      confirm: Bestätigen
+      delete: Löschen
+      decline: Ablehnen
+      dismiss: Ignorieren
+      close_panel: Panel schließen
+      name: Name
+      not_available: N/A
+      reset_to_default: Zurücksetzen auf Standard
+      settings: Einstellungen
+      unknown: Unbekannt
+      unknown_error: Unbekannter Fehler
+      update: Aktualisieren
+      upgrade_to_pro: Auf Pro upgraden
+      expired: Abgelaufen
+      loading: Lädt...
+      creating: Erstellt...
+    trip:
+      show_all_days: Alle Tage anzeigen
+      collapse_all_days: Alle Tage zusammenklappen
+    map:
+      places_layer: Orte-Schicht
+      confirm_delete_point: Möchtest du diesen Punkt wirklich löschen?
+      confirm_delete_point_permanently: |-
+        Diesen Punkt löschen?
+
+        Diese Aktion kann nicht rückgängig gemacht werden.
+      edit_speed_color_scale: Farbskala für Geschwindigkeit bearbeiten
+      failed_to_update_point_position: Aktualisierung der Position des Punkts fehlgeschlagen. Bitte versuche es erneut.
+      display: Anzeigen
+      layer_preferences_failed: 'Speichern der Schichtvorlieben fehlgeschlagen: %{error}'
+      preferred_layer_updated: 'Vorgeschlagene Karten-Schicht aktualisiert auf: %{layer}'
+      stats_summary:
+        one: "%{distance} %{unit} | %{count} Punkt"
+        other: "%{distance} %{unit} | %{count} Punkte"
+      updating: Karte wird aktualisiert...
+    replay:
+      no_data_at_this_time: Keine Daten zurzeit
+      pause: Pause
+      replay: Wiederholen
+      day_count: Tag %{current} von %{total}
+      point_count: Punkt %{current} von %{total}
+      speed: "%{speed} km/h"
+      no_data: Keine Daten
+    places:
+      create_new: Neuer Ort erstellen
+      edit: Ort bearbeiten
+      confirm_delete: Möchtest du diesen Ort wirklich löschen?
+      search_placeholder: Suche nach einem Ort…
+      confirm_move_visit: Dieser Ort ist ~%{distance} m vom Aufenthalt entfernt. Den Aufenthalt hier verschieben?
+      create_here: "+ Ort „%{name}“ hier erstellen"
+      created: Ort „%{name}“ erfolgreich erstellt!
+      filter_by_tag: FILTERN NACH ETIKETTE
+      no_tags: Noch keine Etiketten erstellt
+      none_found: Keine Orte gefunden
+      open_for_suggestions: Öffne das Modale, um nahegelegene Vorschläge zu laden
+      show_all: Alle Orte anzeigen
+      untagged: Unbeschriftete Orte
+      updated: Ort „%{name}“ wurde erfolgreich aktualisiert!
+      create: Ort erstellen
+      update: Ort aktualisieren
+      click_map_to_add: Klicke auf die Karte, um einen Ort hinzuzufügen
+    demo:
+      removing_data: Demo-Daten werden entfernt…
+      already_loaded: Demo-Daten wurden bereits geladen
+      confirm_delete: |-
+        Alle Demo-Daten löschen?
+
+        Dies entfernt die Demo-Punkte, Aufenthalte, Orte, Tags, Tracks und die Prager Reise.
+
+        Deine echten Daten — alles, was du importiert, bearbeitet, bestätigt oder selbst erstellt hast — bleibt unangetastet.
+      creating: Deine Demo-Daten werden erstellt…
+      creating_help: Ein Monat Berlin-Tracking plus eine Prager Wochenende-Reise wird gesät. Das dauert etwa eine Sekunde.
+    visits:
+      add_new: Neuen Aufenthalt hinzufügen
+      create_new: Neuen Aufenthalt erstellen
+      create: Aufenthalt erstellen
+      create_failed: Aufenthalt konnte nicht erstellt werden
+      create_failed_with_error: 'Aufenthalt konnte nicht erstellt werden: %{error}'
+      created: Aufenthalt „%{name}“ erfolgreich erstellt!
+      created_without_name: Aufenthalt erfolgreich erstellt!
+      current_location: Aktueller Standort
+      delete: Aufenthalt löschen
+      details: Aufenthaltsdetails
+      edit: Aufenthalt bearbeiten
+      enable_layers_help: Aktiviere die Schichten „Vorgeschlagene Aufenthalte“ oder „Bestätigte Aufenthalte“ über die Kartensteuerung, um Aufenthalte anzuzeigen.
+      end_time: Endezeit
+      found:
+        one: "%{count} Aufenthalt gefunden"
+        other: "%{count} Aufenthalte gefunden"
+      loading: Aufenthalte werden geladen...
+      update: Aufenthalt aktualisieren
+      recent: Letzte Aufenthalte
+      name: Aufenthaltsname
+      no_data_loaded: Keine Aufenthaltsdaten geladen
+      none_found: Keine Aufenthalte gefunden
+      none_found_for: Keine Aufenthalte gefunden für "%{query}"
+      none_in_timeframe: Keine Aufenthalte im ausgewählten Zeitraum gefunden
+      selected:
+        one: "%{count} Aufenthalt ausgewählt"
+        other: "%{count} Aufenthalte ausgewählt"
+      start_time: Startzeit
+      cancel_selection: Auswahl abbrechen
+      loading_error: Fehler beim Laden der Aufenthalte
+      merge: Verbinden
+      enter_name: Gib den Aufenthaltsnamen ein
+      confirm_delete_keep_points: Diesen Aufenthalt löschen? Deine Standortpunkte bleiben erhalten.
+      end_after_start: Endzeit muss nach Startzeit liegen
+      network_create_error: 'Netzwerkfehler: Erstellung des Aufenthalts fehlgeschlagen'
+      bulk_status_failed: Markierung der Aufenthalte %{status} fehlgeschlagen
+      bulk_status_updated: "%{count} Aufenthalte %{status} erfolgreich"
+      confirm_delete_count_keep_points:
+        one: Lösche %{count} Aufenthalt? Deine Standortpunkte bleiben.
+        other: Lösche %{count} Aufenthalte? Deine Standortpunkte bleiben.
+      confirm_delete_permanently: Bist du sicher, dass du diesen Aufenthalt löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden.
+      confirm_merge:
+        one: Füge %{count} Aufenthalt zu einem zusammen?
+        other: Füge %{count} Aufenthalte zu einem zusammen?
+      confirmed_count:
+        one: Bestätigter %{count} Aufenthalt
+        other: Bestätigte %{count} Aufenthalte
+      deleted_count:
+        one: Gelöschter %{count} Aufenthalt
+        other: Gelöschte %{count} Aufenthalte
+      status_failed: Fehler beim Kennzeichnen des Aufenthalts %{status}
+      status_updated: Aufenthalt %{status} erfolgreich markiert
+      unnamed: Unbenannter Aufenthalt
+    sharing:
+      expires_in: Verfällt in %{time}
+      hours_minutes_remaining: "%{hours}h %{minutes}m verbleibend"
+      minutes_remaining: "%{minutes}m verbleibend"
+      link_copied: Link kopiert!
+    areas:
+      edit: Bereich bearbeiten
+      create_new: Neuen Bereich erstellen
+      enter_name: Gib den Bereichsname ein
+      confirm_delete: Möchtest du diesen Bereich wirklich löschen?
+      confirm_delete_named: |-
+        Bereich "%{name}" löschen?
+
+        Diese Aktion kann nicht rückgängig gemacht werden.
+      deleted: Bereich wurde erfolgreich gelöscht!
+      new: Neuer Bereich
+      save: Bereich speichern
+      update: Bereich aktualisieren
+      create: Bereich erstellen
+    search:
+      locations: Orte suchen
+      locations_placeholder: Orte suchen...
+      failed: Suche fehlgeschlagen
+      finding_suggestions: Vorschläge finden...
+      first_last: erster %{first}, letzter %{last}
+      for_query: für "%{query}"
+      locations_found:
+        one: 'Einen Standort gefunden: %{count}'
+        other: 'Eine Standorte gefunden: %{count}'
+      no_locations: Keine Standorte gefunden
+      results: Ergebnisse
+      searching: Suche…
+      searching_for: Suche nach „%{query}“…
+      searching_for_visits: Suche nach Aufenthalten…
+      searching_visits_to: Suche nach Aufenthalten zu
+      suggestions: Vorschläge
+      suggestions_failed: Vorschläge konnten nicht abgerufen werden
+      unavailable: Suche nicht verfügbar
+      unknown_location: Unbekannter Ort
+      unnamed_location: Unbenannter Ort
+      visits_load_failed: Aufenthalte für diesen Ort konnten nicht geladen werden
+      locations_failed: Suche nach Orten fehlgeschlagen. Bitte versuche es erneut.
+    settings:
+      transportation_recalculation_completed: Berechnung des Verkehrsmittels abgeschlossen!
+      confirm_reset: Alle Einstellungen auf Standardwerte zurücksetzen? Die Seite wird neu geladen.
+      confirm_globe_reload: Die Globusansicht erfordert eine Neuladung der Seite, um zu wirken. Jetzt neu laden?
+      changed_fields: 'Geändert: %{fields}'
+      confirm_reapply_anomaly_filter: |-
+        Dies ist zerstörerisch und dauert lange.
+
+        • Alle vorhandenen Anomaliefahnen werden gelöscht und mit deinen aktuellen Einstellungen neu berechnet.
+        • Tracks, Statistiken und Digests werden danach erneut erstellt.
+        • Je nach Anzahl der Punkte kann dies mehrere Minuten (oder länger für Jahre der Geschichte) dauern.
+        • Während der Wiederherstellung können Tracks und Statistiken auf der Karte vorübergehend unvollständig aussehen.
+
+        Weiter?
+      confirm_recalculate_user_data: |-
+        Dies ist langsam und erneuert abgeleitete Daten.
+
+        • Tracks, Statistiken und Digests werden aus den vorhandenen Punkten und Einstellungen neu erstellt.
+        • Bestehende Tracks/Statistiken werden ersetzt — alles, was du manuell an einem Track angepasst hast, wird überschrieben.
+        • Je nach deiner Geschichte kann dies mehrere Minuten dauern; du erhältst eine Benachrichtigung, sobald es fertig ist.
+
+        Weiter?
+      confirm_transportation_recalculation: |-
+        Die Anwendung dieser Änderungen wird die Verkehrsmittel für ALLE deine Tracks neu berechnen.
+
+        Dieser Prozess kann je nach Anzahl der Tracks einige Zeit dauern, und die Einstellungen werden bis zur Fertigstellung gesperrt.
+
+        Möchtest du fortfahren?
+      custom_style_load_failed: Benutzerdefinierte Kartenstil konnte nicht geladen werden; zurück zum Standardstil.
+      invalid_tile_url: Tile-URL muss {z}, {x} und {y} Platzhalter enthalten oder eine MapLibre-Stil-URL sein
+      layer_unavailable_custom_style: Nicht mit dem benutzerdefinierten Kartenstil verfügbar — es werden keine Beschriftungen oder Sehenswürdigkeiten gezeichnet
+      layer_unavailable_foreign_basemap: Nicht mit einem benutzerdefinierten Raster- oder Stil-Hintergrundkarten verfügbar — diese Schichten stammen von den eingebauten Vektorplättchen
+      make_changes_to_apply: Änderungen vornehmen, um den Anwenden-Button zu aktivieren
+      re_evaluation_queued: Wiederbewertung ist im Warteschlange. Die Karte wird aktualisiert, sobald die Aufgabe fertig ist.
+      recalculation_queued: Wiederherstellung ist im Warteschlange. Du erhältst eine Benachrichtigung, sobald es fertig ist.
+      transportation_recalculation_failed: 'Wiederherstellung fehlgeschlagen: %{error}'
+      transportation_recalculation_progress: Wiederherstellung der Verkehrsmittel... (%{processed}/%{total} Tracks, %{progress}%)
+      transportation_recalculation_started: Einstellungen gespeichert. Wiederherstellung der Verkehrsmittel für alle Tracks...
+      unsaved_count:
+        one: "%{count} ungespeichert"
+        other: "%{count} ungespeichert"
+      unsaved_transportation_changes: Du hast ungespeicherte Änderungen. Klicke auf Anwenden, um zu speichern und neu zu berechnen.
+    upload:
+      complete:
+        one: "%{count} Datei wurde erfolgreich hochgeladen. Bereit zum Absenden."
+        other: "%{count} Dateien wurden erfolgreich hochgeladen. Bereit zum Absenden."
+      compression_failed: Konnte %{name} nicht komprimieren, wird als-is hochgeladen.
+      error: 'Fehler beim Hochladen von %{name}: %{error}'
+      file_size_limit: Dateigröße überschreitet den Limit. Testbenutzer können nur Dateien bis zu 10MB hochladen.
+      import_limit: Importlimit erreicht. Testbenutzer können nur bis zu %{count} Importe erstellen.
+      none_uploaded: Keine Dateien wurden erfolgreich hochgeladen. Bitte versuche es erneut.
+      preparing:
+        one: Vorbereitung von %{count} Datei zum Hochladen...
+        other: Vorbereitung von %{count} Dateien zum Hochladen...
+      progress: Hochladeprogress
+      unsupported_type: 'Nicht unterstützter Dateityp: %{names}. Unterstützte Formate: %{accepted}.'
+      uploading:
+        one: Hochladen von %{count} Datei, bitte warten...
+        other: Hochladen von %{count} Dateien, bitte warten...
+    immich:
+      confirm_enrich:
+        one: GPS-Koordinaten zu %{count} Foto in Immich schreiben? Dies wird die Standortmetadaten aktualisieren.
+        other: GPS-Koordinaten zu %{count} Fotos in Immich schreiben? Dies wird ihre Standortmetadaten aktualisieren.
+      enrich_photos:
+        one: "%{count} Foto bereichern"
+        other: "%{count} Fotos bereichern"
+      enriched:
+        one: "%{count} Foto erfolgreich bereichert!"
+        other: "%{count} Fotos erfolgreich bereichert!"
+      enriching:
+        one: "%{count} Foto wird bereichert..."
+        other: "%{count} Fotos werden bereichert..."
+      marker_title: "%{filename} (%{delta} delta)"
+      matched_summary: "%{matched} von %{total} übereinstimmend"
+      minutes_short: "%{count}m"
+      no_matches: Keine Übereinstimmungen innerhalb der Toleranz gefunden
+      open_in_immich: In Immich öffnen
+      partially_enriched: "%{enriched} Fotos bereichert. %{failed} fehlgeschlagen."
+      photos_without_gps:
+        one: "%{count} Foto ohne GPS"
+        other: "%{count} Fotos ohne GPS"
+      scanning: Immich-Fotos werden gescannt...
+      seconds_short: "%{count}s"
+    selection:
+      anomaly_points_deleted:
+        one: "%{count} Ausreißerpunkt gelöscht"
+        other: "%{count} Ausreißerpunkte gelöscht"
+      confirm_delete_anomaly_points:
+        one: Bist du sicher, dass du den %{count} Anomaliepunkt löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden.
+        other: Bist du sicher, dass du die %{count} Anomaliepunkte löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden.
+      confirm_delete_points:
+        one: Bist du sicher, dass du den %{count} Punkt aus deinem Standortverlauf dauerhaft löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden.
+        other: Bist du sicher, dass du die %{count} Punkte aus deinem Standortverlauf dauerhaft löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden.
+      delete_anomaly_points:
+        one: Lösche %{count} Anomaliepunkt
+        other: Lösche %{count} Anomaliepunkte
+      delete_points:
+        one: Lösche %{count} Punkt
+        other: Lösche %{count} Punkte
+      delete_points_failed: Löschen der Punkte fehlgeschlagen. Bitte versuche es erneut.
+      delete_points_label: Punkte löschen
+      enabled: Auswahlmodus aktiviert. Klicke und ziehe, um einen Bereich auszuwählen.
+      map_refresh_failed: Karte konnte nicht aktualisiert werden. Lade die Seite neu, um die aktualisierten Punkte anzuzeigen.
+      no_points_deleted: Keine Punkte wurden gelöscht. Möglicherweise wurden sie bereits entfernt.
+      points:
+        one: "%{count} Punkt"
+        other: "%{count} Punkte"
+      points_deleted:
+        one: 'Erfolgreich gelöscht: %{count} Punkt'
+        other: 'Erfolgreich gelöscht: %{count} Punkte'
+      selected: 'Ausgewählt: %{items}'
+      too_many_points: Zu viele Punkte (%{requested}). Bitte zeichne einen kleineren Bereich; max. %{limit} pro Löschen.
+      too_many_selected_points: Zu viele Punkte ausgewählt (%{requested}). Bitte zeichne einen kleineren Bereich; max. %{limit} pro Löschen.
+      visits:
+        one: "%{count} Aufenthalt"
+        other: "%{count} Aufenthalte"
+      visits_in_area: Aufenthalte im Bereich (%{count})
+      write_api_requires_pro: Write API erfordert Pro
+    map_info:
+      altitude: Höhe
+      area: Fläche
+      average_speed: Durchschnittsgeschwindigkeit
+      battery: Akku
+      center: Zentrieren
+      coordinates: Koordinaten
+      current_speed: Aktuelle Geschwindigkeit
+      distance: Strecke
+      duration: Dauer
+      duration_hours_minutes: "%{hours} Std. %{minutes} Min."
+      duration_minutes: "%{minutes} Min."
+      email: E-Mail
+      end: Ende
+      h3_index: H3-Index
+      id: ID
+      latitude: Breitengrad
+      location: Standort
+      location_coordinates: Standort (%{latitude}, %{longitude})
+      location_data: Standortdaten
+      location_point: Standortpunkt
+      longitude: Länge
+      meters:
+        one: "%{count} Meter"
+        other: "%{count} Meter"
+      mode: Modus
+      photo: Foto
+      place: Ort
+      points: Punkte
+      radius: Radius
+      reason: Grund
+      route_information: Route-Informationen
+      routes: Route
+      selected_point: Ausgewählter Punkt
+      show_points: Punkte anzeigen
+      show_points_help: Aktivieren, um Punkte anzuzeigen und zu ziehen, um den Track zu bearbeiten
+      source: Quelle
+      speed: Geschwindigkeit
+      start: Start
+      status: Status
+      taken: Aufgenommen
+      time: Zeit
+      time_range: Zeitraum
+      timestamp: Zeitstempel
+      total_distance: Gesamtstrecke
+      track_number: 'Track #%{id}'
+      tracks: Tracks
+      video: Video
+      area_number: Bereich %{id}
+      place_name_locked: "\U0001F512 Du hast diesen Ort benannt, daher ändert sich der automatische Name nicht. Benenne ihn um zu „Vorgeschlagener Ort“, um ihn zurückzugeben."
+    map_controls:
+      add_visit: Füge einen Aufenthalt hinzu
+      create_place: Erstelle einen Ort
+      place_marker_mode: Klicke auf die Karte, um einen Marker zu platzieren (klicke, um abzubrechen)
+      select_area: Bereich auswählen
+      toggle_footer: Footer sichtbarkeit umschalten
+      toggle_panel: Panel umschalten
+      toggle_visits_drawer: Aufenthaltsbereich ein-/ausblenden
+    map_styles:
+      black: Schwarz
+      dark: Dunkel
+      grayscale: Graustufen
+      light: Hell
+      white: Weiß
+    family:
+      loaded_members:
+        one: "%{count} Familienmitglied geladen"
+        other: "%{count} Familienmitglieder geladen"
+      member: Familienmitglied
+      none_sharing: Kein Familienmitglied gibt seinen Standort frei
+      sharing_since:
+        one: Freigegeben seit %{date} (%{count} Tag Verlauf)
+        other: Freigegeben seit %{date} (%{count} Tage Verlauf)
+      sharing_disabled: Der Standort wird nicht mit deiner Familie geteilt
+      sharing_enabled: Der Standort wird mit deiner Familie geteilt
+      locations_updated:
+        one: Familienstandorte aktualisiert (%{count} Mitglied)
+        other: Familienstandorte aktualisiert (%{count} Mitglieder)
+      refresh_failed: Aktualisierung der Familienstandorte fehlgeschlagen
+    hexagons:
+      limit_warning: Zeige die ersten 100.000 Punkte in diesem Bereich — schränke den Zeitraum ein, um dichtere Details anzuzeigen.
+      load_failed: 'Hexagone konnten nicht geladen werden: %{error}'
+      points: "<strong>%{count}</strong> Punkte"
+    layer_preview:
+      ended: "%{layer} Vorschau beendet."
+      remaining: Vorschau von %{layer} — %{seconds} Sekunden verbleibend.
+      started: Vorschau von %{layer} für %{seconds} Sekunden.
+    poster:
+      categories:
+        print: Drucken
+        social: Soziales
+        wallpaper: Hintergrundbild
+      export_failed: 'Poster-Export fehlgeschlagen: %{error}'
+      open_failed: 'Poster-Studio konnte nicht geöffnet werden: %{error}'
+      order_summary: "%{layout} Poster — %{price}"
+      theme_load_failed: 'Thema konnte nicht geladen werden: %{error}'
+      theme_preset_failed: 'Themevorlage konnte nicht geladen werden: %{error}'
+      layouts:
+        print-a5: A5 Hochformat
+        print-a4: A4 Hochformat
+        print-a3: A3 Hochformat
+        print-a2: A2 Hochformat
+        print-a1: A1 Hochformat
+        print-a0: A0 Hochformat
+        print-30x40: 30 × 40 cm
+        print-50x70: 50 × 70 cm
+        print-70x100: 70 × 100 cm
+        print-letter: Letter (USA)
+        print-a4-landscape: A4 Querformat
+        print-a3-landscape: A3 Querformat
+        social-ig-square: Instagram Quadratisch
+        social-ig-portrait: Instagram Hochformat
+        social-story: Story (9:16)
+        social-x-header: X-Header
+        social-youtube-thumb: YouTube-Vorschaubild
+        wallpaper-fhd: Desktop Full HD
+        wallpaper-4k: Desktop 4K
+        wallpaper-ultrawide: Desktop Ultrawide
+        wallpaper-phone: Smartphone
+        wallpaper-tablet: Tablet
+      frame_too_wide: Diese Ansicht ist breiter als der größte Posterbereich — das gespeicherte Poster wird enger zoomt als der Vorschau.
+      load: Laden
+      loading: Lade…
+      loading_tracks: Lade Tracks für den neuen Bereich…
+      no_location_data: Keine Standortdaten in diesem Zeitraum — wähle einen Zeitraum mit Tracks in der Zeitleiste oben aus.
+      no_tracks_in_frame: Keine Tracks im Rahmen — verschiebe oder zoome die Karte über deinen Weg, um sie in die Galerie zu speichern.
+      queued: In der Warteschlange — wird auf der Serverseite in Recent Posters gerendert…
+      rendering: Rendere %{width} × %{height}px…
+      saved: Gespeichert
+      saved_at_dpi: Gespeichert bei %{dpi} dpi (Gerätsgrenze GL)
+      untitled: Unbenannter Poster
+      order_errors:
+        connection: Kann den Bestellservice nicht erreichen — überprüfe deine Verbindung.
+        generic: Bestellupload fehlgeschlagen — versuche es erneut.
+        not_pdf: Der Export hat kein gültiges PDF erzeugt — versuche es erneut.
+        payment_unavailable: Zahlung ist vorübergehend nicht verfügbar — versuche es in einer Minute erneut.
+        too_large: Das exportierte PDF ist zu groß (max. 50 MB). Verringere den DPI-Bereich oder zoome aus.
+        unknown_sku: Dieses Format ist derzeit nicht bestellbar.
+        unreadable: Das exportierte PDF konnte nicht gelesen werden — versuche es erneut.
+        wrong_size: Das exportierte PDF entspricht nicht dem ausgewählten Format — versuche es erneut.
+    legacy_settings:
+      edit_colors: Farben bearbeiten
+      fog_radius: Radius des Nebels des Krieges
+      fog_threshold: Schwellwert des Nebels des Krieges
+      live_map: Live-Karte
+      merge_threshold: Verschmelzschwellwert in Minuten
+      meters_between_routes: Meter zwischen Routen
+      minutes_between_routes: Minuten zwischen Routen
+      points_rendering_mode: Darstellung der Punkte
+      raw: Rohdaten
+      route_opacity: Route-Opacity, %
+      simplified: Vereinfacht
+      speed_color_scale: Geschwindigkeitsfarbskala
+      speed_colored_routes: Geschwindigkeitsfarbige Routen
+      time_threshold: Zeitgrenze in Minuten
+    calendar_panel:
+      loading_visited_places: Lade besuchte Orte...
+      loading_years: Lade Jahre...
+      no_data: Keine Daten verfügbar
+      no_places_visited: Keine Orte besucht während dieser Periode
+      select_year: Jahr auswählen
+      visited_cities: Besuchte Städte
+      visited_places_error: Fehler beim Laden der besuchten Orte
+      whole_year: Ganzes Jahr
+      years_error: Fehler beim Laden der Jahre
+    live_share:
+      ended: Diese Live-Teilung ist beendet.
+      last_seen: 'Zuletzt gesehen: %{date} (%{relative})'
+      last_seen_short: Zuletzt gesehen
+      location_hidden: Standort versteckt.
+      location_unknown: Standort unbekannt — warte auf eine Aktualisierung …
+    speed_gradient:
+      add_stop: Farbstop hinzufügen
+      color: Farbe
+      color_stops: Farbstops
+      help: Dieser Farbverlauf wird auf Routen basierend auf der Geschwindigkeit angewendet
+      preview: Vorschau
+      speed: Geschwindigkeit (km/h)
+      title: Geschwindigkeitsfarbverlauf bearbeiten
+    stats:
+      no_location_data: Keine Standortdaten für %{date} verfügbar
+      location_data_load_failed: Laden der Standortdaten fehlgeschlagen
+      map_initialization_failed: Initialisierung der Karte fehlgeschlagen
+    anomalies:
+      impossible_speed: 'Gefiltert: unmögliche Geschwindigkeit zwischen benachbarten Punkten'
+      low_accuracy: 'Geiltert: niedrige Genauigkeit (%{accuracy}m, Schwellwert %{threshold}m)'
+    live_map:
+      disabled: Live-Modus deaktiviert
+      enabled: Live-Modus aktiviert
+    map_panel:
+      layers: Kartenlayers
+      links: Links
+      search: Suche
+      settings: Einstellungen
+      timeline: Zeitleiste
+      tools: Werkzeuge
+    activity:
+      no_activity: Keine Aktivität
+    datetime:
+      start_before_end: Startdatum muss vor dem Enddatum liegen
+    timeline:
+      action_count: "%{action} %{count}"
+      merge_count: Vereinige %{count}
+      selected: "%{count} ausgewählt"
+      selected_with_max: "%{count} ausgewählt (max %{max})"
+    time:
+      days_short: "%{count}t"
+      hours_short: "%{count}h"
+      invalid_date: Ungültiges Datum
+      minutes_short: "%{count}min"
+  battery_statuses:
+    unknown: unbekannt
+    unplugged: nicht angeschlossen
+    charging: läd auf
+    full: voll
+    connected_not_charging: nicht laden
+    discharging: entladen
+  family_invitations:
+    index:
+      back_to_family: Zur Familie
+      cancel: Abbrechen
+      cancel_confirm: Möchtest du diese Einladung wirklich abbrechen?
+      copy_link: Link kopieren
+      expires_on: Verfällt am
+      invited_on: Eingeladen am
+      no_invitations: Keine offenen Einladungen
+      title: Familien-Einladungen
+      view_invitation: Ansehen

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -38,7 +38,7 @@ de:
         hello: Hallo
         someone_has_requested_a_link_to_change_your_password_you: Jemand hat einen Link angefordert, um dein Passwort zu ändern. Du kannst dies über den Link unten tun.
         if_you_didn_t_request_this_please_ignore_this_email: Wenn du diesen Link nicht angefordert hast, ignoriere bitte diese E-Mail.
-        your_password_won_t_change_until_you_access_the_link: Dein Passwort wird nicht geändert, bis du den Link oben öffnest und ein neues erstellst.
+        your_password_won_t_change_until_you_access_the_link: Dein Passwort wird erst geändert, wenn du den Link oben öffnest und ein neues Passwort festlegst.
         change_my_password: Passwort ändern
       unlock_instructions:
         hello: Hallo
@@ -50,7 +50,7 @@ de:
         change_your_password: Passwort ändern
         enter_your_new_password_below: Gib dein neues Passwort unten ein.
         new_password: Neues Passwort
-        characters_minimum: Zeichen mindestens)
+        characters_minimum: Zeichen erforderlich)
         confirm_new_password: Neues Passwort bestätigen
         change_my_password: Passwort ändern
       new:
@@ -64,7 +64,7 @@ de:
         docs: 'Dokumentation:'
         scan_with_dawarich_app: Mit Dawarich-App scannen
         usage_examples: Anwendungsbeispiele
-        dawarich_ios_or_android_app: Dawarich iOS oder Android-App
+        dawarich_ios_or_android_app: Dawarich-App für iOS oder Android
         provide_your_instance_url: 'Gib deine Instanz-URL an:'
         and_provide_your_api_key: 'Gib deinen API-Schlüssel an:'
         owntracks: OwnTracks
@@ -76,6 +76,7 @@ de:
         you_have_used: Du hast verwendet
         points_of: Punkte von
         available: verfügbar.
+        summary_html: Du hast %{used} von %{limit} verfügbaren Punkten verwendet.
       edit:
         account_settings: Kontoeinstellungen
         profile: Profil
@@ -85,7 +86,7 @@ de:
         currently_waiting_confirmation_for: 'Bestätigung ausstehend für:'
         new_password: Neues Passwort
         leave_blank_to_keep_the_current_one: "(leer lassen, um das aktuelle zu behalten)"
-        characters_minimum: Zeichen mindestens)
+        characters_minimum: Zeichen erforderlich)
         password_confirmation: Passwortbestätigung
         current_password: Aktuelles Passwort
         required_to_confirm_your_changes: "(erforderlich, um deine Änderungen zu bestätigen)"
@@ -109,7 +110,7 @@ de:
         import_my_data: Meine Daten importieren
         danger_zone: Gefahrenzone
         deleting_your_account_is_permanent_and_removes_all_your_data: Das Löschen deines Kontos ist endgültig und entfernt alle deine Daten.
-        cancel_my_account: Mein Konto kündigen
+        cancel_my_account: Mein Konto löschen
         delete_your_account: Dein Konto löschen
         this_is_permanent_and_removes_all_your_data_this_cannot: Dies ist endgültig und entfernt alle deine Daten. Dies kann nicht rückgängig gemacht werden.
         this_is_permanent_and_removes_all_your_data_this_cannot_2: Dies ist endgültig und entfernt alle deine Daten. Dies kann nicht rückgängig gemacht werden. Wir senden dir eine E-Mail mit einem Link zur Bestätigung — dein Konto wird nur gelöscht, nachdem du den Link anklickst.
@@ -123,7 +124,7 @@ de:
         export_my_data: Meine Daten exportieren
         are_you_sure_you_want_to_export_your_data: Bist du sicher, dass du deine Daten exportieren möchtest?
         account: Konto
-        importing: Importiere...
+        importing: Wird importiert …
         delete_my_account: Mein Konto löschen
         email_me_the_confirmation_link: Sende mir den Bestätigungslink per E-Mail
       new:
@@ -140,7 +141,7 @@ de:
         you_re_beautiful: 5. Du bist wunderschön!
         email: E-Mail
         password: Passwort
-        characters_minimum: Zeichen mindestens)
+        characters_minimum: Zeichen erforderlich)
         password_confirmation: Passwortbestätigung
         how_do_you_plan_to_use_dawarich: Wie planst du, Dawarich zu nutzen?
         i_m_self_hosting_and_exploring_the_demo: Ich hoste selbst und erkunde die Demo
@@ -156,10 +157,11 @@ de:
         and_take_control_over_your_location_data: und übernimm die Kontrolle über deine Standortdaten.
         email: E-Mail
         password: Passwort
-        remember_me: Mich erinnern
+        remember_me: Angemeldet bleiben
         sign_in_using_your_organization_s_identity_provider: Mit dem Identitätsanbieter deiner Organisation anmelden
         create_one_here: Eines hier erstellen
         sign_in_accept_invitation: Anmelden & Einladung annehmen
+        log_in: Anmelden
       otp_challenge:
         two_factor_authentication: Zwei-Faktor-Authentifizierung
         enter_the_6_digit_code_from_your_authenticator_app_to: Gib den 6-stelligen Code aus deiner Authenticator-App ein, um fortzufahren.
@@ -278,7 +280,7 @@ de:
       members_created:
         one: "%{count} Mitglied · Erstellt %{date}"
         other: "%{count} Mitglieder · Erstellt %{date}"
-      invited_ago_expires: Einladung %{ago} ago · läuft ab %{date}
+      invited_ago_expires: Vor %{ago} eingeladen · läuft am %{date} ab
       always: immer
       for_duration: für %{duration}
       sharing_status: Freigabe %{duration}
@@ -377,22 +379,24 @@ de:
         back_to_family: Zur Familie
   family_mailer:
     invitation:
-      you_ve_been_invited_to_join_a_family: Du hast eine Einladung erhalten, eine Familie beizutreten!
+      you_ve_been_invited_to_join_a_family: Du wurdest eingeladen, einer Familie beizutreten!
       hi_there: Hallo!
+      invited_by_family_html: <strong>%{email}</strong> hat dich eingeladen, der Familie „<strong>%{family}</strong>“ auf Dawarich beizutreten.
+      invited_by_family_text: "%{email} hat dich eingeladen, der Familie „%{family}“ auf Dawarich beizutreten."
       has_invited_you_to_join_their_family: hat dich eingeladen, ihre Familie "
       on_dawarich: "\" auf Dawarich."
       by_joining_this_family_you_ll_be_able_to: 'Indem du dieser Familie beitrittst, kannst du:'
       share_your_current_location_with_family_members: Deinen aktuellen Standort mit Familienmitgliedern teilen
       see_the_current_location_of_other_family_members: Den aktuellen Standort anderer Familienmitglieder sehen
       stay_connected_with_your_loved_ones: Mit deinen Lieben in Verbindung bleiben
-      control_your_privacy_with_full_sharing_controls: Deine Privatsphäre mit vollständigen Freigabesteuern kontrollieren
+      control_your_privacy_with_full_sharing_controls: Deine Privatsphäre mit umfassenden Freigabeeinstellungen schützen
       important: "⏰ Wichtig:"
       this_invitation_will_expire_in_7_days: Diese Einladung läuft in 7 Tagen ab.
       if_you_don_t_have_a_dawarich_account_yet_you: Wenn du noch kein Dawarich-Konto hast, kannst du eines erstellen, sobald du die Einladung annimmst.
       if_you_didn_t_expect_this_invitation_you_can_safely: Wenn du diese Einladung nicht erwartet hast, kannst du diese E-Mail einfach ignorieren.
       best_regards: Mit freundlichen Grüßen,
       evgenii_from_dawarich: Evgenii von Dawarich
-      you_ve_been_invited_to_join_a_family_hi_there: Du wurdest zu einer Familie eingeladen! Hallo da!
+      you_ve_been_invited_to_join_a_family_hi_there: Du wurdest eingeladen, einer Familie beizutreten! Hallo!
       on_dawarich_by_joining_this_family_you_ll_be_able: "\" auf Dawarich. Durch das Beitreten dieser Familie wirst du in der Lage sein: • Deinen aktuellen Standort mit Familienmitgliedern zu teilen • Den aktuellen Standort anderer Familienmitglieder zu sehen • Mit deinen Lieben in Verbindung zu bleiben • Deine Privatsphäre vollständig zu kontrollieren Akzeptiere die Einladung hier:"
       important_this_invitation_will_expire_in_7_days_if_you: 'WICHTIG: Diese Einladung läuft in 7 Tagen ab. Wenn du noch kein Dawarich-Konto hast, kannst du eines erstellen, sobald du die Einladung annimmst. Wenn du diese Einladung nicht erwartet hast, kannst du diese E-Mail einfach ignorieren. Mit freundlichen Grüßen, Evgenii von Dawarich'
       accept_invitation: Einladung annehmen
@@ -404,7 +408,7 @@ de:
       important_this_invitation_will_expire_in_7_days: 'WICHTIG: Diese Einladung läuft in 7 Tagen ab.'
     location_request:
       location_request: Standortanfrage
-      hi_there: Hallo da!
+      hi_there: Hallo!
       is_requesting_your_location_on_dawarich: fragt deinen Standort über Dawarich an.
       you_can_review_this_request_and_choose_to_accept_or: Du kannst diese Anfrage überprüfen und entscheiden, ob du sie annimmst oder ablehnst. Wenn du annimmst, kannst du auswählen, wie lange du deinen Standort freigibst (1 Stunde, 6 Stunden, 12 Stunden, 24 Stunden oder dauerhaft).
       important: "⏰ Wichtig:"
@@ -421,8 +425,20 @@ de:
       view_request_2: 'Anfrage ansehen:'
       important_this_request_will_expire_in_24_hours_if_not_2: "⏰ Wichtig: Diese Anfrage läuft in 24 Stunden ab, wenn sie nicht bearbeitet wird."
     member_joined:
-      great_news_someone_joined_your_family: "\U0001F389 Toll! Jemand hat deine Familie betreten!"
+      great_news_someone_joined_your_family: "\U0001F389 Gute Nachrichten! Jemand ist deiner Familie beigetreten!"
       hi: Hallo
+      member_joined_family_html: Wir freuen uns, dir mitzuteilen, dass <strong>%{email}</strong> gerade deiner Familie „<strong>%{family}</strong>“ auf Dawarich beigetreten ist!
+      member_joined_family_text: "Wir freuen uns, dir mitzuteilen, dass %{email} gerade deiner Familie „%{family}“ auf Dawarich beigetreten ist!"
+      see_current_location_html: Aktuellen Standort von <strong>%{email}</strong> ansehen (sofern die Standortfreigabe aktiviert ist)
+      see_current_location_text: Aktuellen Standort von %{email} ansehen (sofern die Standortfreigabe aktiviert ist)
+      share_location_with_html: Deinen Standort mit <strong>%{email}</strong> teilen
+      share_location_with_text: Deinen Standort mit %{email} teilen
+      member_count_html:
+        one: Deine Familie hat jetzt <strong>%{count}</strong> Mitglied.
+        other: Deine Familie hat jetzt <strong>%{count}</strong> Mitglieder.
+      member_count:
+        one: Deine Familie hat jetzt %{count} Mitglied.
+        other: Deine Familie hat jetzt %{count} Mitglieder.
       we_re_excited_to_let_you_know_that: Wir freuen uns, dir mitzuteilen, dass
       has_just_joined_your_family: ist gerade deiner Familie „
       on_dawarich: "\" auf Dawarich!"
@@ -438,13 +454,13 @@ de:
       member: Mitglied
       best_regards: Mit freundlichen Grüßen,
       evgenii_from_dawarich: Evgenii von Dawarich
-      great_news_someone_joined_your_family_hi: Großartige Nachricht! Jemand hat deine Familie betreten! Hallo
+      great_news_someone_joined_your_family_hi: Gute Nachrichten! Jemand ist deiner Familie beigetreten! Hallo
       we_re_excited_to_let_you_know_that_2: "! Wir freuen uns, dir mitzuteilen, dass"
       on_dawarich_now_you_can_see: "\" auf Dawarich! Jetzt kannst du: • Deinen"
       s_current_location_if_they_ve_enabled_sharing_stay_connected: "'s aktuellen Standort (falls sie Standortfreigabe aktiviert haben) • Mit deiner wachsenden Familie in Verbindung bleiben • Deinen Standort mit"
       manage_family_members_and_settings_from_your_family_page_tip: "• Familie und Einstellungen von deiner Familien-Übersicht verwalten TIP: Du kannst deine Familie und Privatsphäre-Einstellungen jederzeit von deiner Familien-Übersicht verwalten. Deine Familie hat jetzt"
       best_regards_evgenii_from_dawarich: ". Mit freundlichen Grüßen, Evgenii von Dawarich"
-      great_news_someone_joined_your_family_2: Großartige Nachricht! Jemand hat deine Familie betreten!
+      great_news_someone_joined_your_family_2: Gute Nachrichten! Jemand ist deiner Familie beigetreten!
       see_2: "• Deinen"
       stay_connected_with_your_growing_family_2: "• Mit deiner wachsenden Familie in Verbindung bleiben"
       share_your_location_with_2: "• Deinen Standort mit"
@@ -456,18 +472,18 @@ de:
       the_only_location_history_tracker_you_ll_ever_need: Der einzige Standortverlaufstracker, den du je benötigen wirst.
       or: oder
       location_history_visualisation: Visualisierung des Standortverlaufs
-      effortlessly_import_your_location_history_from_google_maps_timeline_and: Leicht importiere deine Standortverlauf aus Google Maps Timeline und Owntracks. Sieh deine Reisen auf einer interaktiven Karte an, vollständig mit anpassbaren Schichten wie Heatmaps, Punkten und Verbindungslinien, um deine Reisen zu visualisieren.
+      effortlessly_import_your_location_history_from_google_maps_timeline_and: Importiere deinen Standortverlauf mühelos aus Google Maps Timeline und OwnTracks. Erkunde deine Wege auf einer interaktiven Karte und passe Ebenen wie Heatmap, Punkte und Verbindungslinien an.
       comprehensive_travel_statistics: Umfassende Reisestatistiken
       gain_insights_into_your_travel_patterns_with_detailed_statistics_track: Erhalte Einblicke in deine Reisemuster mit detaillierten Statistiken. Verfolge die Anzahl der besuchten Länder und Städte sowie die Gesamtstrecke. Teile deine Daten nach Jahren und Monaten für einen klaren Überblick über deine Reisen.
       self_hosted_and_private: Selbst gehostet und privat
-      maintain_complete_control_over_your_data_with_our_self_hosted: Erhalte volle Kontrolle über deine Daten mit unserer selbsthosteten Lösung. Dawarich stellt sicher, dass dein Standortverlauf privat und sicher bleibt, wodurch du dir während der Nutzung eines robusten Tracking-Systems Ruhe gönnst.
-      find_more_on: Mehr auf
-      the_website: die Website
-      or_check_out_the: ", oder schaue dir die"
+      maintain_complete_control_over_your_data_with_our_self_hosted: Mit der selbst gehosteten Lösung behältst du die volle Kontrolle über deine Daten. Dein Standortverlauf bleibt privat und sicher, während dir alle Funktionen eines leistungsfähigen Tracking-Systems zur Verfügung stehen.
+      find_more_on: Mehr erfährst du auf
+      the_website: der Website
+      or_check_out_the: ", oder sieh dir den"
       source_code: Quellcode
       on_github: auf GitHub an.
-      sign_up: Melde dich an
-      sign_in: Melde dich an
+      sign_up: Registrieren
+      sign_in: Anmelden
   imports:
     extraction_card:
       additional_data: Zusätzliche Daten
@@ -494,14 +510,15 @@ de:
       tracks: Tracks
       journeys_identified_between_those_visits_with_their_classified_transport: "— Reisen, die zwischen diesen Aufenthalten erkannt wurden, mit ihrer klassifizierten Fortbewegungsmethode (Fahren, Gehen, Radfahren, ÖPNV, …)."
       places: Orte
-      the_named_places_home_work_frequent_restaurants_the_source_app: "— die benannten Orte (Zuhause, Arbeit, häufige Restaurants) die die Quelle-App mit deinen Aufenthalten verknüpft."
+      the_named_places_home_work_frequent_restaurants_the_source_app: "— die benannten Orte (Zuhause, Arbeit, häufige Restaurants), die die Quell-App mit deinen Aufenthalten verknüpft."
       click: Klick
       extract: Extrahieren
+      extract_to_add_html: Klicke auf <strong>Extrahieren</strong>, um diese Daten deinem Dawarich-Konto hinzuzufügen. Bestehende Punkte werden nicht verändert. Aufenthalte und Orte, die Dawarich bereits aus deinen Punkten erkannt hat, bleiben parallel zu den importierten Einträgen erhalten.
       to_add_this_data_to_your_dawarich_account_existing_points: um diese Daten deinem Dawarich-Konto hinzuzufügen. Bestehende Punkte werden nicht verändert. Aufenthalte und Orte, die Dawarich bereits aus deinen Punkten erkannt hat, bleiben parallel zu den importierten Einträgen erhalten.
       trust_the_source_app_s_classification: Vertraue der Klassifizierung der Quelle-App
       when_checked_transportation_modes_driving_walking_cycling_transit_the_so: Wenn aktiviert, werden Fortbewegungsmethoden (Fahren, Gehen, Radfahren, ÖPNV) so beibehalten, wie sie die Quelle-App zugeteilt hat. Wenn deaktiviert, führt Dawarich erneut seinen eigenen Erkennungsalgorithmus mit deinen Einstellungen aus.
       cancel: Abbrechen
-      close: schließe
+      close: Schließen
     extraction_remove_button:
       remove_extracted_data: Extrahierte Daten entfernen
       remove_the_visits_places_and_tracks_this_extraction_created_your: Entferne die Aufenthalte, Orte und Tracks, die diese Extraktion erstellt hat? Deine importierten GPS-Punkte werden beibehalten.
@@ -530,11 +547,11 @@ de:
       zip: 'ZIP:'
       archives_containing_any_of_the_above_zip: Archive mit einem der oben genannten Formate (.zip)
       file_format_is_automatically_detected_during_upload: Dateiformat wird während des Uploads automatisch erkannt.
-      for_files_larger_than_200mb_consider_compressing_them_into_a: Für Dateien größer als 200MB solltest du sie vor dem Upload in eine ZIP-Datei komprimieren. Dies reduziert die Uploadzeit deutlich und vermeidet Verbindungsabbrüche.
+      for_files_larger_than_200mb_consider_compressing_them_into_a: Dateien über 200 MB solltest du vor dem Upload in ein ZIP-Archiv packen. Das verkürzt die Uploadzeit deutlich und vermeidet Verbindungsabbrüche.
       trial_limitations_max_5_imports_10mb_per_file: 'Testlimitierungen: Max. 5 Importe, 10MB pro Datei.'
       current_imports: 'Aktuelle Importe:'
       select_one_or_multiple_files: Wähle eine oder mehrere Dateien
-      files_will_be_uploaded_directly_to_storage_please_be_patient: Dateien werden direkt in die Speicherung hochgeladen. Bitte sei während des Uploads geduldig.
+      files_will_be_uploaded_directly_to_storage_please_be_patient: Die Dateien werden direkt in den Speicher hochgeladen. Bitte habe während des Uploads etwas Geduld.
     import:
       name: Name
       imported_points: Importierte Punkte
@@ -555,7 +572,7 @@ de:
       delete_import: Import löschen
     edit:
       editing_import: Import bearbeiten
-      back_to_imports: Zurück zu Imports
+      back_to_imports: Zurück zu den Importen
     index:
       new_import: Neuer Import
       import_from_immich: Von Immich importieren
@@ -571,7 +588,7 @@ de:
       status: Status
       created: Erstellt
     new:
-      back_to_imports: Zurück zu Imports
+      back_to_imports: Zurück zu den Importen
       google_timeline_file_too_large: Google Timeline-Datei zu groß?
       your_data_never_leaves_your_browser: "— deine Daten verlassen nie deinen Browser."
       new_import: Neuer Import
@@ -581,7 +598,7 @@ de:
       edit_this_import: Diesen Import bearbeiten
       destroy_this_import: Diesen Import löschen
       are_you_sure_this_action_will_delete_all_points_imported: Bist du sicher? Diese Aktion wird alle Punkte löschen, die mit dieser Datei importiert wurden
-      back_to_imports: Zurück zu Imports
+      back_to_imports: Zurück zu den Importen
       import: Importieren
   insights:
     activity_breakdown:
@@ -632,7 +649,7 @@ de:
       country: Land
       city: Stadt
       no_new_places_this_month: Keine neuen Orte in diesem Monat
-      vs_previous_month: IM VORHERIGEN MONAT
+      vs_previous_month: IM VERGLEICH ZUM VORMONAT
       distance: Distanz
       countries_2: Länder
       monthly_digest: Monatlicher Überblick
@@ -688,22 +705,22 @@ de:
       days: 35 Tage
       230_km: 4.230 km
       the_great_european_road_trip: "„Der große europäische Roadtrip“"
-      you_started_in: Du begannst in
+      you_started_in: Gestartet bist du in
       berlin: Berlin
-      your_home_base_after_a_week_of_work_you_headed: ", deiner Heimatstadt. Nach einer Woche Arbeit stachst du südlich durch"
+      your_home_base_after_a_week_of_work_you_headed: ", deinem Ausgangspunkt. Nach einer Arbeitswoche ging es über"
       dresden: Dresden
       and: und
       prague: Prag
-      spending_3_days_exploring_the_city_of_a_hundred_spires: ", um drei Tage die Stadt der hundert Spitzengeschäfte zu erkunden."
-      the_journey_continued_through: Die Reise setzte ihren Weg fort durch
+      spending_3_days_exploring_the_city_of_a_hundred_spires: "weiter nach Süden, wo du drei Tage lang die Stadt der hundert Türme erkundet hast."
+      the_journey_continued_through: Weiter ging es nach
       vienna: Wien
-      where_you_spent_a_weekend_before_crossing_into_italy_you: ", wo du einen Wochenendeurlaub verbrachte, bevor du in Italien einfiel. Du durchquerte die Alpen, hieltst an"
+      where_you_spent_a_weekend_before_crossing_into_italy_you: ", wo du ein Wochenende verbracht hast, bevor du nach Italien weitergereist bist. Über die Alpen führte die Reise zum"
       lake_como: See Como
-      for_two_nights_of_swimming_and_pasta: für zwei Nächte Schwimmen und Pasta.
+      for_two_nights_of_swimming_and_pasta: für zwei Nächte voller Badespaß und Pasta.
       rome: Rom
-      welcomed_you_for_5_days_of_ancient_history_then_you: willkommensbereit für 5 Tage antike Geschichte, dann stachst du die Küste südlich zu
+      welcomed_you_for_5_days_of_ancient_history_then_you: bot dir fünf Tage voller antiker Geschichte. Anschließend ging es entlang der Küste weiter nach
       amalfi: Amalfi
-      with_stops_in_naples_and_positano: ", mit Haltepunkten in Neapel und Positano."
+      with_stops_in_naples_and_positano: ", mit Zwischenstopps in Neapel und Positano."
       journey_timeline: REISEZEITLEISTE
       de: DE
       home_base: Heimatbasis
@@ -777,8 +794,8 @@ de:
       dawarich: Dawarich
       try_dawarich_cloud: Probier Dawarich Cloud aus
       shared_with_dawarich: Mit Dawarich geteilt
-      map_your_own_journeys: Karte deine eigenen Reisen.
-      dawarich_turns_your_own_location_history_into_maps_worth_sharing: Dawarich verwandelt deine eigene Standortgeschichte in Karten, die sich teilen lohnen — open-source, selbsthostbar und dein Eigentum.
+      map_your_own_journeys: Zeichne deine eigenen Reisen auf einer Karte auf.
+      dawarich_turns_your_own_location_history_into_maps_worth_sharing: Dawarich verwandelt deinen Standortverlauf in sehenswerte Karten — Open Source, selbst hostbar und unter deiner Kontrolle.
       see_how_it_works: Sieh dir an, wie es funktioniert
       open_source: Open Source
       self_hostable: Selbst hostbar
@@ -795,7 +812,7 @@ de:
       i_have_data: Ich habe Daten
       import_google_takeout_gpx_kml_geojson_or_owntracks_files: Importiere Google Takeout-, GPX-, KML-, GeoJSON- oder OwnTracks-Dateien.
       explore_with_demo_data: Erkunde mit Demo-Daten
-      load_sample_location_data_3_days_in_berlin_to_see: Lade Beispieldaten (3 Tage in Berlin) herunter, um zu sehen, wie deine Karte aussehen könnte. Du kannst sie jederzeit löschen.
+      load_sample_location_data_3_days_in_berlin_to_see: Füge deinem Konto Beispiel-Standortdaten (3 Tage in Berlin) hinzu, um zu sehen, wie deine Karte aussehen könnte. Du kannst die Demo-Daten jederzeit wieder entfernen.
       skip_for_now: Jetzt überspringen
       import_your_data: Importiere deine Daten
       supported_formats: Unterstützte Formate
@@ -809,19 +826,19 @@ de:
       recorder_files_rec: Recorder-Dateien (.rec)
       kml: 'KML:'
       kml_files_kml_kmz: KML-Dateien (.kml, .kmz)
-      file_format_is_automatically_detected_during_upload: Die Dateiformat wird während des Uploads automatisch erkannt.
+      file_format_is_automatically_detected_during_upload: Das Dateiformat wird beim Hochladen automatisch erkannt.
       trial_limitations_max_5_imports_10mb_per_file_current_imports: 'Testzeitraum-Begrenzungen: Maximal 5 Importe, 10 MB pro Datei. Aktuelle Importe:'
       select_one_or_multiple_files: Wähle eine oder mehrere Dateien
-      files_will_be_uploaded_directly_to_storage_please_be_patient: Dateien werden direkt in die Speicherung hochgeladen. Bitte sei geduldig während des Uploads.
+      files_will_be_uploaded_directly_to_storage_please_be_patient: Die Dateien werden direkt in den Speicher hochgeladen. Bitte habe währenddessen etwas Geduld.
       start_tracking: Tracking starten
       download_the_app: Lade die App herunter
-      scan_qr_code_to_connect: Scanne den QR-Code, um zu verbinden
+      scan_qr_code_to_connect: QR-Code zum Verbinden scannen
       scan_this_qr_code_with_the_dawarich_app_to_automatically: Scanne diesen QR-Code mit der Dawarich-App, um die Verbindung automatisch zu konfigurieren.
       or: ODER
       grab_your_api_key_from: Hol dir deinen API-Schlüssel von
       and_follow_the: und folge den
       have_old_location_history_like_a_google_takeout_tracking_works: Du hast alte Standortdaten, wie bei Google Takeout? Tracking funktioniert sofort – du kannst
-      import_your_history_anytime: deine Geschichte jederzeit importieren
+      import_your_history_anytime: deinen Standortverlauf jederzeit importieren
       got_it_let_s_start: Verstanden, los geht's!
       close: schließen
       import_files: Dateien importieren
@@ -829,14 +846,14 @@ de:
       setup_guide: Einrichtungsanleitung
     leaflet:
       settings_modals:
-        route_opacity: Route-Opacity
+        route_opacity: Deckkraft der Route
         value_in_percent: Wert in Prozent.
-        this_value_is_the_opacity_of_the_route_on_the: Dieser Wert ist die Opazität der Route auf der Karte. Der Wert wird in Prozent angegeben und kann zwischen 0 und 100 eingestellt werden. Der Standardwert ist 100, was bedeutet, dass die Route voll sichtbar ist. Wenn du den Wert auf 0 setzt, ist die Route unsichtbar.
+        this_value_is_the_opacity_of_the_route_on_the: Dieser Wert bestimmt die Deckkraft der Route auf der Karte. Er wird in Prozent angegeben und kann zwischen 0 und 100 liegen. Bei 100 ist die Route vollständig sichtbar, bei 0 unsichtbar.
         close: Schließen
-        fog_of_war: Nebel des Krieges
+        fog_of_war: Kartennebel
         value_in_meters: Wert in Metern.
-        here_you_can_set_the_radius_of_the_cleared_area: Hier kannst du den Radius des „geklärten“ Bereichs um einen Punkt festlegen, wenn der Nebel des Krieges-Modus aktiviert ist. Der Bereich um den Punkt wird geclart, und der Rest der Karte wird mit Nebel bedeckt. Der geclarte Bereich wird ein Kreis mit dem Punkt als Mittelpunkt und dem hier festgelegten Radius sein.
-        fog_of_war_line_threshold: Nebel des Krieges Linien-Schwelle
+        here_you_can_set_the_radius_of_the_cleared_area: Hier kannst du den Radius des aufgedeckten Bereichs um jeden Punkt festlegen, wenn der Kartennebel aktiviert ist. Innerhalb dieses Radius bleibt die Karte sichtbar; der übrige Bereich wird vom Nebel verdeckt.
+        fog_of_war_line_threshold: Linien-Schwellenwert des Kartennebels
         value_in_seconds: Wert in Sekunden.
         points_in_the_fog_are_connected_by_lines_this_value: Punkte im Nebel werden durch Linien verbunden. Dieser Wert ist die maximale Zeit zwischen zwei Punkten, um durch eine Linie verbunden zu werden. Wenn die Zeit zwischen zwei Punkten größer als dieser Wert ist, werden sie nicht verbunden.
         meters_between_routes: Meter zwischen Routen
@@ -888,11 +905,11 @@ de:
     maplibre:
       area_creation_modal:
         create_new_area: Neues Gebiet erstellen
-        area_name: Gebietsnamen *
+        area_name: Gebietsname *
         radius: Radius
         meters: Meter
         cancel: Abbrechen
-        e_g_home_office_gym: z. B. Home, Büro, Gym...
+        e_g_home_office_gym: z. B. Zuhause, Büro, Fitnessstudio …
         radius_in_meters: Radius in Metern
         create_area: Gebiet erstellen
         creating: Wird erstellt...
@@ -900,13 +917,13 @@ de:
         map_controls: Kartensteuerung
         timeline: Zeitleiste
         timeline_t: Zeitleiste (T)
-        layers: Schichten
-        layers_l: Schichten (L)
+        layers: Ebenen
+        layers_l: Ebenen (L)
         search: Suche
         search_2: Suche (/)
         create: Erstellen
         create_c: Erstellen (C)
-        replay: Wiederholen
+        replay: Wiedergabe
         replay_points_for_the_current_date_range_r: Standortpunkte für den aktuellen Zeitraum wiedergeben (R)
         poster_studio: Poster-Studio
         settings: Einstellungen
@@ -914,16 +931,16 @@ de:
         links: Links
       residency_modal:
         days_per_country: Tage pro Land
-        distinct_days_with_at_least_one_tracked_point_per_country: Klare Tage mit mindestens einem verfolgten Punkt pro Land. Keine Steuerratgeber.
+        distinct_days_with_at_least_one_tracked_point_per_country: Unterschiedliche Kalendertage mit mindestens einem aufgezeichneten Punkt pro Land. Keine Steuerberatung.
       settings_panel:
         close_panel: Fenster schließen
-        layers: Schichten
+        layers: Ebenen
         search_for_a_place: Suche nach einem Ort
         enter_name_of_a_place: Gib den Namen eines Ortes ein
         search_for_a_location_to_find_places_you_visited: Suche nach einem Ort, um Orte zu finden, die du besucht hast
         points: Punkte
         show_individual_location_points: Zeige einzelne Standortpunkte
-        edit_points: Bearbeite Punkte
+        edit_points: Punkte bearbeiten
         allow_dragging_points_to_correct_their_position: Erlaube das Ziehen von Punkten, um ihre Position zu korrigieren.
         editing_points_is_a_pro_feature_this_stays_on_for: Die Bearbeitung von Punkten ist eine Pro-Funktion — dies bleibt für die aktuelle Sitzung aktiv, und Bewegungen werden auf dem Lite-Plan nicht gespeichert.
         allow_dragging_points_to_correct_their_position_remembered_across_sessio: Erlaube das Ziehen von Punkten, um ihre Position zu korrigieren. Wird über Sitzungen hinweg gespeichert.
@@ -934,7 +951,7 @@ de:
         anomalies: Anomalien
         show_filtered_gps_noise_points: Zeige gefilterte GPS-Rauschpunkte
         tracks: Tracks
-        show_backend_calculated_tracks: Zeige backend-berechnete Tracks
+        show_backend_calculated_tracks: Im Hintergrund berechnete Tracks anzeigen
         flights: Flüge
         show_airtrail_flights_as_arcs_hides_overlapping_gps: Flüge von AirTrail als Bögen anzeigen (überlappende GPS-Daten verbergen)
         heatmap: Heatmap
@@ -951,23 +968,23 @@ de:
         show_your_saved_places: Deine gespeicherten Orte anzeigen
         enable_all_tags: Alle Tags aktivieren
         filter_by_tags: Nach Tags filtern
-        untagged: "\U0001F3F7️ Ungesponsert"
+        untagged: "\U0001F3F7️ Ohne Tag"
         click_tags_to_filter_places: Klick auf Tags, um Orte zu filtern
         photos: Fotos
         show_geotagged_photos: Geotagte Fotos anzeigen
         areas: Flächen
         show_defined_areas: Definierte Flächen anzeigen
-        fog_of_war: Nebel des Krieges
+        fog_of_war: Kartennebel
         show_explored_areas: Erkundete Flächen anzeigen
         per_point: Pro Punkt
         per_hexagon: Pro Sechseck
         scratch_map: Rubbelkarte
-        show_scratched_countries: Rubbelte Länder anzeigen
+        show_scratched_countries: Freigerubbelte Länder anzeigen
         family_members: Familienmitglieder
         show_family_member_locations: Standorte von Familienmitgliedern anzeigen
         click_to_center_on_member: Klicke, um auf Mitglied zu zoomen
         appearance: Erscheinungsbild
-        custom_map_colors_layer_colors_and_vector_tiles_are_pro: Benutzerdefinierte Kartenfarben, Schichtfarben und Vektorfliesen sind Pro-Funktionen – du kannst sie hier vorschauen, aber sie werden im Lite-Plan nicht gespeichert.
+        custom_map_colors_layer_colors_and_vector_tiles_are_pro: Benutzerdefinierte Kartenfarben, Ebenenfarben und Vektorkacheln sind Pro-Funktionen – du kannst sie hier in der Vorschau sehen, aber im Lite-Tarif werden sie nicht gespeichert.
         map_style: Kartenstil
         light: Hell
         dark: Dunkel
@@ -979,15 +996,15 @@ de:
         customize_colors: Farben anpassen
         globe_view: Globusansicht
         render_map_as_a_3d_globe_requires_page_reload: Karte als 3D-Globus rendern (erfordert Neuladen der Seite)
-        route_opacity: Route-Opacity
-        layer_colors: Schichtfarben
+        route_opacity: Deckkraft der Route
+        layer_colors: Ebenenfarben
         reset_to_defaults: Zurücksetzen auf Standardwerte
         distance_unit: Entfernungseinheit
         kilometers: Kilometer
         miles: Meilen
-        custom_basemap_url: Benutzerdefinierte Basemap-URL
-        serve_the_base_map_from_your_own_source_accepts_protomaps: Stelle die Basiskarte von deiner eigenen Quelle bereit. Akzeptiert Protomaps-Schema-Vektor-Tiles oder Raster-XYZ-Tiles (beide müssen {z}, {x} und {y} enthalten), oder eine vollständige MapLibre-Stil-URL. Lasse das leer, um die integrierten Tiles zu verwenden.
-        base_map_layers: Basiskarten-Schichten
+        custom_basemap_url: Benutzerdefinierte Basiskarten-URL
+        serve_the_base_map_from_your_own_source_accepts_protomaps: Verwende eine Basiskarte aus einer eigenen Quelle. Unterstützt werden Protomaps-Vektorkacheln oder Raster-XYZ-Kacheln (jeweils mit {z}, {x} und {y}) sowie vollständige MapLibre-Stil-URLs. Leer lassen, um die integrierten Kacheln zu verwenden.
+        base_map_layers: Basiskartenebenen
         toggle_base_map_elements_changes_apply_immediately: Basiskarten-Elemente ein-/ausschalten. Änderungen werden sofort angewendet.
         pro_feature_you_can_preview_changes_here_but_they_won: Pro-Funktion — du kannst Änderungen hier vorschauen, aber sie werden auf dem Lite-Plan nicht gespeichert.
         the_custom_style_draws_no_labels_or_points_of_interest: Der benutzerdefinierte Stil zeichnet keine Beschriftungen oder Sehenswürdigkeiten — diese Schalter sind während der Aktivierung deaktiviert.
@@ -1000,20 +1017,20 @@ de:
         min_2: 1min
         min_3: 90min
         min_4: 180min
-        time_threshold_for_route_splitting: Zeitgrenze für die Route-Aufteilung
+        time_threshold_for_route_splitting: Schwellenwert für die Routenteilung
         points_rendering_mode: Darstellungsmodus der Punkte
-        raw_all_points: Roh (alle Punkte)
+        raw_all_points: Rohdaten (alle Punkte)
         simplified_reduced_points: Vereinfacht (reduzierte Punkte)
         speed_colored_routes: Geschwindigkeitsfarbige Routen
         color_routes_by_speed: Routen nach Geschwindigkeit färben
-        fog_of_war_radius: Radius des Nebels des Krieges
-        clear_radius_around_visited_points: Radius um besuchte Punkte löschen
-        fog_of_war_threshold: Schwellwert des Nebels des Krieges
-        minimum_points_to_clear_fog: Mindestpunkte zum Wegschaffen des Nebels
+        fog_of_war_radius: Radius des Kartennebels
+        clear_radius_around_visited_points: Radius des aufgedeckten Bereichs um besuchte Punkte
+        fog_of_war_threshold: Schwellenwert des Kartennebels
+        minimum_points_to_clear_fog: Mindestanzahl an Punkten zum Aufdecken
         gps_noise_filtering: GPS-Rauschfilterung
-        hide_readings_that_cannot_be_a_real_position_impossible_jumps: Verstecke Lesungen, die keine echte Position sein können — unmögliche Sprünge, beschädigte Koordinaten. Deaktivieren, um alle Rohpunkte anzuzeigen.
-        re_evaluate_past_data: Vorherige Daten neu bewerten
-        clears_existing_anomaly_flags_and_re_runs_the_filter_on: Löscht vorhandene Anomaliefahnen und führt den Filter erneut auf allen deinen Punkten mit den aktuellen Einstellungen aus. Tracks, Statistiken und Zusammenfassungen werden danach neu erstellt. Läuft im Hintergrund.
+        hide_readings_that_cannot_be_a_real_position_impossible_jumps: Blendet Messwerte aus, die keine echte Position darstellen können — etwa unmögliche Sprünge oder beschädigte Koordinaten. Deaktivieren, um alle Rohpunkte anzuzeigen.
+        re_evaluate_past_data: Vergangene Daten erneut prüfen
+        clears_existing_anomaly_flags_and_re_runs_the_filter_on: Entfernt vorhandene Anomaliemarkierungen und prüft alle Punkte mit den aktuellen Einstellungen erneut. Tracks, Statistiken und Zusammenfassungen werden anschließend im Hintergrund neu erstellt.
         recalculate_tracks_stats: Tracks & Statistiken neu berechnen
         rebuild_tracks_stats_and_digests_from_your_current_points_without: Tracks, Statistiken und Zusammenfassungen aus deinen aktuellen Punkten neu erstellen, ohne Anomalie-Flaggen zu berühren. Nützlich nach Änderung der Routenteilungsschwellen.
         city_statistics: Stadtstatistiken
@@ -1022,13 +1039,13 @@ de:
         min_6: 5 min
         min_7: 120 min
         how_long_you_must_stay_for_a_city_to_count: Wie lange du in einer Stadt bleiben musst, damit sie in den Statistiken gezählt wird
-        max_gap_between_points: Max. Abstand zwischen Punkten
+        max_gap_between_points: Max. Zeitabstand zwischen Punkten
         min_8: 120 min
         min_9: 30 min
         min_10: 195 min
         min_11: 360 min
-        max_gap_between_points_before_assuming_you_left_the_city: Max. Abstand zwischen Punkten, bevor du als verlassen angesehen wirst
-        visit_max_gap: Max. Abstand für einen Aufenthalt
+        max_gap_between_points_before_assuming_you_left_the_city: Maximaler Zeitabstand zwischen Punkten, bevor angenommen wird, dass du die Stadt verlassen hast
+        visit_max_gap: Max. Zeitabstand innerhalb eines Aufenthalts
         min_12: 720 min
         max_time_gap_between_points_within_one_visit_longer_gaps: 'Max. Zeitabstand zwischen Punkten innerhalb eines Aufenthalts. Längere Abstände (z. B. leerer Akku) teilen den Aufenthalt in separate Einträge. Standardwert: 60.'
         live_mode: Live-Modus
@@ -1057,18 +1074,18 @@ de:
         km_h_5: 1 km/h
         train_min_speed: Minimale Geschwindigkeit im Zug
         km_h_6: 80 km/h
-        acceleration_thresholds: Beschleunigungs Grenzen
+        acceleration_thresholds: Beschleunigungsgrenzen
         running_vs_cycling_accel: Laufen vs. Fahrradfahren - Beschleunigung
         cycling_vs_driving_accel: Fahrradfahren vs. Straßenverkehr - Beschleunigung
         segment_detection: Abschnittserkennung
         min_segment_duration: Minimale Abschnittsdauer
         sec: 60 sec
-        time_gap_threshold: Zeitlücke-Schwellwert
+        time_gap_threshold: Schwellenwert für Zeitabstände
         sec_2: 180 sec
         min_flight_distance: Minimale Flugdistanz
         km: 100 km
-        make_changes_to_enable_the_apply_button: Änderungen vornehmen, um den Anwenden-Button zu aktivieren
-        re_runs_auto_classification_across_all_your_tracks_manually_corrected: Auto-Klassifizierung über alle deine Tracks neu durchlaufen. Manuell korrigierte Abschnitte werden beibehalten. Kann mehrere Minuten dauern.
+        make_changes_to_enable_the_apply_button: Nimm Änderungen vor, um die Schaltfläche „Anwenden“ zu aktivieren
+        re_runs_auto_classification_across_all_your_tracks_manually_corrected: Führt die automatische Klassifizierung für alle Tracks erneut aus. Manuell korrigierte Abschnitte bleiben erhalten. Der Vorgang kann mehrere Minuten dauern.
         loading_calendar: Kalender wird geladen…
         less: weniger
         more: mehr
@@ -1082,7 +1099,7 @@ de:
         create_place: Ort erstellen
         select_area: Bereich auswählen
         create_area: Bereich erstellen
-        replay: Wiederholen
+        replay: Wiedergabe
         days_country: Tage / Land
         enrich_photos: Fotos bereichern
         close: Schließen
@@ -1091,7 +1108,7 @@ de:
         to: Nach
         tolerance_minutes: Toleranz (Minuten)
         scan_for_matches: Nach Übereinstimmungen suchen
-        scanning_immich_photos: Scanne Immich-Fotos...
+        scanning_immich_photos: Immich-Fotos werden gescannt …
         all: Alle
         back: Zurück
         enrich: Bereichern
@@ -1126,7 +1143,7 @@ de:
         streets_highways_and_paths: Straßen, Autobahnen und Wege
         railways: Schienenverkehr
         buildings: Gebäude
-        building_numbers_visible_at_high_zoom: Gebäude-nummern (sichtbar bei hohem Zoom)
+        building_numbers_visible_at_high_zoom: Gebäudenummern (bei starker Vergrößerung sichtbar)
         cities_neighborhoods_regions_and_countries: Städte, Viertel, Regionen und Länder
         ocean_lake_and_river_names: Ozeane, Seen und Flussnamen
         water: Wasser
@@ -1144,10 +1161,10 @@ de:
         nature_leisure: Natur & Freizeit
         parks_forests_beaches_playgrounds_stadiums: Parks, Wälder, Strände, Spielplätze, Stadien
         tourism_culture: Tourismus & Kultur
-        museums_theatres_attractions_viewpoints_hotels: Museen, Theatere, Sehenswürdigkeiten, Aussichtspunkte, Hotels
-        services_civic: Dienstleistungen & Bürgerliche
+        museums_theatres_attractions_viewpoints_hotels: Museen, Theater, Sehenswürdigkeiten, Aussichtspunkte, Hotels
+        services_civic: Dienstleistungen & öffentliche Einrichtungen
         post_offices_libraries_schools_hospitals_police_banks: Postämter, Bibliotheken, Schulen, Krankenhäuser, Polizei, Banken
-        benches_toilets_drinking_water_fountains_recycling_shelters: Bänke, Toiletten, Trinkwasser, Brunnen, Recycling, Schutzstellen
+        benches_toilets_drinking_water_fountains_recycling_shelters: Bänke, Toiletten, Trinkwasser, Brunnen, Recycling, Schutzhütten
         theme_aria_label: "%{theme} Thema"
         address_labels: Adresslabels
         background: Hintergrund
@@ -1268,7 +1285,7 @@ de:
         dist: Dist
         avg: Avg
         show_points: Punkte anzeigen
-        replay: Wiederholen
+        replay: Wiedergabe
         share: Teilen
         unknown: Unbekannt
       visit_entry:
@@ -1321,7 +1338,7 @@ de:
       no_nearby_places_found: Keine nahen Orte gefunden
       load_more_search_up_to_distance_m: Weitere laden (Suche bis zu %{distance}m)
     index:
-      hello_there: Hallo da!
+      hello_there: Hallo!
       here_you_ll_find_your_places_created_by_visits_suggestion: Hier findest du deine Orte, die durch den Visits-Vorschlagsprozess erstellt wurden. Aber jetzt gibt es keine.
       name: Name
       created_at: Erstellt am
@@ -1375,9 +1392,9 @@ de:
       germany: Deutschland
       coordinates_line: Koordinatenlinie
       font: Schriftart
-      layers: Schichten
-      track_opacity: Track-Opacity
-      track_width: Track-Breite
+      layers: Ebenen
+      track_opacity: Deckkraft des Tracks
+      track_width: Breite des Tracks
       recent_posters: Letzte Poster
       server_rendered_posters_from_save_to_gallery_they_stay_here: Server-renderte Poster von „Speichern in Galerie“ — sie bleiben hier über Sitzungen hinweg.
       export_a_file: Exportiere eine Datei
@@ -1474,8 +1491,8 @@ de:
         supporter_platform: " via %{platform}"
       index:
         email_preferences: E-Mail-Präferenzen
-        monthly_digest_emails: Monatlicher Newsletter
-        summary_of_your_last_month_sent_on_the_2nd: Zusammenfassung deines letzten Monats, der am 2. des Monats gesendet wird.
+        monthly_digest_emails: Monatliche Zusammenfassung per E-Mail
+        summary_of_your_last_month_sent_on_the_2nd: Zusammenfassung des vergangenen Monats, die jeweils am 2. versendet wird.
         year_end_digest_emails: Jahreszusammenfassung per E-Mail
         receive_an_annual_summary_on_january_2nd_with_your_year: Erhalte eine jährliche Zusammenfassung am 2. Januar mit einem Überblick über dein Jahr.
         news_updates: Nachrichten & Updates
@@ -1484,15 +1501,15 @@ de:
         your_timezone: Deine Zeitzone
         all_dates_and_times_will_be_displayed_in_this_timezone: Alle Daten und Uhrzeiten werden in dieser Zeitzone angezeigt
         supporter_badge: Supporter-Badge
-        show_supporter_badge_in_navbar: Supporter-Badge im Navigationsleiste anzeigen
-        display_a_gem_icon_next_to_your_profile_to_show: Zeige einen Gem-Icon neben deinem Profil an, um deinen Supporter-Status anzuzeigen
+        show_supporter_badge_in_navbar: Unterstützer-Abzeichen in der Navigationsleiste anzeigen
+        display_a_gem_icon_next_to_your_profile_to_show: Zeigt ein Edelstein-Symbol neben deinem Profil an, das deinen Unterstützerstatus kennzeichnet
         general_settings: Allgemeine Einstellungen
         save_changes: Änderungen speichern
     integrations:
       index:
         immich_photoprism_integrations: Immich & Photoprism-Integrationen
         connect_your_photo_management_tools_to_see_your_photos_on: Verbinde deine Foto-Management-Tools, um deine Fotos auf der Karte anzuzeigen. Immich- und Photoprism-Integrationen sind im Pro-Tarif verfügbar.
-        upgrade_to_pro: Auf升级到Pro
+        upgrade_to_pro: Auf Pro upgraden
         immich_integration: Immich-Integration
         immich_url: Immich-URL
         the_base_url_of_your_immich_instance: Die Basis-URL deiner Immich-Instanz
@@ -1530,7 +1547,7 @@ de:
         settings: Einstellungen
     maps:
       index:
-        map_appearance_colors_layers_and_points_of_interest_for_the: Kartendarstellung, Farben, Schichten und Punkte von Interesse für die aktuelle Karte (V2) sind direkt in der
+        map_appearance_colors_layers_and_points_of_interest_for_the: Kartendarstellung, Farben, Ebenen und interessante Orte für die aktuelle Karte (V2) findest du direkt in der
         open_the_settings_panel_there_this_page_only_covers_the: "— öffne das Einstellungspanel dort. Diese Seite beschreibt nur die alte V1 (Leaflet)-Karte."
         general: Allgemein
         preferred_map_version: Bevorzugte Kartenversion
@@ -1550,7 +1567,7 @@ de:
         save_changes: Änderungen speichern
     subscriptions:
       index:
-        hello_there: Hallo da!
+        hello_there: Hallo!
         you_are_currently_subscribed_to_dawarich_hurray: Du bist derzeit bei Dawarich abonniert, hurra!
         your_subscription_will_be_valid_for_the_next: Dein Abonnement ist für die nächsten
         you_are_currently_not_subscribed_to_dawarich_how_about_we: Du bist derzeit nicht bei Dawarich abonniert. Wie wäre es, das zu ändern?
@@ -1620,7 +1637,7 @@ de:
         this_will_permanently_remove_their_account_and_all_associated_data: "? Dadurch werden das Konto und alle zugehörigen Daten dauerhaft gelöscht. Diese Aktion kann nicht rückgängig gemacht werden."
         cancel: Abbrechen
         users_management: Benutzer verwalten
-        clear: Löschen
+        clear: Suche zurücksetzen
         edit: Bearbeiten
         create: Erstellen
         users: Benutzer
@@ -1658,7 +1675,7 @@ de:
       redetect_panel:
         re_run_detection_on_full_history: Erneut Erkennung auf vollständigen Historie ausführen
         replaces_all_suggested_visits_across_your_entire_history_with_fresh: Ersetzt alle vorgeschlagenen Aufenthalte über deine gesamte Historie mit frischen Erkennungen unter Verwendung der Einstellungen oben. Bestätigte Aufenthalte und die Orte, die du benannt hast, bleiben erhalten. Kleine Konten benötigen normalerweise einige Minuten; mehrjährige Historien können 30–60 Minuten dauern und erhöhen vorübergehend den Serverlast.
-        on_the_lite_plan_re_detection_covers_your_visible_12: Auf dem Lite-Plan umfasst die erneute Erkennung nur deinen sichtbaren 12-Monats-Window.
+        on_the_lite_plan_re_detection_covers_your_visible_12: Im Lite-Tarif umfasst die erneute Erkennung nur deinen sichtbaren 12-Monats-Zeitraum.
         available_again_at: Verfügbar wieder ab
         replace_all_suggested_visits_across_your_full_history_confirmed_visits: Ersetze alle vorgeschlagenen Aufenthalte über deine gesamte Historie. Bestätigte Aufenthalte bleiben. Fortfahren?
       show:
@@ -1765,6 +1782,8 @@ de:
       settings: Einstellungen
       subscription: Abonnement
       logout: Abmelden
+      switch_language: English
+      switch_language_aria_label: Sprache auf Englisch umstellen
       see_all: Alle ansehen
       you_re_an_admin_harry: Du bist Admin, Harry!
       dawarich_supporter: Dawarich-Unterstützer
@@ -1786,7 +1805,7 @@ de:
       click_tags_to_select_them_for_this_place: Klick auf Tags, um sie für diesen Ort auszuwählen
       suggested_places: Vorgeschlagene Orte
       nearby_places: Nahegelegene Orte
-      open_modal_to_load_nearby_suggestions: Modal öffnen, um nahegelegene Vorschläge zu laden
+      open_modal_to_load_nearby_suggestions: Dialog öffnen, um Vorschläge in der Nähe zu laden
       cancel: Abbrechen
       enter_place_name: Ortsname eingeben...
       add_a_personal_note_about_this_place: Füge eine persönliche Notiz über diesen Ort hinzu...
@@ -1797,7 +1816,7 @@ de:
       upgrade_to_pro: Auf Pro upgraden
       close: Schließen
     replay_panel:
-      close_replay: Wiederholung schließen
+      close_replay: Wiedergabe schließen
       times: "×"
       previous_day: Vorheriger Tag
       larr: "←"
@@ -1834,7 +1853,7 @@ de:
         live: "● Live"
         connecting: Verbinden…
       missing_resource:
-        this_share_is_no_longer_available: Dieser Share ist nicht mehr verfügbar
+        this_share_is_no_longer_available: Diese Freigabe ist nicht mehr verfügbar
         the_original_content_was_removed_by_the_owner: Der ursprüngliche Inhalt wurde vom Besitzer entfernt.
       timeline:
         shared_on_dawarich: "· Auf Dawarich geteilt"
@@ -1852,12 +1871,12 @@ de:
         public: Öffentlich
         ndash: "–"
         trip_notes: Reisehinweise
-        replay: Wiederholen
+        replay: Wiedergabe
       trip_day_header:
         middot: "·"
         no_data: Keine Daten
       unsupported:
-        this_share_type_is_no_longer_supported: Dieser Teiltyp wird nicht mehr unterstützt
+        this_share_type_is_no_longer_supported: Dieser Freigabetyp wird nicht mehr unterstützt
         the_link_may_have_been_created_by_a_newer_or: Der Link wurde möglicherweise von einer neueren oder älteren Version von Dawarich erstellt.
       not_found:
         this_shared_link_is_no_longer_available: Dieser geteilte Link ist nicht mehr verfügbar
@@ -1940,20 +1959,20 @@ de:
       leave_blank_to_share_without_a_phrase_or_use_the: Lass es leer, um ohne Phrase zu teilen, oder verwende die automatisch generierte.
       show_photos: Fotos anzeigen
       cancel: Abbrechen
-      create_share_link: Share-Link erstellen
+      create_share_link: Freigabelink erstellen
     modal_track_create_form:
       magic_phrase_optional: Magische Phrase (optional)
       leave_blank_to_share_without_a_phrase_or_use_the: Lass es leer, um ohne Phrase zu teilen, oder verwende die automatisch generierte.
       show_photos: Fotos anzeigen
       show_stats: Statistiken anzeigen
       cancel: Abbrechen
-      create_share_link: Share-Link erstellen
+      create_share_link: Freigabelink erstellen
     modal_trip_create_form:
       magic_phrase_optional: Magische Phrase (optional)
       leave_blank_to_share_without_a_phrase_or_use_the: Lass es leer, um ohne Phrase zu teilen, oder verwende die automatisch generierte.
       what_to_include_on_the_public_page: Was auf der öffentlichen Seite enthalten sein soll
       cancel: Abbrechen
-      create_share_link: Share-Link erstellen
+      create_share_link: Freigabelink erstellen
       stats_countries_distance_duration: Statistiken & Länder (Entfernung, Dauer)
       day_by_day_breakdown: Tag-für-Tag-Übersicht
       per_day_notes: Tägliche Notizen
@@ -1965,7 +1984,7 @@ de:
       available_on_pro: Verfügbar auf Pro
       upgrade_to_pro: Auf Pro upgraden
     month:
-      monthly_digest: Monatlicher Digest
+      monthly_digest: Monatsrückblick
       share: Teilen
       distance_traveled: Gefahrene Strecke
       active_days: Aktive Tage
@@ -1975,7 +1994,7 @@ de:
       points: Punkte
       daily_activity: Tägliche Aktivität
       peak_day: 'Höhepunkt:'
-      quietest_week: "• Ruhestige Woche:"
+      quietest_week: "• Ruhigste Woche:"
       countries_cities: Länder & Städte
       no_location_data_available_for_this_month: Keine Standortdaten für diesen Monat verfügbar
       cities_visited: 'Besuchte Städte:'
@@ -2026,7 +2045,7 @@ de:
       loading_hexagons: Hexagone werden geladen...
       daily_activity: Tägliche Aktivität
       peak_day: 'Höchstaktiv am:'
-      quietest_week: "• Ruheständige Woche:"
+      quietest_week: "• Ruhigste Woche:"
       countries_cities: Länder & Städte
       cities: Städte
       cities_visited: 'Besuchte Städte:'
@@ -2085,8 +2104,8 @@ de:
         no_segments_for_this_track_yet: Noch keine Segmente für diesen Track
     share_links:
       new:
-        this_track_is_shared_via_a_public_link: Dieser Track wird über eine öffentliche Link geteilt.
-        share_track: Track teilen %{track}
+        this_track_is_shared_via_a_public_link: Dieser Track wird über einen öffentlichen Link geteilt.
+        share_track: "%{track} teilen"
   trial:
     resume:
       show:
@@ -2163,8 +2182,8 @@ de:
       photos: Fotos
       toggle_airtrail_flights_on_map: AirTrail-Flüge auf Karte ein-/ausschalten
       flights: Flüge
-      replay_the_trip: Reise wiederholen
-      replay: Wiederholen
+      replay_the_trip: Reise wiedergeben
+      replay: Wiedergabe
       show_all_days: Alle Tage anzeigen
       poster: Poster
       middot: "·"
@@ -2185,7 +2204,7 @@ de:
     share_links:
       new:
         share_trip: Teile %{trip}
-        trip_is_shared_via_a_public_link: "%{trip} wird über eine öffentliche Link geteilt."
+        trip_is_shared_via_a_public_link: "%{trip} wird über einen öffentlichen Link geteilt."
   users:
     digests:
       index:
@@ -2201,12 +2220,12 @@ de:
         cities: Städte
         view_details: Details ansehen
       public_year:
-        year_in_review: Jahr in Überblick
-        your_journey_by_the_numbers: Deine Reise, im Zahlenbild
+        year_in_review: Jahresrückblick
+        your_journey_by_the_numbers: Deine Reise in Zahlen
         distance_traveled: Gesamtstrecke
         countries_visited: Besuchte Länder
         cities_explored: Besuchte Städte
-        first_time_visits: Erstmalige Aufenthalte
+        first_time_visits: Erstmals besucht
         new_countries: Neue Länder
         new_cities: Neue Städte
         more: mehr
@@ -2215,42 +2234,42 @@ de:
         countries_cities: Länder & Städte
         cities: Städte
         cities_visited: 'Städte besucht:'
-        all_time_stats: All-Time Statistiken
+        all_time_stats: Gesamtstatistik
         total_distance: Gesamtstrecke
         track_your_own_adventures_with: Verfolge deine eigenen Abenteuer mit
         dawarich: Dawarich
-        your_personal_memories_mapper: "— dein persönlicher Erinnerungskartenmapper."
+        your_personal_memories_mapper: "— deine persönliche Erinnerungskarte."
         month: Monat
         distance: Strecke
         first_time_count:
-          one: "%{count} erstmaliger Aufenthalt"
-          other: "%{count} erstmalige Aufenthalte"
+          one: "%{count} erstmals besucht"
+          other: "%{count} erstmals besucht"
       show:
-        year_in_review: Jahr in Überblick
+        year_in_review: Jahresrückblick
         your_journey_by_the_numbers: Deine Reise, im Überblick
         share: Teilen
         distance_traveled: Gesamtstrecke
         compared_to: im Vergleich zu
         countries: Länder
         cities: Städte
-        first_time_visits: Erstmalige Aufenthalte
+        first_time_visits: Erstmals besucht
         new_countries: Neue Länder
         new_cities: Neue Städte
         more: mehr
         your_year_month_by_month: Dein Jahr, Monat für Monat
         where_you_spent_the_most_time: Wo du am meisten Zeit verbracht hast
         no_tracking_data: Keine Nachverfolgungsdaten
-        track_more_in: Melde mehr in
-        to_see_a_fuller_picture_of_your_travels: um ein vollständigeres Bild deiner Reisen zu erhalten!
+        track_more_in: Zeichne im Jahr
+        to_see_a_fuller_picture_of_your_travels: mehr auf, um ein vollständigeres Bild deiner Reisen zu erhalten!
         countries_cities: Länder & Städte
         no_location_data_available: Keine Standortdaten verfügbar
-        all_time_stats: Alle Zeit Statistiken
+        all_time_stats: Gesamtstatistik
         countries_visited: Besuchte Länder
         cities_explored: Erkundete Städte
-        total_distance: Gesamter Weg
+        total_distance: Gesamtstrecke
         want_more_insights: Möchtest du mehr Einblicke?
-        upgrade_to_pro_to_see_your_full_year_in_review: Upgrade zu Pro, um dein vollständiges Jahresrückblick mit monatlicher Aufschlüsselung, detaillierten Stadtranglisten, Ländervergleichen, Verkehrsanalyse und allen Zeitrekorde zu sehen.
-        upgrade_to_pro: Upgrade zu Pro
+        upgrade_to_pro_to_see_your_full_year_in_review: Wechsle zu Pro, um deinen vollständigen Jahresrückblick mit monatlicher Aufschlüsselung, detaillierten Städteranglisten, Ländervergleichen, Verkehrsanalyse und Allzeitrekorden zu sehen.
+        upgrade_to_pro: Zu Pro wechseln
         back_to_all_digests: Zurück zu allen Rückblicken
         delete: Löschen
         sharing_settings: Freigabeeinstellungen
@@ -2263,11 +2282,11 @@ de:
         done: Fertig
         month: Monat
         distance: Entfernung
-        year_year_in_review: "%{year} Jahr im Überblick"
-        are_you_sure_you_want_to_delete_the_year_digest: Bist du sicher, dass du den %{year} Digest löschen möchtest? Dies kann nicht rückgängig gemacht werden.
+        year_year_in_review: "Jahresrückblick %{year}"
+        are_you_sure_you_want_to_delete_the_year_digest: Möchtest du den Jahresrückblick %{year} wirklich löschen? Dies kann nicht rückgängig gemacht werden.
         first_time_count:
-          one: "%{count} erste Zeit"
-          other: "%{count} erste Zeit"
+          one: "%{count} erstmals besucht"
+          other: "%{count} erstmals besucht"
         day_count:
           one: "%{count} Tag"
           other: "%{count} Tage"
@@ -2277,28 +2296,28 @@ de:
     digests_mailer:
       monthly_digest:
         your: Dein
-        in_review: in Überblick
+        in_review: im Rückblick
         here_s_what_your_location_history_looked_like_last_month: Hier ist ein Überblick, wie dein Standortverlauf im letzten Monat aussah.
         overview: ÜBERBLICK
         distance: Entfernung
         active_days: Aktive Tage
         countries: Länder
         cities: Städte
-        weekly_pattern: Wöchentlicher Muster
-        daily_distance: Tägliche Distanz
-        top_countries: Top Länder
-        top_cities: Top Städte
-        first_visits_this_month: ERSTMALIGE AUFENTHALTE IN DIESEM MONAT
+        weekly_pattern: WÖCHENTLICHES MUSTER
+        daily_distance: TAGESSTRECKE
+        top_countries: TOP-LÄNDER
+        top_cities: TOP-STÄDTE
+        first_visits_this_month: ERSTMALS BESUCHT IN DIESEM MONAT
         vs_previous_month: Im Vergleich zum Vormonat
         view_full_insights_rarr: Vollständige Einblicke ansehen →
-        you_re_receiving_this_because_monthly_digest_emails_are_on: Du erhältst dies, weil monatliche Zusammenfassung-E-Mails für dein Konto aktiviert sind.
+        you_re_receiving_this_because_monthly_digest_emails_are_on: Du erhältst diese E-Mail, weil monatliche Zusammenfassungen für dein Konto aktiviert sind.
         manage_email_preferences: E-Mail-Voreinstellungen verwalten
-        in_review_here_s_what_your_location_history_looked_like: in Revisionsmodus ───────────────────────── Hier ist ein Überblick, wie dein Standortverlauf im letzten Monat aussah. Distanz
+        in_review_here_s_what_your_location_history_looked_like: im Rückblick ───────────────────────── So sah dein Standortverlauf im letzten Monat aus. Strecke
         new_country: "(neues Land)"
-        new_city: "(ne Stadt)"
-        vs_previous_month_distance: Im Vergleich zum Vormonat Distanz
+        new_city: "(neue Stadt)"
+        vs_previous_month_distance: IM VERGLEICH ZUM VORMONAT Strecke
         view_full_insights: "→ Vollständige Einblicke:"
-        you_re_receiving_this_because_monthly_digest_emails_are_on_2: "───────────────────────────────────────── Du erhältst dies, weil monatliche Zusammenfassung-E-Mails aktiviert sind. E-Mail-Voreinstellungen verwalten:"
+        you_re_receiving_this_because_monthly_digest_emails_are_on_2: "───────────────────────────────────────── Du erhältst diese E-Mail, weil monatliche Zusammenfassungen aktiviert sind. E-Mail-Einstellungen verwalten:"
         weekday_totals: "@weekday_totals,"
         labels_w_mon_tue_wed_thu_fri_sat_sun: 'labels: %w[Montag Dienstag Mittwoch Donnerstag Freitag Samstag Sonntag],'
         width_20: 'width: 20,'
@@ -2306,12 +2325,14 @@ de:
         31_map_d_daily_distances_d_to_s_to: "(1..31).map { |d| @daily_distances[d.to_s].to_f }"
         reject_zero: ".reject(&:zero?)"
         presence_0: ".presence || [0]"
-        you_re_receiving_this_because_monthly_digest_emails_are_on_3: Du erhältst diese E-Mail, weil monatliche Zusammenfassungsemails aktiviert sind.
+        you_re_receiving_this_because_monthly_digest_emails_are_on_3: Du erhältst diese E-Mail, weil monatliche Zusammenfassungen aktiviert sind.
         manage_email_preferences_2: 'E-Mail-Einstellungen verwalten:'
-        month_year_in_review: Dein %{month} %{year} im Überblick
-        new_country_line: "→ %{country}  (neuer Land)"
+        month_year_in_review: Dein %{month} %{year} im Rückblick
+        new_country_line: "→ %{country}  (neues Land)"
         new_city_line: "→ %{city}  (neue Stadt)"
       year_end_digest:
+        year_in_review_title: Dein Jahresrückblick %{year}
+        year_at_a_glance: Dein Jahr %{year} auf einen Blick.
         your: Dein
         year_in_review: Jahr im Überblick
         here_s_your: Hier ist dein
@@ -2320,26 +2341,26 @@ de:
         distance: Entfernung
         countries: Länder
         cities: Städte
-        activity_heatmap: AKTIVITÄTSGEWINN
+        activity_heatmap: AKTIVITÄTS-HEATMAP
         none_light_moderate_high_peak: "· keine ░ gering ▒ mittel ▓ hoch █ Spitze"
         monthly_distance: MONATLICHE ENTFERNUNG
         top_countries: TOP LÄNDER
-        vs_previous_year: IM VORHERIGEN JAHR
+        vs_previous_year: IM VERGLEICH ZUM VORJAHR
         view_full_insights_rarr: Vollständige Einblicke →
         share_your_year_rarr: Dein Jahr teilen →
-        you_re_receiving_this_because_yearly_digest_emails_are_on: Du erhältst dies, weil jährliche Zusammenfassungsmails für dein Konto aktiviert sind.
+        you_re_receiving_this_because_yearly_digest_emails_are_on: Du erhältst diese E-Mail, weil jährliche Zusammenfassungen für dein Konto aktiviert sind.
         manage_email_preferences: E-Mail-Einstellungen verwalten
         year_in_review_here_s_your: Jahr in der Übersicht ────────────────────────────── Hier ist dein
         at_a_glance_the_numbers_distance: im Überblick. DIE ZAHLEN Entfernung
-        vs_previous_year_distance: IM VORHERIGEN JAHR Entfernung
+        vs_previous_year_distance: IM VERGLEICH ZUM VORJAHR Strecke
         view_full_insights: "-> Vollständige Einblicke:"
         share_your_year: "-> Dein Jahr teilen:"
-        you_re_receiving_this_because_yearly_digest_emails_are_on_2: "───────────────────────────────────────── Du erhältst diese E-Mail, weil jährliche Zusammenfassungsmails aktiviert sind. E-Mail-Einstellungen verwalten:"
+        you_re_receiving_this_because_yearly_digest_emails_are_on_2: "───────────────────────────────────────── Du erhältst diese E-Mail, weil jährliche Zusammenfassungen aktiviert sind. E-Mail-Einstellungen verwalten:"
         12_map_m_monthly_distances_m_to_s_to: "(1..12).map { |m| @monthly_distances[m.to_s].to_f.round },"
         labels_date_abbr_monthnames_1_12: 'labels: Date::ABBR_MONTHNAMES[1..12],'
         width_24: 'width: 24,'
         suffix_distance_unit: 'suffix: " #{@distance_unit}"'
-        you_re_receiving_this_because_yearly_digest_emails_are_on_3: Du erhältst diese E-Mail, weil jährliche Zusammenfassungsmails aktiviert sind.
+        you_re_receiving_this_because_yearly_digest_emails_are_on_3: Du erhältst diese E-Mail, weil jährliche Zusammenfassungen aktiviert sind.
         manage_email_preferences_2: 'E-Mail-Einstellungen verwalten:'
   users_mailer:
     account_destroy_confirmation:
@@ -2367,9 +2388,9 @@ de:
       your_oldest_location_data_will_be_archived_in_about: Deine ältesten Standortdaten werden in etwa
       weeks: 2 Wochen
       on_the_lite_plan_your_most_recent_12_months_of: Auf dem Lite-Plan bleiben deine letzten 12 Monate Daten vollständig suchbar und interaktiv. Ältere Daten werden archiviert — sie können immer exportiert werden, erscheinen aber nicht auf deiner Karte, in der Suche, den Statistiken oder der Zeitleistenwiedergabe.
-      upgrade_to_pro_to_keep_your_full_history: 'Aufstieg zum Pro-Plan, um deine vollständige Historie zu behalten:'
+      upgrade_to_pro_to_keep_your_full_history: 'Upgrade auf Pro, um deinen vollständigen Verlauf zu behalten:'
       unlimited_searchable_history_every_month_every_year: Unbegrenzter Suchverlauf — monatlich, jährlich
-      heatmap_fog_of_war_and_globe_view: Heatmap, Nebel des Krieges und Globusansicht
+      heatmap_fog_of_war_and_globe_view: Heatmap, Kartennebel und Globusansicht
       full_write_api_access: Vollständiger Schreibzugriff über die API
       immich_and_photoprism_integrations: Integrationen mit Immich und PhotoPrism
       upgrade_to_pro: Auf Pro upgraden
@@ -2378,11 +2399,11 @@ de:
       best_regards: Mit freundlichen Grüßen,
       evgenii_from_dawarich: Evgenii von Dawarich
       your_data_history_is_filling_up_hi: Deine Datenhistorie füllt sich auf Hi
-      this_is_evgenii_from_dawarich_heads_up_your_oldest_location: ", das ist Evgenii von Dawarich. Achtung: Deine ältesten Standortdaten werden in etwa zwei Wochen archiviert. Auf dem Lite-Plan bleiben deine letzten 12 Monate Daten vollständig suchbar und interaktiv. Ältere Daten sind archiviert — sie können immer exportiert werden, erscheinen aber nicht auf deiner Karte, in der Suche, den Statistiken oder in der Zeitleistenwiedergabe. Auf Pro upgraden, um deinen gesamten Verlauf zu behalten: - Unbegrenzter Suchverlauf — monatlich, jährlich - Heatmap, Nebel des Krieges und Globusansicht - Vollständiger Schreibzugriff über die API - Integrationen mit Immich und PhotoPrism Jetzt upgraden:"
+      this_is_evgenii_from_dawarich_heads_up_your_oldest_location: ", hier ist Evgenii von Dawarich. Achtung: Deine ältesten Standortdaten werden in etwa zwei Wochen archiviert. Im Lite-Tarif bleiben die Daten deiner letzten 12 Monate vollständig durchsuchbar und interaktiv. Ältere Daten werden archiviert — du kannst sie weiterhin exportieren, sie erscheinen aber nicht mehr auf der Karte, in der Suche, in Statistiken oder in der Zeitleistenwiedergabe. Upgrade auf Pro, um deinen gesamten Verlauf zu behalten: - Unbegrenzt durchsuchbarer Verlauf für alle Monate und Jahre - Heatmap, Kartennebel und Globusansicht - Vollständiger Schreibzugriff über die API - Integrationen mit Immich und PhotoPrism Jetzt upgraden:"
       your_data_is_always_yours_pro_simply_makes_all_of_2: Deine Daten sind immer dein Eigentum — Pro macht einfach alles suchbar und interaktiv in der App. Fragen? Schreib mir eine Nachricht an hi@dawarich.app oder antworte einfach auf diese E-Mail. Mit freundlichen Grüßen, Evgenii von Dawarich
       heads_up_your_oldest_location_data_will_be_archived_in: 'Achtung: Deine ältesten Standortdaten werden in etwa zwei Wochen archiviert.'
       unlimited_searchable_history_every_month_every_year_2: "- Unbegrenzter Suchverlauf — monatlich, jährlich"
-      heatmap_fog_of_war_and_globe_view_2: "- Heatmap, Nebel des Krieges und Globusansicht"
+      heatmap_fog_of_war_and_globe_view_2: "- Heatmap, Kartennebel und Globusansicht"
       full_write_api_access_2: "- Vollständiger Schreibzugriff über die API"
       immich_and_photoprism_integrations_2: "- Immich und PhotoPrism-Integrationen"
       upgrade_now: 'Jetzt upgraden:'
@@ -2397,7 +2418,7 @@ de:
       statistics_analytics: "\U0001F4CA Statistiken & Analysen"
       view_detailed_insights_about_distances_traveled_and_time_spent_in: Betrachte detaillierte Einblicke zu zurückgelegten Entfernungen und verbrachten Zeiten in verschiedenen Orten.
       interactive_maps: "\U0001F5FA️ Interaktive Karten"
-      visualize_your_tracks_on_beautiful_maps_with_different_layers_and: Visualisiere deine Tracks auf schönen Karten mit verschiedenen Schichten und Stiloptionen.
+      visualize_your_tracks_on_beautiful_maps_with_different_layers_and: Zeige deine Tracks auf ansprechenden Karten mit verschiedenen Ebenen und Darstellungsoptionen an.
       places_visits: "\U0001F4CD Orte & Aufenthalte"
       discover_the_places_you_ve_visited_and_get_automatic_visit: Entdecke die Orte, die du besucht hast, und nutze die automatische Aufenthaltserkennung für häufig besuchte Orte.
       data_export: "\U0001F4E4 Datenexport"
@@ -2411,61 +2432,63 @@ de:
       explore_dawarich_features_hi: Dawarich-Funktionen erkunden Hi
       this_is_evgenii_from_dawarich_you_re_now_2_days: ", hier ist Evgenii von Dawarich. Du nutzt deinen Dawarich-Testzeitraum nun seit 2 Tagen! Ich hoffe, dir gefällt die Aufzeichnung deiner Standortdaten. Diese leistungsstarken Funktionen kannst du ausprobieren: ✈️ Reisen wiedererleben Erkunde vergangene Reisen mit detaillierten Karten und Einblicken. \U0001F4CA Statistiken & Analysen Erhalte detaillierte Einblicke in zurückgelegte Strecken und die an verschiedenen Orten verbrachte Zeit. \U0001F5FA️ Interaktive Karten Visualisiere deine Tracks auf ansprechenden Karten mit unterschiedlichen Ebenen und Darstellungen. \U0001F4CD Orte & Aufenthalte Entdecke besuchte Orte und nutze die automatische Aufenthaltserkennung für häufig besuchte Orte. \U0001F4E4 Datenexport Exportiere deine Standortdaten zur Sicherung oder Verwendung in anderen Anwendungen in mehreren Formaten (GPX, GeoJSON). Weiter erkunden: https://my.dawarich.app Dein Testzeitraum läuft noch 5 Tage. Nutze sie voll aus! Viele Grüße, Evgenii von Dawarich"
       continue_exploring_https_my_dawarich_app: 'Weiter erkunden: https://my.dawarich.app'
-      you_have_5_days_left_in_your_trial_make_the: Du hast 5 Tage noch in deinem Testzeitraum. Nutze ihn sinnvoll!
+      you_have_5_days_left_in_your_trial_make_the: Dein Testzeitraum läuft noch 5 Tage. Nutze sie voll aus!
     oauth_account_link:
       confirm_account_link: Kontoverknüpfung bestätigen
       hi: Hallo
+      account_link_request_html: Jemand – hoffentlich du – versucht, die Anmeldemethode <strong>%{provider}</strong> mit deinem Dawarich-Konto zu verknüpfen. Mit der Schaltfläche unten erlaubst du dieser Anmeldemethode künftig den Zugriff auf dieses Konto.
+      account_link_request_text: Jemand – hoffentlich du – versucht, die Anmeldemethode %{provider} mit deinem Dawarich-Konto zu verknüpfen. Mit dem Link unten erlaubst du dieser Anmeldemethode künftig den Zugriff auf dieses Konto.
       someone_hopefully_you_is_trying_to_link: Jemand – hoffentlich du – versucht, eine Verknüpfung herzustellen
       sign_in_to_your_dawarich_account_clicking_the_button_below: Anmeldung bei deinem Dawarich-Konto zu verknüpfen. Klicke auf die Schaltfläche unten, damit diese Anmeldemethode künftig auf das Konto zugreifen kann.
       link: Verknüpfen
-      didn_t_request_this: Dies hat keinen Anspruch?
+      didn_t_request_this: Warst du das nicht?
       ignore_this_email_the_link_expires_in_15_minutes_and: Ignoriere diese E-Mail — der Link läuft in 15 Minuten ab und wird keine Änderungen an deinem Konto vornehmen. Wenn du diese E-Mails weiterhin erhältst, ändere dein Passwort.
       link_2: 'Link:'
       confirm_account_link_hi: Bestätige die Kontoverknüpfung Hi
       someone_hopefully_you_is_trying_to_link_2: ", Jemand — hoffentlich du — versucht, sich"
       sign_in_to_your_dawarich_account_clicking_the_link_below: Anmeldung bei deinem Dawarich-Konto zu verknüpfen. Klicke auf den Link unten, damit diese Anmeldemethode künftig auf das Konto zugreifen kann. Link
-      didn_t_request_this_ignore_this_email_the_link_expires: Dies hat keinen Anspruch? Ignoriere diese E-Mail — der Link läuft in 15 Minuten ab und wird keine Änderungen an deinem Konto vornehmen. Wenn du diese E-Mails weiterhin erhältst, ändere dein Passwort.
+      didn_t_request_this_ignore_this_email_the_link_expires: Warst du das nicht? Ignoriere diese E-Mail — der Link läuft in 15 Minuten ab und es werden keine Änderungen an deinem Konto vorgenommen. Wenn du solche E-Mails weiterhin erhältst, ändere dein Passwort.
       sign_in_to_your_dawarich_account_clicking_the_link_below_2: Anmeldung bei deinem Dawarich-Konto zu verknüpfen. Klicke auf den Link unten, damit diese Anmeldemethode künftig auf das Konto zugreifen kann.
     otp_account_locked:
       account_temporarily_locked: Konto vorübergehend gesperrt
       hi: Hallo
       your_dawarich_account_has_been: Dein Dawarich-Konto wurde
       temporarily_locked: vorübergehend gesperrt
-      because_10_consecutive_failed_two_factor_authentication_attempts_were_de: weil 10 aufeinanderfolgende fehlgeschlagene zweistufige Authentifizierungsversuche erkannt wurden.
-      the_lock_will_automatically_lift_after: Die Sperrung wird automatisch nach
-      minutes: 30 Minuten aufheben
-      no_action_is_required_if_this_was_you: ". Keine Aktion ist erforderlich, wenn dies dich betrifft."
-      didn_t_recognise_this_activity: Erkannt dieser Aktivität nicht?
-      someone_may_be_trying_to_access_your_account_we_recommend: Jemand könnte versuchen, dein Konto zu accessieren. Wir empfehlen, dein Passwort sofort zu ändern.
-      reset_your_password: Passwort ändern
+      because_10_consecutive_failed_two_factor_authentication_attempts_were_de: weil 10 Zwei-Faktor-Anmeldeversuche in Folge fehlgeschlagen sind.
+      the_lock_will_automatically_lift_after: Die Sperre wird nach
+      minutes: 30 Minuten automatisch aufgehoben
+      no_action_is_required_if_this_was_you: ". Wenn du das warst, musst du nichts unternehmen."
+      didn_t_recognise_this_activity: Warst du das nicht?
+      someone_may_be_trying_to_access_your_account_we_recommend: Möglicherweise versucht jemand, auf dein Konto zuzugreifen. Wir empfehlen dir, dein Passwort sofort zurückzusetzen.
+      reset_your_password: Passwort zurücksetzen
       if_you_need_further_assistance_contact_us_at: Wenn du weitere Hilfe benötigst, kontaktiere uns unter
       security_dawarich_app: security@dawarich.app
-      account_temporarily_locked_hi: Konto temporär gesperrt Hi
-      your_dawarich_account_has_been_temporarily_locked_because_10_consecutive: ", Dein Dawarich-Konto wurde temporär gesperrt, weil 10 aufeinanderfolgende fehlgeschlagene Zwei-Faktor-Authentifizierungsversuche erkannt wurden. Die Sperrung wird automatisch nach 30 Minuten aufgehoben. Keine Aktion ist erforderlich, wenn dies du warst. Erkannt dieser Aktivität nicht? Jemand könnte versuchen, dein Konto zu accessieren. Wir empfehlen, dein Passwort sofort zu ändern. Passwort ändern:"
+      account_temporarily_locked_hi: Konto vorübergehend gesperrt Hallo
+      your_dawarich_account_has_been_temporarily_locked_because_10_consecutive: ", dein Dawarich-Konto wurde vorübergehend gesperrt, weil 10 Zwei-Faktor-Anmeldeversuche in Folge fehlgeschlagen sind. Die Sperre wird nach 30 Minuten automatisch aufgehoben. Wenn du das warst, musst du nichts unternehmen. Warst du das nicht? Möglicherweise versucht jemand, auf dein Konto zuzugreifen. Wir empfehlen dir, dein Passwort sofort zurückzusetzen. Passwort zurücksetzen:"
       if_you_need_further_assistance_contact_us_at_security_dawarich: Wenn du weitere Hilfe benötigst, kontaktiere uns unter security@dawarich.app.
-      your_dawarich_account_has_been_temporarily_locked_because_10_consecutive_2: Dein Dawarich-Konto wurde temporär gesperrt, weil 10 aufeinanderfolgende fehlgeschlagene Zwei-Faktor-Authentifizierungsversuche erkannt wurden.
-      the_lock_will_automatically_lift_after_30_minutes_no_action: Die Sperrung wird automatisch nach 30 Minuten aufgehoben. Keine Aktion ist erforderlich, wenn dies du warst.
-      didn_t_recognise_this_activity_someone_may_be_trying_to: Erkannt dieser Aktivität nicht? Jemand könnte versuchen, dein Konto zu accessieren. Wir empfehlen, dein Passwort sofort zu ändern.
-      reset_your_password_2: 'Passwort ändern:'
+      your_dawarich_account_has_been_temporarily_locked_because_10_consecutive_2: Dein Dawarich-Konto wurde vorübergehend gesperrt, weil 10 Zwei-Faktor-Anmeldeversuche in Folge fehlgeschlagen sind.
+      the_lock_will_automatically_lift_after_30_minutes_no_action: Die Sperre wird nach 30 Minuten automatisch aufgehoben. Wenn du das warst, musst du nichts unternehmen.
+      didn_t_recognise_this_activity_someone_may_be_trying_to: Warst du das nicht? Möglicherweise versucht jemand, auf dein Konto zuzugreifen. Wir empfehlen dir, dein Passwort sofort zurückzusetzen.
+      reset_your_password_2: 'Passwort zurücksetzen:'
     welcome:
       welcome_to_dawarich: Willkommen bei Dawarich!
       hi: Hallo
       this_is_evgenii_from_dawarich: ", das ist Evgenii von Dawarich."
       welcome_to_dawarich_i_m_excited_to_have_you_on: Willkommen bei Dawarich! Ich freue mich, dich an Bord zu haben.
-      your_7_day_free_trial_has_started_during_this_time: 'Dein 7-tägiger kostenloses Testzeitraum hat begonnen. Während dieser Zeit kannst du:'
+      your_7_day_free_trial_has_started_during_this_time: 'Dein kostenloser 7-tägiger Testzeitraum hat begonnen. Während dieser Zeit kannst du:'
       track_your_location_data: Deine Standortdaten verfolgen
       view_your_movement_patterns_on_beautiful_maps: Deine Bewegungsmuster auf schönen Karten ansehen
-      analyze_your_travel_statistics: Deine Reise statistiken analysieren
+      analyze_your_travel_statistics: Deine Reisestatistiken analysieren
       export_your_data_in_various_formats: Deine Daten in verschiedenen Formaten exportieren
       start_exploring_dawarich: Mit der Erkundung von Dawarich beginnen
       if_you_have_any_questions_feel_free_to_drop_me: Falls du Fragen hast, melde dich einfach bei mir per E-Mail an hi@dawarich.app oder antworte einfach auf diese E-Mail.
-      happy_tracking: Freue dich auf die Verfolgung!
+      happy_tracking: Viel Freude beim Aufzeichnen!
       evgenii_from_dawarich: Evgenii von Dawarich
       welcome_to_dawarich_hi: Willkommen bei Dawarich! Hallo
-      this_is_evgenii_from_dawarich_welcome_to_dawarich_i_m: ", das bin ich, Evgenii von Dawarich. Willkommen bei Dawarich! Ich freue mich, dich an Bord zu haben. Dein 7-tägiger kostenloses Testzeitraum hat begonnen. Während dieser Zeit kannst du: - Deine Standortdaten verfolgen - Deine Bewegungsmuster auf schönen Karten ansehen - Deine Reise statistiken analysieren - Deine Daten in verschiedenen Formaten exportieren Mit der Erkundung von Dawarich beginnen: https://my.dawarich.app Falls du Fragen hast, melde dich einfach bei mir per E-Mail an hi@dawarich.app oder antworte einfach auf diese E-Mail. Freue dich auf die Verfolgung! Evgenii von Dawarich"
+      this_is_evgenii_from_dawarich_welcome_to_dawarich_i_m: ", hier ist Evgenii von Dawarich. Willkommen bei Dawarich! Ich freue mich, dich an Bord zu haben. Dein kostenloser 7-tägiger Testzeitraum hat begonnen. Während dieser Zeit kannst du: - Deine Standortdaten aufzeichnen - Deine Bewegungsmuster auf ansprechenden Karten ansehen - Deine Reisestatistiken analysieren - Deine Daten in verschiedenen Formaten exportieren Dawarich erkunden: https://my.dawarich.app Falls du Fragen hast, schreib mir an hi@dawarich.app oder antworte einfach auf diese E-Mail. Viel Freude beim Aufzeichnen! Evgenii von Dawarich"
       track_your_location_data_2: "- Deine Standortdaten verfolgen"
       view_your_movement_patterns_on_beautiful_maps_2: "- Deine Bewegungsmuster auf schönen Karten ansehen"
-      analyze_your_travel_statistics_2: "- Deine Reise statistiken analysieren"
+      analyze_your_travel_statistics_2: "- Deine Reisestatistiken analysieren"
       export_your_data_in_various_formats_2: "- Deine Daten in verschiedenen Formaten exportieren"
       start_exploring_dawarich_https_my_dawarich_app: 'Mit der Erkundung von Dawarich beginnen: https://my.dawarich.app'
   visits:
@@ -2561,6 +2584,8 @@ de:
   common:
     app_name: Dawarich
     not_available: N/A
+    time_ago: "vor %{time}"
+    time_from_now: "in %{time}"
   enums:
     export:
       file_type:
@@ -2630,8 +2655,8 @@ de:
     datetime_formatting:
       expires_on: Verfällt am %{date}
     insights:
-      monthly_digest: Monatlicher Newsletter
-      monthly_digest_title: "%{month} %{year} Newsletter"
+      monthly_digest: Monatsrückblick
+      monthly_digest_title: "%{month} %{year} im Rückblick"
       minute_count:
         one: "%{count} min"
         other: "%{count} min"
@@ -2644,11 +2669,11 @@ de:
     users:
       digests:
         distance_with_unit: "%{distance} %{unit}"
-        moon_distance: Das sind %{percentage}% der Entfernung zur Mond!
-        earth_circumference: Das sind %{percentage}% der Erdumfang!
+        moon_distance: Das sind %{percentage}% der Entfernung zum Mond!
+        earth_circumference: Das sind %{percentage}% des Erdumfangs!
       digests_mailer:
-        same: "→ gleiche"
-        new: "↑ neue"
+        same: "→ unverändert"
+        new: "↑ neu"
     trips:
       duration:
         years:
@@ -2819,7 +2844,7 @@ de:
         maps:
           hexagons:
             missing_required_parameter_param: 'Fehlender erforderlicher Parameter: %{parameter}'
-            shared_stats_not_found_or_no_longer_available: Gemeinsame Statistiken nicht gefunden oder nicht mehr verfügbar
+            shared_stats_not_found_or_no_longer_available: Geteilte Statistiken wurden nicht gefunden oder sind nicht mehr verfügbar
             invalid_date_format: Ungültiges Datum im Format
             failed_to_generate_hexagon_grid: Erzeugung der Hexagon-Grid fehlgeschlagen
         notes:
@@ -2850,7 +2875,7 @@ de:
         recalculations:
           invalid_year: Ungültiges Jahr
           recalculation_already_in_progress_for_this_user: Neuberechnung läuft bereits für diesen Benutzer.
-          recalculation_queued_tracks_stats_and_digests_will_be_regenerated_in: Wiederaufbereitung ist im Warteschlange. Tracks, Statistiken und Digests werden im Hintergrund neu erstellt.
+          recalculation_queued_tracks_stats_and_digests_will_be_regenerated_in: Die Neuberechnung wurde eingereiht. Tracks, Statistiken und Zusammenfassungen werden im Hintergrund neu erstellt.
         settings:
           mobile:
             settings_updated: Einstellungen aktualisiert
@@ -2953,7 +2978,7 @@ de:
     exports:
       export_was_successfully_initiated_please_wait_until_it_s_finished: Export wurde erfolgreich gestartet. Bitte warte, bis es fertig ist.
       export_failed_to_initiate_please_try_again: Export konnte nicht gestartet werden. Bitte versuche es erneut.
-      export_was_successfully_destroyed: Export wurde erfolgreich zerstört.
+      export_was_successfully_destroyed: Export wurde erfolgreich gelöscht.
     families:
       family_created_successfully: Familie erfolgreich erstellt!
       family_updated_successfully: Familie erfolgreich aktualisiert!
@@ -3004,7 +3029,7 @@ de:
       import_is_being_deleted: Import wird gelöscht.
       points_limit_exceeded: Punktegrenze überschritten
     insights:
-      all_time: Alle Zeit
+      all_time: Gesamter Zeitraum
       year_overview: "%{year} Übersicht"
     notifications:
       all_notifications_marked_as_read: Alle Benachrichtigungen als gelesen markiert.
@@ -3075,16 +3100,16 @@ de:
         default_name: 'Zeitleiste: %{start_date} → %{end_date}'
     shared:
       digests:
-        shared_digest_not_found_or_no_longer_available: Gemeinsamer Digest nicht gefunden oder nicht mehr verfügbar
-        failed_to_update_sharing_settings: Aktualisierung der Freigabestellungen fehlgeschlagen
+        shared_digest_not_found_or_no_longer_available: Geteilter Rückblick nicht gefunden oder nicht mehr verfügbar
+        failed_to_update_sharing_settings: Freigabeeinstellungen konnten nicht aktualisiert werden
         sharing_enabled: Freigabe erfolgreich aktiviert
         sharing_disabled: Freigabe erfolgreich deaktiviert
         auto_saved: Automatisch gespeichert
       links:
-        incorrect_phrase: Dieser Phrase hat nicht funktioniert. Versuche es erneut.
+        incorrect_phrase: Diese Phrase hat nicht funktioniert. Versuche es erneut.
       stats:
-        shared_stats_not_found_or_no_longer_available: Gemeinsame Statistiken nicht gefunden oder nicht mehr verfügbar
-        failed_to_update_sharing_settings: Aktualisierung der Freigabestellungen fehlgeschlagen
+        shared_stats_not_found_or_no_longer_available: Geteilte Statistiken wurden nicht gefunden oder sind nicht mehr verfügbar
+        failed_to_update_sharing_settings: Freigabeeinstellungen konnten nicht aktualisiert werden
         sharing_enabled: Freigabe erfolgreich aktiviert
         sharing_disabled: Freigabe erfolgreich deaktiviert
         auto_saved: Automatisch gespeichert
@@ -3111,8 +3136,8 @@ de:
         another_user_is_already_signed_in: Ein anderer Benutzer ist bereits angemeldet.
         this_welcome_link_has_already_been_used: Dieser Willkommenslink wurde bereits verwendet.
         link_invalid_or_expired_please_sign_in: Link ungültig oder abgelaufen. Bitte melde dich an.
-        account_no_longer_exists_please_sign_up_again: Konto existiert nicht mehr. Bitte melde dich erneut an.
-        trial_active_until: Willkommen bei Dawarich — dein 7-tägiger kostenloses Testzeitraum läuft bis %{date}.
+        account_no_longer_exists_please_sign_up_again: Das Konto existiert nicht mehr. Bitte registriere dich erneut.
+        trial_active_until: Willkommen bei Dawarich — dein kostenloser 7-tägiger Testzeitraum läuft bis zum %{date}.
         trial_activating: Willkommen bei Dawarich — dein Testzeitraum wird gerade aktiviert.
     trips:
       notes:
@@ -3217,7 +3242,7 @@ de:
       explore_features:
         subject: Entdecke die Funktionen von Dawarich!
       archival_approaching:
-        subject: Behalte deinen vollständigen Historie – upgrade zu Pro
+        subject: Mit Pro bleibt dein vollständiger Verlauf erhalten
       oauth_account_link:
         subject: Bestätige die Verknüpfung %{provider} mit deinem Dawarich-Konto
       account_destroy_confirmation:
@@ -3228,7 +3253,7 @@ de:
         year_end:
           subject: Dein %{year} Jahresrückblick – Dawarich
         monthly:
-          subject: Dein %{month} %{year} in Überprüfung — Dawarich
+          subject: Dein %{month} %{year} im Rückblick — Dawarich
   models:
     family:
       location_request:
@@ -3285,28 +3310,28 @@ de:
         unsupported_file_format: 'Nicht unterstütztes Dateiformat: %{format}'
     families:
       accept_invitation:
-        you_must_leave_your_current_family_before_joining_a_new: Du musst dein aktuelles Familienmitglied verlassen, bevor du ein neues anschließt.
+        you_must_leave_your_current_family_before_joining_a_new: Du musst deine aktuelle Familie verlassen, bevor du einer neuen beitreten kannst.
         this_invitation_is_no_longer_valid_or_has_expired: Diese Einladung ist nicht mehr gültig oder ist abgelaufen.
         this_invitation_is_not_for_your_email_address: Diese Einladung gilt nicht für deine E-Mail-Adresse.
         this_family_s_plan_is_no_longer_active: Das Familienabonnement ist nicht mehr aktiv.
         this_family_has_reached_the_maximum_number_of_members: Diese Familie hat die maximale Anzahl an Mitgliedern erreicht.
         welcome_to_family: Willkommen in der Familie!
-        you_ve_joined_the_family_name: Du hast die Familie „%{name}“ beigetreten
+        you_ve_joined_the_family_name: Du bist der Familie „%{name}“ beigetreten
         new_family_member: Neues Familienmitglied!
-        email_has_joined_your_family: "%{email} hat deine Familie beigetreten"
+        email_has_joined_your_family: "%{email} ist deiner Familie beigetreten"
         an_unexpected_error_occurred_while_joining_the_family_please_try: Beim Beitreten zur Familie ist ein unerwarteter Fehler aufgetreten. Bitte versuche es erneut
         failed_to_join: 'Beitritt zur Familie fehlgeschlagen: %{message}'
       create:
         family_name_is_required: Familienname ist erforderlich
         family_name_must_be_50_characters_or_less: Familienname muss 50 Zeichen oder weniger sein
-        you_must_leave_your_current_family_before_creating_a_new: Du musst dein aktuelles Familienmitglied verlassen, bevor du eines erstellst
+        you_must_leave_your_current_family_before_creating_a_new: Du musst deine aktuelle Familie verlassen, bevor du eine neue erstellen kannst
         you_have_already_created_a_family_each_user_can_only: Du hast bereits eine Familie erstellt. Jeder Benutzer kann nur eine Familie erstellen
         family_feature_requires_an_active_subscription: Die Familien-Funktion erfordert ein aktives Abonnement
         family_created: Familie erstellt
         you_ve_successfully_created_the_family_name: Du hast die Familie '%{name}' erfolgreich erstellt
         a_family_with_this_name_already_exists_for_your_account: Eine Familie mit diesem Namen existiert bereits für dein Konto
         an_unexpected_error_occurred_while_creating_the_family_please_try: Beim Erstellen der Familie ist ein unerwarteter Fehler aufgetreten. Bitte versuche es erneut
-        failed_to_create_family: 'Familie nicht erstellen: %{message}'
+        failed_to_create_family: 'Familie konnte nicht erstellt werden: %{message}'
       create_location_request:
         an_error_occurred: Ein Fehler ist aufgetreten
         location_request: Standortanfrage
@@ -3320,26 +3345,26 @@ de:
         failed_to_send_invitation_email_please_try_again_later: Einladungs-E-Mail konnte nicht gesendet werden. Bitte versuche es später erneut
         an_unexpected_error_occurred_while_sending_the_invitation_please_try: Ein unerwarteter Fehler ist aufgetreten, während die Einladung gesendet wurde. Bitte versuche es erneut
         failed_to_send_invitation: Einladung konnte nicht gesendet werden
-        owner_required: Du musst ein Familien-Owner sein, um Einladungen senden zu können
+        owner_required: Du musst Inhaber der Familie sein, um Einladungen senden zu können
         family_full: Familie ist voll
         user_already_in_family: Benutzer ist bereits in einer Familie
         invitation_already_sent: Einladung wurde bereits an diese E-Mail gesendet
-        sent_self_hosted: Familien-Einladung an %{email} gesendet, wenn SMTP korrekt konfiguriert ist. Wenn du nicht SMTP verwendest, kopiere den Einladungslink von der Familien-Seite und teile ihn manuell.
+        sent_self_hosted: Die Familieneinladung an %{email} wurde gesendet, sofern SMTP korrekt konfiguriert ist. Falls du kein SMTP verwendest, kopiere den Einladungslink von der Familienseite und teile ihn manuell.
         sent: Familien-Einladung an %{email} gesendet
         failed_to_create: 'Einladung konnte nicht erstellt werden: %{message}'
       memberships:
         destroy:
           user_is_not_currently_in_a_family: Benutzer ist derzeit nicht in einer Familie.
-          family_owners_cannot_remove_their_own_membership_to_leave_the: Familien-Owners können ihre eigene Mitgliedschaft nicht entfernen, um die Familie zu verlassen. Um die Familie zu verlassen, lösche sie stattdessen.
-          only_family_owners_can_remove_other_members: Nur Familien-Owners können andere Mitglieder entfernen.
+          family_owners_cannot_remove_their_own_membership_to_leave_the: Familieninhaber können ihre eigene Mitgliedschaft nicht entfernen. Lösche stattdessen die Familie, wenn du sie verlassen möchtest.
+          only_family_owners_can_remove_other_members: Nur Familieninhaber können andere Mitglieder entfernen.
           cannot_remove_members_from_a_different_family: Man kann Mitglieder aus einer anderen Familie nicht entfernen.
-          cannot_remove_the_family_owner_the_owner_must_delete_the: Man kann den Familien-Owner nicht entfernen. Der Owner muss die Familie löschen oder selbst verlassen.
-          left_family: Verlassen Familie
+          cannot_remove_the_family_owner_the_owner_must_delete_the: Der Familieninhaber kann nicht entfernt werden. Er muss die Familie stattdessen löschen.
+          left_family: Familie verlassen
           you_ve_left_the_family_family_name: Du hast die Familie "%{family_name}" verlassen
-          family_member_left: Mitglied verlassen
+          family_member_left: Familienmitglied ausgetreten
           email_has_left_the_family_family_name: '%{email} hat die Familie "%{family_name}" verlassen'
           removed_from_family: Von der Familie entfernt
-          you_have_been_removed_from_the_family_family_name_by: Du wurdest von der Familie "%{family_name}" von %{email} entfernt
+          you_have_been_removed_from_the_family_family_name_by: Du wurdest von %{email} aus der Familie „%{family_name}“ entfernt
           member_removed: Mitglied entfernt
           email_has_been_removed_from_the_family_family_name: '%{email} wurde von der Familie "%{family_name}" entfernt'
           an_unexpected_error_occurred_while_removing_the_membership_please_try: Beim Entfernen der Mitgliedschaft ist ein unerwarteter Fehler aufgetreten. Bitte versuche es erneut
@@ -3355,11 +3380,11 @@ de:
     fit:
       importer:
         fit_parsing_error_message: 'FIT-Parser-Fehler: %{message}'
-        no_activities_found_in_fit_file: Keine Aktivitäten im FIT-Datei gefunden
+        no_activities_found_in_fit_file: Keine Aktivitäten in der FIT-Datei gefunden
     google_maps:
       semantic_history_importer:
         google_maps_timeline_import_error: Fehler beim Importieren des Google Maps Timeline-Verlaufs
-        batch_failed: 'Verarbeitung der Standortbatch fehlgeschlagen: %{message}'
+        batch_failed: 'Verarbeitung der Standortdaten fehlgeschlagen: %{message}'
     immich:
       connection_tester:
         immich_connection_verified: Immich-Verbindung bestätigt
@@ -3402,26 +3427,26 @@ de:
         zip_unclassified: Zip-Inhalt konnte nicht klassifiziert werden – Datei könnte beschädigt sein
       source_detector:
         amazon_order: Dies ist eine Amazon-Exportdatei, nicht Standortdaten. Dawarich importiert Standortverläufe aus Google Takeout, OwnTracks, GPX und ähnlichen Quellen.
-        apple_plist: Apple binäre plist-Dateien (.plist) werden nicht unterstützt.
+        apple_plist: Binäre Apple-Property-List-Dateien (.plist) werden nicht unterstützt.
         ds_store: Dies ist eine macOS-Finder-Metadatendatei (.DS_Store), keine Datendatei. Lade stattdessen deine tatsächliche Standort-Exportdatei hoch.
         empty_file: Die hochgeladene Datei ist leer (0 Bytes).
         empty_json: Die hochgeladene Datei enthält keine Daten (leeres JSON-Objekt oder -Array).
         encrypted_timeline: Deine Google Timeline-Daten sind verschlüsselt. Öffne die Google Maps-App, deaktiviere die Timeline-Verschlüsselung in den Einstellungen und exportiere deine Daten erneut.
-        google_settings: Diese Datei enthält deine Google Maps-Einstellungen, keine Standortdaten. Suche nach "Records.json" oder Dateien innerhalb von "Timeline/" in deinem Google Takeout.
-        gzip: Gzip-komprimierte Dateien (.gz) werden nicht automatisch dekomprimiert. Bitte dekomprimiere die Datei und hochlade den Inhalt erneut.
-        heic: HEIC-Bild-Dateien werden nicht unterstützt. Fotos enthalten keine Standortverlauf; verbinde deine Foto-Bibliothek über die Immich- oder PhotoPrism-Integration, um Standortdaten aus Fotos zu importieren.
-        html_page: Dies ist eine HTML-Seite (vermutlich "archive_browser.html" aus deinem Google Takeout), keine Daten-Datei. Öffne das Takeout-Archiv und suche nach der .json oder .kml-Datei darin.
-        jpeg: JPEG-Bild-Dateien werden nicht unterstützt. Fotos enthalten keine Standortverlauf; verbinde deine Foto-Bibliothek über die Immich- oder PhotoPrism-Integration, um Standortdaten aus Fotos zu importieren.
-        json_fragment: Die hochgeladene Datei sieht aus wie ein abgeschnittenes oder beschädigtes JSON-fragment (es beginnt nicht mit "{" oder "["). Bitte exportiere und hochlade die ursprüngliche vollständige Datei erneut.
-        my_activity: Dies ist ein Google "My Activity"-Log (Such- und Kartenaktivitäten), keine Standortverlauf. Suche nach "Records.json" oder Dateien innerhalb von "Timeline/" in deinem Google Takeout.
-        office_document: Microsoft Office-Dokumente (Word/Excel) werden nicht unterstützt. Bitte hochlade deine Standortdaten-Datei.
-        pdf: PDF-Dateien werden nicht unterstützt. Öffne das PDF und finde deine tatsächliche Standortdaten-Datei.
-        place_feedback: Dies ist eine Google Maps-Ort-Feedback-Datei (Maps-Fragen wie "War dieser Ort geöffnet?"), keine Standortverlauf. Suche nach "Records.json" oder Dateien innerhalb von "Timeline/" in deinem Google Takeout.
-        png: PNG-Bild-Dateien werden nicht unterstützt. Bitte hochlade deine Standortdaten-Datei (.json, .gpx, .kml, etc).
-        rar: RAR-Archive werden nicht unterstützt. Extrahiere das Archiv und hochlade die Daten-Dateien darin.
-        saved_places: Dies ist eine Google saved-places / Geocodes-Datei, nicht dein Standortverlauf. Suche nach „Records.json“ oder Dateien innerhalb von „Timeline/“ in deiner Google Takeout-Exportdatei.
+        google_settings: Diese Datei enthält deine Google-Maps-Einstellungen, aber keine Standortdaten. Suche in deinem Google Takeout nach „Records.json“ oder Dateien im Ordner „Timeline“.
+        gzip: Gzip-komprimierte Dateien (.gz) werden nicht automatisch entpackt. Entpacke die Datei und lade den Inhalt erneut hoch.
+        heic: HEIC-Bilddateien werden nicht unterstützt. Fotos enthalten keinen Standortverlauf; verbinde deine Fotobibliothek über Immich oder PhotoPrism, um Standorte aus Fotos zu importieren.
+        html_page: Dies ist eine HTML-Seite (vermutlich „archive_browser.html“ aus deinem Google Takeout), keine Datendatei. Öffne das Takeout-Archiv und suche darin nach der JSON- oder KML-Datei.
+        jpeg: JPEG-Bilddateien werden nicht unterstützt. Fotos enthalten keinen Standortverlauf; verbinde deine Fotobibliothek über Immich oder PhotoPrism, um Standorte aus Fotos zu importieren.
+        json_fragment: Die hochgeladene Datei scheint ein abgeschnittenes oder beschädigtes JSON-Fragment zu sein; sie beginnt weder mit „{“ noch mit „[“. Exportiere die ursprüngliche vollständige Datei erneut und lade sie hoch.
+        my_activity: Dies ist ein Google-„Meine Aktivitäten“-Protokoll mit Such- und Kartenaktivitäten, kein Standortverlauf. Suche in deinem Google Takeout nach „Records.json“ oder Dateien im Ordner „Timeline“.
+        office_document: Microsoft-Office-Dokumente (Word/Excel) werden nicht unterstützt. Lade stattdessen deine Standortdatendatei hoch.
+        pdf: PDF-Dateien werden nicht unterstützt. Öffne das PDF und suche nach deiner eigentlichen Standortdatendatei.
+        place_feedback: Dies ist eine Google-Maps-Feedbackdatei zu Orten, kein Standortverlauf. Suche in deinem Google Takeout nach „Records.json“ oder Dateien im Ordner „Timeline“.
+        png: PNG-Bilddateien werden nicht unterstützt. Lade stattdessen deine Standortdatendatei (.json, .gpx, .kml usw.) hoch.
+        rar: RAR-Archive werden nicht unterstützt. Entpacke das Archiv und lade die enthaltenen Datendateien hoch.
+        saved_places: Dies ist eine Datei mit in Google gespeicherten Orten oder Geocodes, nicht dein Standortverlauf. Suche in deinem Google-Takeout-Export nach „Records.json“ oder Dateien im Ordner „Timeline“.
         snapchat_export: Dies sieht aus wie ein Snapchat-Datenexport, nicht Standortdaten. Dawarich importiert Standortverläufe von Google Takeout, OwnTracks, GPX und ähnlichen Quellen.
-        timeline_edits: Der Google Timeline Edits-Format wird nicht unterstützt. Hochlade stattdessen Records.json oder die Dateien innerhalb des Timeline-Ordners deiner Google Takeout-Exportdatei.
+        timeline_edits: Das Format „Google Timeline Edits“ wird noch nicht unterstützt. Lade stattdessen „Records.json“ oder Dateien aus dem Timeline-Ordner deines Google-Takeout-Exports hoch.
         unknown_format: Dateiformat konnte nicht erkannt werden
       watcher:
         unsupported_source: 'Nicht unterstützte Quelle: %{source}'
@@ -3557,16 +3582,16 @@ de:
     lite:
       archival_warning_job:
         your_oldest_data_will_archive_in_30_days: Deine ältesten Daten werden in 30 Tagen archiviert
-        your_oldest_month_of_location_data_will_be_archived_soon: Dein ältestes Monat Standortdaten wird bald archiviert. Upgrade zu Pro, um deinen vollständigen Verlauf suchbar zu halten.
+        your_oldest_month_of_location_data_will_be_archived_soon: Dein ältester Monat mit Standortdaten wird bald archiviert. Upgrade auf Pro, damit dein vollständiger Verlauf durchsuchbar bleibt.
         data_has_been_archived: Daten wurden archiviert
         month_of_location_data_has_been_archived_your_archived: 1 Monat Standortdaten wurde archiviert. Deine archivierten Daten können jederzeit exportiert werden. Upgrade zu Pro, um sie wieder in der App sichtbar und interaktiv zu machen.
     stale_jobs_recovery_job:
-      export_timed_out_after_being_stuck_in_processing: Export ist nach Verhängen in Verarbeitung abgebrochen
+      export_timed_out_after_being_stuck_in_processing: Der Export war zu lange in Verarbeitung und wurde abgebrochen
       export_failed: Export fehlgeschlagen
-      export_name_was_stuck_in_processing_and_has_been_marked: Export "%{name}" war in Verarbeitung verhängen und wurde als fehlgeschlagen markiert.
-      import_timed_out_after_being_stuck_in_processing: Import ist nach Verhängen in Verarbeitung abgebrochen
+      export_name_was_stuck_in_processing_and_has_been_marked: Der Export „%{name}“ war zu lange in Verarbeitung und wurde als fehlgeschlagen markiert.
+      import_timed_out_after_being_stuck_in_processing: Der Import war zu lange in Verarbeitung und wurde abgebrochen
       import_failed: Import fehlgeschlagen
-      import_name_was_stuck_in_processing_and_has_been_marked: Import "%{name}" war in Verarbeitung verhängen und wurde als fehlgeschlagen markiert.
+      import_name_was_stuck_in_processing_and_has_been_marked: Der Import „%{name}“ war zu lange in Verarbeitung und wurde als fehlgeschlagen markiert.
     stats:
       calculating_job:
         stats_update_failed: Statistikupdate fehlgeschlagen
@@ -3575,7 +3600,7 @@ de:
       digests:
         monthly:
           calculating_job:
-            monthly_digest_calculation_failed: Monatlicher Digestberechnung fehlgeschlagen
+            monthly_digest_calculation_failed: Der Monatsrückblick konnte nicht berechnet werden
             message_stacktrace_backtrace: "%{message}, stacktrace: %{backtrace}"
         yearly:
           calculating_job:
@@ -3583,7 +3608,7 @@ de:
             message_stacktrace_backtrace: "%{message}, stacktrace: %{backtrace}"
       import_data_job:
         data_import_failed: Datenimport fehlgeschlagen
-        your_data_import_failed_with_error_message_please_check_the: 'Deine Datenimport ist fehlgeschlagen mit Fehler: %{message}. Bitte prüfe das Archivformat und versuche es erneut.'
+        your_data_import_failed_with_error_message_please_check_the: 'Dein Datenimport ist mit folgendem Fehler fehlgeschlagen: %{message}. Bitte prüfe das Archivformat und versuche es erneut.'
       recalculate_data_job:
         data_recalculation_busy: Datenberechnung beschäftigt
         another_recalculation_is_already_running_please_try_again_in_a: Eine andere Berechnung läuft bereits. Bitte versuche es in ein paar Minuten erneut.
@@ -3610,10 +3635,10 @@ de:
       failed_to_copy_please_copy_manually: Kopieren fehlgeschlagen. Bitte kopiere manuell.
       copied_to_clipboard: In die Zwischenablage kopiert!
       location_sharing_has_expired: Standortfreigabe ist abgelaufen
-      invalid_tile_url_reverting_to_openstreetmap: Ungültige Kachel-URL. Zurück zur OpenStreetMap.
+      invalid_tile_url_reverting_to_openstreetmap: Ungültige Kachel-URL. Es wird wieder OpenStreetMap verwendet.
       please_select_a_date_range: Bitte wähle einen Datumsbereich aus
       failed_to_scan_photos: Fotoscannen fehlgeschlagen
-      failed_to_enrich_photos: Fotos nicht bereichert
+      failed_to_enrich_photos: Fotos konnten nicht angereichert werden
       draw_a_rectangle_on_the_map_to_select_points: Zeichne ein Rechteck auf der Karte, um Punkte auszuwählen
       fetching_data_in_selected_area: Daten im ausgewählten Bereich werden geladen...
       no_data_found_in_selected_area: Keine Daten im ausgewählten Bereich gefunden
@@ -3639,42 +3664,42 @@ de:
       failed_to_load_location_data_please_try_again: Daten zum Standort konnten nicht geladen werden. Bitte versuche es erneut.
       click_on_the_map_to_place_a_place: Klicke auf die Karte, um einen Ort zu platzieren
       failed_to_reload_routes: Route konnte nicht neu geladen werden
-      failed_to_load_scratch_layer: Scratch-Schicht konnte nicht geladen werden
+      failed_to_load_scratch_layer: Rubbelkartenebene konnte nicht geladen werden
       failed_to_load_photos: Fotos konnten nicht geladen werden
       failed_to_load_areas: Gebiete konnten nicht geladen werden
       failed_to_load_tracks: Tracks konnten nicht geladen werden
       failed_to_load_flights: Flüge konnten nicht geladen werden
       failed_to_load_anomalies: Anomalien konnten nicht geladen werden
       reloading_routes: Route wird neu geladen...
-      cannot_update_recalculation_is_already_in_progress: 'Aktualisierung nicht möglich: Rechnung ist bereits im Gange'
+      cannot_update_recalculation_is_already_in_progress: 'Aktualisierung nicht möglich: Eine Neuberechnung läuft bereits.'
       transportation_settings_saved: Transporteinstellungen gespeichert
       globe_view_will_be_applied_after_page_reload: Globusansicht wird nach Neuladen der Seite angewendet
       settings_updated_successfully: Einstellungen wurden erfolgreich aktualisiert
       reloading_map_data_with_new_settings: Kartendaten werden mit den neuen Einstellungen neu geladen...
       api_key_not_available_please_reload_the_page: API-Schlüssel nicht verfügbar; bitte die Seite neu laden.
-      could_not_queue_re_evaluation_please_try_again: Kann Re-Bewertung nicht in die Warteschlange stecken. Bitte versuche es erneut.
-      could_not_queue_recalculation_please_try_again: Kann Berechnung nicht in die Warteschlange stecken. Bitte versuche es erneut.
+      could_not_queue_re_evaluation_please_try_again: Die erneute Auswertung konnte nicht gestartet werden. Bitte versuche es erneut.
+      could_not_queue_recalculation_please_try_again: Die Neuberechnung konnte nicht gestartet werden. Bitte versuche es erneut.
       click_on_the_map_to_place_a_visit_esc_to: Klicke auf die Karte, um einen Aufenthalt zu platzieren (Esc zum Abbrechen)
-      visit_creation_modal_not_available: Modals für Aufenthalt-Erstellung nicht verfügbar
+      visit_creation_modal_not_available: Dialog zum Erstellen eines Aufenthalts ist nicht verfügbar
       visit_creation_controller_not_available: Controller für Aufenthalt-Erstellung nicht verfügbar
       area_drawer_controller_not_available: Controller für Flächenzeichnung nicht verfügbar
       area_created_successfully: Fläche erfolgreich erstellt!
-      failed_to_reload_areas: Flächen nicht erneut laden
+      failed_to_reload_areas: Gebiete konnten nicht neu geladen werden
       family_feature_not_available: Familienfunktion nicht verfügbar
-      failed_to_load_family_members: Familienmitglieder nicht laden
+      failed_to_load_family_members: Familienmitglieder konnten nicht geladen werden
       centered_on_family_member: Auf Familienmitglied zentriert
-      failed_to_load_visit_details: Aufenthalt-Details nicht laden
-      failed_to_load_area_details: Flächen-Details nicht laden
+      failed_to_load_visit_details: Aufenthaltsdetails konnten nicht geladen werden
+      failed_to_load_area_details: Gebietsdetails konnten nicht geladen werden
       point_deleted_successfully: Punkt erfolgreich gelöscht
-      failed_to_delete_point: Punkt nicht löschen
-      deleting_area: Fläche löschen...
+      failed_to_delete_point: Punkt konnte nicht gelöscht werden
+      deleting_area: Gebiet wird gelöscht…
       area_deleted_successfully: Bereich erfolgreich gelöscht
       failed_to_delete_area: Bereich konnte nicht gelöscht werden
-      failed_to_load_place_details: Platzdetails konnten nicht geladen werden
+      failed_to_load_place_details: Ortsdetails konnten nicht geladen werden
       connected_to_real_time_updates: Verbunden mit Echtzeit-Updates
       disconnected_from_real_time_updates: Von Echtzeit-Updates getrennt
       new_location_recorded: Neuer Standort erfasst
-      error_saving_layer_preferences: Fehler beim Speichern der Layer-Einstellungen
+      error_saving_layer_preferences: Ebeneneinstellungen konnten nicht gespeichert werden
       failed_to_update_settings: Einstellungen konnten nicht aktualisiert werden
       at_least_one_gradient_stop_is_required: Mindestens ein Gradientenstopp ist erforderlich.
       failed_to_load_demo_data_please_try_again: Demo-Daten konnten nicht geladen werden. Bitte versuche es erneut.
@@ -3683,7 +3708,7 @@ de:
       please_select_and_upload_files_first: Bitte wähle zuerst Dateien aus und lade sie hoch
       please_select_a_valid_zip_file: Bitte wähle eine gültige ZIP-Datei aus.
       failed_to_fetch_photos: Fotos konnten nicht geladen werden
-      failed_to_fetch_photos_after_multiple_attempts: Fotos konnten nicht geladen werden, nach mehreren Versuchen
+      failed_to_fetch_photos_after_multiple_attempts: Fotos konnten auch nach mehreren Versuchen nicht geladen werden
       place_deleted_successfully: Ort erfolgreich gelöscht
       failed_to_delete_place: Löschen des Ortes fehlgeschlagen
       failed_to_load_visits_in_selected_area: Laden der Aufenthalte im ausgewählten Bereich fehlgeschlagen
@@ -3705,17 +3730,17 @@ de:
       delete: Löschen
       edit: Bearbeiten
       your_lite_plan_includes_the_last_12_months_of_data: Dein Lite-Plan beinhaltet die letzten 12 Monate Daten.
-      globe_view_is_a_pro_feature: Globe View ist eine Pro-Funktion.
+      globe_view_is_a_pro_feature: Die Globusansicht ist eine Pro-Funktion.
       map_styles: Kartenstile
-      untagged: Unbeschriftet
+      untagged: Ohne Tag
       suggested: Vorgeschlagen
       confirmed: Bestätigt
-      layers: Schichten
+      layers: Ebenen
       points: Punkte
       routes: Routen
       tracks: Tracks
       heatmap: Heatmap
-      fog_of_war: Nebel des Krieges
+      fog_of_war: Kartennebel
       scratch_map: Rubbelkarte
       areas: Gebiete
       photos: Fotos
@@ -3728,8 +3753,8 @@ de:
       cycling: Radfahren
       nature_leisure: Natur & Freizeit
       tourism_culture: Tourismus & Kultur
-      services_civic: Dienstleistungen & Bürgerliches
-      urban_amenities: Stadtentwicklung
+      services_civic: Dienstleistungen & öffentliche Einrichtungen
+      urban_amenities: Städtische Einrichtungen
     common:
       add_row: Zeile hinzufügen
       and: und
@@ -3750,13 +3775,13 @@ de:
       update: Aktualisieren
       upgrade_to_pro: Auf Pro upgraden
       expired: Abgelaufen
-      loading: Lädt...
-      creating: Erstellt...
+      loading: Wird geladen…
+      creating: Wird erstellt…
     trip:
       show_all_days: Alle Tage anzeigen
       collapse_all_days: Alle Tage zusammenklappen
     map:
-      places_layer: Orte-Schicht
+      places_layer: Ortsebene
       confirm_delete_point: Möchtest du diesen Punkt wirklich löschen?
       confirm_delete_point_permanently: |-
         Diesen Punkt löschen?
@@ -3765,8 +3790,8 @@ de:
       edit_speed_color_scale: Farbskala für Geschwindigkeit bearbeiten
       failed_to_update_point_position: Aktualisierung der Position des Punkts fehlgeschlagen. Bitte versuche es erneut.
       display: Anzeigen
-      layer_preferences_failed: 'Speichern der Schichtvorlieben fehlgeschlagen: %{error}'
-      preferred_layer_updated: 'Vorgeschlagene Karten-Schicht aktualisiert auf: %{layer}'
+      layer_preferences_failed: 'Ebeneneinstellungen konnten nicht gespeichert werden: %{error}'
+      preferred_layer_updated: 'Bevorzugte Kartenebene geändert zu: %{layer}'
       stats_summary:
         one: "%{distance} %{unit} | %{count} Punkt"
         other: "%{distance} %{unit} | %{count} Punkte"
@@ -3774,7 +3799,7 @@ de:
     replay:
       no_data_at_this_time: Keine Daten zurzeit
       pause: Pause
-      replay: Wiederholen
+      replay: Wiedergabe
       day_count: Tag %{current} von %{total}
       point_count: Punkt %{current} von %{total}
       speed: "%{speed} km/h"
@@ -3790,7 +3815,7 @@ de:
       filter_by_tag: FILTERN NACH ETIKETTE
       no_tags: Noch keine Etiketten erstellt
       none_found: Keine Orte gefunden
-      open_for_suggestions: Öffne das Modale, um nahegelegene Vorschläge zu laden
+      open_for_suggestions: Öffne den Dialog, um Vorschläge in der Nähe zu laden
       show_all: Alle Orte anzeigen
       untagged: Unbeschriftete Orte
       updated: Ort „%{name}“ wurde erfolgreich aktualisiert!
@@ -3820,7 +3845,7 @@ de:
       delete: Aufenthalt löschen
       details: Aufenthaltsdetails
       edit: Aufenthalt bearbeiten
-      enable_layers_help: Aktiviere die Schichten „Vorgeschlagene Aufenthalte“ oder „Bestätigte Aufenthalte“ über die Kartensteuerung, um Aufenthalte anzuzeigen.
+      enable_layers_help: Aktiviere die Ebenen „Vorgeschlagene Aufenthalte“ oder „Bestätigte Aufenthalte“ über die Kartensteuerung, um Aufenthalte anzuzeigen.
       end_time: Endezeit
       found:
         one: "%{count} Aufenthalt gefunden"
@@ -3870,7 +3895,7 @@ de:
     areas:
       edit: Bereich bearbeiten
       create_new: Neuen Bereich erstellen
-      enter_name: Gib den Bereichsname ein
+      enter_name: Gib den Bereichsnamen ein
       confirm_delete: Möchtest du diesen Bereich wirklich löschen?
       confirm_delete_named: |-
         Bereich "%{name}" löschen?
@@ -3890,7 +3915,7 @@ de:
       for_query: für "%{query}"
       locations_found:
         one: 'Einen Standort gefunden: %{count}'
-        other: 'Eine Standorte gefunden: %{count}'
+        other: '%{count} Standorte gefunden'
       no_locations: Keine Standorte gefunden
       results: Ergebnisse
       searching: Suche…
@@ -3935,13 +3960,13 @@ de:
       custom_style_load_failed: Benutzerdefinierte Kartenstil konnte nicht geladen werden; zurück zum Standardstil.
       invalid_tile_url: Tile-URL muss {z}, {x} und {y} Platzhalter enthalten oder eine MapLibre-Stil-URL sein
       layer_unavailable_custom_style: Nicht mit dem benutzerdefinierten Kartenstil verfügbar — es werden keine Beschriftungen oder Sehenswürdigkeiten gezeichnet
-      layer_unavailable_foreign_basemap: Nicht mit einem benutzerdefinierten Raster- oder Stil-Hintergrundkarten verfügbar — diese Schichten stammen von den eingebauten Vektorplättchen
+      layer_unavailable_foreign_basemap: Nicht mit einer benutzerdefinierten Raster- oder Stil-Basiskarte verfügbar — diese Ebenen stammen aus den integrierten Vektorkacheln
       make_changes_to_apply: Änderungen vornehmen, um den Anwenden-Button zu aktivieren
-      re_evaluation_queued: Wiederbewertung ist im Warteschlange. Die Karte wird aktualisiert, sobald die Aufgabe fertig ist.
-      recalculation_queued: Wiederherstellung ist im Warteschlange. Du erhältst eine Benachrichtigung, sobald es fertig ist.
+      re_evaluation_queued: Die erneute Prüfung wurde eingereiht. Die Karte wird aktualisiert, sobald die Aufgabe abgeschlossen ist.
+      recalculation_queued: Die Neuberechnung wurde eingereiht. Du erhältst eine Benachrichtigung, sobald sie abgeschlossen ist.
       transportation_recalculation_failed: 'Wiederherstellung fehlgeschlagen: %{error}'
-      transportation_recalculation_progress: Wiederherstellung der Verkehrsmittel... (%{processed}/%{total} Tracks, %{progress}%)
-      transportation_recalculation_started: Einstellungen gespeichert. Wiederherstellung der Verkehrsmittel für alle Tracks...
+      transportation_recalculation_progress: Fortbewegungsarten werden neu berechnet … (%{processed}/%{total} Tracks, %{progress} %)
+      transportation_recalculation_started: Einstellungen gespeichert. Die Fortbewegungsarten aller Tracks werden neu berechnet …
       unsaved_count:
         one: "%{count} ungespeichert"
         other: "%{count} ungespeichert"
@@ -4165,14 +4190,14 @@ de:
     legacy_settings:
       edit_colors: Farben bearbeiten
       fog_radius: Radius des Nebels des Krieges
-      fog_threshold: Schwellwert des Nebels des Krieges
+      fog_threshold: Schwellenwert des Kartennebels
       live_map: Live-Karte
       merge_threshold: Verschmelzschwellwert in Minuten
       meters_between_routes: Meter zwischen Routen
       minutes_between_routes: Minuten zwischen Routen
       points_rendering_mode: Darstellung der Punkte
       raw: Rohdaten
-      route_opacity: Route-Opacity, %
+      route_opacity: Deckkraft der Route, %
       simplified: Vereinfacht
       speed_color_scale: Geschwindigkeitsfarbskala
       speed_colored_routes: Geschwindigkeitsfarbige Routen
@@ -4207,7 +4232,7 @@ de:
       map_initialization_failed: Initialisierung der Karte fehlgeschlagen
     anomalies:
       impossible_speed: 'Gefiltert: unmögliche Geschwindigkeit zwischen benachbarten Punkten'
-      low_accuracy: 'Geiltert: niedrige Genauigkeit (%{accuracy}m, Schwellwert %{threshold}m)'
+      low_accuracy: 'Gefiltert: geringe Genauigkeit (%{accuracy} m, Schwellenwert %{threshold} m)'
     live_map:
       disabled: Live-Modus deaktiviert
       enabled: Live-Modus aktiviert
@@ -4235,10 +4260,10 @@ de:
   battery_statuses:
     unknown: unbekannt
     unplugged: nicht angeschlossen
-    charging: läd auf
+    charging: wird geladen
     full: voll
-    connected_not_charging: nicht laden
-    discharging: entladen
+    connected_not_charging: wird nicht geladen
+    discharging: entlädt sich
   family_invitations:
     index:
       back_to_family: Zur Familie

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -73,9 +73,6 @@ de:
         generate_new_api_key: Neuen API-Schlüssel generieren
         are_you_sure_this_will_invalidate_the_current_api_key: Bist du sicher? Dies wird den aktuellen API-Schlüssel ungültig machen.
       points_usage:
-        you_have_used: Du hast verwendet
-        points_of: Punkte von
-        available: verfügbar.
         summary_html: Du hast %{used} von %{limit} verfügbaren Punkten verwendet.
       edit:
         account_settings: Kontoeinstellungen
@@ -383,8 +380,6 @@ de:
       hi_there: Hallo!
       invited_by_family_html: <strong>%{email}</strong> hat dich eingeladen, der Familie „<strong>%{family}</strong>“ auf Dawarich beizutreten.
       invited_by_family_text: "%{email} hat dich eingeladen, der Familie „%{family}“ auf Dawarich beizutreten."
-      has_invited_you_to_join_their_family: hat dich eingeladen, ihre Familie "
-      on_dawarich: "\" auf Dawarich."
       by_joining_this_family_you_ll_be_able_to: 'Indem du dieser Familie beitrittst, kannst du:'
       share_your_current_location_with_family_members: Deinen aktuellen Standort mit Familienmitgliedern teilen
       see_the_current_location_of_other_family_members: Den aktuellen Standort anderer Familienmitglieder sehen
@@ -396,9 +391,6 @@ de:
       if_you_didn_t_expect_this_invitation_you_can_safely: Wenn du diese Einladung nicht erwartet hast, kannst du diese E-Mail einfach ignorieren.
       best_regards: Mit freundlichen Grüßen,
       evgenii_from_dawarich: Evgenii von Dawarich
-      you_ve_been_invited_to_join_a_family_hi_there: Du wurdest eingeladen, einer Familie beizutreten! Hallo!
-      on_dawarich_by_joining_this_family_you_ll_be_able: "\" auf Dawarich. Durch das Beitreten dieser Familie wirst du in der Lage sein: • Deinen aktuellen Standort mit Familienmitgliedern zu teilen • Den aktuellen Standort anderer Familienmitglieder zu sehen • Mit deinen Lieben in Verbindung zu bleiben • Deine Privatsphäre vollständig zu kontrollieren Akzeptiere die Einladung hier:"
-      important_this_invitation_will_expire_in_7_days_if_you: 'WICHTIG: Diese Einladung läuft in 7 Tagen ab. Wenn du noch kein Dawarich-Konto hast, kannst du eines erstellen, sobald du die Einladung annimmst. Wenn du diese Einladung nicht erwartet hast, kannst du diese E-Mail einfach ignorieren. Mit freundlichen Grüßen, Evgenii von Dawarich'
       accept_invitation: Einladung annehmen
       share_your_current_location_with_family_members_2: "• Deinen aktuellen Standort mit Familienmitgliedern teilen"
       see_the_current_location_of_other_family_members_2: "• Den aktuellen Standort anderer Familienmitglieder sehen"
@@ -439,31 +431,15 @@ de:
       member_count:
         one: Deine Familie hat jetzt %{count} Mitglied.
         other: Deine Familie hat jetzt %{count} Mitglieder.
-      we_re_excited_to_let_you_know_that: Wir freuen uns, dir mitzuteilen, dass
-      has_just_joined_your_family: ist gerade deiner Familie „
-      on_dawarich: "\" auf Dawarich!"
       now_you_can: 'Jetzt kannst du:'
-      see: sehen
-      s_current_location_if_they_ve_enabled_sharing: "'s aktuellen Standort (falls sie Standortfreigabe aktiviert haben)"
       stay_connected_with_your_growing_family: Mit deiner wachsenden Familie verbunden bleiben
-      share_your_location_with: Deinen Standort mit
       manage_family_members_and_settings_from_your_family_page: Verwalte Familienmitglieder und Einstellungen auf deiner Familienseite
       tip: "\U0001F4A1 Tipp:"
       you_can_manage_your_family_members_and_privacy_settings_at: Du kannst deine Familienmitglieder und Datenschutzeinstellungen jederzeit in der Familienübersicht verwalten.
-      your_family_now_has: Deine Familie hat jetzt
-      member: Mitglied
       best_regards: Mit freundlichen Grüßen,
       evgenii_from_dawarich: Evgenii von Dawarich
-      great_news_someone_joined_your_family_hi: Gute Nachrichten! Jemand ist deiner Familie beigetreten! Hallo
-      we_re_excited_to_let_you_know_that_2: "! Wir freuen uns, dir mitzuteilen, dass"
-      on_dawarich_now_you_can_see: "\" auf Dawarich! Jetzt kannst du: • Deinen"
-      s_current_location_if_they_ve_enabled_sharing_stay_connected: "'s aktuellen Standort (falls sie Standortfreigabe aktiviert haben) • Mit deiner wachsenden Familie in Verbindung bleiben • Deinen Standort mit"
-      manage_family_members_and_settings_from_your_family_page_tip: "• Familie und Einstellungen von deiner Familien-Übersicht verwalten TIP: Du kannst deine Familie und Privatsphäre-Einstellungen jederzeit von deiner Familien-Übersicht verwalten. Deine Familie hat jetzt"
-      best_regards_evgenii_from_dawarich: ". Mit freundlichen Grüßen, Evgenii von Dawarich"
       great_news_someone_joined_your_family_2: Gute Nachrichten! Jemand ist deiner Familie beigetreten!
-      see_2: "• Deinen"
       stay_connected_with_your_growing_family_2: "• Mit deiner wachsenden Familie in Verbindung bleiben"
-      share_your_location_with_2: "• Deinen Standort mit"
       manage_family_members_and_settings_from_your_family_page_2: "• Familie und Einstellungen von deiner Familien-Übersicht verwalten"
       tip_you_can_manage_your_family_members_and_privacy_settings: 'TIP: Du kannst deine Familie und Privatsphäre-Einstellungen jederzeit von deiner Familien-Übersicht verwalten.'
   home:
@@ -511,10 +487,8 @@ de:
       journeys_identified_between_those_visits_with_their_classified_transport: "— Reisen, die zwischen diesen Aufenthalten erkannt wurden, mit ihrer klassifizierten Fortbewegungsmethode (Fahren, Gehen, Radfahren, ÖPNV, …)."
       places: Orte
       the_named_places_home_work_frequent_restaurants_the_source_app: "— die benannten Orte (Zuhause, Arbeit, häufige Restaurants), die die Quell-App mit deinen Aufenthalten verknüpft."
-      click: Klick
       extract: Extrahieren
       extract_to_add_html: Klicke auf <strong>Extrahieren</strong>, um diese Daten deinem Dawarich-Konto hinzuzufügen. Bestehende Punkte werden nicht verändert. Aufenthalte und Orte, die Dawarich bereits aus deinen Punkten erkannt hat, bleiben parallel zu den importierten Einträgen erhalten.
-      to_add_this_data_to_your_dawarich_account_existing_points: um diese Daten deinem Dawarich-Konto hinzuzufügen. Bestehende Punkte werden nicht verändert. Aufenthalte und Orte, die Dawarich bereits aus deinen Punkten erkannt hat, bleiben parallel zu den importierten Einträgen erhalten.
       trust_the_source_app_s_classification: Vertraue der Klassifizierung der Quelle-App
       when_checked_transportation_modes_driving_walking_cycling_transit_the_so: Wenn aktiviert, werden Fortbewegungsmethoden (Fahren, Gehen, Radfahren, ÖPNV) so beibehalten, wie sie die Quelle-App zugeteilt hat. Wenn deaktiviert, führt Dawarich erneut seinen eigenen Erkennungsalgorithmus mit deinen Einstellungen aus.
       cancel: Abbrechen
@@ -2333,10 +2307,6 @@ de:
       year_end_digest:
         year_in_review_title: Dein Jahresrückblick %{year}
         year_at_a_glance: Dein Jahr %{year} auf einen Blick.
-        your: Dein
-        year_in_review: Jahr im Überblick
-        here_s_your: Hier ist dein
-        at_a_glance: in Kürze.
         the_numbers: DIE ZAHLEN
         distance: Entfernung
         countries: Länder
@@ -2350,16 +2320,8 @@ de:
         share_your_year_rarr: Dein Jahr teilen →
         you_re_receiving_this_because_yearly_digest_emails_are_on: Du erhältst diese E-Mail, weil jährliche Zusammenfassungen für dein Konto aktiviert sind.
         manage_email_preferences: E-Mail-Einstellungen verwalten
-        year_in_review_here_s_your: Jahr in der Übersicht ────────────────────────────── Hier ist dein
-        at_a_glance_the_numbers_distance: im Überblick. DIE ZAHLEN Entfernung
-        vs_previous_year_distance: IM VERGLEICH ZUM VORJAHR Strecke
         view_full_insights: "-> Vollständige Einblicke:"
         share_your_year: "-> Dein Jahr teilen:"
-        you_re_receiving_this_because_yearly_digest_emails_are_on_2: "───────────────────────────────────────── Du erhältst diese E-Mail, weil jährliche Zusammenfassungen aktiviert sind. E-Mail-Einstellungen verwalten:"
-        12_map_m_monthly_distances_m_to_s_to: "(1..12).map { |m| @monthly_distances[m.to_s].to_f.round },"
-        labels_date_abbr_monthnames_1_12: 'labels: Date::ABBR_MONTHNAMES[1..12],'
-        width_24: 'width: 24,'
-        suffix_distance_unit: 'suffix: " #{@distance_unit}"'
         you_re_receiving_this_because_yearly_digest_emails_are_on_3: Du erhältst diese E-Mail, weil jährliche Zusammenfassungen aktiviert sind.
         manage_email_preferences_2: 'E-Mail-Einstellungen verwalten:'
   users_mailer:
@@ -2438,17 +2400,11 @@ de:
       hi: Hallo
       account_link_request_html: Jemand – hoffentlich du – versucht, die Anmeldemethode <strong>%{provider}</strong> mit deinem Dawarich-Konto zu verknüpfen. Mit der Schaltfläche unten erlaubst du dieser Anmeldemethode künftig den Zugriff auf dieses Konto.
       account_link_request_text: Jemand – hoffentlich du – versucht, die Anmeldemethode %{provider} mit deinem Dawarich-Konto zu verknüpfen. Mit dem Link unten erlaubst du dieser Anmeldemethode künftig den Zugriff auf dieses Konto.
-      someone_hopefully_you_is_trying_to_link: Jemand – hoffentlich du – versucht, eine Verknüpfung herzustellen
-      sign_in_to_your_dawarich_account_clicking_the_button_below: Anmeldung bei deinem Dawarich-Konto zu verknüpfen. Klicke auf die Schaltfläche unten, damit diese Anmeldemethode künftig auf das Konto zugreifen kann.
       link: Verknüpfen
       didn_t_request_this: Warst du das nicht?
       ignore_this_email_the_link_expires_in_15_minutes_and: Ignoriere diese E-Mail — der Link läuft in 15 Minuten ab und wird keine Änderungen an deinem Konto vornehmen. Wenn du diese E-Mails weiterhin erhältst, ändere dein Passwort.
       link_2: 'Link:'
-      confirm_account_link_hi: Bestätige die Kontoverknüpfung Hi
-      someone_hopefully_you_is_trying_to_link_2: ", Jemand — hoffentlich du — versucht, sich"
-      sign_in_to_your_dawarich_account_clicking_the_link_below: Anmeldung bei deinem Dawarich-Konto zu verknüpfen. Klicke auf den Link unten, damit diese Anmeldemethode künftig auf das Konto zugreifen kann. Link
       didn_t_request_this_ignore_this_email_the_link_expires: Warst du das nicht? Ignoriere diese E-Mail — der Link läuft in 15 Minuten ab und es werden keine Änderungen an deinem Konto vorgenommen. Wenn du solche E-Mails weiterhin erhältst, ändere dein Passwort.
-      sign_in_to_your_dawarich_account_clicking_the_link_below_2: Anmeldung bei deinem Dawarich-Konto zu verknüpfen. Klicke auf den Link unten, damit diese Anmeldemethode künftig auf das Konto zugreifen kann.
     otp_account_locked:
       account_temporarily_locked: Konto vorübergehend gesperrt
       hi: Hallo

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -240,7 +240,7 @@ de:
       your_location_sharing: Deine Standortfreigabe
       delete_family: Familie löschen
       leave_family: Familie verlassen
-      renew_family_plan: Familienplan erneuern
+      renew_family_plan: Family-Tarif erneuern
       view_pending_invitations: Ausstehende Einladungen ansehen
       delete_this_family_this_cannot_be_undone: Diese Familie löschen? Dies kann nicht rückgängig gemacht werden.
       are_you_sure_you_want_to_leave_this_family: Möchtest du diese Familie wirklich verlassen?
@@ -946,8 +946,8 @@ de:
         click_tags_to_filter_places: Klick auf Tags, um Orte zu filtern
         photos: Fotos
         show_geotagged_photos: Geotagte Fotos anzeigen
-        areas: Flächen
-        show_defined_areas: Definierte Flächen anzeigen
+        areas: Gebiete
+        show_defined_areas: Definierte Gebiete anzeigen
         fog_of_war: Kartennebel
         show_explored_areas: Erkundete Flächen anzeigen
         per_point: Pro Punkt
@@ -1627,7 +1627,7 @@ de:
         tracks: Tracks
         imports: Importe
         exports: Exporte
-        areas: Flächen
+        areas: Gebiete
         sign_in_history: Anmeldehistorie
         total_sign_ins: Gesamtanzahl Anmeldungen
         last_sign_in: Letzte Anmeldung
@@ -3569,6 +3569,9 @@ de:
         data_recalculation_busy: Datenberechnung beschäftigt
         another_recalculation_is_already_running_please_try_again_in_a: Eine andere Berechnung läuft bereits. Bitte versuche es in ein paar Minuten erneut.
         data_recalculation_completed: Datenberechnung abgeschlossen
+        year_count:
+          one: "%{count} Jahr"
+          other: "%{count} Jahre"
         stats_tracks_and_digests_have_been_recalculated_for_year_label: Statistiken, Tracks und Zusammenfassungen wurden für %{year_label} berechnet.
         data_recalculation_failed: Datenberechnung fehlgeschlagen
         message_stacktrace_n: "%{message}, Stacktrace: %{backtrace}"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1714,6 +1714,10 @@ de:
       refund_policy: Rückgabepolitik
       impressum: Impressum
       blog: Blog
+    locale_suggestion:
+      message: Dawarich ist auch auf Deutsch verfügbar.
+      switch: Auf Deutsch wechseln
+      dismiss: Schließen
     navbar:
       family: Familie
       my_data: Meine Daten

--- a/config/locales/devise.de.yml
+++ b/config/locales/devise.de.yml
@@ -1,0 +1,65 @@
+de:
+  devise:
+    confirmations:
+      confirmed: Deine E-Mail-Adresse wurde erfolgreich bestätigt.
+      send_instructions: In ein paar Minuten erhältst du eine E-Mail mit Anweisungen, wie du deine E-Mail-Adresse bestätigen kannst.
+      send_paranoid_instructions: Falls deine E-Mail-Adresse in unserer Datenbank existiert, erhältst du in ein paar Minuten eine E-Mail mit Anweisungen, wie du deine E-Mail-Adresse bestätigen kannst.
+    failure:
+      already_authenticated: Du bist bereits angemeldet.
+      inactive: Dein Konto ist noch nicht aktiviert.
+      invalid: Ungültiges %{authentication_keys} oder Passwort.
+      locked: Dein Konto ist gesperrt.
+      last_attempt: Du hast noch einen weiteren Versuch, bevor dein Konto gesperrt wird.
+      not_found_in_database: Ungültiges %{authentication_keys} oder Passwort.
+      timeout: Deine Sitzung ist abgelaufen. Bitte melde dich erneut an, um fortzufahren.
+      unauthenticated: Du musst dich anmelden oder registrieren, bevor du weitermachst.
+      unconfirmed: Du musst deine E-Mail-Adresse bestätigen, bevor du weitermachst.
+      deleted: Dein Konto wurde gelöscht.
+    mailer:
+      confirmation_instructions:
+        subject: Bestätigungsanweisungen
+      reset_password_instructions:
+        subject: Anweisungen zum Zurücksetzen des Passworts
+      unlock_instructions:
+        subject: Entsperrungsanweisungen
+      email_changed:
+        subject: E-Mail geändert
+      password_change:
+        subject: Passwort geändert
+    omniauth_callbacks:
+      failure: 'Authentifizierung mit %{kind} fehlgeschlagen: %{reason}.'
+      success: Erfolgreich mit %{kind} authentifiziert.
+    passwords:
+      no_token: Du kannst diese Seite nicht ohne Weiterleitung von einer E-Mail zum Passwort-Reset betreten. Falls du von einer E-Mail zum Passwort-Reset kommst, stelle sicher, dass du die vollständige URL verwendet hast.
+      send_instructions: In ein paar Minuten erhältst du eine E-Mail mit Anweisungen, wie du dein Passwort zurücksetzen kannst.
+      send_paranoid_instructions: Falls deine E-Mail-Adresse in unserer Datenbank vorhanden ist, erhältst du in ein paar Minuten einen Link zum Passwort-Reset an deine E-Mail-Adresse.
+      updated: Dein Passwort wurde erfolgreich geändert. Du bist jetzt angemeldet.
+      updated_not_active: Dein Passwort wurde erfolgreich geändert.
+    registrations:
+      destroyed: Dein Konto wird gelöscht. Auf Wiedersehen!
+      cannot_delete: Du kannst dein Konto nicht löschen, solange du ein Familienkonto mit anderen Mitgliedern besitzt.
+      signed_up: Willkommen! Du hast dich erfolgreich angemeldet.
+      signed_up_but_inactive: Du hast dich erfolgreich angemeldet. Allerdings konnten wir dich nicht anmelden, weil dein Konto noch nicht aktiviert ist.
+      signed_up_but_locked: Du hast dich erfolgreich angemeldet. Allerdings konnten wir dich nicht anmelden, weil dein Konto gesperrt ist.
+      signed_up_but_unconfirmed: Eine E-Mail mit einem Bestätigungslink wurde an deine E-Mail-Adresse gesendet. Bitte folge dem Link, um dein Konto zu aktivieren.
+      update_needs_confirmation: Du hast dein Konto erfolgreich aktualisiert, aber wir müssen deine neue E-Mail-Adresse überprüfen. Bitte prüfe deine E-Mail und folge dem Bestätigungslink, um deine neue E-Mail-Adresse zu bestätigen.
+      updated: Dein Konto wurde erfolgreich aktualisiert.
+      updated_but_not_signed_in: Dein Konto wurde erfolgreich aktualisiert, aber da dein Passwort geändert wurde, musst du dich erneut anmelden.
+    sessions:
+      signed_in: Erfolgreich angemeldet.
+      signed_out: Erfolgreich abgemeldet.
+      already_signed_out: Erfolgreich abgemeldet.
+    unlocks:
+      send_instructions: Du erhältst in ein paar Minuten eine E-Mail mit Anweisungen, wie du dein Konto entsperren kannst.
+      send_paranoid_instructions: Falls dein Konto existiert, erhältst du in ein paar Minuten eine E-Mail mit Anweisungen, wie du es entsperren kannst.
+      unlocked: Dein Konto wurde erfolgreich entsperrt. Bitte melde dich an, um fortzufahren.
+  errors:
+    messages:
+      already_confirmed: war bereits bestätigt, bitte versuche dich anzumelden
+      confirmation_period_expired: muss innerhalb von %{period} bestätigt werden, bitte fordere einen neuen an
+      expired: ist abgelaufen, bitte fordere einen neuen an
+      not_found: nicht gefunden
+      not_locked: war nicht gesperrt
+      not_saved:
+        one: '1 Fehler hat das Speichern von %{resource} verhindert:'
+        other: '%{count} Fehler haben das Speichern von %{resource} verhindert:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3514,6 +3514,9 @@ en:
         data_recalculation_busy: Data recalculation busy
         another_recalculation_is_already_running_please_try_again_in_a: Another recalculation is already running. Please try again in a few minutes.
         data_recalculation_completed: Data recalculation completed
+        year_count:
+          one: "%{count} year"
+          other: "%{count} years"
         stats_tracks_and_digests_have_been_recalculated_for_year_label: Stats, tracks, and digests have been recalculated for %{year_label}.
         data_recalculation_failed: Data recalculation failed
         message_stacktrace_n: "%{message}, stacktrace: %{backtrace}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,7 @@ en:
         you_have_used: You have used
         points_of: points of
         available: available.
+        summary_html: You have used %{used} points of %{limit} available.
       edit:
         account_settings: Account settings
         profile: Profile
@@ -160,6 +161,7 @@ en:
         sign_in_using_your_organization_s_identity_provider: Sign in using your organization's identity provider
         create_one_here: Create one here
         sign_in_accept_invitation: Sign in & Accept Invitation
+        log_in: Log in
       otp_challenge:
         two_factor_authentication: Two-Factor Authentication
         enter_the_6_digit_code_from_your_authenticator_app_to: Enter the 6-digit code from your authenticator app to continue.
@@ -379,6 +381,8 @@ en:
     invitation:
       you_ve_been_invited_to_join_a_family: You've been invited to join a family!
       hi_there: Hi there!
+      invited_by_family_html: <strong>%{email}</strong> has invited you to join their family "<strong>%{family}</strong>" on Dawarich.
+      invited_by_family_text: '%{email} has invited you to join their family "%{family}" on Dawarich.'
       has_invited_you_to_join_their_family: has invited you to join their family "
       on_dawarich: "\" on Dawarich."
       by_joining_this_family_you_ll_be_able_to: 'By joining this family, you''ll be able to:'
@@ -423,6 +427,18 @@ en:
     member_joined:
       great_news_someone_joined_your_family: "\U0001F389 Great news! Someone joined your family!"
       hi: Hi
+      member_joined_family_html: We're excited to let you know that <strong>%{email}</strong> has just joined your family "<strong>%{family}</strong>" on Dawarich!
+      member_joined_family_text: 'We''re excited to let you know that %{email} has just joined your family "%{family}" on Dawarich!'
+      see_current_location_html: See <strong>%{email}</strong>'s current location (if they've enabled sharing)
+      see_current_location_text: See %{email}'s current location (if they've enabled sharing)
+      share_location_with_html: Share your location with <strong>%{email}</strong>
+      share_location_with_text: Share your location with %{email}
+      member_count_html:
+        one: Your family now has <strong>%{count}</strong> member.
+        other: Your family now has <strong>%{count}</strong> members.
+      member_count:
+        one: Your family now has %{count} member.
+        other: Your family now has %{count} members.
       we_re_excited_to_let_you_know_that: We're excited to let you know that
       has_just_joined_your_family: has just joined your family "
       on_dawarich: "\" on Dawarich!"
@@ -497,6 +513,7 @@ en:
       the_named_places_home_work_frequent_restaurants_the_source_app: "— the named places (home, work, frequent restaurants) the source app associated with your visits."
       click: Click
       extract: Extract
+      extract_to_add_html: Click <strong>Extract</strong> to add this data to your Dawarich account. Existing points are not modified. Visits and places already detected from your points by Dawarich are kept side-by-side with the imported ones.
       to_add_this_data_to_your_dawarich_account_existing_points: to add this data to your Dawarich account. Existing points are not modified. Visits and places already detected from your points by Dawarich are kept side-by-side with the imported ones.
       trust_the_source_app_s_classification: Trust the source app's classification
       when_checked_transportation_modes_driving_walking_cycling_transit_the_so: When checked, transportation modes (driving, walking, cycling, transit) the source app assigned are kept as-is. When unchecked, Dawarich re-runs its own detector using your settings.
@@ -1765,6 +1782,8 @@ en:
       settings: Settings
       subscription: Subscription
       logout: Logout
+      switch_language: Deutsch
+      switch_language_aria_label: Switch language to German
       see_all: See all
       you_re_an_admin_harry: You're an admin, Harry!
       dawarich_supporter: Dawarich Supporter
@@ -2312,6 +2331,8 @@ en:
         new_country_line: "→ %{country}  (new country)"
         new_city_line: "→ %{city}  (new city)"
       year_end_digest:
+        year_in_review_title: Your %{year} Year in Review
+        year_at_a_glance: Here's your %{year} at a glance.
         your: Your
         year_in_review: Year in Review
         here_s_your: Here's your
@@ -2415,6 +2436,8 @@ en:
     oauth_account_link:
       confirm_account_link: Confirm account link
       hi: Hi
+      account_link_request_html: Someone — hopefully you — is trying to link <strong>%{provider}</strong> sign-in to your Dawarich account. Clicking the button below will allow that sign-in method to access this account going forward.
+      account_link_request_text: Someone — hopefully you — is trying to link %{provider} sign-in to your Dawarich account. Clicking the link below will allow that sign-in method to access this account going forward.
       someone_hopefully_you_is_trying_to_link: Someone — hopefully you — is trying to link
       sign_in_to_your_dawarich_account_clicking_the_button_below: sign-in to your Dawarich account. Clicking the button below will allow that sign-in method to access this account going forward.
       link: Link
@@ -2506,6 +2529,8 @@ en:
   common:
     app_name: Dawarich
     not_available: N/A
+    time_ago: "%{time} ago"
+    time_from_now: "%{time} from now"
   enums:
     export:
       file_type:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1714,6 +1714,10 @@ en:
       refund_policy: Refund policy
       impressum: Impressum
       blog: Blog
+    locale_suggestion:
+      message: Dawarich is also available in English.
+      switch: Switch to English
+      dismiss: Dismiss
     navbar:
       family: Family
       my_data: My data

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,9 +73,6 @@ en:
         generate_new_api_key: Generate new API key
         are_you_sure_this_will_invalidate_the_current_api_key: Are you sure? This will invalidate the current API key.
       points_usage:
-        you_have_used: You have used
-        points_of: points of
-        available: available.
         summary_html: You have used %{used} points of %{limit} available.
       edit:
         account_settings: Account settings
@@ -383,8 +380,6 @@ en:
       hi_there: Hi there!
       invited_by_family_html: <strong>%{email}</strong> has invited you to join their family "<strong>%{family}</strong>" on Dawarich.
       invited_by_family_text: '%{email} has invited you to join their family "%{family}" on Dawarich.'
-      has_invited_you_to_join_their_family: has invited you to join their family "
-      on_dawarich: "\" on Dawarich."
       by_joining_this_family_you_ll_be_able_to: 'By joining this family, you''ll be able to:'
       share_your_current_location_with_family_members: Share your current location with family members
       see_the_current_location_of_other_family_members: See the current location of other family members
@@ -396,9 +391,6 @@ en:
       if_you_didn_t_expect_this_invitation_you_can_safely: If you didn't expect this invitation, you can safely ignore this email.
       best_regards: Best regards,
       evgenii_from_dawarich: Evgenii from Dawarich
-      you_ve_been_invited_to_join_a_family_hi_there: You've been invited to join a family! Hi there!
-      on_dawarich_by_joining_this_family_you_ll_be_able: "\" on Dawarich. By joining this family, you'll be able to: • Share your current location with family members • See the current location of other family members • Stay connected with your loved ones • Control your privacy with full sharing controls Accept your invitation here:"
-      important_this_invitation_will_expire_in_7_days_if_you: 'IMPORTANT: This invitation will expire in 7 days. If you don''t have a Dawarich account yet, you''ll be able to create one when you accept the invitation. If you didn''t expect this invitation, you can safely ignore this email. Best regards, Evgenii from Dawarich'
       accept_invitation: Accept Invitation
       share_your_current_location_with_family_members_2: "• Share your current location with family members"
       see_the_current_location_of_other_family_members_2: "• See the current location of other family members"
@@ -439,31 +431,15 @@ en:
       member_count:
         one: Your family now has %{count} member.
         other: Your family now has %{count} members.
-      we_re_excited_to_let_you_know_that: We're excited to let you know that
-      has_just_joined_your_family: has just joined your family "
-      on_dawarich: "\" on Dawarich!"
       now_you_can: 'Now you can:'
-      see: See
-      s_current_location_if_they_ve_enabled_sharing: "'s current location (if they've enabled sharing)"
       stay_connected_with_your_growing_family: Stay connected with your growing family
-      share_your_location_with: Share your location with
       manage_family_members_and_settings_from_your_family_page: Manage family members and settings from your family page
       tip: "\U0001F4A1 Tip:"
       you_can_manage_your_family_members_and_privacy_settings_at: You can manage your family members and privacy settings at any time from your family dashboard.
-      your_family_now_has: Your family now has
-      member: member
       best_regards: Best regards,
       evgenii_from_dawarich: Evgenii from Dawarich
-      great_news_someone_joined_your_family_hi: Great news! Someone joined your family! Hi
-      we_re_excited_to_let_you_know_that_2: "! We're excited to let you know that"
-      on_dawarich_now_you_can_see: "\" on Dawarich! Now you can: • See"
-      s_current_location_if_they_ve_enabled_sharing_stay_connected: "'s current location (if they've enabled sharing) • Stay connected with your growing family • Share your location with"
-      manage_family_members_and_settings_from_your_family_page_tip: "• Manage family members and settings from your family page TIP: You can manage your family members and privacy settings at any time from your family dashboard. Your family now has"
-      best_regards_evgenii_from_dawarich: ". Best regards, Evgenii from Dawarich"
       great_news_someone_joined_your_family_2: Great news! Someone joined your family!
-      see_2: "• See"
       stay_connected_with_your_growing_family_2: "• Stay connected with your growing family"
-      share_your_location_with_2: "• Share your location with"
       manage_family_members_and_settings_from_your_family_page_2: "• Manage family members and settings from your family page"
       tip_you_can_manage_your_family_members_and_privacy_settings: 'TIP: You can manage your family members and privacy settings at any time from your family dashboard.'
   home:
@@ -511,10 +487,8 @@ en:
       journeys_identified_between_those_visits_with_their_classified_transport: "— journeys identified between those visits, with their classified transportation mode (driving, walking, cycling, transit, …)."
       places: Places
       the_named_places_home_work_frequent_restaurants_the_source_app: "— the named places (home, work, frequent restaurants) the source app associated with your visits."
-      click: Click
       extract: Extract
       extract_to_add_html: Click <strong>Extract</strong> to add this data to your Dawarich account. Existing points are not modified. Visits and places already detected from your points by Dawarich are kept side-by-side with the imported ones.
-      to_add_this_data_to_your_dawarich_account_existing_points: to add this data to your Dawarich account. Existing points are not modified. Visits and places already detected from your points by Dawarich are kept side-by-side with the imported ones.
       trust_the_source_app_s_classification: Trust the source app's classification
       when_checked_transportation_modes_driving_walking_cycling_transit_the_so: When checked, transportation modes (driving, walking, cycling, transit) the source app assigned are kept as-is. When unchecked, Dawarich re-runs its own detector using your settings.
       cancel: Cancel
@@ -2333,10 +2307,6 @@ en:
       year_end_digest:
         year_in_review_title: Your %{year} Year in Review
         year_at_a_glance: Here's your %{year} at a glance.
-        your: Your
-        year_in_review: Year in Review
-        here_s_your: Here's your
-        at_a_glance: at a glance.
         the_numbers: THE NUMBERS
         distance: Distance
         countries: Countries
@@ -2350,16 +2320,8 @@ en:
         share_your_year_rarr: Share your year →
         you_re_receiving_this_because_yearly_digest_emails_are_on: You're receiving this because yearly digest emails are on for your account.
         manage_email_preferences: Manage email preferences
-        year_in_review_here_s_your: Year in Review ────────────────────────────── Here's your
-        at_a_glance_the_numbers_distance: at a glance. THE NUMBERS Distance
-        vs_previous_year_distance: VS PREVIOUS YEAR Distance
         view_full_insights: "-> View full insights:"
         share_your_year: "-> Share your year:"
-        you_re_receiving_this_because_yearly_digest_emails_are_on_2: "───────────────────────────────────────── You're receiving this because yearly digest emails are on. Manage email preferences:"
-        12_map_m_monthly_distances_m_to_s_to: "(1..12).map { |m| @monthly_distances[m.to_s].to_f.round },"
-        labels_date_abbr_monthnames_1_12: 'labels: Date::ABBR_MONTHNAMES[1..12],'
-        width_24: 'width: 24,'
-        suffix_distance_unit: 'suffix: " #{@distance_unit}"'
         you_re_receiving_this_because_yearly_digest_emails_are_on_3: You're receiving this because yearly digest emails are on.
         manage_email_preferences_2: 'Manage email preferences:'
   users_mailer:
@@ -2438,17 +2400,11 @@ en:
       hi: Hi
       account_link_request_html: Someone — hopefully you — is trying to link <strong>%{provider}</strong> sign-in to your Dawarich account. Clicking the button below will allow that sign-in method to access this account going forward.
       account_link_request_text: Someone — hopefully you — is trying to link %{provider} sign-in to your Dawarich account. Clicking the link below will allow that sign-in method to access this account going forward.
-      someone_hopefully_you_is_trying_to_link: Someone — hopefully you — is trying to link
-      sign_in_to_your_dawarich_account_clicking_the_button_below: sign-in to your Dawarich account. Clicking the button below will allow that sign-in method to access this account going forward.
       link: Link
       didn_t_request_this: Didn't request this?
       ignore_this_email_the_link_expires_in_15_minutes_and: Ignore this email — the link expires in 15 minutes and no change will be made to your account. If you keep getting these emails, change your password.
       link_2: 'Link:'
-      confirm_account_link_hi: Confirm account link Hi
-      someone_hopefully_you_is_trying_to_link_2: ", Someone — hopefully you — is trying to link"
-      sign_in_to_your_dawarich_account_clicking_the_link_below: sign-in to your Dawarich account. Clicking the link below will allow that sign-in method to access this account going forward. Link
       didn_t_request_this_ignore_this_email_the_link_expires: Didn't request this? Ignore this email — the link expires in 15 minutes and no change will be made to your account. If you keep getting these emails, change your password.
-      sign_in_to_your_dawarich_account_clicking_the_link_below_2: sign-in to your Dawarich account. Clicking the link below will allow that sign-in method to access this account going forward.
     otp_account_locked:
       account_temporarily_locked: Account temporarily locked
       hi: Hi

--- a/config/locales/rails.de.yml
+++ b/config/locales/rails.de.yml
@@ -1,0 +1,190 @@
+# German Rails framework translations adapted from rails-i18n:
+# https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/de.yml
+#
+# Copyright (c) 2008-2012 Sven Fuchs and contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+de:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Datensatz kann nicht gelöscht werden, da ein abhängiger %{record}-Datensatz existiert.
+          has_many: Datensatz kann nicht gelöscht werden, da abhängige %{record} existieren.
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: etwa eine Stunde
+        other: etwa %{count} Stunden
+      about_x_months:
+        one: etwa ein Monat
+        other: etwa %{count} Monate
+      about_x_years:
+        one: etwa ein Jahr
+        other: etwa %{count} Jahre
+      almost_x_years:
+        one: fast ein Jahr
+        other: fast %{count} Jahre
+      half_a_minute: eine halbe Minute
+      less_than_x_seconds:
+        one: weniger als eine Sekunde
+        other: weniger als %{count} Sekunden
+      less_than_x_minutes:
+        one: weniger als eine Minute
+        other: weniger als %{count} Minuten
+      over_x_years:
+        one: mehr als ein Jahr
+        other: mehr als %{count} Jahre
+      x_seconds:
+        one: eine Sekunde
+        other: '%{count} Sekunden'
+      x_minutes:
+        one: eine Minute
+        other: '%{count} Minuten'
+      x_days:
+        one: ein Tag
+        other: '%{count} Tage'
+      x_months:
+        one: ein Monat
+        other: '%{count} Monate'
+      x_years:
+        one: ein Jahr
+        other: '%{count} Jahre'
+    prompts:
+      second: Sekunde
+      minute: Minute
+      hour: Stunde
+      day: Tag
+      month: Monat
+      year: Jahr
+    relative:
+      future: 'in %{time}'
+      past: 'vor %{time}'
+  errors:
+    format: '%{attribute} %{message}'
+    messages:
+      accepted: muss akzeptiert werden
+      blank: muss ausgefüllt werden
+      confirmation: stimmt nicht mit %{attribute} überein
+      empty: muss ausgefüllt werden
+      equal_to: muss genau %{count} sein
+      even: muss gerade sein
+      exclusion: ist nicht verfügbar
+      greater_than: muss größer als %{count} sein
+      greater_than_or_equal_to: muss größer oder gleich %{count} sein
+      in: muss in %{count} enthalten sein
+      inclusion: ist kein gültiger Wert
+      invalid: ist nicht gültig
+      less_than: muss kleiner als %{count} sein
+      less_than_or_equal_to: muss kleiner oder gleich %{count} sein
+      model_invalid: 'Gültigkeitsprüfung ist fehlgeschlagen: %{errors}'
+      not_a_number: ist keine Zahl
+      not_an_integer: muss ganzzahlig sein
+      odd: muss ungerade sein
+      other_than: darf nicht gleich %{count} sein
+      password_too_long: ist zu lang
+      present: darf nicht ausgefüllt werden
+      required: muss ausgefüllt werden
+      taken: ist bereits vergeben
+      too_long:
+        one: ist zu lang (mehr als %{count} Zeichen)
+        other: ist zu lang (mehr als %{count} Zeichen)
+      too_short:
+        one: ist zu kurz (weniger als %{count} Zeichen)
+        other: ist zu kurz (weniger als %{count} Zeichen)
+      wrong_length:
+        one: hat die falsche Länge (muss genau %{count} Zeichen haben)
+        other: hat die falsche Länge (muss genau %{count} Zeichen haben)
+    template:
+      body: 'Bitte überprüfe die folgenden Felder:'
+      header:
+        one: 'Konnte %{model} nicht speichern: ein Fehler.'
+        other: 'Konnte %{model} nicht speichern: %{count} Fehler.'
+  helpers:
+    select:
+      prompt: Bitte auswählen
+    submit:
+      create: '%{model} erstellen'
+      submit: '%{model} speichern'
+      update: '%{model} aktualisieren'
+  number:
+    currency:
+      format:
+        delimiter: '.'
+        format: '%n %u'
+        precision: 2
+        separator: ','
+        significant: false
+        strip_insignificant_zeros: false
+        unit: €
+    format:
+      delimiter: '.'
+      precision: 2
+      round_mode: default
+      separator: ','
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: '%n %u'
+        units:
+          billion:
+            one: Milliarde
+            other: Milliarden
+          million:
+            one: Million
+            other: Millionen
+          quadrillion:
+            one: Billiarde
+            other: Billiarden
+          thousand: Tausend
+          trillion:
+            one: Billion
+            other: Billionen
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: '%n %u'
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: '%n %'
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ' und '
+      two_words_connector: ' und '
+      words_connector: ', '

--- a/config/locales/rails.de.yml
+++ b/config/locales/rails.de.yml
@@ -67,6 +67,44 @@ de:
       x_years:
         one: ein Jahr
         other: '%{count} Jahre'
+      dative:
+        about_x_hours:
+          one: etwa einer Stunde
+          other: etwa %{count} Stunden
+        about_x_months:
+          one: etwa einem Monat
+          other: etwa %{count} Monaten
+        about_x_years:
+          one: etwa einem Jahr
+          other: etwa %{count} Jahren
+        almost_x_years:
+          one: fast einem Jahr
+          other: fast %{count} Jahren
+        half_a_minute: einer halben Minute
+        less_than_x_seconds:
+          one: weniger als einer Sekunde
+          other: weniger als %{count} Sekunden
+        less_than_x_minutes:
+          one: weniger als einer Minute
+          other: weniger als %{count} Minuten
+        over_x_years:
+          one: mehr als einem Jahr
+          other: mehr als %{count} Jahren
+        x_seconds:
+          one: einer Sekunde
+          other: '%{count} Sekunden'
+        x_minutes:
+          one: einer Minute
+          other: '%{count} Minuten'
+        x_days:
+          one: einem Tag
+          other: '%{count} Tagen'
+        x_months:
+          one: einem Monat
+          other: '%{count} Monaten'
+        x_years:
+          one: einem Jahr
+          other: '%{count} Jahren'
     prompts:
       second: Sekunde
       minute: Minute

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -42,6 +42,22 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#persist_locale!' do
+    it 'updates only the locale when its settings snapshot is stale' do
+      stale_user = create(:user)
+      User.where(id: stale_user.id).update_all(
+        settings: stale_user.settings.merge('concurrent_preference' => 'preserved')
+      )
+
+      stale_user.persist_locale!(:de)
+
+      expect(stale_user.reload.settings).to include(
+        'locale' => 'de',
+        'concurrent_preference' => 'preserved'
+      )
+    end
+  end
+
   describe 'archival warning reset on plan change' do
     it 'clears archival warnings and stale lite_since when the plan leaves lite' do
       user = create(:user, skip_auto_trial: true)

--- a/spec/regressions/api_locale_stability_spec.rb
+++ b/spec/regressions/api_locale_stability_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API locale stability', type: :request do
+  let(:user) { create(:user, settings: { 'locale' => 'de' }) }
+
+  it 'answers in the default locale despite a German Accept-Language header' do
+    delete '/api/v1/points/bulk_destroy',
+           headers: { 'Authorization' => "Bearer #{user.api_key}", 'Accept-Language' => 'de-DE,de;q=0.9' }
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(response.parsed_body['error']).to eq('No points selected')
+  end
+
+  it 'ignores an explicit locale parameter' do
+    delete '/api/v1/points/bulk_destroy',
+           params: { locale: 'de' },
+           headers: { 'Authorization' => "Bearer #{user.api_key}" }
+
+    expect(response.parsed_body['error']).to eq('No points selected')
+  end
+
+  it 'does not persist a locale preference from an API request' do
+    expect do
+      delete '/api/v1/points/bulk_destroy',
+             params: { locale: 'de' },
+             headers: { 'Authorization' => "Bearer #{user.api_key}" }
+    end.not_to(change { user.reload.settings })
+  end
+end

--- a/spec/regressions/german_locale_coverage_spec.rb
+++ b/spec/regressions/german_locale_coverage_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'German locale coverage' do
+  def deep_merge(target, additions)
+    target.merge(additions) do |_key, old_value, new_value|
+      old_value.is_a?(Hash) && new_value.is_a?(Hash) ? deep_merge(old_value, new_value) : new_value
+    end
+  end
+
+  def locale_tree(locale)
+    Dir[Rails.root.join('config/locales/*.yml')].sort.each_with_object({}) do |path, translations|
+      document = YAML.safe_load_file(path, aliases: true)
+      next unless document.key?(locale)
+
+      translations.replace(deep_merge(translations, document.fetch(locale)))
+    end
+  end
+
+  def flatten(value, path = [], result = {})
+    case value
+    when Hash
+      value.each { |key, child| flatten(child, path + [key], result) }
+    when Array
+      value.each_with_index { |child, index| flatten(child, path + [index], result) }
+    else
+      result[path] = value
+    end
+    result
+  end
+
+  let(:english) { flatten(locale_tree('en')) }
+  let(:german) { flatten(locale_tree('de')) }
+  let(:fragile_token_pattern) do
+    %r!
+      %\{[^}]+\} |
+      \#\{[^}]+\} |
+      <[^>]+> |
+      https?://[^\s"']+ |
+      [\w.+-]+@[\w.-]+\.[A-Za-z]{2,} |
+      &[A-Za-z]+; |
+      \{[zxy]\}
+    !x
+  end
+
+  it 'contains every English locale leaf with the same value type' do
+    missing = english.keys - german.keys
+    mismatched = english.filter_map do |path, value|
+      next if missing.include?(path) || german.fetch(path).instance_of?(value.class)
+
+      path.join('.')
+    end
+
+    expect(missing.map { |path| path.join('.') }).to be_empty
+    expect(mismatched).to be_empty
+  end
+
+  it 'preserves interpolation, markup, URL, and template tokens' do
+    mismatched = english.filter_map do |path, value|
+      next unless value.is_a?(String)
+
+      english_tokens = value.scan(fragile_token_pattern).sort
+      german_tokens = german.fetch(path).scan(fragile_token_pattern).sort
+      path.join('.') unless english_tokens == german_tokens
+    end
+
+    expect(mismatched).to be_empty
+  end
+
+  it 'provides German Rails localization data' do
+    I18n.with_locale(:de) do
+      expect(I18n.l(Date.new(2026, 3, 4), format: :long)).to eq('4. März 2026')
+      expect(I18n.l(Date.new(2026, 3, 4), format: :medium_padded)).to eq('04. Mär 2026')
+      expect(I18n.l(Date.new(2026, 3, 8), format: '%A')).to eq('Sonntag')
+      expect(I18n.t('datetime.distance_in_words.x_minutes', count: 3)).to eq('3 Minuten')
+      expect(I18n.t('errors.messages.blank')).to eq('muss ausgefüllt werden')
+    end
+  end
+end

--- a/spec/regressions/german_locale_ui_copy_spec.rb
+++ b/spec/regressions/german_locale_ui_copy_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'German interface copy', type: :helper do
+  helper DatetimeFormattingHelper
+
+  include ActiveSupport::Testing::TimeHelpers
+
+  around do |example|
+    I18n.with_locale(:de) { example.run }
+  end
+
+  it 'distinguishes registration from sign-in actions' do
+    expect(I18n.t('home.index.sign_up')).to eq('Registrieren')
+    expect(I18n.t('home.index.sign_in')).to eq('Anmelden')
+  end
+
+  it 'describes map controls by their user-visible effect' do
+    expect(I18n.t('map.maplibre.residency_modal.distinct_days_with_at_least_one_tracked_point_per_country'))
+      .to eq('Unterschiedliche Kalendertage mit mindestens einem aufgezeichneten Punkt pro Land. Keine Steuerberatung.')
+    expect(I18n.t('map.maplibre.settings_panel.untagged')).to eq('🏷️ Ohne Tag')
+    expect(I18n.t('map.maplibre.settings_panel.clear_radius_around_visited_points'))
+      .to eq('Radius des aufgedeckten Bereichs um besuchte Punkte')
+    expect(I18n.t('map.maplibre.button_cluster.replay')).to eq('Wiedergabe')
+    expect(I18n.t('javascript.messages.cannot_update_recalculation_is_already_in_progress'))
+      .to eq('Aktualisierung nicht möglich: Eine Neuberechnung läuft bereits.')
+    expect(I18n.t('settings.integrations.index.upgrade_to_pro')).to eq('Auf Pro upgraden')
+  end
+
+  it 'places relative-time words in natural German order' do
+    travel_to Time.zone.local(2026, 8, 5, 12) do
+      three_days = helper.relative_distance_in_words(3.days.ago)
+      one_day = helper.relative_distance_in_words(1.day.from_now)
+
+      expect(I18n.t('common.time_ago', time: three_days)).to eq('vor 3 Tagen')
+      expect(I18n.t('common.time_from_now', time: one_day)).to eq('in einem Tag')
+      expect(I18n.t('families.show.invited_ago_expires', ago: three_days, date: '8. Aug.'))
+        .to eq('Vor 3 Tagen eingeladen · läuft am 8. Aug. ab')
+    end
+  end
+
+  it 'uses complete sentences for copy whose word order varies by locale' do
+    expect(I18n.t('devise.registrations.points_usage.summary_html', used: '42', limit: '100'))
+      .to eq('Du hast 42 von 100 verfügbaren Punkten verwendet.')
+    expect(I18n.t('family_mailer.invitation.invited_by_family_text',
+                  email: 'anna@example.com', family: 'Reisefreunde'))
+      .to eq('anna@example.com hat dich eingeladen, der Familie „Reisefreunde“ auf Dawarich beizutreten.')
+    expect(I18n.t('family_mailer.member_joined.member_count', count: 2))
+      .to eq('Deine Familie hat jetzt 2 Mitglieder.')
+  end
+
+  it 'uses correct plural and feature terminology' do
+    expect(I18n.t('javascript.search.locations_found', count: 2)).to eq('2 Standorte gefunden')
+    expect(I18n.t('users.digests.public_year.first_time_count', count: 2)).to eq('2 erstmals besucht')
+    expect(I18n.t('services.families.accept_invitation.you_must_leave_your_current_family_before_joining_a_new'))
+      .to eq('Du musst deine aktuelle Familie verlassen, bevor du einer neuen beitreten kannst.')
+  end
+
+  it 'renders clear German security emails in HTML and text' do
+    user = create(:user, settings: { 'locale' => 'de' })
+
+    oauth_html, oauth_text = I18n.with_locale(:de) do
+      mail = UsersMailer.with(
+        user: user,
+        provider_label: 'Google',
+        link_url: 'https://example.test/link'
+      ).oauth_account_link
+      [mail.html_part.body.decoded, mail.text_part.body.decoded]
+    end
+    otp_html, otp_text = I18n.with_locale(:de) do
+      mail = UsersMailer.with(user: user).otp_account_locked
+      [mail.html_part.body.decoded, mail.text_part.body.decoded]
+    end
+
+    expect(oauth_html).to include('Warst du das nicht?')
+    expect(oauth_text).to include('Anmeldemethode Google mit deinem Dawarich-Konto zu verknüpfen')
+    expect(otp_html).to include('Möglicherweise versucht jemand, auf dein Konto zuzugreifen')
+    expect(otp_text).to include('Wenn du das warst, musst du nichts unternehmen')
+  end
+
+  it 'keeps the request locale for signup mail before the preference is persisted' do
+    user = create(:user)
+
+    subject = I18n.with_locale(:de) { UsersMailer.with(user: user).welcome.subject }
+
+    expect(subject).to eq('Willkommen bei Dawarich!')
+  end
+
+  it 'renders grammatical German family emails in HTML and text' do
+    owner = create(:user, email: 'anna@example.com', settings: { 'locale' => 'de' })
+    family = create(:family, creator: owner, name: 'Reise & Freunde')
+    create(:family_membership, :owner, family: family, user: owner)
+    member = create(:user, email: 'ben@example.com')
+    create(:family_membership, family: family, user: member)
+    invitation = create(:family_invitation, family: family, invited_by: owner)
+
+    invitation_html, invitation_text = I18n.with_locale(:de) do
+      mail = FamilyMailer.invitation(invitation)
+      [mail.html_part.body.decoded, mail.text_part.body.decoded]
+    end
+    joined_html, joined_text = I18n.with_locale(:de) do
+      mail = FamilyMailer.member_joined(family, member)
+      [mail.html_part.body.decoded, mail.text_part.body.decoded]
+    end
+
+    expect(invitation_html).to include('der Familie „<strong>Reise &amp; Freunde</strong>“')
+    expect(invitation_text).to include('der Familie „Reise & Freunde“ auf Dawarich beizutreten')
+    expect(joined_html).to include('Deine Familie hat jetzt <strong>2</strong> Mitglieder.')
+    expect(joined_text).to include('Deine Familie hat jetzt 2 Mitglieder.')
+    expect(joined_text).not_to include("ben@example.com's")
+  end
+
+  it 'uses the persisted locale when a digest is rendered outside a request' do
+    user = create(:user, settings: { 'locale' => 'de' })
+    digest = create(
+      :users_digest,
+      user: user,
+      year: 2026,
+      month: 8,
+      period_type: :monthly,
+      distance: 1_000,
+      monthly_distances: { '1' => 1_000 },
+      time_spent_by_location: { 'countries' => [], 'cities' => [] },
+      first_time_visits: { 'countries' => [], 'cities' => [] },
+      year_over_year: {}
+    )
+
+    subject, html = I18n.with_locale(:en) do
+      mail = Users::DigestsMailer.with(user: user, digest: digest).monthly_digest
+      [mail.subject, mail.html_part.body.decoded]
+    end
+
+    expect(subject).to eq('Dein August 2026 im Rückblick — Dawarich')
+    expect(html).to include('ÜBERBLICK')
+  end
+end

--- a/spec/regressions/german_locale_ui_copy_spec.rb
+++ b/spec/regressions/german_locale_ui_copy_spec.rb
@@ -11,21 +11,29 @@ RSpec.describe 'German interface copy', type: :helper do
     I18n.with_locale(:de) { example.run }
   end
 
+  # Long prose carries no grammar or interpolation logic worth pinning word for
+  # word, so assert only that it is present and actually translated. Anything
+  # with a placeholder, a plural, or locale-dependent word order stays exact.
+  def expect_translated(key)
+    german = I18n.t(key, locale: :de)
+
+    expect(german).to be_present
+    expect(german).not_to eq(I18n.t(key, locale: :en))
+  end
+
   it 'distinguishes registration from sign-in actions' do
     expect(I18n.t('home.index.sign_up')).to eq('Registrieren')
     expect(I18n.t('home.index.sign_in')).to eq('Anmelden')
   end
 
   it 'describes map controls by their user-visible effect' do
-    expect(I18n.t('map.maplibre.residency_modal.distinct_days_with_at_least_one_tracked_point_per_country'))
-      .to eq('Unterschiedliche Kalendertage mit mindestens einem aufgezeichneten Punkt pro Land. Keine Steuerberatung.')
     expect(I18n.t('map.maplibre.settings_panel.untagged')).to eq('🏷️ Ohne Tag')
-    expect(I18n.t('map.maplibre.settings_panel.clear_radius_around_visited_points'))
-      .to eq('Radius des aufgedeckten Bereichs um besuchte Punkte')
     expect(I18n.t('map.maplibre.button_cluster.replay')).to eq('Wiedergabe')
-    expect(I18n.t('javascript.messages.cannot_update_recalculation_is_already_in_progress'))
-      .to eq('Aktualisierung nicht möglich: Eine Neuberechnung läuft bereits.')
     expect(I18n.t('settings.integrations.index.upgrade_to_pro')).to eq('Auf Pro upgraden')
+
+    expect_translated('map.maplibre.residency_modal.distinct_days_with_at_least_one_tracked_point_per_country')
+    expect_translated('map.maplibre.settings_panel.clear_radius_around_visited_points')
+    expect_translated('javascript.messages.cannot_update_recalculation_is_already_in_progress')
   end
 
   it 'places relative-time words in natural German order' do
@@ -53,8 +61,8 @@ RSpec.describe 'German interface copy', type: :helper do
   it 'uses correct plural and feature terminology' do
     expect(I18n.t('javascript.search.locations_found', count: 2)).to eq('2 Standorte gefunden')
     expect(I18n.t('users.digests.public_year.first_time_count', count: 2)).to eq('2 erstmals besucht')
-    expect(I18n.t('services.families.accept_invitation.you_must_leave_your_current_family_before_joining_a_new'))
-      .to eq('Du musst deine aktuelle Familie verlassen, bevor du einer neuen beitreten kannst.')
+
+    expect_translated('services.families.accept_invitation.you_must_leave_your_current_family_before_joining_a_new')
   end
 
   it 'renders clear German security emails in HTML and text' do

--- a/spec/regressions/german_locale_ui_copy_spec.rb
+++ b/spec/regressions/german_locale_ui_copy_spec.rb
@@ -11,29 +11,21 @@ RSpec.describe 'German interface copy', type: :helper do
     I18n.with_locale(:de) { example.run }
   end
 
-  # Long prose carries no grammar or interpolation logic worth pinning word for
-  # word, so assert only that it is present and actually translated. Anything
-  # with a placeholder, a plural, or locale-dependent word order stays exact.
-  def expect_translated(key)
-    german = I18n.t(key, locale: :de)
-
-    expect(german).to be_present
-    expect(german).not_to eq(I18n.t(key, locale: :en))
-  end
-
   it 'distinguishes registration from sign-in actions' do
     expect(I18n.t('home.index.sign_up')).to eq('Registrieren')
     expect(I18n.t('home.index.sign_in')).to eq('Anmelden')
   end
 
   it 'describes map controls by their user-visible effect' do
+    expect(I18n.t('map.maplibre.residency_modal.distinct_days_with_at_least_one_tracked_point_per_country'))
+      .to eq('Unterschiedliche Kalendertage mit mindestens einem aufgezeichneten Punkt pro Land. Keine Steuerberatung.')
     expect(I18n.t('map.maplibre.settings_panel.untagged')).to eq('🏷️ Ohne Tag')
+    expect(I18n.t('map.maplibre.settings_panel.clear_radius_around_visited_points'))
+      .to eq('Radius des aufgedeckten Bereichs um besuchte Punkte')
     expect(I18n.t('map.maplibre.button_cluster.replay')).to eq('Wiedergabe')
+    expect(I18n.t('javascript.messages.cannot_update_recalculation_is_already_in_progress'))
+      .to eq('Aktualisierung nicht möglich: Eine Neuberechnung läuft bereits.')
     expect(I18n.t('settings.integrations.index.upgrade_to_pro')).to eq('Auf Pro upgraden')
-
-    expect_translated('map.maplibre.residency_modal.distinct_days_with_at_least_one_tracked_point_per_country')
-    expect_translated('map.maplibre.settings_panel.clear_radius_around_visited_points')
-    expect_translated('javascript.messages.cannot_update_recalculation_is_already_in_progress')
   end
 
   it 'places relative-time words in natural German order' do
@@ -61,8 +53,8 @@ RSpec.describe 'German interface copy', type: :helper do
   it 'uses correct plural and feature terminology' do
     expect(I18n.t('javascript.search.locations_found', count: 2)).to eq('2 Standorte gefunden')
     expect(I18n.t('users.digests.public_year.first_time_count', count: 2)).to eq('2 erstmals besucht')
-
-    expect_translated('services.families.accept_invitation.you_must_leave_your_current_family_before_joining_a_new')
+    expect(I18n.t('services.families.accept_invitation.you_must_leave_your_current_family_before_joining_a_new'))
+      .to eq('Du musst deine aktuelle Familie verlassen, bevor du einer neuen beitreten kannst.')
   end
 
   it 'renders clear German security emails in HTML and text' do

--- a/spec/regressions/locale_prefetch_persistence_spec.rb
+++ b/spec/regressions/locale_prefetch_persistence_spec.rb
@@ -21,4 +21,23 @@ RSpec.describe 'Locale persistence and link prefetching', type: :request do
 
     expect(user.reload.preferred_locale).to eq(:de)
   end
+
+  it 'does not carry a prefetched locale into the next request' do
+    get edit_user_registration_path,
+        params: { locale: 'de' },
+        headers: { 'Sec-Purpose' => 'prefetch' }
+
+    get edit_user_registration_path
+
+    expect(response.body).to include('<html lang="en"')
+  end
+
+  it 'does not carry a prefetched locale into the next request for a visitor' do
+    sign_out user
+
+    get root_path, params: { locale: 'de' }, headers: { 'Sec-Purpose' => 'prefetch' }
+    get root_path
+
+    expect(response.body).to include('<html lang="en"')
+  end
 end

--- a/spec/regressions/locale_prefetch_persistence_spec.rb
+++ b/spec/regressions/locale_prefetch_persistence_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Locale persistence and link prefetching', type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  it 'does not save a preference when Turbo prefetches the switch link' do
+    get edit_user_registration_path,
+        params: { locale: 'de' },
+        headers: { 'Sec-Purpose' => 'prefetch' }
+
+    expect(response.body).to include('<html lang="de"')
+    expect(user.reload.preferred_locale).to be_nil
+  end
+
+  it 'still saves a preference on a real navigation' do
+    get edit_user_registration_path, params: { locale: 'de' }
+
+    expect(user.reload.preferred_locale).to eq(:de)
+  end
+end

--- a/spec/regressions/locale_suggestion_spec.rb
+++ b/spec/regressions/locale_suggestion_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Browser language suggestion', type: :request do
+  def rendered_locale(body)
+    body[/<html lang="(\w+)"/, 1]
+  end
+
+  def suggestion(body)
+    Nokogiri::HTML(body).at_css('[data-testid="locale-suggestion"]')
+  end
+
+  it 'never switches language on its own' do
+    get root_path, headers: { 'Accept-Language' => 'de-DE,de;q=0.9' }
+
+    expect(rendered_locale(response.body)).to eq('en')
+  end
+
+  it 'offers the browser language instead of applying it' do
+    get root_path, headers: { 'Accept-Language' => 'de-DE,de;q=0.9' }
+
+    banner = suggestion(response.body)
+    expect(banner).to be_present
+    expect(banner.text).to include('Deutsch')
+    expect(banner.at_css('a')['href']).to eq('/?locale=de')
+  end
+
+  it 'writes the suggestion in the language being offered' do
+    get root_path, headers: { 'Accept-Language' => 'de-DE,de;q=0.9' }
+
+    expect(suggestion(response.body).text).to include(I18n.t('shared.locale_suggestion.message', locale: :de))
+  end
+
+  it 'stays quiet when the browser already matches the interface' do
+    get root_path, headers: { 'Accept-Language' => 'en-US,en;q=0.9' }
+
+    expect(suggestion(response.body)).to be_nil
+  end
+
+  it 'stays quiet when the visitor already picked a language this session' do
+    get root_path, params: { locale: 'en' }, headers: { 'Accept-Language' => 'de-DE,de;q=0.9' }
+    get root_path, headers: { 'Accept-Language' => 'de-DE,de;q=0.9' }
+
+    expect(suggestion(response.body)).to be_nil
+  end
+
+  it 'stays quiet when the account already has a saved language' do
+    user = create(:user, settings: { 'locale' => 'en' })
+    sign_in user
+
+    get root_path, headers: { 'Accept-Language' => 'de-DE,de;q=0.9' }
+
+    expect(suggestion(response.body)).to be_nil
+  end
+
+  it 'keeps the offer on the page the visitor is actually reading' do
+    get new_user_session_path, params: { foo: 'bar' }, headers: { 'Accept-Language' => 'de-DE,de;q=0.9' }
+
+    expect(suggestion(response.body).at_css('a')['href']).to eq('/users/sign_in?foo=bar&locale=de')
+  end
+
+  it 'applies the language when the offer is accepted' do
+    get root_path, params: { locale: 'de' }, headers: { 'Accept-Language' => 'de-DE,de;q=0.9' }
+
+    expect(rendered_locale(response.body)).to eq('de')
+    expect(suggestion(response.body)).to be_nil
+  end
+end

--- a/spec/regressions/locale_switch_link_spec.rb
+++ b/spec/regressions/locale_switch_link_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Locale switch link', type: :request do
+  def switch_link_href(body)
+    Nokogiri::HTML(body).at_css('a[hreflang]')&.[]('href')
+  end
+
+  it 'keeps the link on this host when the query string carries a host' do
+    get root_path, params: { host: 'evil.example.com' }
+
+    expect(response).to have_http_status(:ok)
+
+    href = switch_link_href(response.body)
+    expect(href).to start_with('/')
+    expect(href).not_to start_with('//')
+    expect(href).not_to include('://')
+  end
+
+  it 'renders when the query string carries routing keys' do
+    get root_path, params: { controller: 'nope', action: 'nope' }
+
+    expect(response).to have_http_status(:ok)
+    expect(switch_link_href(response.body)).to start_with('/?')
+  end
+
+  it 'preserves unrelated query parameters' do
+    get root_path, params: { utm_source: 'newsletter' }
+
+    expect(switch_link_href(response.body)).to eq('/?locale=de&utm_source=newsletter')
+  end
+
+  it 'points at a reachable path when a form re-renders after a validation error' do
+    user = create(:user, password: 'password123456')
+    sign_in user
+
+    patch user_registration_path,
+          params: { user: { email: '', current_password: 'password123456' } }
+
+    expect(response).to have_http_status(:unprocessable_content)
+
+    href = switch_link_href(response.body)
+    expect(href).to be_present
+    expect(Rails.application.routes.recognize_path(href.split('?').first, method: :get)).to be_present
+  end
+end

--- a/spec/regressions/localized_fragment_cache_spec.rb
+++ b/spec/regressions/localized_fragment_cache_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Localized fragment caching', type: :request do
+  let(:user) { create(:user) }
+
+  around do |example|
+    store = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    caching = ActionController::Base.perform_caching
+    ActionController::Base.perform_caching = true
+
+    example.run
+
+    ActionController::Base.perform_caching = caching
+    Rails.cache = store
+  end
+
+  before do
+    create(:stat, user: user, year: 2026, month: 3)
+    sign_in user
+  end
+
+  it 'does not serve English stats markup to a German request' do
+    get stats_path, params: { locale: 'en' }
+    expect(response.body).to include('Total distance')
+
+    get stats_path, params: { locale: 'de' }
+
+    expect(response.body).to include(I18n.t('stats.index.total_distance', locale: :de))
+    expect(response.body).not_to include('Total distance')
+  end
+
+  it 'does not serve English insights markup to a German request' do
+    get insights_path, params: { locale: 'en' }
+    expect(response.body).to include('Activity Overview')
+
+    get insights_path, params: { locale: 'de' }
+
+    expect(response.body).to include('Aktivitätsübersicht')
+    expect(response.body).not_to include('Activity Overview')
+  end
+end

--- a/spec/regressions/notification_recipient_locale_spec.rb
+++ b/spec/regressions/notification_recipient_locale_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Notification recipient locale' do
+  let(:german_user) { create(:user, settings: { 'locale' => 'de' }) }
+
+  it 'localizes a failure notification raised inside a per-user job' do
+    allow(Stats::CalculateMonth).to receive(:new).and_raise(StandardError, 'boom')
+
+    Stats::CalculatingJob.perform_now(german_user.id, 2026, 3)
+
+    expect(german_user.notifications.last.title).to eq('Statistikupdate fehlgeschlagen')
+  end
+
+  it 'localizes per recipient when one job notifies several users' do
+    english_user = create(:user)
+    [german_user, english_user].each do |user|
+      create(:export, user: user, status: :processing)
+        .update_column(:processing_started_at, 3.hours.ago)
+    end
+
+    StaleJobsRecoveryJob.perform_now
+
+    expect(german_user.notifications.last.title).to eq('Export fehlgeschlagen')
+    expect(english_user.notifications.last.title).to eq('Export failed')
+  end
+
+  it 'localizes export notifications produced by a service' do
+    export = create(:export, user: german_user, status: :processing)
+    allow_any_instance_of(Exports::Create).to receive(:build_export_tempfile).and_raise(StandardError, 'boom')
+
+    Exports::Create.new(export: export).call
+
+    expect(german_user.notifications.last.title).to eq('Export fehlgeschlagen')
+  end
+
+  it 'leaves the ambient locale untouched after notifying' do
+    allow(Stats::CalculateMonth).to receive(:new).and_raise(StandardError, 'boom')
+
+    Stats::CalculatingJob.perform_now(german_user.id, 2026, 3)
+
+    expect(I18n.locale).to eq(:en)
+  end
+end

--- a/spec/requests/locale_selection_spec.rb
+++ b/spec/requests/locale_selection_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Locale selection', type: :request do
+  it 'uses the best supported browser language' do
+    get root_path, headers: { 'Accept-Language' => 'fr;q=1.0, en;q=0.9, de-DE;q=0.8' }
+
+    expect(response.body).to include('<html lang="en"')
+    expect(response.body).to include('The only location history tracker')
+  end
+
+  it 'renders German for a German browser language' do
+    get root_path, headers: { 'Accept-Language' => 'de-DE,de;q=0.9,en;q=0.8' }
+
+    expect(response.body).to include('<html lang="de"')
+    expect(response.body).to include('Der einzige Standortverlaufstracker')
+    expect(response.body).to include('English')
+  end
+
+  it 'localizes the primary sign-in action' do
+    get new_user_session_path, params: { locale: 'de' }
+
+    expect(response.body).to include('value="Anmelden"')
+    expect(response.body).not_to include('value="Log in"')
+  end
+
+  it 'persists an explicit supported locale in the session' do
+    get root_path, params: { locale: 'de' }
+    get root_path
+
+    expect(response.body).to include('<html lang="de"')
+    expect(response.body).to include('Der einzige Standortverlaufstracker')
+  end
+
+  it 'ignores an unsupported explicit locale' do
+    get root_path, params: { locale: 'fr' }
+
+    expect(response.body).to include('<html lang="en"')
+    expect(response.body).to include('The only location history tracker')
+  end
+
+  it 'persists the preference for a signed-in user and lets an explicit choice override it' do
+    user = create(:user)
+    sign_in user
+
+    get edit_user_registration_path, params: { locale: 'de' }
+    expect(user.reload.preferred_locale).to eq(:de)
+    switch_link = Nokogiri::HTML(response.body).at_css('a[hreflang="en"]')
+    expect(switch_link['href']).to eq('/users/edit?locale=en')
+
+    get edit_user_registration_path, headers: { 'Accept-Language' => 'en' }
+    expect(response.body).to include('<html lang="de"')
+
+    get edit_user_registration_path, params: { locale: 'en' }
+    expect(user.reload.preferred_locale).to eq(:en)
+    expect(response.body).to include('<html lang="en"')
+  end
+
+  it 'does not persist an inferred locale while browsing as a signed-in user' do
+    user = create(:user, settings: { 'timezone' => 'Europe/Berlin' })
+    sign_in user
+
+    get edit_user_registration_path, headers: { 'Accept-Language' => 'de' }
+
+    expect(response.body).to include('<html lang="de"')
+    expect(user.reload.settings).to eq('timezone' => 'Europe/Berlin')
+  end
+
+  it 'preserves a saved preference when the user signs in from a differently configured browser' do
+    user = create(:user, password: 'password123456', settings: { 'locale' => 'de' })
+
+    post user_session_path,
+         params: { user: { email: user.email, password: 'password123456' } },
+         headers: { 'Accept-Language' => 'en' }
+
+    expect(response).to have_http_status(:see_other)
+    expect(user.reload.preferred_locale).to eq(:de)
+  end
+end

--- a/spec/requests/locale_selection_spec.rb
+++ b/spec/requests/locale_selection_spec.rb
@@ -3,19 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe 'Locale selection', type: :request do
-  it 'uses the best supported browser language' do
-    get root_path, headers: { 'Accept-Language' => 'fr;q=1.0, en;q=0.9, de-DE;q=0.8' }
+  it 'defaults to English regardless of the browser language' do
+    get root_path, headers: { 'Accept-Language' => 'de-DE,de;q=0.9,en;q=0.8' }
 
     expect(response.body).to include('<html lang="en"')
     expect(response.body).to include('The only location history tracker')
-  end
-
-  it 'renders German for a German browser language' do
-    get root_path, headers: { 'Accept-Language' => 'de-DE,de;q=0.9,en;q=0.8' }
-
-    expect(response.body).to include('<html lang="de"')
-    expect(response.body).to include('Der einzige Standortverlaufstracker')
-    expect(response.body).to include('English')
+    expect(response.body).not_to include('Der einzige Standortverlaufstracker')
   end
 
   it 'localizes the primary sign-in action' do
@@ -57,13 +50,13 @@ RSpec.describe 'Locale selection', type: :request do
     expect(response.body).to include('<html lang="en"')
   end
 
-  it 'does not persist an inferred locale while browsing as a signed-in user' do
+  it 'leaves a signed-in user in English until they choose otherwise' do
     user = create(:user, settings: { 'timezone' => 'Europe/Berlin' })
     sign_in user
 
     get edit_user_registration_path, headers: { 'Accept-Language' => 'de' }
 
-    expect(response.body).to include('<html lang="de"')
+    expect(response.body).to include('<html lang="en"')
     expect(user.reload.settings).to eq('timezone' => 'Europe/Berlin')
   end
 

--- a/spec/requests/shared/digests_spec.rb
+++ b/spec/requests/shared/digests_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe 'Shared::Digests', type: :request do
           expect(response.body).to include('Distance traveled')
           expect(response.body).to include('Countries visited')
         end
+
+        it 'uses German month abbreviations in the shared yearly chart' do
+          get shared_users_digest_url(digest.sharing_uuid), params: { locale: 'de' }
+
+          %w[Mär Mai Okt Dez].each { |month| expect(response.body).to include(month) }
+        end
       end
 
       context 'with invalid sharing UUID' do

--- a/spec/requests/users/digests_spec.rb
+++ b/spec/requests/users/digests_spec.rb
@@ -98,6 +98,12 @@ RSpec.describe '/digests', type: :request do
           expect(response.body).to include('All-Time Stats')
           expect(response.body).to include('Countries & Cities')
         end
+
+        it 'uses German month abbreviations in the yearly chart' do
+          get users_digest_url(year: 2024), params: { locale: 'de' }
+
+          %w[Mär Mai Okt Dez].each { |month| expect(response.body).to include(month) }
+        end
       end
 
       context 'when user is on Lite plan' do


### PR DESCRIPTION
## Summary

- Add a complete German application locale matching every English translation key.
- Add German Devise and Rails framework messages, including date, time, number, duration, validation, and form localization.
- Add regression coverage for locale parity, value types, fragile tokens, and representative German formatting.

## Why

Dawarich's interface is now backed by English i18n keys, but users could not yet select a complete German translation. This adds end-to-end German coverage while keeping English as the default locale.

## How to validate

1. Start Dawarich and switch the locale to `de`.
2. Visit the main map, imports, settings, family, authentication, and mailer-backed flows.
3. Confirm interface text and validation messages are German.
4. Confirm dates use German month and weekday names and browser-side translations load successfully.

Automated checks:

- `asdf exec bundle exec rspec` — 7,539 examples, 0 failures
- `asdf exec bundle exec rspec spec/regressions/german_locale_coverage_spec.rb` — 3 examples, 0 failures
- `asdf exec bundle exec rubocop --cache false spec/regressions/german_locale_coverage_spec.rb` — no offenses
- Locale audit — all 3,590 English leaf keys covered with matching types and fragile tokens
- Rails runtime check — German locale and JavaScript translation payload load successfully

## Risk / rollout notes

- Locale-only change; no database migration.
- English remains the default locale.
- Regression coverage will detect missing German keys and interpolation-token drift as the English catalog evolves.
