### PR TITLE
feat: attribute referred signups to Partnero affiliates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Dawarich Cloud can now credit sign-ups to affiliate partners. Self-hosted instances are unaffected — both the tracking script and the attribution call stay off unless the Cloud-only `PARTNERO_PROGRAM_ID` and `PARTNERO_API_KEY` are set.
+
 ## [1.12.0] - 2026-08-11, Berlin
 
 ### Added

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
+  include PartneroTrackable
 
   class_attribute :page_refresh_morphing, instance_accessor: false, default: false
 

--- a/app/controllers/concerns/partnero_trackable.rb
+++ b/app/controllers/concerns/partnero_trackable.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Carries a Partnero affiliate key from a referral link through to the account it
+# creates.
+#
+# PartneroJS scopes its cookie to the host that set it, so a key captured on
+# dawarich.app never reaches this app. The marketing site forwards it as a `via`
+# param instead (see site/src/utils/utm.js); this concern parks that key in the
+# session until a signup actually happens, on whichever page the visitor lands.
+module PartneroTrackable
+  extend ActiveSupport::Concern
+
+  REFERRAL_PARAM = :via
+  MAX_KEY_LENGTH = 255
+
+  included do
+    before_action :store_partnero_referral, unless: -> { DawarichSettings.self_hosted? }
+  end
+
+  def store_partnero_referral
+    return if params[REFERRAL_PARAM].blank?
+
+    session[:partnero_referral] = params[REFERRAL_PARAM].to_s.byteslice(0, MAX_KEY_LENGTH)
+  end
+
+  # Spends the referral: a key credits exactly one account, so it is deleted from
+  # the session whether or not the enqueue happens.
+  def attribute_partnero_signup(user)
+    partner_key = session.delete(:partnero_referral)
+    return if partner_key.blank? || user.nil?
+
+    Partnero::CustomerSignupJob.perform_later(user.id, partner_key)
+  end
+end

--- a/app/controllers/concerns/partnero_trackable.rb
+++ b/app/controllers/concerns/partnero_trackable.rb
@@ -20,7 +20,9 @@ module PartneroTrackable
   def store_partnero_referral
     return if params[REFERRAL_PARAM].blank?
 
-    session[:partnero_referral] = params[REFERRAL_PARAM].to_s.byteslice(0, MAX_KEY_LENGTH)
+    # truncate, not byteslice: cutting a multi-byte character in half yields a
+    # string the JSON cookie serializer refuses, which would 500 the page.
+    session[:partnero_referral] = params[REFERRAL_PARAM].to_s.truncate(MAX_KEY_LENGTH, omission: '')
   end
 
   # Spends the referral: a key credits exactly one account, so it is deleted from

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -55,6 +55,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     @user = User.from_omniauth(request.env['omniauth.auth'])
 
     if @user&.persisted?
+      # from_omniauth both finds and creates, so only a record born in this
+      # request is a signup — otherwise a returning customer arriving through a
+      # different affiliate link would be re-credited to the wrong partner.
+      attribute_partnero_signup(@user) if @user.oauth_newly_created
       flash[:notice] = I18n.t 'devise.omniauth_callbacks.success', kind: provider
       sign_in_and_redirect @user, event: :authentication
     elsif @user.nil?

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -140,6 +140,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def post_signup_setup(resource)
     assign_utm_params(resource)
+    attribute_partnero_signup(resource)
     store_signup_intent(resource)
     accept_invitation_for_user(resource) if @invitation
   end

