### PR TITLE
feat(e2e): seed per-worker demo users for parallel Playwright runs

### DIFF
--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -15,9 +15,13 @@ namespace :demo do
     puts '🚀 Starting demo data generation...'
     puts '=' * 60
 
-    # 1. Create demo user
+    # 1. Create demo user. E2E_SEED_EMAIL / E2E_SEED_API_KEY / E2E_SEED_SUFFIX /
+    # E2E_SEED_SKIP_LITE let e2e:reset_and_seed clone the full demo dataset onto
+    # extra per-Playwright-worker users (see lib/tasks/e2e.rake).
+    demo_email = ENV.fetch('E2E_SEED_EMAIL', 'demo@dawarich.app')
+    demo_api_key = ENV.fetch('E2E_SEED_API_KEY', 'demo_api_key_001')
     puts "\n📝 Creating demo user..."
-    user = User.find_or_initialize_by(email: 'demo@dawarich.app')
+    user = User.find_or_initialize_by(email: demo_email)
 
     if user.new_record?
       user.password = 'safepassword'
@@ -32,7 +36,7 @@ namespace :demo do
 
     # Set specific API key and enable live mode for e2e testing
     user.update!(
-      api_key: 'demo_api_key_001',
+      api_key: demo_api_key,
       settings: (user.settings || {}).merge('live_map_enabled' => true)
     )
     puts "   API Key: #{user.api_key}"
@@ -95,51 +99,54 @@ namespace :demo do
 
     # 8. Create family with members
     puts "\n👨‍👩‍👧‍👦 Creating demo family..."
-    family_members = create_family_with_members(user)
+    family_members = create_family_with_members(user, suffix: ENV['E2E_SEED_SUFFIX'].to_s)
     puts "✅ Created family with #{family_members.count} members"
 
-    # 9. Create Lite demo user
-    puts "\n📝 Creating Lite demo user..."
-    lite_user = User.find_or_initialize_by(email: 'lite@dawarich.app')
-    if lite_user.new_record?
-      lite_user.password = 'safepassword'
-      lite_user.password_confirmation = 'safepassword'
-      lite_user.save!
-      puts "✅ Lite user created: #{lite_user.email}"
-    else
-      puts "ℹ️  Lite user already exists: #{lite_user.email}"
+    # 9. Create Lite demo user (skipped for per-worker clone seeds)
+    lite_user = nil
+    unless ENV['E2E_SEED_SKIP_LITE'] == '1'
+      puts "\n📝 Creating Lite demo user..."
+      lite_user = User.find_or_initialize_by(email: 'lite@dawarich.app')
+      if lite_user.new_record?
+        lite_user.password = 'safepassword'
+        lite_user.password_confirmation = 'safepassword'
+        lite_user.save!
+        puts "✅ Lite user created: #{lite_user.email}"
+      else
+        puts "ℹ️  Lite user already exists: #{lite_user.email}"
+      end
+
+      lite_user.update_columns(
+        api_key: 'lite_demo_api_key_001',
+        plan: User.plans[:lite],
+        status: User.statuses[:active],
+        active_until: 1000.years.from_now,
+        signup_variant: 'legacy_trial'
+      )
+      lite_user.update!(settings: (lite_user.settings || {}).merge('live_map_enabled' => true))
+      puts "   API Key: #{lite_user.api_key}"
+      puts '   Plan: lite'
+      puts "   Signup Variant: #{lite_user.signup_variant}"
+
+      # 9a. Create recent points for Lite user (within 12-month window)
+      puts "\n📍 Creating recent points for Lite user..."
+      recent_points_count = create_lite_recent_points(lite_user)
+      puts "✅ Created #{recent_points_count} recent points"
+
+      # 9b. Create old points for Lite user (outside 12-month window)
+      puts "\n📍 Creating old points for Lite user..."
+      old_points_count = create_lite_old_points(lite_user)
+      puts "✅ Created #{old_points_count} old points"
+
+      # 9c. Create visits and areas for Lite user
+      puts "\n🏠 Creating visits for Lite user..."
+      lite_confirmed = create_visits(lite_user, 3, :confirmed)
+      puts "✅ Created #{lite_confirmed} confirmed visits"
+
+      puts "\n📍 Creating areas for Lite user..."
+      lite_areas = create_areas(lite_user, 2)
+      puts "✅ Created #{lite_areas} areas"
     end
