### PR TITLE
Use unlogged tables instead of temporary ones in dedupe migrations

### DIFF
--- a/db/migrate/20260730210150_dedupe_visits_before_unique_index.rb
+++ b/db/migrate/20260730210150_dedupe_visits_before_unique_index.rb
@@ -25,7 +25,7 @@ class DedupeVisitsBeforeUniqueIndex < ActiveRecord::Migration[8.0]
   def build_plan
     execute("DROP TABLE IF EXISTS #{PLAN_TABLE}")
     execute(<<~SQL.squish)
-      CREATE TEMPORARY TABLE #{PLAN_TABLE} AS
+      CREATE UNLOGGED TABLE #{PLAN_TABLE} AS
       SELECT min(id) AS keeper, array_agg(id) AS ids
       FROM visits
       WHERE place_id IS NOT NULL

--- a/db/migrate/20260730210200_add_unique_index_to_visits.rb
+++ b/db/migrate/20260730210200_add_unique_index_to_visits.rb
@@ -45,7 +45,7 @@ class AddUniqueIndexToVisits < ActiveRecord::Migration[8.0]
   # without its points ever being moved, orphaning them or failing the FK.
   def collapse_stragglers
     execute("DROP TABLE IF EXISTS #{STRAGGLER_TABLE}")
-    execute("CREATE TEMPORARY TABLE #{STRAGGLER_TABLE} AS #{losers_sql}")
+    execute("CREATE UNLOGGED TABLE #{STRAGGLER_TABLE} AS #{losers_sql}")
 
     execute(<<~SQL.squish)
       UPDATE points SET visit_id = #{STRAGGLER_TABLE}.keeper

--- a/db/migrate/20260730210250_dedupe_track_segments_before_unique_index.rb
+++ b/db/migrate/20260730210250_dedupe_track_segments_before_unique_index.rb
@@ -25,7 +25,7 @@ class DedupeTrackSegmentsBeforeUniqueIndex < ActiveRecord::Migration[8.0]
   def build_plan
     execute("DROP TABLE IF EXISTS #{PLAN_TABLE}")
     execute(<<~SQL.squish)
-      CREATE TEMPORARY TABLE #{PLAN_TABLE} AS
+      CREATE UNLOGGED TABLE #{PLAN_TABLE} AS
       SELECT id FROM (
         SELECT id,
                row_number() OVER (PARTITION BY track_id, start_index ORDER BY id) AS position


### PR DESCRIPTION
Replaces `CREATE TEMPORARY TABLE` with `CREATE UNLOGGED TABLE` in the three dedupe migrations that build a plan table.

## Why

All three migrations declare `disable_ddl_transaction!`, so every `execute` runs in its own transaction. Behind a connection pooler in transaction mode — which Dawarich Cloud uses — consecutive statements are not guaranteed to land on the same backend, and a `TEMPORARY` table is visible only to the session that created it.

The dedupe loops depend on that table surviving across statements:

```ruby
rows = execute("SELECT keeper, ids FROM #{PLAN_TABLE} LIMIT #{BATCH_SIZE}")
break if rows.empty?
# ... collapse work ...
execute("DELETE FROM #{PLAN_TABLE} WHERE keeper IN (...)")
```

Two failure modes follow from that:

- **Loud:** the `DELETE` lands on a backend that never had the table and the migration dies on `PG::UndefinedTable`. This blocked a production deploy on 2026-08-12, inside `20260730210150`.
- **Silent:** the `DELETE` lands on a backend that has a *stale* plan table from an earlier failed attempt. It succeeds, deletes zero rows, and raises nothing — so the next `SELECT` returns the same batch and `break if rows.empty?` is never reached. The migration loops forever with no error and no progress.

The second one is the more dangerous of the two, because a pooler that does not run `DISCARD ALL` as its reset query leaves those stale tables lying around for exactly this to happen.

An unlogged table is a real table visible from every backend, and still skips WAL — which is the only property these plan tables actually needed.

## Trade-off

An unlogged table is a shared named object, so it loses the per-session isolation a temporary table gave. Two concurrent `db:migrate` runs would clobber a single plan table. That is acceptable for a single-deploy setup, and advisory locks already serialise migrations wherever they are enabled. Do not copy this pattern into code that runs under real concurrency.

## Scope

These migrations have already run on Cloud, so this changes nothing there. It matters for fresh installs and for self-hosters who run their own pooler in transaction mode, both of which would otherwise hit the same trap.

Checked: `ruby -c` on all three files, `rubocop` clean, and no `CREATE TEMPORARY TABLE` remaining anywhere under `db/migrate/`. The migrations themselves are not re-runnable on an instance that has already applied them, so this has not been exercised end-to-end against a fresh database.