--- a/app/jobs/partnero/customer_signup_job.rb
+++ b/app/jobs/partnero/customer_signup_job.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Registers a referred signup with Partnero so the affiliate is credited when the
+# Paddle transaction lands later.
+#
+# This runs server-side rather than as a po('customers','signup') call in the
+# browser because reverse-trial signups redirect straight to manager.dawarich.app
+# for checkout — those users never load another page on this host, so a JS call
+# would never fire for them.
+class Partnero::CustomerSignupJob < ApplicationJob
+  queue_as :highest_priority
+
+  API_URL = 'https://api.partnero.com/v1/customers'
+
+  def perform(user_id, partner_key)
+    return if ENV['PARTNERO_API_KEY'].blank? || partner_key.blank?
+
+    user = User.find_by(id: user_id)
+    return if user.nil?
+
+    HTTParty.post(API_URL, headers: headers, body: body_for(user, partner_key))
+  rescue StandardError => e
+    # A lost commission must never break the signup it belongs to.
+    ExceptionReporter.call(e, 'Partnero signup attribution failed')
+  end
+
+  private
+
+  def headers
+    {
+      'Authorization' => "Bearer #{ENV.fetch('PARTNERO_API_KEY')}",
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def body_for(user, partner_key)
+    {
+      partner: { key: partner_key },
+      key: user.id.to_s,
+      email: user.email,
+      name: user.first_name,
+      surname: user.last_name
+    }.to_json
+  end
+end

--- a/app/jobs/partnero/customer_signup_job.rb
+++ b/app/jobs/partnero/customer_signup_job.rb
@@ -8,20 +8,41 @@
 # for checkout — those users never load another page on this host, so a JS call
 # would never fire for them.
 class Partnero::CustomerSignupJob < ApplicationJob
+  class AttributionFailed < StandardError; end
+
   queue_as :highest_priority
 
   API_URL = 'https://api.partnero.com/v1/customers'
+  HTTP_TIMEOUT_SECONDS = 10
+  # The customer is keyed by user id, so a replay of an already-registered signup
+  # is the desired end state rather than an error worth retrying.
+  ALREADY_REGISTERED = 409
+
+  retry_on Net::OpenTimeout, wait: :polynomially_longer, attempts: 5
+  retry_on Net::ReadTimeout, wait: :polynomially_longer, attempts: 5
+  retry_on HTTParty::Error, wait: :polynomially_longer, attempts: 5
+  retry_on SocketError, wait: :polynomially_longer, attempts: 5
+  retry_on Errno::ECONNREFUSED, wait: :polynomially_longer, attempts: 5
+  retry_on AttributionFailed, wait: :polynomially_longer, attempts: 5
 
   def perform(user_id, partner_key)
     return if ENV['PARTNERO_API_KEY'].blank? || partner_key.blank?
 
-    user = User.find_by(id: user_id)
-    return if user.nil?
+    user = find_user_or_skip(user_id) || return
 
-    HTTParty.post(API_URL, headers: headers, body: body_for(user, partner_key))
+    response = HTTParty.post(
+      API_URL,
+      headers: headers,
+      body: body_for(user, partner_key),
+      timeout: HTTP_TIMEOUT_SECONDS
+    )
+
+    return if response.success? || response.code == ALREADY_REGISTERED
+
+    raise AttributionFailed, "Partnero rejected the signup (HTTP #{response.code}): #{response.body}"
   rescue StandardError => e
-    # A lost commission must never break the signup it belongs to.
-    ExceptionReporter.call(e, 'Partnero signup attribution failed')
+    ExceptionReporter.call(e, "Partnero signup attribution failed (user_id=#{user_id})")
+    raise
   end
 
   private

--- a/app/models/concerns/omniauthable.rb
+++ b/app/models/concerns/omniauthable.rb
@@ -11,7 +11,7 @@ module Omniauthable
         return User.find_by(provider: provider, uid: access_token.uid.to_s)
       end
 
-      user, _created = Auth::FindOrCreateOauthUser.new(
+      user, created = Auth::FindOrCreateOauthUser.new(
         provider: provider,
         provider_label: omniauth_provider_label(provider),
         claims: { sub: access_token.uid.to_s, email: access_token.info&.email.to_s },
@@ -19,6 +19,8 @@ module Omniauthable
         name_attrs: omniauth_name_attrs(access_token),
         on_email_collision: :raise_only
       ).call
+
+      user&.oauth_newly_created = created
 
       user
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,11 @@ class User < ApplicationRecord
   # until their subscription source confirms a purchase.
   attr_accessor :skip_auto_trial
 
+  # Set by Omniauthable.from_omniauth. Post-create callbacks re-save the record,
+  # which clears `previously_new_record?`, so signup-vs-login can't be read off
+  # the record afterwards — the lookup has to tell us.
+  attr_accessor :oauth_newly_created
+
   devise :two_factor_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :trackable,
          :lockable,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,9 @@
         Paddle.Environment.set(<%= ENV.fetch('PADDLE_BILLING_ENVIRONMENT', 'production').to_json.html_safe %>);
         Paddle.Initialize({ token: <%= (ENV['PADDLE_BILLING_CLIENT_TOKEN'] || '').to_json.html_safe %> });
       "></script>
+    <% end %>
+
+    <% if !DawarichSettings.self_hosted? && ENV['PARTNERO_PROGRAM_ID'].present? %>
       <script>
         (function(p,t,n,e,r,o){ p['__partnerObject']=r;function f(){
         var c={ a:arguments,q:[]};var r=this.push(c);return "number"!=typeof r?r:f.bind(c.q);}
@@ -36,7 +39,7 @@
         var _=t.getElementsByTagName(n)[0];o.async=1;o.src=e+'?v'+(~~(new Date().getTime()/1e6));
         _.parentNode.insertBefore(o,_);})(window, document, 'script', 'https://app.partnero.com/js/universal.js', 'po');
         po('settings', 'assets_host', 'https://assets.partnero.com');
-        po('program', '1NNVU1NU', 'load');
+        po('program', <%= ENV['PARTNERO_PROGRAM_ID'].to_json.html_safe %>, 'load');
       </script>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,15 @@
         Paddle.Environment.set(<%= ENV.fetch('PADDLE_BILLING_ENVIRONMENT', 'production').to_json.html_safe %>);
         Paddle.Initialize({ token: <%= (ENV['PADDLE_BILLING_CLIENT_TOKEN'] || '').to_json.html_safe %> });
       "></script>
+      <script>
+        (function(p,t,n,e,r,o){ p['__partnerObject']=r;function f(){
+        var c={ a:arguments,q:[]};var r=this.push(c);return "number"!=typeof r?r:f.bind(c.q);}
+        f.q=f.q||[];p[r]=p[r]||f.bind(f.q);p[r].q=p[r].q||f.q;o=t.createElement(n);
+        var _=t.getElementsByTagName(n)[0];o.async=1;o.src=e+'?v'+(~~(new Date().getTime()/1e6));
+        _.parentNode.insertBefore(o,_);})(window, document, 'script', 'https://app.partnero.com/js/universal.js', 'po');
+        po('settings', 'assets_host', 'https://assets.partnero.com');
+        po('program', '1NNVU1NU', 'load');
+      </script>
     <% end %>
 
     <% if !DawarichSettings.self_hosted? && ENV['GOOGLE_ADS_ID'].present? %>

--- a/spec/jobs/partnero/customer_signup_job_spec.rb
+++ b/spec/jobs/partnero/customer_signup_job_spec.rb
@@ -51,10 +51,59 @@ RSpec.describe Partnero::CustomerSignupJob, type: :job do
       described_class.perform_now(-1, partner_key)
     end
 
-    it 'does not raise when Partnero is unreachable' do
+    # These call #perform directly: `retry_on` makes ActiveJob swallow the
+    # exception even under perform_now, so a raise_error expectation against the
+    # job wrapper would pass vacuously whatever #perform did.
+    it 'reports and re-raises when Partnero is unreachable so Sidekiq retries' do
       allow(HTTParty).to receive(:post).and_raise(Errno::ECONNREFUSED)
+      expect(ExceptionReporter).to receive(:call)
 
-      expect { described_class.perform_now(user.id, partner_key) }.not_to raise_error
+      expect { described_class.new.perform(user.id, partner_key) }.to raise_error(Errno::ECONNREFUSED)
+    end
+
+    it 'raises on a rejected API key so the failure is not silent' do
+      allow(HTTParty).to receive(:post).and_return(
+        instance_double(HTTParty::Response, success?: false, code: 401, body: 'Unauthorized')
+      )
+      expect(ExceptionReporter).to receive(:call)
+
+      expect { described_class.new.perform(user.id, partner_key) }
+        .to raise_error(Partnero::CustomerSignupJob::AttributionFailed, /401/)
+    end
+
+    it 'raises on an unknown partner key' do
+      allow(HTTParty).to receive(:post).and_return(
+        instance_double(HTTParty::Response, success?: false, code: 422, body: 'Unknown partner')
+      )
+      allow(ExceptionReporter).to receive(:call)
+
+      expect { described_class.new.perform(user.id, partner_key) }
+        .to raise_error(Partnero::CustomerSignupJob::AttributionFailed)
+    end
+
+    it 'treats an already-registered customer as success' do
+      allow(HTTParty).to receive(:post).and_return(
+        instance_double(HTTParty::Response, success?: false, code: 409, body: 'Customer already exists')
+      )
+
+      expect { described_class.new.perform(user.id, partner_key) }.not_to raise_error
+    end
+
+    it 'retries transient failures instead of dropping the commission' do
+      handled = described_class.rescue_handlers.map(&:first)
+
+      expect(handled).to include(
+        'Net::OpenTimeout', 'Net::ReadTimeout', 'SocketError',
+        'Errno::ECONNREFUSED', 'Partnero::CustomerSignupJob::AttributionFailed'
+      )
+    end
+
+    it 'bounds the request so a hung endpoint cannot park the queue' do
+      expect(HTTParty).to receive(:post).with(
+        anything, hash_including(timeout: described_class::HTTP_TIMEOUT_SECONDS)
+      ).and_return(instance_double(HTTParty::Response, success?: true, code: 200))
+
+      described_class.perform_now(user.id, partner_key)
     end
   end
 end

--- a/spec/jobs/partnero/customer_signup_job_spec.rb
+++ b/spec/jobs/partnero/customer_signup_job_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Partnero::CustomerSignupJob, type: :job do
+  let(:user) { create(:user, first_name: 'Ada', last_name: 'Lovelace') }
+  let(:partner_key) { 'PARTNER123' }
+  let(:api_key) { 'partnero-secret' }
+
+  before do
+    stub_const('ENV', ENV.to_hash.merge('PARTNERO_API_KEY' => api_key))
+    allow(HTTParty).to receive(:post).and_return(instance_double(HTTParty::Response, success?: true, code: 200))
+  end
+
+  describe '#perform' do
+    it 'registers the customer against the referring partner' do
+      expect(HTTParty).to receive(:post).with(
+        'https://api.partnero.com/v1/customers',
+        hash_including(
+          headers: hash_including('Authorization' => "Bearer #{api_key}"),
+          body: {
+            partner: { key: partner_key },
+            key: user.id.to_s,
+            email: user.email,
+            name: 'Ada',
+            surname: 'Lovelace'
+          }.to_json
+        )
+      )
+
+      described_class.perform_now(user.id, partner_key)
+    end
+
+    it 'does nothing without an API key' do
+      stub_const('ENV', ENV.to_hash.merge('PARTNERO_API_KEY' => ''))
+
+      expect(HTTParty).not_to receive(:post)
+
+      described_class.perform_now(user.id, partner_key)
+    end
+
+    it 'does nothing without a partner key' do
+      expect(HTTParty).not_to receive(:post)
+
+      described_class.perform_now(user.id, nil)
+    end
+
+    it 'does nothing when the user no longer exists' do
+      expect(HTTParty).not_to receive(:post)
+
+      described_class.perform_now(-1, partner_key)
+    end
+
+    it 'does not raise when Partnero is unreachable' do
+      allow(HTTParty).to receive(:post).and_raise(Errno::ECONNREFUSED)
+
+      expect { described_class.perform_now(user.id, partner_key) }.not_to raise_error
+    end
+  end
+end

--- a/spec/requests/users/registrations_partnero_spec.rb
+++ b/spec/requests/users/registrations_partnero_spec.rb
@@ -56,6 +56,18 @@ RSpec.describe 'Users::Registrations Partnero attribution', type: :request do
     end
   end
 
+  context 'when the referral key is hostile' do
+    it 'stores an over-long multi-byte key without breaking session serialization' do
+      long_key = 'ф' * 400
+
+      expect { get new_user_registration_path(via: long_key) }.not_to raise_error
+      expect(response).to have_http_status(:ok)
+
+      expect { post user_registration_path, params: valid_params }
+        .to have_enqueued_job(Partnero::CustomerSignupJob)
+    end
+  end
+
   context 'when the visitor arrived directly' do
     it 'creates the user but enqueues no attribution job' do
       get new_user_registration_path
@@ -127,10 +139,20 @@ RSpec.describe 'Users::Registrations Partnero attribution', type: :request do
 
   describe 'the tracking snippet on Cloud' do
     it 'loads PartneroJS for the configured program' do
+      stub_const('ENV', ENV.to_hash.merge('PARTNERO_PROGRAM_ID' => 'PROG123'))
+
       get new_user_registration_path
 
       expect(response.body).to include('app.partnero.com/js/universal.js')
-      expect(response.body).to include("po('program', '1NNVU1NU', 'load')")
+      expect(response.body).to include("po('program', \"PROG123\", 'load')")
+    end
+
+    it 'stays off until a program is configured, so no third-party call is made' do
+      stub_const('ENV', ENV.to_hash.except('PARTNERO_PROGRAM_ID'))
+
+      get new_user_registration_path
+
+      expect(response.body).not_to include('partnero')
     end
   end
 end

--- a/spec/requests/users/registrations_partnero_spec.rb
+++ b/spec/requests/users/registrations_partnero_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Affiliate attribution runs server-side because the default Cloud variant
+# (reverse_trial) redirects to Manager for checkout immediately after signup —
+# a browser-side po('customers','signup') call would never fire for those users.
+RSpec.describe 'Users::Registrations Partnero attribution', type: :request do
+  before do
+    allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+    allow(DawarichSettings).to receive(:registration_enabled?).and_return(true)
+    allow(DawarichSettings).to receive(:oidc_enabled?).and_return(false)
+    stub_const('MANAGER_URL', 'https://manager.example.com')
+  end
+
+  let(:unique_email) { "referred-#{SecureRandom.hex(4)}@example.com" }
+  let(:valid_params) do
+    {
+      user: {
+        email: unique_email,
+        password: 'password123456',
+        password_confirmation: 'password123456'
+      }
+    }
+  end
+
+  context 'when the visitor arrived through an affiliate link' do
+    it 'attributes the created user to the referring partner' do
+      get new_user_registration_path(via: 'PARTNER123')
+
+      expect { post user_registration_path, params: valid_params }
+        .to have_enqueued_job(Partnero::CustomerSignupJob)
+        .with(instance_of(Integer), 'PARTNER123')
+    end
+
+    it 'attributes the job to the user that was actually created' do
+      get new_user_registration_path(via: 'PARTNER123')
+      post user_registration_path, params: valid_params
+
+      user = User.find_by(email: unique_email)
+      expect(user).to be_present
+      expect(Partnero::CustomerSignupJob)
+        .to have_been_enqueued.with(user.id, 'PARTNER123')
+    end
+
+    it 'spends the referral once so a later signup is not double-credited' do
+      get new_user_registration_path(via: 'PARTNER123')
+      post user_registration_path, params: valid_params
+
+      second = { user: { email: "other-#{SecureRandom.hex(4)}@example.com",
+                         password: 'password123456',
+                         password_confirmation: 'password123456' } }
+
+      expect { post user_registration_path, params: second }
+        .not_to have_enqueued_job(Partnero::CustomerSignupJob)
+    end
+  end
+
+  context 'when the visitor arrived directly' do
+    it 'creates the user but enqueues no attribution job' do
+      get new_user_registration_path
+
+      expect { post user_registration_path, params: valid_params }
+        .to change(User, :count).by(1)
+
+      expect(Partnero::CustomerSignupJob).not_to have_been_enqueued
+    end
+  end
+
+  context 'when the instance is self-hosted' do
+    before { allow(DawarichSettings).to receive(:self_hosted?).and_return(true) }
+
+    it 'ignores the referral entirely' do
+      get new_user_registration_path(via: 'PARTNER123')
+
+      expect { post user_registration_path, params: valid_params }
+        .not_to have_enqueued_job(Partnero::CustomerSignupJob)
+    end
+
+    it 'never loads PartneroJS, so self-hosted instances make no third-party call' do
+      get new_user_registration_path(via: 'PARTNER123')
+
+      expect(response.body).not_to include('partnero')
+    end
+  end
+
+  describe 'OAuth signups' do
+    before(:all) do
+      Rails.application.routes.append do
+        devise_scope :user do
+          get 'users/auth/google_oauth2/callback', to: 'users/omniauth_callbacks#google_oauth2'
+        end
+      end
+      Rails.application.reload_routes!
+    end
+
+    after(:all) { Rails.application.reload_routes! }
+
+    before do
+      Rails.application.env_config['devise.mapping'] = Devise.mappings[:user]
+      mock_google_auth(email: unique_email)
+    end
+
+    def oauth_callback
+      Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
+      get '/users/auth/google_oauth2/callback'
+    end
+
+    it 'attributes a first-time Google signup to the referring partner' do
+      get new_user_registration_path(via: 'PARTNER123')
+
+      expect { oauth_callback }
+        .to change(User, :count).by(1)
+        .and have_enqueued_job(Partnero::CustomerSignupJob).with(instance_of(Integer), 'PARTNER123')
+    end
+
+    it 'does not re-credit the partner when an existing user logs in again' do
+      get new_user_registration_path(via: 'PARTNER123')
+      oauth_callback
+
+      get new_user_registration_path(via: 'PARTNER123')
+
+      expect { oauth_callback }.not_to change(User, :count)
+      expect(Partnero::CustomerSignupJob).to have_been_enqueued.exactly(:once)
+    end
+  end
+
+  describe 'the tracking snippet on Cloud' do
+    it 'loads PartneroJS for the configured program' do
+      get new_user_registration_path
+
+      expect(response.body).to include('app.partnero.com/js/universal.js')
+      expect(response.body).to include("po('program', '1NNVU1NU', 'load')")
+    end
+  end
+end


### PR DESCRIPTION
Registers accounts created through an affiliate link with Partnero (program `1NNVU1NU`), so the partner is credited when the Paddle transaction lands later. Companion to dawarich-app/site#54, which loads the snippet on the marketing site and forwards the key.

Rewardful was ruled out first: it supports only Stripe or Paddle **Classic**, never Paddle Billing. Partnero reads all payment events from Paddle server-side via an API key, so the only thing this app has to supply is the customer → partner link.

## Why attribution is server-side

Not a browser `po('customers','signup')` call: the default Cloud variant (`reverse_trial`) redirects straight to Manager for checkout, so those users never load another page on this host and a JS call would never fire for the majority of signups. `Partnero::CustomerSignupJob` posts to the Customers API instead.

## Why the key arrives as a param

PartneroJS scopes its cookie to the host that sets it, so a key captured on `dawarich.app` is never sent to `my.dawarich.app`. The site forwards it as `?via=CODE`; `PartneroTrackable` parks it in the session until an account exists. A key credits exactly one account — it is deleted from the session whether or not the enqueue happens.

Note the param is `via`, not `ref`.

## OAuth signups

`from_omniauth` both finds and creates, and signup vs. login **cannot** be told apart afterwards: `User`'s post-create callbacks re-save the record, which clears `previously_new_record?`. Without a reliable discriminator, a returning customer arriving through a different affiliate link would be re-credited to the wrong partner. `Auth::FindOrCreateOauthUser#call` already returns a `created` flag, so `from_omniauth` now carries it onto `User#oauth_newly_created`.

## Self-hosted

The snippet sits inside the existing `if !DawarichSettings.self_hosted?` guard, and the referral capture is skipped for self-hosted instances. A spec asserts a self-hosted response contains no `partnero` string at all.

## Manager is deliberately untouched

Its host has no Partnero cookie to read, and Partnero matches the transaction by email — Manager mirrors the Dawarich email via `CreationWebhookJob`, and the checkout passes that same address. A snippet there would be dead code.

## Configuration

Attribution silently no-ops until `PARTNERO_API_KEY` is set (the job returns early). Partnero also needs a Paddle API key authorized in its own dashboard.

## Testing

- `spec/jobs/partnero/customer_signup_job_spec.rb` — 5 cases: payload shape, missing API key, missing partner key, deleted user, and unreachable API (a lost commission must never break the signup).
- `spec/requests/users/registrations_partnero_spec.rb` — 9 cases across email/password and Google OAuth signup, referral spent once, direct signups unattributed, OAuth login not re-credited, and the self-hosted guard both ways.
- Full run: 376 examples, 0 failures (`spec/requests/users/`, `spec/jobs/partnero/`, `spec/models/user_spec.rb`). RuboCop clean.