-
-    lite_user.update_columns(
-      api_key: 'lite_demo_api_key_001',
-      plan: User.plans[:lite],
-      status: User.statuses[:active],
-      active_until: 1000.years.from_now,
-      signup_variant: 'legacy_trial'
-    )
-    lite_user.update!(settings: (lite_user.settings || {}).merge('live_map_enabled' => true))
-    puts "   API Key: #{lite_user.api_key}"
-    puts '   Plan: lite'
-    puts "   Signup Variant: #{lite_user.signup_variant}"
-
-    # 9a. Create recent points for Lite user (within 12-month window)
-    puts "\n📍 Creating recent points for Lite user..."
-    recent_points_count = create_lite_recent_points(lite_user)
-    puts "✅ Created #{recent_points_count} recent points"
-
-    # 9b. Create old points for Lite user (outside 12-month window)
-    puts "\n📍 Creating old points for Lite user..."
-    old_points_count = create_lite_old_points(lite_user)
-    puts "✅ Created #{old_points_count} old points"
-
-    # 9c. Create visits and areas for Lite user
-    puts "\n🏠 Creating visits for Lite user..."
-    lite_confirmed = create_visits(lite_user, 3, :confirmed)
-    puts "✅ Created #{lite_confirmed} confirmed visits"
-
-    puts "\n📍 Creating areas for Lite user..."
-    lite_areas = create_areas(lite_user, 2)
-    puts "✅ Created #{lite_areas} areas"
 
     puts "\n#{'=' * 60}"
     puts '🎉 Demo data generation complete!'
@@ -154,18 +161,22 @@ namespace :demo do
     puts "   Tracks: #{user.tracks.count}"
     puts "   Track Segments: #{TrackSegment.joins(:track).where(tracks: { user_id: user.id }).count}"
     puts "   Family Members: #{family_members.count}"
-    puts "\n   Lite User: #{lite_user.email}"
-    puts "   Lite Points: #{Point.where(user_id: lite_user.id).count}"
-    lite_points = Point.where(user_id: lite_user.id)
-    puts "   Lite Recent Points: #{lite_points.where('timestamp >= ?', 12.months.ago.to_i).count}"
-    puts "   Lite Old Points: #{lite_points.where('timestamp < ?', 12.months.ago.to_i).count}"
-    puts "   Lite Visits: #{lite_user.visits.count}"
-    puts "   Lite Areas: #{lite_user.areas.count}"
+    if lite_user
+      puts "\n   Lite User: #{lite_user.email}"
+      puts "   Lite Points: #{Point.where(user_id: lite_user.id).count}"
+      lite_points = Point.where(user_id: lite_user.id)
+      puts "   Lite Recent Points: #{lite_points.where('timestamp >= ?', 12.months.ago.to_i).count}"
+      puts "   Lite Old Points: #{lite_points.where('timestamp < ?', 12.months.ago.to_i).count}"
+      puts "   Lite Visits: #{lite_user.visits.count}"
+      puts "   Lite Areas: #{lite_user.areas.count}"
+    end
     puts "\n🔐 Login credentials:"
-    puts '   Email: demo@dawarich.app'
+    puts "   Email: #{user.email}"
     puts '   Password: safepassword'
-    puts "\n   Lite Email: lite@dawarich.app"
-    puts '   Lite Password: safepassword'
+    if lite_user
+      puts "\n   Lite Email: lite@dawarich.app"
+      puts '   Lite Password: safepassword'
+    end
     puts "\n👨‍👩‍👧‍👦 Family member credentials:"
     family_members.each_with_index do |member, index|
       puts "   Member #{index + 1}: #{member.email} / safepassword / API Key: #{member.api_key}"
