### PR TITLE
perf: consolidate points indexes and guard full-history track rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- Consolidated `points` table indexes: a new `(user_id, timestamp, lonlat)` unique index replaces three redundant indexes, roughly halving the write cost of every point. The index is built concurrently at boot during the upgrade; on instances with millions of points this can take several minutes — the app stays usable while it builds.
+- Automatic daily track generation no longer rebuilds a user's entire history when their tracks are missing and their history exceeds 100k points; such rebuilds now require explicitly running a backfill.
+
 ## [1.12.1] - 2026-08-13, Berlin
 
 ### Fixed

--- a/app/jobs/tracks/daily_generation_job.rb
+++ b/app/jobs/tracks/daily_generation_job.rb
@@ -21,6 +21,12 @@ class Tracks::DailyGenerationJob < ApplicationJob
 
   queue_as :tracks
 
+  # A user with no tracks and a history this large is backfill territory, not
+  # daily-catch-up territory: without the guard, a wiped tracks table makes
+  # start_timestamp fall back to the user's very first point and the daily job
+  # rewrites track_id across the entire history (non-HOT updates × every index).
+  BOOTSTRAP_POINTS_LIMIT = 100_000
+
   def perform
     User.active_or_trial.find_each do |user|
       next if user.points_count&.zero?
@@ -38,6 +44,7 @@ class Tracks::DailyGenerationJob < ApplicationJob
       start_timestamp = start_timestamp(user)
 
       return unless user.points.where('timestamp >= ?', start_timestamp).exists?
+      return if full_history_rebuild_blocked?(user)
 
       Tracks::ParallelGeneratorJob.perform_later(
         user.id,
@@ -46,6 +53,18 @@ class Tracks::DailyGenerationJob < ApplicationJob
         mode: 'daily'
       )
     end
+  end
+
+  def full_history_rebuild_blocked?(user)
+    return false if user.tracks.exists?
+    return false if user.points_count.to_i <= BOOTSTRAP_POINTS_LIMIT
+
+    message = "user #{user.id} has no tracks and #{user.points_count} points; " \
+              'skipping full-history rebuild — run Tracks::BackfillGenerationJob explicitly'
+    Rails.logger.warn("Tracks::DailyGenerationJob: #{message}")
+    ExceptionReporter.call('Tracks::DailyGenerationJob full-history rebuild skipped', message)
+
+    true
   end
 
   def start_timestamp(user)

--- a/app/models/concerns/archivable.rb
+++ b/app/models/concerns/archivable.rb
@@ -17,7 +17,7 @@ module Archivable
     before_save :reset_archival_on_raw_data_change
   end
 
-  UPSERT_CONFLICT_KEYS = %i[lonlat timestamp user_id].freeze
+  UPSERT_CONFLICT_KEYS = %i[user_id timestamp lonlat].freeze
   UPSERT_MAX_RETRIES = 3
   UPSERT_BACKOFF_BASE = 0.1
   UPSERT_BACKOFF_JITTER = 0.05

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -68,7 +68,7 @@ class Point < ApplicationRecord
   end
 
   # Build a key whose equivalence classes match the PostgreSQL UNIQUE index
-  # on (lonlat, timestamp, user_id). The raw lonlat WKT string from
+  # on (user_id, timestamp, lonlat). The raw lonlat WKT string from
   # Points::Params / Overland::Params can differ character-by-character for
   # points that collapse to the same geography(Point, 4326) double, so a
   # plain string `uniq` keeps both variants and the subsequent

--- a/app/queries/stats_query.rb
+++ b/app/queries/stats_query.rb
@@ -18,9 +18,10 @@ class StatsQuery
   end
 
   def cached_points_geocoded_stats
