### PR TITLE
Bound the adjacency query in BoundaryDetector

### DIFF
--- a/app/services/tracks/boundary_detector.rb
+++ b/app/services/tracks/boundary_detector.rb
@@ -15,6 +15,8 @@ class Tracks::BoundaryDetector
   # don't auto-stitch them into one continuous track.
   SAME_TRACKER_MAX_GAP_METERS = 5_000
 
+  ADJACENCY_QUERY_BATCH_SIZE = 25
+
   attr_reader :user
 
   def initialize(user)
@@ -104,8 +106,8 @@ class Tracks::BoundaryDetector
   def find_boundary_track_candidates
     recent_tracks = user.tracks
                         .where('created_at > ?', 1.hour.ago)
-                        .includes(:points)
                         .order(:start_at)
+                        .to_a
 
     return [] if recent_tracks.empty?
 
@@ -135,11 +137,20 @@ class Tracks::BoundaryDetector
   def adjacent_existing_tracks(recent_tracks)
     return [] if recent_tracks.empty?
 
-    window = adjacency_window
-    recent_ids = recent_tracks.map(&:id)
+    recent_ids = recent_tracks.map(&:id).to_set
     tracker_ids = recent_tracks.map(&:tracker_id).uniq
 
-    conditions = recent_tracks.flat_map do |track|
+    recent_tracks
+      .each_slice(ADJACENCY_QUERY_BATCH_SIZE)
+      .flat_map { |slice| adjacent_tracks_for_slice(slice, tracker_ids) }
+      .uniq(&:id)
+      .reject { |track| recent_ids.include?(track.id) }
+  end
+
+  def adjacent_tracks_for_slice(slice, tracker_ids)
+    window = adjacency_window
+
+    conditions = slice.flat_map do |track|
       [
         ['end_at BETWEEN ? AND ?', track.start_at - window, track.start_at],
         ['start_at BETWEEN ? AND ?', track.end_at, track.end_at + window],
@@ -151,10 +162,9 @@ class Tracks::BoundaryDetector
     bindings = conditions.flat_map { |c| c[1..] }
 
     user.tracks
-        .where.not(id: recent_ids)
         .where(tracker_id: tracker_ids)
         .where(sql, *bindings)
-        .includes(:points)
+        .to_a
   end
 
   # Time gap that still counts as "adjacent" for boundary merging.

--- a/spec/services/tracks/boundary_detector_spec.rb
+++ b/spec/services/tracks/boundary_detector_spec.rb
@@ -174,6 +174,60 @@ RSpec.describe Tracks::BoundaryDetector do
   end
 
   describe 'private methods' do
+    describe '#adjacent_existing_tracks' do
+      def tracks_queries_during
+        queries = []
+        subscriber = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+          queries << payload[:sql] if payload[:sql].to_s.include?('FROM "tracks"')
+        end
+        yield
+        queries
+      ensure
+        ActiveSupport::Notifications.unsubscribe(subscriber)
+      end
+
+      let(:base) { 6.hours.ago }
+
+      let!(:recent_tracks) do
+        Array.new(60) do |i|
+          create(:track, user: user,
+                         created_at: 5.minutes.ago,
+                         start_at: base + (i * 10).minutes,
+                         end_at: base + ((i * 10) + 5).minutes)
+        end
+      end
+
+      it 'bounds the OR conditions in each query regardless of recent track count' do
+        queries = tracks_queries_during do
+          detector.send(:adjacent_existing_tracks, recent_tracks).to_a
+        end
+
+        expect(queries).not_to be_empty
+        expect(queries.map { |sql| sql.scan(/ OR /).size }.max).to be <= 80
+      end
+
+      it 'does not build a NOT IN list over every recent track id' do
+        queries = tracks_queries_during do
+          detector.send(:adjacent_existing_tracks, recent_tracks).to_a
+        end
+
+        expect(queries).not_to be_empty
+        expect(queries.select { |sql| sql.include?('NOT IN') }).to be_empty
+      end
+
+      it 'still finds an older adjacent track and excludes the recent ones' do
+        older = create(:track, user: user,
+                               created_at: 12.hours.ago,
+                               start_at: base - 20.minutes,
+                               end_at: base - 1.minute)
+
+        result = detector.send(:adjacent_existing_tracks, recent_tracks)
+
+        expect(result.map(&:id)).to include(older.id)
+        expect(result.map(&:id)).not_to include(*recent_tracks.map(&:id))
+      end
+    end
+
     describe '#find_connected_tracks' do
       let!(:base_track) { create(:track, user: user, start_at: 2.hours.ago, end_at: 1.5.hours.ago) }
       let!(:connected_track) { create(:track, user: user, start_at: 1.hour.ago, end_at: 30.minutes.ago) }


### PR DESCRIPTION
Bounds the adjacency query in `Tracks::BoundaryDetector` so it stops degrading into a multi-hour sequential scan.

## Why

`adjacent_existing_tracks` built a single `WHERE` clause containing three OR'd time-range conditions for **every** track created in the last hour, plus a `NOT IN` listing all of their ids:

```sql
SELECT "tracks".* FROM "tracks"
WHERE user_id = $1 AND id NOT IN ($2..$61)
  AND (end_at BETWEEN .. OR start_at BETWEEN .. OR ..)   -- 179 OR branches, 421 binds
```

During bulk import or track regeneration `recent_tracks` is thousands of rows, so one statement carried tens of thousands of OR branches. The planner abandons the index for a parallel sequential scan, and the query runs for hours.

Two production incidents came out of this:

- **2026-07-20** — gigadb at load 17–20 on 12 cores, 16 backends stuck 3+ hours on this query.
- **2026-08-12** — two of these queries, each with three parallel workers, held open transactions for over an hour and blocked a `CREATE INDEX CONCURRENTLY` in a deploy migration. `CREATE INDEX CONCURRENTLY` waits for every concurrent transaction in the database, so a stalled adjacency query stalls unrelated schema changes.

Both times the backends were effectively unkillable: `pg_cancel_backend` and `pg_terminate_backend` both return `t` and nothing dies, because PostgreSQL only notices a dead client when it next writes to the socket, and a query hours deep in the executor that has never emitted a row never does.

## What changed

- **Slice into batches of 25.** `ADJACENCY_QUERY_BATCH_SIZE` caps the OR branches any single statement can carry, keeping each one planner-friendly regardless of how many tracks were just generated.
- **Drop the `NOT IN`.** Recent ids are rejected with a `Set` in Ruby instead, which removes the second unbounded list from the statement.
- **Remove both `includes(:points)`.** Every use site re-queries points through `points.order(:timestamp)`, so eager-loading every point of every candidate track was wasted work against the largest table in the schema. Only `points.exists?` benefited, and Rails short-circuits that on a loaded association — a trivial saving next to the load cost.
- **Materialise with `to_a`** so callers cannot re-execute the relation.

## Verification

- `spec/services/tracks/` — **242 examples, 0 failures**, run against an isolated per-worktree database.
- `rubocop` clean on both changed files.
- Three specs assert the properties that matter: the OR count stays bounded, no `NOT IN` is emitted, and adjacency results are unchanged.

## Note on scope

`find_connected_tracks` remains O(n²) over candidate tracks. The integer time-window check prunes most pairs cheaply and it did not contribute to either incident, but it will matter at higher track counts. Deliberately left alone here.

A missing index compounded both incidents: `idx_tracks_user_tracker_end_at`, which covers exactly this query's columns, had been sitting in an invalid state since May 2026 and so was ignored by the planner. That has been repaired separately on the database. This change makes the query safe even when the planner does not have that index available.