@@ -201,6 +212,11 @@ namespace :demo do
       rounded_lat = point.lat.round(5)
       rounded_lon = point.lon.round(5)
 
+      # Deliberately ownerless (no user_id): ownerless places are invisible to
+      # the user-scoped places API and immutable through app flows, so multiple
+      # e2e worker users can safely share these rows (visits reference them
+      # read-only). Scoping them per-user would surface ~100 extra "manual"
+      # places on the Places layer.
       place = Place.find_or_initialize_by(
         latitude: rounded_lat,
         longitude: rounded_lon
@@ -306,7 +322,7 @@ namespace :demo do
     family_member_3_api_key
   ].freeze
 
-  def create_family_with_members(owner)
+  def create_family_with_members(owner, suffix: '')
     # Create or find family
     family = Family.find_or_initialize_by(creator: owner)
 
@@ -325,12 +341,9 @@ namespace :demo do
       role: :owner
     )
 
-    # Create 3 family members with location data
-    member_emails = [
-      'family.member1@dawarich.app',
-      'family.member2@dawarich.app',
-      'family.member3@dawarich.app'
-    ]
+    # Create 3 family members with location data. The suffix (e.g. ".w1")
+    # produces per-Playwright-worker families: family.member1.w1@dawarich.app.
+    member_emails = (1..3).map { |n| "family.member#{n}#{suffix}@dawarich.app" }
 
     family_members = []
 
@@ -351,8 +364,8 @@ namespace :demo do
         puts "   ℹ️  Family member already exists: #{member.email}"
       end
 
-      # Set specific API key for e2e testing
-      member.update!(api_key: FAMILY_API_KEYS[index])
+      # Set specific API key for e2e testing (suffix ".w1" -> "_w1")
+      member.update!(api_key: "#{FAMILY_API_KEYS[index]}#{suffix.tr('.', '_')}")
 
       # Add member to family
       Family::Membership.find_or_create_by!(
@@ -762,7 +775,7 @@ lon_offset: 0.009, note: nil }
       lat = (BERLIN_BASE[:lat] + cat[:lat_offset]).round(5)
       lon = (BERLIN_BASE[:lon] + cat[:lon_offset]).round(5)
 
-      place = Place.find_or_initialize_by(latitude: lat, longitude: lon)
+      place = Place.find_or_initialize_by(latitude: lat, longitude: lon, user_id: user.id)
       place.user    ||= user
       place.name      = cat[:name]
       place.lonlat    = "POINT(#{lon} #{lat})"

--- a/lib/tasks/e2e.rake
+++ b/lib/tasks/e2e.rake
@@ -79,6 +79,38 @@ namespace :e2e do
     abort '✋ Refusing to run e2e:reset in production. Set ALLOW_E2E_RESET=1 to override.'
   end
 
+  # Parallel-worker seeding: E2E_PARALLEL_USERS=N clones the full demo dataset
+  # onto N-1 extra users (e2e-worker1..@dawarich.app, each with its own family)
+  # so each Playwright worker owns an isolated copy. Worker 0 stays
+  # demo@dawarich.app. Naming must stay in sync with
+  # e2e-dawarich-playwright/v2/helpers/constants.js and setup/auth.setup.js.
+  def e2e_parallel_users
+    [ENV.fetch('E2E_PARALLEL_USERS', '1').to_i, 1].max
+  end
+
+  def e2e_worker_emails
+    (1...e2e_parallel_users).flat_map do |i|
+      ["e2e-worker#{i}@dawarich.app"] +
+        (1..3).map { |n| "family.member#{n}.w#{i}@dawarich.app" }
+    end
+  end
+
+  def wait_for_sidekiq_to_settle
+    require 'sidekiq/api'
+    deadline = Time.current + 5.minutes
+    loop do
+      busy = Sidekiq::Workers.new.size
+      enqueued = Sidekiq::Queue.all.sum(&:size)
+      break if busy.zero? && enqueued.zero?
+
+      if Time.current > deadline
+        puts "  ↪ still busy after 5 minutes (busy=#{busy} enqueued=#{enqueued}) — continuing anyway"
+        break
+      end
+      sleep 2
+    end
+  end
+
   desc 'Reset demo + lite + family users to a clean state and re-seed canonical e2e data'
   task reset_and_seed: :environment do
     assert_safe_environment!