-    # Split into two queries to leverage partial indexes:
-    # - index_points_on_user_id_and_reverse_geocoded_at
-    # - index_points_on_user_id_and_empty_geodata
+    # No index serves these filters since the 2026-08 points index
+    # consolidation; both are daily-cached counts that scan the user's rows
+    # via the (user_id, ...) composite index. The without_data count retires
+    # together with the geodata column.
     geocoded_sql = ActiveRecord::Base.sanitize_sql_array(
       [
         <<~SQL.squish,

--- a/app/services/google_maps/semantic_history_importer.rb
+++ b/app/services/google_maps/semantic_history_importer.rb
@@ -31,7 +31,7 @@ class GoogleMaps::SemanticHistoryImporter
 
     Point.upsert_all(
       records,
-      unique_by: %i[lonlat timestamp user_id],
+      unique_by: %i[user_id timestamp lonlat],
       returning: false,
       on_duplicate: :skip
     )

--- a/app/services/imports/bulk_insertable.rb
+++ b/app/services/imports/bulk_insertable.rb
@@ -19,7 +19,7 @@ module Imports
 
       result = Point.upsert_all(
         unique_batch,
-        unique_by: %i[lonlat timestamp user_id],
+        unique_by: %i[user_id timestamp lonlat],
         returning: Arel.sql('id'),
         on_duplicate: :skip
       )

--- a/app/services/users/import_data/points.rb
+++ b/app/services/users/import_data/points.rb
@@ -91,7 +91,7 @@ class Users::ImportData::Points
     begin
       result = Point.upsert_all(
         normalized_batch,
-        unique_by: %i[lonlat timestamp user_id],
+        unique_by: %i[user_id timestamp lonlat],
         returning: %w[id],
         on_duplicate: :skip
       )

--- a/db/migrate/20260813120000_add_user_id_timestamp_lonlat_unique_index_to_points.rb
+++ b/db/migrate/20260813120000_add_user_id_timestamp_lonlat_unique_index_to_points.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddUserIdTimestampLonlatUniqueIndexToPoints < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :points, %i[user_id timestamp lonlat],
+              unique: true,
+              name: 'index_points_on_user_id_timestamp_lonlat',
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+end

--- a/db/migrate/20260813120100_drop_redundant_points_indexes.rb
+++ b/db/migrate/20260813120100_drop_redundant_points_indexes.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class DropRedundantPointsIndexes < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :points, name: 'index_points_on_user_id', algorithm: :concurrently, if_exists: true
+    remove_index :points, name: 'index_points_on_track_id', algorithm: :concurrently, if_exists: true
+    remove_index :points, name: 'index_points_on_user_id_and_empty_geodata',
+                 algorithm: :concurrently, if_exists: true
+  end
+
+  def down
+    add_index :points, :user_id, name: 'index_points_on_user_id',
+                                 algorithm: :concurrently, if_not_exists: true
+    add_index :points, :track_id, name: 'index_points_on_track_id',
+                                  algorithm: :concurrently, if_not_exists: true
+    add_index :points, %i[user_id geodata], name: 'index_points_on_user_id_and_empty_geodata',
+                                            where: "geodata = '{}'::jsonb",
+                                            algorithm: :concurrently, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_09_090100) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_120100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -370,14 +370,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_09_090100) do
     t.index ["lonlat"], name: "index_points_on_lonlat", using: :gist
     t.index ["raw_data_archive_id"], name: "index_points_on_raw_data_archive_id"
     t.index ["track_id", "timestamp"], name: "idx_points_track_id_timestamp"
-    t.index ["track_id"], name: "index_points_on_track_id"
     t.index ["user_id", "country_name"], name: "idx_points_user_country_name"
-    t.index ["user_id", "geodata"], name: "index_points_on_user_id_and_empty_geodata", where: "(geodata = '{}'::jsonb)"
     t.index ["user_id", "id"], name: "index_points_on_unarchived", where: "((raw_data_archived = false) AND (raw_data <> '{}'::jsonb))"
+    t.index ["user_id", "timestamp", "lonlat"], name: "index_points_on_user_id_timestamp_lonlat", unique: true
     t.index ["user_id", "timestamp"], name: "idx_points_user_visit_null_timestamp", where: "(visit_id IS NULL)"
     t.index ["user_id", "timestamp"], name: "index_points_on_user_id_and_timestamp", order: { timestamp: :desc }
     t.index ["user_id"], name: "idx_points_user_id_legacy_tracker", where: "((tracker_id)::text = ANY (ARRAY[('google-maps-timeline-export'::character varying)::text, ('google-maps-phone-timeline-export'::character varying)::text]))"
-    t.index ["user_id"], name: "index_points_on_user_id"
     t.index ["visit_id"], name: "index_points_on_visit_id"
   end
 

--- a/spec/jobs/tracks/daily_generation_job_spec.rb
+++ b/spec/jobs/tracks/daily_generation_job_spec.rb
@@ -107,6 +107,55 @@ RSpec.describe Tracks::DailyGenerationJob, type: :job do
       end
     end
 
