### PR TITLE
Filter leaped points: departed visit reports and cold-start fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - The map no longer stays blank after an upgrade when the `dawarich_public` Docker volume still holds precompiled assets from an older version. The asset manifest now ships inside the app image instead of the public volume, the boot-time asset sync stages from inside the app directory (a tmpfs-mounted `/tmp` can no longer skip it), and the container logs a warning if the sync still cannot run. (#3346)
 - User data exports no longer fail when a legacy place has no spatial coordinates. (#3344)
+- The map no longer leaps to a just-left place or a phantom spot off your route: iOS visit reports delivered after departure and coarse cell-tower fixes without motion data are now filtered out as anomalies. Existing histories are re-evaluated automatically after the upgrade, and tracks and stats are rebuilt along the way.
 
 ## [1.12.1] - 2026-08-13, Berlin
 
 ### Fixed
 
 - Fix to recently added migrations that could fail on some self-hosted instances with a large number of visits. The migration now runs in smaller batches and is resumable if interrupted.
-
 
 ## [1.12.0] - 2026-08-11, Berlin
 

--- a/app/jobs/points/anomaly_backfill_user_job.rb
+++ b/app/jobs/points/anomaly_backfill_user_job.rb
@@ -75,7 +75,9 @@ class Points::AnomalyBackfillUserJob < ApplicationJob
 
       chunk_end = (month_start + 1.month).to_i
 
-      marked = Points::AnomalyFilter.new(user.id, chunk_start, chunk_end).call
+      marked = Points::AnomalyFilter.new(
+        user.id, chunk_start, chunk_end, invalidate_dependents: false
+      ).call
       Rails.logger.info(
         "[AnomalyBackfill] User #{user.id}: month #{index + 1}/#{total_months}, marked #{marked} anomalies"
       )

--- a/app/jobs/points/anomaly_backfill_user_job.rb
+++ b/app/jobs/points/anomaly_backfill_user_job.rb
@@ -17,7 +17,7 @@ class Points::AnomalyBackfillUserJob < ApplicationJob
       end
 
       step :filter_months, start: 0 do |step|
-        run_filter_in_monthly_chunks(user, step)
+        run_filter_in_monthly_chunks(user, step, invalidate_dependents: !reset)
       end
 
       true
@@ -59,7 +59,10 @@ class Points::AnomalyBackfillUserJob < ApplicationJob
     Rails.logger.info("[AnomalyBackfill] User #{user.id}: cleared #{cleared} anomaly flags before re-evaluation")
   end
 
-  def run_filter_in_monthly_chunks(user, step)
+  # invalidate_dependents mirrors the reset flow: a resetting run rebuilds
+  # tracks and stats wholesale afterwards, a non-resetting one has no rebuild
+  # coming and must let the filter queue its own.
+  def run_filter_in_monthly_chunks(user, step, invalidate_dependents:)
     populated_months = user.points
                            .distinct
                            .pluck(Arel.sql("date_trunc('month', to_timestamp(timestamp))"))
@@ -76,7 +79,7 @@ class Points::AnomalyBackfillUserJob < ApplicationJob
       chunk_end = (month_start + 1.month).to_i
 
       marked = Points::AnomalyFilter.new(
-        user.id, chunk_start, chunk_end, invalidate_dependents: false
+        user.id, chunk_start, chunk_end, invalidate_dependents: invalidate_dependents
       ).call
       Rails.logger.info(
         "[AnomalyBackfill] User #{user.id}: month #{index + 1}/#{total_months}, marked #{marked} anomalies"

--- a/app/jobs/points/anomaly_filter_job.rb
+++ b/app/jobs/points/anomaly_filter_job.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class Points::AnomalyFilterJob < ApplicationJob
-  queue_as :low_priority
+  # Realtime track generation fires 45 seconds after ingest on the tracks
+  # queue; the filter must beat it there, or a freshly built track bakes in
+  # the very points it is about to flag. low_priority sits behind every other
+  # queue and loses that race under any load.
+  queue_as :points
 
   retry_on ActiveRecord::Deadlocked, wait: :polynomially_longer, attempts: 3 do |job, error|
     user_id, start_time, end_time = job.arguments

--- a/app/jobs/tracks/recalculate_job.rb
+++ b/app/jobs/tracks/recalculate_job.rb
@@ -10,9 +10,11 @@ class Tracks::RecalculateJob < ApplicationJob
       return
     end
 
-    # A track everyone left cannot be recalculated — an empty path would be
-    # stored and the husk would keep rendering its stale geometry forever.
-    if track.points.none?
+    # A track needs two points to form a path: calculate_path nils the path
+    # below that, the presence validation then rejects the save, and the husk
+    # would keep rendering its stale geometry forever. Points are nullified on
+    # destroy, so a survivor goes back to being an ordinary untracked point.
+    if track.points.count < 2
       track.destroy
       return
     end

--- a/app/jobs/tracks/recalculate_job.rb
+++ b/app/jobs/tracks/recalculate_job.rb
@@ -10,6 +10,13 @@ class Tracks::RecalculateJob < ApplicationJob
       return
     end
 
+    # A track everyone left cannot be recalculated — an empty path would be
+    # stored and the husk would keep rendering its stale geometry forever.
+    if track.points.none?
+      track.destroy
+      return
+    end
+
     track.recalculate_path_and_distance!
 
     track.broadcast_geojson_updated

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -40,6 +40,33 @@ class Points::AnomalyFilter
   STAY_RADIUS_METERS = 25_000        # how close two fixes must be to be one stay
   MIN_EXCURSION_METERS = 50_000      # how far the excursion must depart from it
   MAX_EXCURSION_SPAN_SECONDS = 1_800 # dwell above this is a visit, not a stray fix
+  # Radius above which a fix whose motion fields are all CoreLocation
+  # sentinels (speed -1, vertical accuracy -1) is treated as a tower position
+  # rather than a reading of the user. Wifi trilateration also reports the
+  # sentinel combination but lands at 150-450 m and is positionally usable —
+  # a stationary indoor point sits where it says. Cell positioning starts
+  # around half a kilometre and lands wherever the tower is. The gate sits
+  # between the two tiers so only the tower tier is judged at all.
+  SENTINEL_ACCURACY_METERS = 500
+  # What counts as the precise fix a sentinel one is judged against — a
+  # radius any GPS or wifi lock beats, and no tower position reaches.
+  PRECISE_FIX_METERS = 100
+  # A sentinel fix is only judged against tracking that could have done
+  # better: it is flagged when a precise fix sits within this many seconds of
+  # it, and kept otherwise. Reduced-accuracy permission, significant-change
+  # tracking and genuinely off-grid stretches produce nothing but coarse
+  # fixes — there the tower position is the only record there is, and erasing
+  # the history it forms is worse than showing its precision honestly. Six
+  # hours spans any GPS dropout inside a tracked day without reaching into a
+  # neighbouring coarse-only era.
+  SENTINEL_PRECISE_NEIGHBOR_SECONDS = 6 * 60 * 60
+  # Where a visit report keeps its departure date. motion_data first: raw_data
+  # is emptied by archival, and a flag that cannot be re-derived would silently
+  # return on the next reset re-run. Both values are untrusted client strings,
+  # so the passes prefix-test them instead of casting — a timestamptz cast
+  # raises on junk and would fail the whole batch.
+  DEPARTURE_DATE_SQL = "COALESCE(motion_data->>'departure_date', " \
+                       "raw_data->'properties'->>'departure_date')"
 
   def initialize(user_id, start_time, end_time)
     @user_id = user_id
@@ -53,6 +80,8 @@ class Points::AnomalyFilter
     count = 0
     count += filter_null_island
     count += filter_by_accuracy
+    count += filter_visit_reports
+    count += filter_sentinel_fixes
     count += filter_by_speed
     count
   end
@@ -84,6 +113,71 @@ class Points::AnomalyFilter
          .not_anomaly
          .where.not(accuracy: nil)
          .where('accuracy > ?', ABSURD_ACCURACY_METERS)
+         .update_all(anomaly: true, updated_at: Time.current)
+  end
+
+  # Visit-report pass: iOS visit monitoring (Overland `action: visit`) delivers
+  # a stay summary AFTER the stay ended — the visit centroid plus arrival and
+  # departure dates, stamped with delivery time. The device is already moving
+  # away by then, so the track leaps to the centroid and back. The coordinate
+  # is right and its radius often single-digit metres; only the timeline
+  # placement is wrong, which no accuracy or speed gate can see. An arrival
+  # report (no departure date yet) is delivered in place and stays useful —
+  # CLVisit marks "not departed" with a distant-future placeholder (year
+  # 4001), so the year guard treats any far-future date the same as none. A
+  # report whose departure date is unrecoverable (raw payload archived before
+  # motion_data kept a copy) cannot be classified and is left alone —
+  # under-flagging is the safer failure.
+  def filter_visit_reports
+    # The departure date is copied into motion_data as part of the flagging
+    # UPDATE: raw_data archival would otherwise strip the only evidence, and a
+    # later reset re-run would silently unflag the point and bring the leap
+    # back.
+    Point.where(user_id: @user_id, timestamp: @start_time..@end_time)
+         .not_anomaly
+         .where("motion_data->>'action' = 'visit'")
+         .where("#{DEPARTURE_DATE_SQL} ~ '^\\d{4}-'")
+         .where("#{DEPARTURE_DATE_SQL} < '3000-'")
+         .update_all(
+           'anomaly = TRUE, updated_at = NOW(), ' \
+           "motion_data = motion_data || jsonb_build_object('departure_date', #{DEPARTURE_DATE_SQL})"
+         )
+  end
+
+  # Sentinel pass: a fix whose motion fields are all invalid markers (speed
+  # -1, vertical accuracy -1) with a coarse radius did not come from GPS at
+  # all — it is a tower or cell-grid position, delivered wherever coverage
+  # begins, and each one drags the track sideways by its full radius, so a
+  # burst inside an otherwise-tracked day is flagged whole. The precise-fix
+  # neighbour test keeps the pass away from histories that are coarse all the
+  # way through: reduced-accuracy permission, significant-change tracking and
+  # off-grid stretches produce nothing better, and there the tower position
+  # is the only record there is. The neighbour must come from the same device
+  # — a second tracker on reduced-accuracy permission stays coarse even when
+  # the account's other device is precise, the same per-stream rule the speed
+  # pass applies. Imported histories are untouched because their points do
+  # not carry the sentinel combination.
+  def filter_sentinel_fixes
+    # The candidate window reaches back past the caller's range: a wake-up
+    # tower fix often arrives in a batch of one, before the precise fixes
+    # that condemn it exist, and the batch that brings those fixes starts
+    # after it. Each run therefore re-judges the recent past.
+    Point.where(user_id: @user_id,
+                timestamp: (@start_time - SENTINEL_PRECISE_NEIGHBOR_SECONDS)..@end_time)
+         .not_anomaly
+         .where(vertical_accuracy: ...0)
+         .where("velocity LIKE '-%'")
+         .where('accuracy > ?', SENTINEL_ACCURACY_METERS)
+         .where(
+           'EXISTS (SELECT 1 FROM points precise ' \
+           'WHERE precise.user_id = points.user_id ' \
+           'AND precise.tracker_id IS NOT DISTINCT FROM points.tracker_id ' \
+           'AND precise.timestamp BETWEEN points.timestamp - :window AND points.timestamp + :window ' \
+           'AND precise.accuracy <= :radius ' \
+           'AND precise.anomaly IS NOT TRUE ' \
+           'AND precise.id <> points.id)',
+           window: SENTINEL_PRECISE_NEIGHBOR_SECONDS, radius: PRECISE_FIX_METERS
+         )
          .update_all(anomaly: true, updated_at: Time.current)
   end
 

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -82,12 +82,14 @@ class Points::AnomalyFilter
   def call
     return 0 unless filtering_enabled?
 
+    @flagged_for_rebuild = []
     count = 0
     count += filter_null_island
     count += filter_by_accuracy
     count += filter_visit_reports
     count += filter_sentinel_fixes
     count += filter_by_speed
+    enqueue_dependent_rebuilds if @invalidate_dependents && @flagged_for_rebuild.any?
     count
   end
 
@@ -190,8 +192,8 @@ class Points::AnomalyFilter
 
   # A flagged point leaves its track in the same UPDATE: recalculation reads
   # track.points, so a stale track_id would keep feeding the leap back into
-  # the geometry it exists to fix. The track and the month's stats both baked
-  # the point in, so each gets queued for a rebuild — in one bulk enqueue.
+  # the geometry it exists to fix. The rows are collected across passes and
+  # their tracks and months rebuilt once, at the end of the run.
   def flag_anomalies(relation, extra_set = nil)
     flagged = relation.pluck(:id, :track_id, :timestamp)
     return 0 if flagged.empty?
@@ -200,17 +202,17 @@ class Points::AnomalyFilter
     set_clause = "#{set_clause}, #{extra_set}" if extra_set
     Point.where(id: flagged.map(&:first)).update_all(set_clause)
 
-    enqueue_dependent_rebuilds(flagged) if @invalidate_dependents
+    @flagged_for_rebuild.concat(flagged)
 
     flagged.size
   end
 
-  def enqueue_dependent_rebuilds(flagged)
-    track_jobs = flagged.filter_map { |_, track_id, _| track_id }.uniq
-                        .map { |track_id| Tracks::RecalculateJob.new(track_id) }
-    stats_jobs = flagged.map { |_, _, timestamp| Time.zone.at(timestamp) }
-                        .map { |time| [time.year, time.month] }.uniq
-                        .map { |year, month| Stats::CalculatingJob.new(@user_id, year, month) }
+  def enqueue_dependent_rebuilds
+    track_jobs = @flagged_for_rebuild.filter_map { |_, track_id, _| track_id }.uniq
+                                     .map { |track_id| Tracks::RecalculateJob.new(track_id) }
+    stats_jobs = @flagged_for_rebuild.map { |_, _, timestamp| Time.zone.at(timestamp) }
+                                     .map { |time| [time.year, time.month] }.uniq
+                                     .map { |year, month| Stats::CalculatingJob.new(@user_id, year, month) }
 
     ActiveJob.perform_all_later(track_jobs + stats_jobs)
   end

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -68,10 +68,15 @@ class Points::AnomalyFilter
   DEPARTURE_DATE_SQL = "COALESCE(motion_data->>'departure_date', " \
                        "raw_data->'properties'->>'departure_date')"
 
-  def initialize(user_id, start_time, end_time)
+  # invalidate_dependents: flagging detaches points from their tracks and
+  # queues the track and the month's stats for a rebuild. The backfill path
+  # opts out — it rebuilds every track and stat wholesale after the filter
+  # finishes, and per-point enqueues there would only duplicate that work.
+  def initialize(user_id, start_time, end_time, invalidate_dependents: true)
     @user_id = user_id
     @start_time = start_time
     @end_time = end_time
+    @invalidate_dependents = invalidate_dependents
   end
 
   def call
@@ -133,15 +138,16 @@ class Points::AnomalyFilter
     # UPDATE: raw_data archival would otherwise strip the only evidence, and a
     # later reset re-run would silently unflag the point and bring the leap
     # back.
-    Point.where(user_id: @user_id, timestamp: @start_time..@end_time)
-         .not_anomaly
-         .where("motion_data->>'action' = 'visit'")
-         .where("#{DEPARTURE_DATE_SQL} ~ '^\\d{4}-'")
-         .where("#{DEPARTURE_DATE_SQL} < '3000-'")
-         .update_all(
-           'anomaly = TRUE, updated_at = NOW(), ' \
-           "motion_data = motion_data || jsonb_build_object('departure_date', #{DEPARTURE_DATE_SQL})"
-         )
+    relation = Point.where(user_id: @user_id, timestamp: @start_time..@end_time)
+                    .not_anomaly
+                    .where("motion_data->>'action' = 'visit'")
+                    .where("#{DEPARTURE_DATE_SQL} ~ '^\\d{4}-'")
+                    .where("#{DEPARTURE_DATE_SQL} < '3000-'")
+
+    flag_anomalies(
+      relation,
+      "motion_data = motion_data || jsonb_build_object('departure_date', #{DEPARTURE_DATE_SQL})"
+    )
   end
 
   # Sentinel pass: a fix whose motion fields are all invalid markers (speed
@@ -162,23 +168,51 @@ class Points::AnomalyFilter
     # tower fix often arrives in a batch of one, before the precise fixes
     # that condemn it exist, and the batch that brings those fixes starts
     # after it. Each run therefore re-judges the recent past.
-    Point.where(user_id: @user_id,
-                timestamp: (@start_time - SENTINEL_PRECISE_NEIGHBOR_SECONDS)..@end_time)
-         .not_anomaly
-         .where(vertical_accuracy: ...0)
-         .where("velocity LIKE '-%'")
-         .where('accuracy > ?', SENTINEL_ACCURACY_METERS)
-         .where(
-           'EXISTS (SELECT 1 FROM points precise ' \
-           'WHERE precise.user_id = points.user_id ' \
-           'AND precise.tracker_id IS NOT DISTINCT FROM points.tracker_id ' \
-           'AND precise.timestamp BETWEEN points.timestamp - :window AND points.timestamp + :window ' \
-           'AND precise.accuracy <= :radius ' \
-           'AND precise.anomaly IS NOT TRUE ' \
-           'AND precise.id <> points.id)',
-           window: SENTINEL_PRECISE_NEIGHBOR_SECONDS, radius: PRECISE_FIX_METERS
-         )
-         .update_all(anomaly: true, updated_at: Time.current)
+    relation = Point.where(user_id: @user_id,
+                           timestamp: (@start_time - SENTINEL_PRECISE_NEIGHBOR_SECONDS)..@end_time)
+                    .not_anomaly
+                    .where(vertical_accuracy: ...0)
+                    .where("velocity LIKE '-%'")
+                    .where('accuracy > ?', SENTINEL_ACCURACY_METERS)
+                    .where(
+                      'EXISTS (SELECT 1 FROM points precise ' \
+                      'WHERE precise.user_id = points.user_id ' \
+                      'AND precise.tracker_id IS NOT DISTINCT FROM points.tracker_id ' \
+                      'AND precise.timestamp BETWEEN points.timestamp - :window AND points.timestamp + :window ' \
+                      'AND precise.accuracy <= :radius ' \
+                      'AND precise.anomaly IS NOT TRUE ' \
+                      'AND precise.id <> points.id)',
+                      window: SENTINEL_PRECISE_NEIGHBOR_SECONDS, radius: PRECISE_FIX_METERS
+                    )
+
+    flag_anomalies(relation)
+  end
+
+  # A flagged point leaves its track in the same UPDATE: recalculation reads
+  # track.points, so a stale track_id would keep feeding the leap back into
+  # the geometry it exists to fix. The track and the month's stats both baked
+  # the point in, so each gets queued for a rebuild — in one bulk enqueue.
+  def flag_anomalies(relation, extra_set = nil)
+    flagged = relation.pluck(:id, :track_id, :timestamp)
+    return 0 if flagged.empty?
+
+    set_clause = 'anomaly = TRUE, track_id = NULL, updated_at = NOW()'
+    set_clause = "#{set_clause}, #{extra_set}" if extra_set
+    Point.where(id: flagged.map(&:first)).update_all(set_clause)
+
+    enqueue_dependent_rebuilds(flagged) if @invalidate_dependents
+
+    flagged.size
+  end
+
+  def enqueue_dependent_rebuilds(flagged)
+    track_jobs = flagged.filter_map { |_, track_id, _| track_id }.uniq
+                        .map { |track_id| Tracks::RecalculateJob.new(track_id) }
+    stats_jobs = flagged.map { |_, _, timestamp| Time.zone.at(timestamp) }
+                        .map { |time| [time.year, time.month] }.uniq
+                        .map { |year, month| Stats::CalculatingJob.new(@user_id, year, month) }
+
+    ActiveJob.perform_all_later(track_jobs + stats_jobs)
   end
 
   # Pass 2: Speed-based sandwich test (chunked by month to handle large imports)

--- a/app/services/points/motion_data_extractor.rb
+++ b/app/services/points/motion_data_extractor.rb
@@ -8,17 +8,22 @@ module Points
   # The `from_raw_data` method auto-detects the source and is used by the backfill job.
   class MotionDataExtractor
     class << self
-      # Overland / GeoJSON / Points API — motion, activity, action from properties hash
+      # Overland / GeoJSON / Points API — motion, activity, action and visit
+      # departure_date from properties hash. The departure date rides along
+      # because raw_data is emptied by archival, and the anomaly filter must
+      # still tell a departed visit report from an arrival one afterwards.
       def from_overland_properties(properties)
         return {} unless properties
 
         data = {}
-        motion   = properties[:motion] || properties['motion']
-        activity = properties[:activity]  || properties['activity']
-        action   = properties[:action]    || properties['action']
+        motion    = properties[:motion] || properties['motion']
+        activity  = properties[:activity]  || properties['activity']
+        action    = properties[:action]    || properties['action']
+        departure = properties[:departure_date] || properties['departure_date']
         data['motion']   = motion   if motion
         data['activity'] = activity if activity
         data['action']   = action   if action
+        data['departure_date'] = departure if departure
         data
       end
 

--- a/db/migrate/20260811120000_enqueue_leaped_point_recalculation.rb
+++ b/db/migrate/20260811120000_enqueue_leaped_point_recalculation.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Two anomaly passes were added after 1.12.0: visit reports delivered after
+# departure, and coarse tower fixes carrying no motion data. Points flagged by
+# neither pass sat in every history the 1.11.0 recalculation already swept, and
+# its dispatcher trusts the per-user completion stamps it left behind — so
+# without clearing those stamps the fleet would never see the new rules. Strip
+# the stamps, then hand the fleet back to the same dispatcher; per-user
+# ordering, concurrency and the track/stat rebuilds are unchanged.
+#
+# Every user is re-swept, including histories the new passes cannot touch:
+# telling them apart up front would mean scanning each account's points inside
+# the migration, which is exactly the work the staggered sweep exists to
+# spread out. The repeat completion notification is accepted for the same
+# reason — and the filter did change, so it is not even wrong.
+#
+# Enqueue only: the migration hands the work to Sidekiq and returns immediately.
+# An instance whose queue is unreachable at upgrade time boots anyway and can
+# start the job by hand afterwards. A NameError still aborts — that is a broken
+# deploy, not an infrastructure hiccup, and must not be swallowed.
+class EnqueueLeapedPointRecalculation < ActiveRecord::Migration[8.0]
+  # Sidekiq receives the job the moment perform_later runs, and a worker from
+  # the still-running old deployment can pop it before a wrapping migration
+  # transaction commits the stamp-clearing UPDATE. The dispatcher would then
+  # see every user still stamped, hand out nobody, and — having found no work
+  # — never reschedule itself: the fleet sweep silently never happens. Without
+  # the transaction the UPDATE is committed before the job exists.
+  disable_ddl_transaction!
+
+  def up
+    clear_completion_stamps
+    enqueue_recalculation
+  end
+
+  def down; end
+
+  private
+
+  def stamp_keys
+    [
+      DataMigrations::RecalculateAnomaliesUserJob::QUEUED_SETTINGS_KEY,
+      DataMigrations::RecalculateAnomaliesUserJob::RECALCULATED_SETTINGS_KEY,
+      DataMigrations::RecalculateAnomaliesUserJob::FAILED_SETTINGS_KEY
+    ]
+  end
+
+  # Failed stamps are cleared too: those users never finished under the old
+  # rules, and this sweep is their retry.
+  def clear_completion_stamps
+    quoted = stamp_keys.map { |key| connection.quote(key) }.join(', ')
+
+    execute(<<~SQL.squish)
+      UPDATE users
+      SET settings = settings - ARRAY[#{quoted}]::text[]
+      WHERE settings ?| ARRAY[#{quoted}]::text[]
+    SQL
+  end
+
+  def enqueue_recalculation
+    DataMigrations::RecalculateAnomaliesJob.perform_later
+  rescue NameError
+    raise
+  rescue StandardError => e
+    Rails.logger.error(
+      "[EnqueueLeapedPointRecalculation] could not enqueue the anomaly recalculation: #{e.class}: #{e.message}. " \
+      'Start it later with: DataMigrations::RecalculateAnomaliesJob.perform_later'
+    )
+  end
+end

--- a/spec/jobs/points/anomaly_backfill_user_job_spec.rb
+++ b/spec/jobs/points/anomaly_backfill_user_job_spec.rb
@@ -97,6 +97,19 @@ RSpec.describe Points::AnomalyBackfillUserJob, type: :job do
         described_class.new.perform(user.id)
       end.not_to have_enqueued_job(Users::RecalculateDataJob)
     end
+
+    it 'rebuilds affected tracks itself, since no wholesale rebuild follows' do
+      point = create(:point, user: user, accuracy: 6, timestamp: 30.minutes.ago.to_i,
+                     latitude: 51.3402, longitude: 12.3712, lonlat: 'POINT(12.3712 51.3402)',
+                     motion_data: { 'action' => 'visit',
+                                    'departure_date' => '2026-05-19T18:34:25Z' })
+      track = create(:track, user: user)
+      point.update_column(:track_id, track.id)
+
+      expect do
+        described_class.new.perform(user.id)
+      end.to have_enqueued_job(Tracks::RecalculateJob).with(track.id)
+    end
   end
 
   describe '#perform skips empty chunks for sparse data' do

--- a/spec/jobs/points/anomaly_backfill_user_job_spec.rb
+++ b/spec/jobs/points/anomaly_backfill_user_job_spec.rb
@@ -115,9 +115,9 @@ RSpec.describe Points::AnomalyBackfillUserJob, type: :job do
 
     it 'invokes the AnomalyFilter once per populated month, not per 30-day chunk in the span' do
       filter_calls = 0
-      allow(Points::AnomalyFilter).to receive(:new).and_wrap_original do |original, *args|
+      allow(Points::AnomalyFilter).to receive(:new).and_wrap_original do |original, *args, **kwargs|
         filter_calls += 1
-        original.call(*args)
+        original.call(*args, **kwargs)
       end
 
       described_class.new.perform(sparse_user.id)

--- a/spec/jobs/points/anomaly_filter_job_spec.rb
+++ b/spec/jobs/points/anomaly_filter_job_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.describe Points::AnomalyFilterJob do
   include ActiveJob::TestHelper
 
+  it 'runs on the points queue so flags land before realtime track generation' do
+    expect(described_class.new.queue_name).to eq('points')
+  end
+
   it 'retries transient database deadlocks' do
     filter = instance_double(Points::AnomalyFilter)
     allow(Points::AnomalyFilter).to receive(:new).with(42, 100, 200).and_return(filter)

--- a/spec/jobs/tracks/recalculate_job_spec.rb
+++ b/spec/jobs/tracks/recalculate_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Tracks::RecalculateJob, type: :job do
     let(:user) { create(:user) }
     let(:track) do
       create(:track, user: user).tap do |t|
-        create(:point, user: user).update_column(:track_id, t.id)
+        2.times { create(:point, user: user).update_column(:track_id, t.id) }
       end
     end
 
@@ -36,6 +36,16 @@ RSpec.describe Tracks::RecalculateJob, type: :job do
 
         expect { described_class.perform_now(empty_track.id) }
           .to change { Track.exists?(empty_track.id) }.to(false)
+      end
+    end
+
+    context 'when a track is left with a single point' do
+      it 'destroys it, since one point cannot form a path' do
+        thin_track = create(:track, user: user)
+        create(:point, user: user).update_column(:track_id, thin_track.id)
+
+        expect { described_class.perform_now(thin_track.id) }
+          .to change { Track.exists?(thin_track.id) }.to(false)
       end
     end
 

--- a/spec/jobs/tracks/recalculate_job_spec.rb
+++ b/spec/jobs/tracks/recalculate_job_spec.rb
@@ -5,7 +5,11 @@ require 'rails_helper'
 RSpec.describe Tracks::RecalculateJob, type: :job do
   describe '#perform' do
     let(:user) { create(:user) }
-    let(:track) { create(:track, user: user) }
+    let(:track) do
+      create(:track, user: user).tap do |t|
+        create(:point, user: user).update_column(:track_id, t.id)
+      end
+    end
 
     before do
       allow(ExceptionReporter).to receive(:call)
@@ -24,6 +28,15 @@ RSpec.describe Tracks::RecalculateJob, type: :job do
 
     it 'queues in the tracks queue' do
       expect(described_class.new.queue_name).to eq('tracks')
+    end
+
+    context 'when every point has left the track' do
+      it 'destroys the track instead of storing an empty path' do
+        empty_track = create(:track, user: user)
+
+        expect { described_class.perform_now(empty_track.id) }
+          .to change { Track.exists?(empty_track.id) }.to(false)
+      end
     end
 
     context 'when track does not exist' do

--- a/spec/migrations/enqueue_leaped_point_recalculation_spec.rb
+++ b/spec/migrations/enqueue_leaped_point_recalculation_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260811120000_enqueue_leaped_point_recalculation.rb')
+
+RSpec.describe EnqueueLeapedPointRecalculation do
+  subject(:migration) { described_class.new }
+
+  let(:stamp_keys) do
+    [
+      DataMigrations::RecalculateAnomaliesUserJob::QUEUED_SETTINGS_KEY,
+      DataMigrations::RecalculateAnomaliesUserJob::RECALCULATED_SETTINGS_KEY,
+      DataMigrations::RecalculateAnomaliesUserJob::FAILED_SETTINGS_KEY
+    ]
+  end
+
+  it 'strips every completion stamp so the dispatcher hands users out again' do
+    user = create(:user)
+    user.update_columns(
+      settings: (user.settings || {}).merge(
+        stamp_keys[0] => '2026-08-02T12:00:00Z',
+        stamp_keys[1] => '2026-08-02T13:00:00Z',
+        stamp_keys[2] => '2026-08-02T14:00:00Z'
+      )
+    )
+
+    migration.up
+
+    settings = user.reload.settings
+    stamp_keys.each { |key| expect(settings).not_to have_key(key) }
+  end
+
+  it 'leaves every other settings key untouched' do
+    user = create(:user)
+    user.update_columns(
+      settings: (user.settings || {}).merge(
+        'maps' => { 'distance_unit' => 'km' },
+        stamp_keys[1] => '2026-08-02T13:00:00Z'
+      )
+    )
+
+    migration.up
+
+    expect(user.reload.settings['maps']).to eq({ 'distance_unit' => 'km' })
+  end
+
+  it 'runs without a wrapping transaction so stamps are committed before the job can see them' do
+    expect(described_class.disable_ddl_transaction).to be true
+  end
+
+  it 'hands the work to a background job instead of doing it inline' do
+    expect { migration.up }.to have_enqueued_job(DataMigrations::RecalculateAnomaliesJob)
+  end
+
+  it 'does not abort the migration when the job queue is unreachable' do
+    allow(DataMigrations::RecalculateAnomaliesJob)
+      .to receive(:perform_later).and_raise(StandardError, 'Connection refused')
+
+    expect { migration.up }.not_to raise_error
+  end
+
+  it 'aborts on a missing constant instead of hiding a broken deploy' do
+    allow(DataMigrations::RecalculateAnomaliesJob)
+      .to receive(:perform_later).and_raise(NameError, 'uninitialized constant')
+
+    expect { migration.up }.to raise_error(NameError)
+  end
+
+  it 'logs how to start the recalculation by hand when enqueueing failed' do
+    allow(DataMigrations::RecalculateAnomaliesJob)
+      .to receive(:perform_later).and_raise(StandardError, 'Connection refused')
+    allow(Rails.logger).to receive(:error)
+
+    migration.up
+
+    expect(Rails.logger)
+      .to have_received(:error).with(/DataMigrations::RecalculateAnomaliesJob\.perform_later/)
+  end
+end

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -639,5 +639,322 @@ RSpec.describe Points::AnomalyFilter do
         expect(after_zero.reload.anomaly).not_to be true
       end
     end
+
+    # iOS visit monitoring (Overland `action: visit`) reports a stay after it
+    # ended: the payload carries the visit centroid plus arrival and departure
+    # dates, but the point is stamped with its delivery time — minutes after
+    # departure, while the device is already moving away. The coordinate is
+    # right, its place in the timeline is not, so the track leaps to the
+    # centroid and back. No accuracy or speed gate can catch that.
+    context 'Pass 4: departed visit reports' do
+      let(:base_time) { 1.hour.ago.to_i }
+
+      def walk_point(offset, lat, lon)
+        create(:point, user: user, accuracy: 5, timestamp: base_time + offset,
+               latitude: lat, longitude: lon, lonlat: "POINT(#{lon} #{lat})")
+      end
+
+      let!(:walk) do
+        [walk_point(0, 51.3404, 12.3754),
+         walk_point(60, 51.3400, 12.3747),
+         walk_point(120, 51.3396, 12.3740)]
+      end
+
+      let!(:departed_report) do
+        create(:point, user: user, accuracy: 4, timestamp: base_time + 90,
+               latitude: 51.3418, longitude: 12.3790, lonlat: 'POINT(12.3790 51.3418)',
+               motion_data: { 'action' => 'visit' },
+               raw_data: { 'properties' => { 'action' => 'visit',
+                                             'arrival_date' => '2026-05-19T18:27:54Z',
+                                             'departure_date' => '2026-05-19T18:34:25Z' } })
+      end
+
+      let!(:arrival_report) do
+        create(:point, user: user, accuracy: 30, timestamp: base_time + 150,
+               latitude: 51.3395, longitude: 12.3739, lonlat: 'POINT(12.3739 51.3395)',
+               motion_data: { 'action' => 'visit' },
+               raw_data: { 'properties' => { 'action' => 'visit',
+                                             'arrival_date' => '2026-05-19T18:27:54Z',
+                                             'departure_date' => nil } })
+      end
+
+      let!(:archived_report) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time + 180,
+               latitude: 51.3394, longitude: 12.3738, lonlat: 'POINT(12.3738 51.3394)',
+               motion_data: { 'action' => 'visit' },
+               raw_data: {}, raw_data_archived: true)
+      end
+
+      let!(:distant_future_report) do
+        create(:point, user: user, accuracy: 20, timestamp: base_time + 210,
+               latitude: 51.3393, longitude: 12.3737, lonlat: 'POINT(12.3737 51.3393)',
+               motion_data: { 'action' => 'visit' },
+               raw_data: { 'properties' => { 'action' => 'visit',
+                                             'arrival_date' => '2026-05-19T18:27:54Z',
+                                             'departure_date' => '4001-01-01T00:00:00Z' } })
+      end
+
+      let!(:archived_departed_report) do
+        create(:point, user: user, accuracy: 12, timestamp: base_time + 240,
+               latitude: 51.3392, longitude: 12.3736, lonlat: 'POINT(12.3736 51.3392)',
+               motion_data: { 'action' => 'visit', 'departure_date' => '2026-05-19T18:34:25Z' },
+               raw_data: {}, raw_data_archived: true)
+      end
+
+      let!(:departed_non_visit) do
+        create(:point, user: user, accuracy: 8, timestamp: base_time + 270,
+               latitude: 51.3391, longitude: 12.3735, lonlat: 'POINT(12.3735 51.3391)',
+               motion_data: { 'motion' => ['walking'] },
+               raw_data: { 'properties' => { 'departure_date' => '2026-05-19T18:34:25Z' } })
+      end
+
+      before { described_class.new(user.id, 2.hours.ago.to_i, Time.current.to_i).call }
+
+      it 'flags a departed visit report despite its perfect accuracy' do
+        expect(departed_report.reload.anomaly).to be true
+      end
+
+      it 'keeps an arrival report, which is delivered while the device is still there' do
+        expect(arrival_report.reload.anomaly).not_to be true
+      end
+
+      it 'keeps a visit report whose raw payload was archived, since it cannot be classified' do
+        expect(archived_report.reload.anomaly).not_to be true
+      end
+
+      it 'keeps a report whose departure date is the distant-future placeholder' do
+        expect(distant_future_report.reload.anomaly).not_to be true
+      end
+
+      it 'flags a departed report after archival when motion_data kept the departure date' do
+        expect(archived_departed_report.reload.anomaly).to be true
+      end
+
+      it 'keeps a non-visit point that happens to carry a departure date' do
+        expect(departed_non_visit.reload.anomaly).not_to be true
+      end
+
+      it 'persists the departure date into motion_data when flagging' do
+        expect(departed_report.reload.motion_data['departure_date']).to eq('2026-05-19T18:34:25Z')
+      end
+
+      it 'keeps the surrounding walk' do
+        walk.each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
+
+    # After a tracking gap the first fix often comes from cell towers with
+    # every CoreLocation sentinel set: speed -1, vertical accuracy -1 and a
+    # kilometre-scale radius. It lands wherever the tower is — far below the
+    # absurd-accuracy gate, yet nowhere near the route.
+    context 'Pass 5: cold-start sentinel fixes' do
+      let(:base_time) { 1.hour.ago.to_i }
+
+      let!(:cold_start) do
+        create(:point, user: user, accuracy: 1414, velocity: '-1', vertical_accuracy: -1,
+               timestamp: base_time, latitude: 51.3336, longitude: 12.3777,
+               lonlat: 'POINT(12.3777 51.3336)')
+      end
+
+      let!(:stationary_invalid_speed) do
+        create(:point, user: user, accuracy: 15, velocity: '-1', vertical_accuracy: -1,
+               timestamp: base_time + 60, latitude: 51.3355, longitude: 12.3742,
+               lonlat: 'POINT(12.3742 51.3355)')
+      end
+
+      let!(:coarse_with_valid_motion) do
+        create(:point, user: user, accuracy: 1500, velocity: '2', vertical_accuracy: 5,
+               timestamp: base_time + 120, latitude: 51.3356, longitude: 12.3743,
+               lonlat: 'POINT(12.3743 51.3356)')
+      end
+
+      let!(:at_the_gate) do
+        create(:point, user: user, accuracy: 500, velocity: '-1', vertical_accuracy: -1,
+               timestamp: base_time + 180, latitude: 51.3357, longitude: 12.3744,
+               lonlat: 'POINT(12.3744 51.3357)')
+      end
+
+      let!(:wifi_tier_sentinel) do
+        create(:point, user: user, accuracy: 165, velocity: '-1', vertical_accuracy: -1,
+               timestamp: base_time + 210, latitude: 51.3365, longitude: 12.3752,
+               lonlat: 'POINT(12.3752 51.3365)')
+      end
+
+      let!(:no_vertical_reading) do
+        create(:point, user: user, accuracy: 1500, velocity: '-1', vertical_accuracy: nil,
+               timestamp: base_time + 240, latitude: 51.3358, longitude: 12.3745,
+               lonlat: 'POINT(12.3745 51.3358)')
+      end
+
+      let!(:tower_run) do
+        3.times.map do |i|
+          create(:point, user: user, accuracy: 2000, velocity: '-1', vertical_accuracy: -1,
+                 timestamp: base_time + 300 + (i * 60),
+                 latitude: 51.3359 + (i * 0.0001), longitude: 12.3746 + (i * 0.0001),
+                 lonlat: "POINT(#{12.3746 + (i * 0.0001)} #{51.3359 + (i * 0.0001)})")
+        end
+      end
+
+      let!(:sentinel_without_accuracy) do
+        create(:point, user: user, accuracy: nil, velocity: '-1', vertical_accuracy: -1,
+               timestamp: base_time + 480, latitude: 51.3363, longitude: 12.3750,
+               lonlat: 'POINT(12.3750 51.3363)')
+      end
+
+      let!(:negative_speed_with_altitude) do
+        create(:point, user: user, accuracy: 1500, velocity: '-1', vertical_accuracy: 5,
+               timestamp: base_time + 540, latitude: 51.3364, longitude: 12.3751,
+               lonlat: 'POINT(12.3751 51.3364)')
+      end
+
+      before { described_class.new(user.id, 2.hours.ago.to_i, Time.current.to_i).call }
+
+      it 'flags the coarse fix whose motion fields are all sentinels' do
+        expect(cold_start.reload.anomaly).to be true
+      end
+
+      it 'keeps a sentinel fix whose radius is still tight' do
+        expect(stationary_invalid_speed.reload.anomaly).not_to be true
+      end
+
+      it 'keeps a coarse fix that carries valid motion data' do
+        expect(coarse_with_valid_motion.reload.anomaly).not_to be true
+      end
+
+      it 'keeps a sentinel fix exactly at the accuracy gate' do
+        expect(at_the_gate.reload.anomaly).not_to be true
+      end
+
+      it 'keeps a wifi-tier sentinel fix, which is positionally usable' do
+        expect(wifi_tier_sentinel.reload.anomaly).not_to be true
+      end
+
+      it 'keeps a coarse fix with no vertical accuracy reading at all' do
+        expect(no_vertical_reading.reload.anomaly).not_to be true
+      end
+
+      it 'flags an entire run of tower fixes, not only the first' do
+        expect(tower_run.map { |point| point.reload.anomaly }).to all(be(true))
+      end
+
+      it 'keeps a sentinel-shaped fix with no accuracy reading at all' do
+        expect(sentinel_without_accuracy.reload.anomaly).not_to be true
+      end
+
+      it 'keeps a coarse negative-speed fix whose vertical accuracy is valid' do
+        expect(negative_speed_with_altitude.reload.anomaly).not_to be true
+      end
+    end
+
+    # Reduced-accuracy permission and significant-change tracking produce
+    # nothing but coarse sentinel fixes. There the tower position is the only
+    # record there is, and a pass that erased it would blank the whole map.
+    context 'Pass 5: a history that is coarse all the way through' do
+      let(:base_time) { 1.hour.ago.to_i }
+
+      let!(:coarse_stream) do
+        5.times.map do |i|
+          create(:point, user: user, accuracy: 1800, velocity: '-1', vertical_accuracy: -1,
+                 timestamp: base_time + (i * 300),
+                 latitude: 51.34 + (i * 0.001), longitude: 12.37 + (i * 0.001),
+                 lonlat: "POINT(#{12.37 + (i * 0.001)} #{51.34 + (i * 0.001)})")
+        end
+      end
+
+      before { described_class.new(user.id, 2.hours.ago.to_i, Time.current.to_i).call }
+
+      it 'keeps every fix, since nothing better was ever available' do
+        coarse_stream.each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
+
+    # A second device on reduced-accuracy permission is coarse all the way
+    # through even when the account's other device tracks precisely. Each
+    # device is its own stream — the same rule the speed pass applies.
+    context 'Pass 5: a coarse-only device next to a precise one' do
+      let(:base_time) { 1.hour.ago.to_i }
+
+      let!(:precise_phone) do
+        3.times.map do |i|
+          create(:point, user: user, accuracy: 5, velocity: '1', vertical_accuracy: 5,
+                 tracker_id: 'iphone', timestamp: base_time + (i * 60),
+                 latitude: 51.3402 + (i * 0.0001), longitude: 12.3712,
+                 lonlat: "POINT(12.3712 #{51.3402 + (i * 0.0001)})")
+        end
+      end
+
+      let!(:coarse_watch) do
+        3.times.map do |i|
+          create(:point, user: user, accuracy: 1500, velocity: '-1', vertical_accuracy: -1,
+                 tracker_id: 'watch', timestamp: base_time + 30 + (i * 60),
+                 latitude: 51.3412 + (i * 0.001), longitude: 12.3722,
+                 lonlat: "POINT(12.3722 #{51.3412 + (i * 0.001)})")
+        end
+      end
+
+      before { described_class.new(user.id, 2.hours.ago.to_i, Time.current.to_i).call }
+
+      it 'keeps the coarse device intact' do
+        coarse_watch.each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+
+      it 'leaves the precise device alone too' do
+        precise_phone.each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
+
+    context 'Pass 5: the only precise neighbour is itself an anomaly' do
+      let(:base_time) { 1.hour.ago.to_i }
+
+      let!(:flagged_neighbor) do
+        create(:point, user: user, accuracy: 10, velocity: '1', vertical_accuracy: 5,
+               timestamp: base_time, latitude: 51.3370, longitude: 12.3760,
+               lonlat: 'POINT(12.3760 51.3370)', anomaly: true)
+      end
+
+      let!(:orphan_sentinel) do
+        create(:point, user: user, accuracy: 1500, velocity: '-1', vertical_accuracy: -1,
+               timestamp: base_time + 60, latitude: 51.3380, longitude: 12.3770,
+               lonlat: 'POINT(12.3770 51.3380)')
+      end
+
+      before { described_class.new(user.id, 2.hours.ago.to_i, Time.current.to_i).call }
+
+      it 'keeps the sentinel fix, since flagged points cannot justify more flags' do
+        expect(orphan_sentinel.reload.anomaly).not_to be true
+      end
+    end
+
+    # At ingest each batch is filtered alone, and a wake-up tower fix often
+    # arrives in a batch of one — its precise context only exists a few
+    # minutes later, in the next batch, whose window starts after it.
+    context 'Pass 5: a cold start that arrived in an earlier batch' do
+      let(:base_time) { 1.hour.ago.to_i }
+
+      let!(:earlier_tower_fix) do
+        create(:point, user: user, accuracy: 1500, velocity: '-1', vertical_accuracy: -1,
+               timestamp: base_time, latitude: 51.3350, longitude: 12.3730,
+               lonlat: 'POINT(12.3730 51.3350)')
+      end
+
+      let!(:later_precise) do
+        3.times.map do |i|
+          create(:point, user: user, accuracy: 8, velocity: '1', vertical_accuracy: 5,
+                 timestamp: base_time + 300 + (i * 60),
+                 latitude: 51.3352 + (i * 0.0001), longitude: 12.3732,
+                 lonlat: "POINT(12.3732 #{51.3352 + (i * 0.0001)})")
+        end
+      end
+
+      before { described_class.new(user.id, base_time + 300, Time.current.to_i).call }
+
+      it 'flags the fix even though it predates the window' do
+        expect(earlier_tower_fix.reload.anomaly).to be true
+      end
+
+      it 'leaves the precise batch alone' do
+        later_precise.each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
   end
 end

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -993,6 +993,41 @@ RSpec.describe Points::AnomalyFilter do
       end
     end
 
+    context 'both passes flag points in the same month' do
+      let(:base_time) { 1.hour.ago.to_i }
+
+      let!(:precise_context) do
+        3.times.map do |i|
+          create(:point, user: user, accuracy: 5, velocity: '1', vertical_accuracy: 5,
+                 timestamp: base_time + (i * 60),
+                 latitude: 51.3431 + (i * 0.0001), longitude: 12.3781,
+                 lonlat: "POINT(12.3781 #{51.3431 + (i * 0.0001)})")
+        end
+      end
+
+      let!(:departed_report) do
+        create(:point, user: user, accuracy: 6, timestamp: base_time + 30,
+               latitude: 51.3438, longitude: 12.3788, lonlat: 'POINT(12.3788 51.3438)',
+               motion_data: { 'action' => 'visit' },
+               raw_data: { 'properties' => { 'action' => 'visit',
+                                             'departure_date' => '2026-05-19T18:34:25Z' } })
+      end
+
+      let!(:tower_fix) do
+        create(:point, user: user, accuracy: 1500, velocity: '-1', vertical_accuracy: -1,
+               timestamp: base_time + 90, latitude: 51.3448, longitude: 12.3798,
+               lonlat: 'POINT(12.3798 51.3448)')
+      end
+
+      it 'enqueues one stats refresh for the shared month, not one per pass' do
+        time = Time.zone.at(departed_report.timestamp)
+
+        expect { described_class.new(user.id, 2.hours.ago.to_i, Time.current.to_i).call }
+          .to have_enqueued_job(Stats::CalculatingJob)
+          .with(user.id, time.year, time.month).exactly(:once)
+      end
+    end
+
     # At ingest each batch is filtered alone, and a wake-up tower fix often
     # arrives in a batch of one — its precise context only exists a few
     # minutes later, in the next batch, whose window starts after it.

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -925,6 +925,74 @@ RSpec.describe Points::AnomalyFilter do
       end
     end
 
+    # A point can be flagged after realtime generation already baked it into a
+    # track: stored geometry and monthly distance keep the leap until both are
+    # rebuilt, and recalculation reads track.points, which a stale track_id
+    # would keep feeding.
+    context 'a departed visit report already baked into a track' do
+      let(:base_time) { 1.hour.ago.to_i }
+
+      let!(:walk) do
+        2.times.map do |i|
+          create(:point, user: user, accuracy: 5, timestamp: base_time + (i * 60),
+                 latitude: 51.3421 + (i * 0.0001), longitude: 12.3761,
+                 lonlat: "POINT(12.3761 #{51.3421 + (i * 0.0001)})")
+        end
+      end
+
+      let!(:baked_report) do
+        create(:point, user: user, accuracy: 6, timestamp: base_time + 90,
+               latitude: 51.3428, longitude: 12.3768, lonlat: 'POINT(12.3768 51.3428)',
+               motion_data: { 'action' => 'visit' },
+               raw_data: { 'properties' => { 'action' => 'visit',
+                                             'departure_date' => '2026-05-19T18:34:25Z' } })
+      end
+
+      let!(:track) do
+        create(:track, user: user,
+               start_at: Time.zone.at(base_time), end_at: Time.zone.at(base_time + 120)).tap do |t|
+          Point.where(id: walk.map(&:id) + [baked_report.id]).update_all(track_id: t.id)
+        end
+      end
+
+      def run_filter(**options)
+        described_class.new(user.id, 2.hours.ago.to_i, Time.current.to_i, **options).call
+      end
+
+      it 'detaches the flagged point from its track' do
+        run_filter
+        expect(baked_report.reload.track_id).to be_nil
+      end
+
+      it 'leaves the clean points attached' do
+        run_filter
+        walk.each { |point| expect(point.reload.track_id).to eq(track.id) }
+      end
+
+      it 'enqueues a recalculation for the affected track' do
+        expect { run_filter }.to have_enqueued_job(Tracks::RecalculateJob).with(track.id)
+      end
+
+      it 'enqueues a stats refresh for the affected month' do
+        time = Time.zone.at(baked_report.timestamp)
+
+        expect { run_filter }
+          .to have_enqueued_job(Stats::CalculatingJob).with(user.id, time.year, time.month)
+      end
+
+      it 'skips the dependent rebuilds when the caller rebuilds wholesale' do
+        expect { run_filter(invalidate_dependents: false) }
+          .not_to have_enqueued_job(Tracks::RecalculateJob)
+      end
+
+      it 'still flags and detaches the point when the rebuilds are skipped' do
+        run_filter(invalidate_dependents: false)
+
+        expect(baked_report.reload.anomaly).to be true
+        expect(baked_report.track_id).to be_nil
+      end
+    end
+
     # At ingest each batch is filtered alone, and a wake-up tower fix often
     # arrives in a batch of one — its precise context only exists a few
     # minutes later, in the next batch, whose window starts after it.

--- a/spec/services/points/motion_data_extractor_spec.rb
+++ b/spec/services/points/motion_data_extractor_spec.rb
@@ -11,6 +11,20 @@ RSpec.describe Points::MotionDataExtractor do
       expect(result).to eq({ 'motion' => ['driving'], 'activity' => 'other_navigation', 'action' => 'moving' })
     end
 
+    it 'keeps a visit report departure date so it survives raw_data archival' do
+      properties = { action: 'visit', departure_date: '2026-05-19T18:34:25Z' }
+      result = described_class.from_overland_properties(properties)
+
+      expect(result).to eq({ 'action' => 'visit', 'departure_date' => '2026-05-19T18:34:25Z' })
+    end
+
+    it 'omits a nil departure date' do
+      properties = { action: 'visit', departure_date: nil }
+      result = described_class.from_overland_properties(properties)
+
+      expect(result).to eq({ 'action' => 'visit' })
+    end
+
     it 'handles string-keyed input' do
       properties = { 'motion' => ['walking'], 'activity' => 'stationary' }
       result = described_class.from_overland_properties(properties)


### PR DESCRIPTION
## What

Two new passes in `Points::AnomalyFilter` that catch small-scale "leaped" points the existing teleport-oriented passes cannot see:

- **Departed visit reports.** iOS visit monitoring (Overland `action: visit`) delivers a stay summary after departure: the visit centroid plus arrival/departure dates, stamped with delivery time. The device is already moving away by then, so the track leaps to the centroid and back. Accuracy can be single-digit metres — the coordinate is right, only its place in the timeline is wrong — so no accuracy or speed gate can catch it. Reports carrying a departure date are flagged; arrival reports (delivered while still at the place, including CLVisit's distant-future placeholder) are kept. The departure date is persisted into `motion_data` so classification survives raw_data archival.
- **Cold-start / tower fixes.** Fixes whose motion fields are all CoreLocation sentinels (speed −1, vertical accuracy −1) with a radius above 500 m are tower positions (wifi-tier radii below that are positionally usable and stay), not readings of the user. They are flagged only when the same device produced a precise fix within six hours — reduced-accuracy and significant-change histories are coarse throughout, and there the tower position is the only record, so they are left alone.

Both passes run before the speed pass so it computes speeds over clean context. Flagging an already-tracked point detaches it and queues its track and month for a rebuild in one bulk enqueue; a track left with fewer than two points is destroyed outright. `Points::AnomalyFilterJob` moves from `low_priority` to the `points` queue so flags land before the 45 s realtime track-generation debounce. Flagged points are excluded from tracks, visits detection and the map by the existing `anomaly` plumbing; nothing is deleted.

## Validation

Run against a real 977k-point account (14.5 months of live iOS streaming):

- 988 points flagged: 895 departed visit reports, 88 cold starts, 5 by the existing speed pass.
- Leap-and-return spikes (hop >150 m on both sides while the neighbours agree within 100 m): **798 → 115 (−86%)**. The residue is coarse-but-valid fixes and arrival reports, both deliberately kept.
- The precise-neighbour guard changes nothing on this dataset (all 107 sentinel matches have a precise fix within 6 h) — it exists to protect coarse-only histories.
- After track regeneration, no flagged point remains a track vertex.

## Rollout

Handled automatically by the upgrade: migration `20260811120000` clears the 1.11.0 recalculation stamps and re-enqueues `DataMigrations::RecalculateAnomaliesJob`, which re-filters each account and rebuilds tracks/stats along the way (staggered, same pipeline as the 1.11.0 sweep). The migration runs outside a transaction so a Sidekiq worker from the old deployment cannot pop the sweep before the cleared stamps are committed. New ingest applies the passes per batch as before.

## Tests

108 examples green across filter, extractor, job and migration specs; RuboCop clean.