@@ -93,41 +125,50 @@ namespace :e2e do
     File.write(geojson_path, geojson)
     puts "✅ Wrote #{File.size(geojson_path)} bytes"
 
-    puts "\n🚀 Invoking demo:seed_data..."
-    Rake::Task['demo:seed_data'].invoke(geojson_path)
+    seed_tasks = %w[
+      demo:seed_data
+      e2e:seed_anomalies
+      e2e:seed_demo_trip
+      e2e:seed_tag_fixtures
+      e2e:seed_fixture_tracks
+    ]
 
-    # The import enqueues track generation / geocoding / stats jobs. Those
-    # rebuild tracks, which nullifies any track_id assigned below (the #2630
-    # polluter) — wait for the churn to settle before planting fixtures.
-    puts "\n⏳ Waiting for background jobs to settle..."
-    require 'sidekiq/api'
-    deadline = Time.current + 5.minutes
-    loop do
-      busy = Sidekiq::Workers.new.size
-      enqueued = Sidekiq::Queue.all.sum(&:size)
-      break if busy.zero? && enqueued.zero?
-
-      if Time.current > deadline
-        puts "  ↪ still busy after 5 minutes (busy=#{busy} enqueued=#{enqueued}) — continuing anyway"
-        break
+    (0...e2e_parallel_users).each do |worker|
+      if worker.zero?
+        %w[E2E_SEED_EMAIL E2E_SEED_API_KEY E2E_SEED_SUFFIX E2E_SEED_SKIP_LITE]
+          .each { |key| ENV.delete(key) }
+      else
+        ENV['E2E_SEED_EMAIL']     = "e2e-worker#{worker}@dawarich.app"
+        ENV['E2E_SEED_API_KEY']   = "demo_api_key_w#{worker}"
+        ENV['E2E_SEED_SUFFIX']    = ".w#{worker}"
+        ENV['E2E_SEED_SKIP_LITE'] = '1'
       end
-      sleep 2
+
+      puts "\n🚀 Seeding worker #{worker} (#{ENV.fetch('E2E_SEED_EMAIL', 'demo@dawarich.app')})..."
+      seed_tasks.each { |name| Rake::Task[name].reenable }
+      Rake::Task['demo:seed_data'].invoke(geojson_path)
+
+      # The import enqueues track generation / geocoding / stats jobs. Those
+      # rebuild tracks, which nullifies any track_id assigned below (the #2630
+      # polluter) — wait for the churn to settle before planting fixtures.
+      puts "\n⏳ Waiting for background jobs to settle..."
+      wait_for_sidekiq_to_settle
+
+      puts "\n⚠️  Planting anomaly fixtures..."
+      Rake::Task['e2e:seed_anomalies'].invoke
+
+      puts "\n🧭 Seeding the anomaly-window demo trip..."
+      Rake::Task['e2e:seed_demo_trip'].invoke
+
+      puts "\n🏷️  Seeding tag fixtures..."
+      Rake::Task['e2e:seed_tag_fixtures'].invoke
+
+      puts "\n🛤️  Seeding fixture tracks (timeline-replay + journey-leg specs)..."
+      Rake::Task['e2e:seed_fixture_tracks'].invoke
     end
 