+    context 'when a large-history user has no tracks' do
+      let!(:wiped_user) { create(:user) }
+      let!(:wiped_user_points) do
+        [
+          create(:point, user: wiped_user, timestamp: 200.days.ago.to_i),
+          create(:point, user: wiped_user, timestamp: 1.hour.ago.to_i)
+        ]
+      end
+
+      before do
+        wiped_user.update!(points_count: described_class::BOOTSTRAP_POINTS_LIMIT + 1)
+        allow(User).to receive(:active_or_trial)
+          .and_return(User.where(id: [wiped_user.id]))
+        allow(ExceptionReporter).to receive(:call)
+      end
+
+      it 'does not enqueue a full-history rebuild' do
+        expect { described_class.perform_now }.not_to \
+          have_enqueued_job(Tracks::ParallelGeneratorJob)
+      end
+
+      it 'reports the skipped rebuild so a backfill can be run explicitly' do
+        described_class.perform_now
+
+        expect(ExceptionReporter).to have_received(:call).at_least(:once)
+      end
+    end
+
+    context 'when a small-history user has no tracks' do
+      let!(:new_user) { create(:user) }
+      let!(:new_user_points) do
+        create_list(:point, 3, user: new_user, timestamp: 2.hours.ago.to_i)
+      end
+
+      before do
+        new_user.update!(points_count: new_user.points.count)
+        allow(User).to receive(:active_or_trial)
+          .and_return(User.where(id: [new_user.id]))
+      end
+
+      it 'still bootstraps track generation' do
+        expect { described_class.perform_now }.to \
+          have_enqueued_job(Tracks::ParallelGeneratorJob).with(
+            new_user.id,
+            hash_including(mode: 'daily')
+          )
+      end
+    end
+
     context 'when user has tracks but no new points' do
       let!(:user_with_current_tracks) { create(:user) }
       let!(:recent_points) { create_list(:point, 2, user: user_with_current_tracks, timestamp: 1.hour.ago.to_i) }

--- a/spec/services/points/create_spec.rb
+++ b/spec/services/points/create_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Points::Create do
 
         it 'uses the correct unique constraint' do
           expect(Point).to receive(:upsert_all) do |_data, options|
-            expect(options[:unique_by]).to eq(%i[lonlat timestamp user_id])
+            expect(options[:unique_by]).to eq(%i[user_id timestamp lonlat])
             deduplicated_upsert_result
           end
 


### PR DESCRIPTION
## What

First step of the points index consolidation: every non-HOT update to `points` writes an entry into all 16 of its index structures, which is what turned routine track rebuilds into multi-GB write storms on large instances. This PR reduces the index count without dropping anything the query planner still needs.

## Changes

**Migrations** (both concurrent, no table locks, safe on running instances):

- `AddUserIdTimestampLonlatUniqueIndexToPoints` — adds `UNIQUE (user_id, timestamp, lonlat)`. Column order in a unique constraint does not change which tuples collide, so this enforces the exact same dedup constraint as the existing `(lonlat, timestamp, user_id)` index — but in this order it also serves every `user_id + timestamp` range query, including `ORDER BY timestamp DESC` via backward scans. Guarded with `if_not_exists` so pre-built indexes are picked up as-is.
- `DropRedundantPointsIndexes` — drops `index_points_on_user_id` and `index_points_on_track_id` (pure prefixes of existing composite indexes) and `index_points_on_user_id_and_empty_geodata` (all `if_exists`).

**Code:**

- Upsert conflict keys reordered to `%i[user_id timestamp lonlat]` in `Archivable::UPSERT_CONFLICT_KEYS` and the three importer call sites. PostgreSQL's `ON CONFLICT` inference is column-order-independent, but ActiveRecord's `unique_by:` resolves against index columns in order, so the arrays must match the new index.
- `Tracks::DailyGenerationJob` now refuses to enqueue a full-history rebuild for users with no tracks and more than 100k points (`BOOTSTRAP_POINTS_LIMIT`), reporting via `ExceptionReporter` instead. A wiped tracks table previously made the daily job regenerate a user's entire history. Small accounts still bootstrap automatically.

## Notes

- The old `(lonlat, timestamp, user_id)` unique index is intentionally **not** dropped here. Both unique indexes coexist for one release so old and new code both resolve their conflict target during deploys; the drop follows in a separate PR.
- The two dropped prefix indexes were validated with EXPLAIN before/after: all query shapes fall through to the composite indexes.

## Testing

- Both migrations run cleanly forward and are idempotent (`if_exists` / `if_not_exists`); `db/schema.rb` diff is exactly +1 index, −3 indexes.
- 360 examples across upsert/ingest/import/track-generation specs, 0 failures; RuboCop clean.