-    puts "\n⚠️  Planting anomaly fixtures..."
-    Rake::Task['e2e:seed_anomalies'].invoke
-
-    puts "\n🧭 Seeding the anomaly-window demo trip..."
-    Rake::Task['e2e:seed_demo_trip'].invoke
-
-    puts "\n🏷️  Seeding tag fixtures..."
-    Rake::Task['e2e:seed_tag_fixtures'].invoke
-
-    puts "\n🛤️  Seeding fixture tracks (timeline-replay + journey-leg specs)..."
-    Rake::Task['e2e:seed_fixture_tracks'].invoke
-
     puts "\n🔕 Suppressing the changelog prompt + onboarding modal for e2e users..."
-    User.where(email: E2E_USER_EMAILS).find_each do |user|
+    User.where(email: E2E_USER_EMAILS + e2e_worker_emails).find_each do |user|
       user.update_columns(
         changelog_consent: User.changelog_consents[:declined],
         settings: (user.settings || {}).merge('onboarding_completed' => true)
@@ -139,7 +180,7 @@ namespace :e2e do
   task seed_anomalies: :environment do
     assert_safe_environment!
 
-    user = User.find_by!(email: 'demo@dawarich.app')
+    user = User.find_by!(email: ENV.fetch('E2E_SEED_EMAIL', 'demo@dawarich.app'))
     base_day = Time.zone.parse('2025-10-15')
 
     user.points.where(tracker_id: %w[e2e-anomaly e2e-backbone]).delete_all
@@ -206,7 +247,7 @@ namespace :e2e do
   task seed_demo_trip: :environment do
     assert_safe_environment!
 
-    user = User.find_by!(email: 'demo@dawarich.app')
+    user = User.find_by!(email: ENV.fetch('E2E_SEED_EMAIL', 'demo@dawarich.app'))
 
     user.trips.where(name: E2E_ANOMALY_TRIP_NAME).destroy_all
 
@@ -227,7 +268,7 @@ namespace :e2e do
   task seed_tag_fixtures: :environment do
     assert_safe_environment!
 
-    user = User.find_by!(email: 'demo@dawarich.app')
+    user = User.find_by!(email: ENV.fetch('E2E_SEED_EMAIL', 'demo@dawarich.app'))
 
     tags = E2E_TAG_NAMES.map do |name|
       user.tags.find_or_create_by!(name: name)
@@ -251,7 +292,7 @@ namespace :e2e do
   task seed_fixture_tracks: :environment do
     assert_safe_environment!
 
-    user = User.find_by!(email: 'demo@dawarich.app')
+    user = User.find_by!(email: ENV.fetch('E2E_SEED_EMAIL', 'demo@dawarich.app'))
 
     _seed_fixture_track(
       user,
@@ -317,7 +358,7 @@ namespace :e2e do
   task reset: :environment do
     assert_safe_environment!
 
-    User.where(email: E2E_USER_EMAILS).find_each do |user|
+    User.where(email: E2E_USER_EMAILS + e2e_worker_emails).find_each do |user|
       print "  ↪ #{user.email} ... "
       reset_user_data!(user)
       puts 'done'

--- a/lib/tasks/e2e.rake
+++ b/lib/tasks/e2e.rake
@@ -88,11 +88,13 @@ namespace :e2e do
     [ENV.fetch('E2E_PARALLEL_USERS', '1').to_i, 1].max
   end
 
-  def e2e_worker_emails
-    (1...e2e_parallel_users).flat_map do |i|
-      ["e2e-worker#{i}@dawarich.app"] +
-        (1..3).map { |n| "family.member#{n}.w#{i}@dawarich.app" }
-    end
+  # Matches ALL worker clones by email pattern, regardless of the current
+  # E2E_PARALLEL_USERS value, so e2e:reset cannot strand clones left behind
+  # by a prior seed with a higher N.
+  def e2e_seeded_users
+    User.where(email: E2E_USER_EMAILS)
+        .or(User.where("email LIKE 'e2e-worker%@dawarich.app'"))
+        .or(User.where("email LIKE 'family.member_.w%@dawarich.app'"))
   end
 
   def wait_for_sidekiq_to_settle
@@ -133,42 +135,47 @@ namespace :e2e do
       e2e:seed_fixture_tracks
     ]
 
-    (0...e2e_parallel_users).each do |worker|
-      if worker.zero?
-        %w[E2E_SEED_EMAIL E2E_SEED_API_KEY E2E_SEED_SUFFIX E2E_SEED_SKIP_LITE]
-          .each { |key| ENV.delete(key) }
-      else
-        ENV['E2E_SEED_EMAIL']     = "e2e-worker#{worker}@dawarich.app"
-        ENV['E2E_SEED_API_KEY']   = "demo_api_key_w#{worker}"
-        ENV['E2E_SEED_SUFFIX']    = ".w#{worker}"
-        ENV['E2E_SEED_SKIP_LITE'] = '1'
+    seed_env_keys = %w[E2E_SEED_EMAIL E2E_SEED_API_KEY E2E_SEED_SUFFIX E2E_SEED_SKIP_LITE]
+
+    begin
+      (0...e2e_parallel_users).each do |worker|
+        if worker.zero?
+          seed_env_keys.each { |key| ENV.delete(key) }
+        else
+          ENV['E2E_SEED_EMAIL']     = "e2e-worker#{worker}@dawarich.app"
+          ENV['E2E_SEED_API_KEY']   = "demo_api_key_w#{worker}"
+          ENV['E2E_SEED_SUFFIX']    = ".w#{worker}"
+          ENV['E2E_SEED_SKIP_LITE'] = '1'
+        end
+
+        puts "\n🚀 Seeding worker #{worker} (#{ENV.fetch('E2E_SEED_EMAIL', 'demo@dawarich.app')})..."
+        seed_tasks.each { |name| Rake::Task[name].reenable }
+        Rake::Task['demo:seed_data'].invoke(geojson_path)
+
+        # The import enqueues track generation / geocoding / stats jobs. Those
+        # rebuild tracks, which nullifies any track_id assigned below (the #2630
+        # polluter) — wait for the churn to settle before planting fixtures.
+        puts "\n⏳ Waiting for background jobs to settle..."
+        wait_for_sidekiq_to_settle
+
+        puts "\n⚠️  Planting anomaly fixtures..."
+        Rake::Task['e2e:seed_anomalies'].invoke
+
+        puts "\n🧭 Seeding the anomaly-window demo trip..."
+        Rake::Task['e2e:seed_demo_trip'].invoke
+
+        puts "\n🏷️  Seeding tag fixtures..."
+        Rake::Task['e2e:seed_tag_fixtures'].invoke
+
+        puts "\n🛤️  Seeding fixture tracks (timeline-replay + journey-leg specs)..."
+        Rake::Task['e2e:seed_fixture_tracks'].invoke
       end
-
-      puts "\n🚀 Seeding worker #{worker} (#{ENV.fetch('E2E_SEED_EMAIL', 'demo@dawarich.app')})..."
-      seed_tasks.each { |name| Rake::Task[name].reenable }
-      Rake::Task['demo:seed_data'].invoke(geojson_path)
-
-      # The import enqueues track generation / geocoding / stats jobs. Those
-      # rebuild tracks, which nullifies any track_id assigned below (the #2630
-      # polluter) — wait for the churn to settle before planting fixtures.
-      puts "\n⏳ Waiting for background jobs to settle..."
-      wait_for_sidekiq_to_settle
-
-      puts "\n⚠️  Planting anomaly fixtures..."
-      Rake::Task['e2e:seed_anomalies'].invoke
-
-      puts "\n🧭 Seeding the anomaly-window demo trip..."
-      Rake::Task['e2e:seed_demo_trip'].invoke
-
-      puts "\n🏷️  Seeding tag fixtures..."
-      Rake::Task['e2e:seed_tag_fixtures'].invoke
-
-      puts "\n🛤️  Seeding fixture tracks (timeline-replay + journey-leg specs)..."
-      Rake::Task['e2e:seed_fixture_tracks'].invoke
+    ensure
+      seed_env_keys.each { |key| ENV.delete(key) }
     end
 
     puts "\n🔕 Suppressing the changelog prompt + onboarding modal for e2e users..."
-    User.where(email: E2E_USER_EMAILS + e2e_worker_emails).find_each do |user|
+    e2e_seeded_users.find_each do |user|
       user.update_columns(
         changelog_consent: User.changelog_consents[:declined],
         settings: (user.settings || {}).merge('onboarding_completed' => true)
@@ -358,7 +365,7 @@ namespace :e2e do
   task reset: :environment do
     assert_safe_environment!
 
-    User.where(email: E2E_USER_EMAILS + e2e_worker_emails).find_each do |user|
+    e2e_seeded_users.find_each do |user|
       print "  ↪ #{user.email} ... "
       reset_user_data!(user)
       puts 'done'

--- a/spec/tasks/e2e_reset_spec.rb
+++ b/spec/tasks/e2e_reset_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'e2e:reset' do
+  let!(:demo_user) { create(:user, email: 'demo@dawarich.app') }
+  let!(:worker_user) { create(:user, email: 'e2e-worker2@dawarich.app') }
+  let!(:worker_family_member) { create(:user, email: 'family.member1.w2@dawarich.app') }
+  let!(:regular_user) { create(:user, email: 'someone@example.com') }
+
+  before do
+    [demo_user, worker_user, worker_family_member, regular_user].each do |user|
+      create(:point, user: user)
+    end
+  end
+
+  it 'wipes worker clones from prior seeds even when E2E_PARALLEL_USERS is unset' do
+    Rake::Task['e2e:reset'].execute
+
+    expect(demo_user.points.count).to eq(0)
+    expect(worker_user.points.count).to eq(0)
+    expect(worker_family_member.points.count).to eq(0)
+    expect(regular_user.points.count).to eq(1)
+  end
+end


### PR DESCRIPTION
## What

Adds an opt-in parallel-seeding mode to the e2e seed tasks so the Playwright suite can run with N workers, each signing in as its own fully seeded clone of the demo user.

- `E2E_PARALLEL_USERS=N bin/rails e2e:reset_and_seed` seeds the usual `demo@dawarich.app` (worker 0, unchanged) plus `e2e-worker1..N-1@dawarich.app`, each with the full demo dataset: 1050 points, 100 visits, 10 areas, 20 tracks, timeline fixtures, anomaly fixtures, the anomaly-window trip, tag fixtures, fixture tracks, and an own family (`family.member<n>.w<i>@dawarich.app` / `family_member_<n>_api_key_w<i>`).
- `demo:seed_data` is parameterized via `E2E_SEED_EMAIL` / `E2E_SEED_API_KEY` / `E2E_SEED_SUFFIX`, and `E2E_SEED_SKIP_LITE=1` skips the Lite user for clone seeds.
- Timeline demo places are scoped per user (`find_or_initialize_by(..., user_id:)`). Without this, a clone seed finds the first user's place rows by coordinates and attaches its tags to them. Plain visit-places stay deliberately ownerless: they are invisible to the user-scoped places API and immutable through app flows, so clones can share them safely without surfacing ~100 extra manual places on the Places layer.
- `e2e:reset` also wipes the worker clones and their families.

## Why

The e2e suite is pinned to `--workers=1` because concurrent specs sharing one demo user delete each other's data (timeline isolation window). With per-worker users, a 3-worker experiment against this branch ran the suite with zero cross-user data races; remaining flakes were client-side map-boot contention, addressed separately in the e2e repo (per-worker storageState + scaled boot budgets there).

## Behavior without the env vars

Unchanged — worker 0 seeding is byte-identical to the current flow; verified with a serial run of the touched surfaces (timeline-filters, interactions, trips-anomaly, family realtime: 29 passed / 0 failed).