### PR TITLE
feat: throttled full-history track backfill for large users

### DIFF
--- a/app/jobs/tracks/daily_generation_job.rb
+++ b/app/jobs/tracks/daily_generation_job.rb
@@ -25,6 +25,8 @@ class Tracks::DailyGenerationJob < ApplicationJob
   # daily-catch-up territory: without the guard, a wiped tracks table makes
   # start_timestamp fall back to the user's very first point and the daily job
   # rewrites track_id across the entire history (non-HOT updates × every index).
+  # Such users are handed to Tracks::ThrottledBackfillJob, which walks the
+  # history newest-first at a bounded rate.
   BOOTSTRAP_POINTS_LIMIT = 100_000
 
   def perform
@@ -59,10 +61,11 @@ class Tracks::DailyGenerationJob < ApplicationJob
     return false if user.tracks.exists?
     return false if user.points_count.to_i <= BOOTSTRAP_POINTS_LIMIT
 
-    message = "user #{user.id} has no tracks and #{user.points_count} points; " \
-              'skipping full-history rebuild — run Tracks::BackfillGenerationJob explicitly'
-    Rails.logger.warn("Tracks::DailyGenerationJob: #{message}")
-    ExceptionReporter.call('Tracks::DailyGenerationJob full-history rebuild skipped', message)
+    newly_scheduled = Tracks::ThrottledBackfillJob.schedule(user)
+    Rails.logger.info(
+      "Tracks::DailyGenerationJob: user #{user.id} has no tracks and #{user.points_count} points; " \
+      "throttled backfill #{newly_scheduled ? 'scheduled' : 'already in progress'}"
+    )
 
     true
   end

--- a/app/jobs/tracks/daily_generation_job.rb
+++ b/app/jobs/tracks/daily_generation_job.rb
@@ -58,6 +58,10 @@ class Tracks::DailyGenerationJob < ApplicationJob
   end
 
   def full_history_rebuild_blocked?(user)
+    # Self-hosted instances rebuild directly: the write-amplification risk this
+    # guard mitigates is a shared-database concern, and a self-hoster's history
+    # should appear as fast as their own hardware allows.
+    return false if DawarichSettings.self_hosted?
     return false if user.tracks.exists?
     return false if user.points_count.to_i <= BOOTSTRAP_POINTS_LIMIT
 

--- a/app/jobs/tracks/throttled_backfill_job.rb
+++ b/app/jobs/tracks/throttled_backfill_job.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Serial, rate-limited full-history track generation for users whose history is
+# too large for Tracks::DailyGenerationJob's catch-up path (no tracks and more
+# than BOOTSTRAP_POINTS_LIMIT points). Walks the history newest-first, one
+# SLICE at a time, handing each slice to the existing parallel generator with
+# untracked_only so re-runs and overlaps never rewrite already-tracked points.
+# The per-user lock inside ParallelGeneratorJob serializes overlapping slices;
+# the pause between slices bounds the write rate to roughly one slice a minute
+# instead of enqueueing thousands of chunk jobs at once.
+class Tracks::ThrottledBackfillJob < ApplicationJob
+  queue_as :low_priority
+
+  SLICE = 30.days
+  PAUSE = 1.minute
+  DEDUP_KEY_TTL = 12.hours
+
+  def self.redis_key(user_id)
+    "track_throttled_backfill:user:#{user_id}"
+  end
+
+  def self.schedule(user)
+    newly_scheduled = Sidekiq.redis do |redis|
+      redis.set(redis_key(user.id), 1, nx: true, ex: DEDUP_KEY_TTL.to_i)
+    end
+
+    perform_later(user.id, nil) if newly_scheduled
+
+    newly_scheduled
+  end
+
+  def perform(user_id, cursor_timestamp = nil)
+    user = User.find_by(id: user_id)
+    return release_key(user_id) unless user
+
+    cursor = cursor_timestamp || Time.current.to_i
+    slice_end = user.points.where(timestamp: ...cursor).maximum(:timestamp)
+    return complete(user_id) if slice_end.nil?
+
+    slice_start = slice_end - SLICE.to_i
+
+    Tracks::ParallelGeneratorJob.perform_later(
+      user_id,
+      start_at: Time.zone.at(slice_start),
+      end_at: Time.zone.at(slice_end),
+      mode: :bulk,
+      chunk_size: SLICE,
+      untracked_only: true
+    )
+
+    refresh_key(user_id)
+    self.class.set(wait: PAUSE).perform_later(user_id, slice_start)
+  end
+
+  private
+
+  def complete(user_id)
+    Rails.logger.info("Tracks::ThrottledBackfillJob: backfill complete for user #{user_id}")
+    release_key(user_id)
+  end
+
+  def release_key(user_id)
+    Sidekiq.redis { |redis| redis.del(self.class.redis_key(user_id)) }
+  end
+
+  def refresh_key(user_id)
+    Sidekiq.redis { |redis| redis.set(self.class.redis_key(user_id), 1, ex: DEDUP_KEY_TTL.to_i) }
+  end
+end

--- a/spec/jobs/tracks/daily_generation_job_spec.rb
+++ b/spec/jobs/tracks/daily_generation_job_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe Tracks::DailyGenerationJob, type: :job do
         wiped_user.update!(points_count: described_class::BOOTSTRAP_POINTS_LIMIT + 1)
         allow(User).to receive(:active_or_trial)
           .and_return(User.where(id: [wiped_user.id]))
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
         Sidekiq.redis { |redis| redis.del(Tracks::ThrottledBackfillJob.redis_key(wiped_user.id)) }
       end
 
@@ -138,6 +139,25 @@ RSpec.describe Tracks::DailyGenerationJob, type: :job do
 
         expect { described_class.perform_now }.not_to \
           have_enqueued_job(Tracks::ThrottledBackfillJob).twice
+      end
+
+      context 'when self-hosted' do
+        before do
+          allow(DawarichSettings).to receive(:self_hosted?).and_return(true)
+        end
+
+        it 'rebuilds directly without throttling' do
+          expect { described_class.perform_now }.to \
+            have_enqueued_job(Tracks::ParallelGeneratorJob).with(
+              wiped_user.id,
+              hash_including(mode: 'daily')
+            )
+        end
+
+        it 'does not schedule the throttled walker' do
+          expect { described_class.perform_now }.not_to \
+            have_enqueued_job(Tracks::ThrottledBackfillJob)
+        end
       end
     end
 

--- a/spec/jobs/tracks/daily_generation_job_spec.rb
+++ b/spec/jobs/tracks/daily_generation_job_spec.rb
@@ -120,18 +120,24 @@ RSpec.describe Tracks::DailyGenerationJob, type: :job do
         wiped_user.update!(points_count: described_class::BOOTSTRAP_POINTS_LIMIT + 1)
         allow(User).to receive(:active_or_trial)
           .and_return(User.where(id: [wiped_user.id]))
-        allow(ExceptionReporter).to receive(:call)
+        Sidekiq.redis { |redis| redis.del(Tracks::ThrottledBackfillJob.redis_key(wiped_user.id)) }
       end
 
-      it 'does not enqueue a full-history rebuild' do
+      it 'does not enqueue a full-history rebuild through the daily path' do
         expect { described_class.perform_now }.not_to \
           have_enqueued_job(Tracks::ParallelGeneratorJob)
       end
 
-      it 'reports the skipped rebuild so a backfill can be run explicitly' do
+      it 'hands the user off to the throttled backfill walker' do
+        expect { described_class.perform_now }.to \
+          have_enqueued_job(Tracks::ThrottledBackfillJob).with(wiped_user.id, nil)
+      end
+
+      it 'does not stack a second walker on the next daily run' do
         described_class.perform_now
 
-        expect(ExceptionReporter).to have_received(:call).at_least(:once)
+        expect { described_class.perform_now }.not_to \
+          have_enqueued_job(Tracks::ThrottledBackfillJob).twice
       end
     end
 

--- a/spec/jobs/tracks/throttled_backfill_job_spec.rb
+++ b/spec/jobs/tracks/throttled_backfill_job_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tracks::ThrottledBackfillJob, type: :job do
+  let(:user) { create(:user) }
+
+  before do
+    Sidekiq.redis { |redis| redis.del(described_class.redis_key(user.id)) }
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+  end
+
+  describe '.schedule' do
+    it 'enqueues the walker for a user' do
+      expect { described_class.schedule(user) }.to \
+        have_enqueued_job(described_class).with(user.id, nil)
+    end
+
+    it 'does not enqueue a second walker while one is scheduled' do
+      described_class.schedule(user)
+
+      expect { described_class.schedule(user) }.not_to \
+        have_enqueued_job(described_class).twice
+    end
+  end
+
+  describe '#perform' do
+    context 'when the user has points below the cursor' do
+      let!(:old_point) { create(:point, user: user, timestamp: 100.days.ago.to_i) }
+      let!(:newest_point) { create(:point, user: user, timestamp: 1.day.ago.to_i) }
+
+      it 'generates one slice anchored at the newest point, untracked only' do
+        described_class.perform_now(user.id, nil)
+
+        expect(Tracks::ParallelGeneratorJob).to have_been_enqueued.with(
+          user.id,
+          hash_including(
+            untracked_only: true,
+            end_at: Time.zone.at(newest_point.timestamp)
+          )
+        )
+      end
+
+      it 're-enqueues itself with the cursor moved below the slice' do
+        described_class.perform_now(user.id, nil)
+
+        expect(described_class).to have_been_enqueued.with(
+          user.id,
+          newest_point.timestamp - described_class::SLICE.to_i
+        )
+      end
+    end
+
+    context 'when history has a gap below the cursor' do
+      let!(:ancient_point) { create(:point, user: user, timestamp: 400.days.ago.to_i) }
+
+      it 'jumps the slice to the newest point below the cursor instead of walking empty windows' do
+        described_class.perform_now(user.id, 100.days.ago.to_i)
+
+        expect(Tracks::ParallelGeneratorJob).to have_been_enqueued.with(
+          user.id,
+          hash_including(end_at: Time.zone.at(ancient_point.timestamp))
+        )
+      end
+    end
+
+    context 'when no points remain below the cursor' do
+      let!(:recent_point) { create(:point, user: user, timestamp: 1.day.ago.to_i) }
+
+      before do
+        Sidekiq.redis { |redis| redis.set(described_class.redis_key(user.id), 1) }
+      end
+
+      it 'does not enqueue any generation and releases the dedup key' do
+        described_class.perform_now(user.id, 300.days.ago.to_i)
+
+        expect(Tracks::ParallelGeneratorJob).not_to have_been_enqueued
+        expect(described_class).not_to have_been_enqueued
+
+        key_exists = Sidekiq.redis { |redis| redis.exists(described_class.redis_key(user.id)) }
+        expect(key_exists).to eq(0)
+      end
+    end
+
+    context 'when the user no longer exists' do
+      it 'releases the dedup key and stops' do
+        Sidekiq.redis { |redis| redis.set(described_class.redis_key(0), 1) }
+
+        described_class.perform_now(0, nil)
+
+        expect(described_class).not_to have_been_enqueued
+        key_exists = Sidekiq.redis { |redis| redis.exists(described_class.redis_key(0)) }
+        expect(key_exists).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Follow-up to #3359. That PR's guard stops `Tracks::DailyGenerationJob` from silently rebuilding a user's entire history when their tracks table is empty and their history is large (>100k points). This PR makes sure those users still get their tracks.

**Scoping:** the guard and the throttled walker apply to **Cloud only**. Self-hosted instances bypass the guard entirely and rebuild full history directly through the daily path — the write-amplification risk is a shared-database concern, and a self-hoster's history should appear as fast as their own hardware allows.

## How it works (Cloud)

`Tracks::ThrottledBackfillJob` (new, `low_priority` queue) walks the user's history **newest-first, one 30-day slice per minute**:

- Each slice is handed to the existing `Tracks::ParallelGeneratorJob` with `untracked_only: true` and `chunk_size` equal to the slice — exactly one chunk job in flight per slice, instead of thousands enqueued at once.
- `untracked_only` makes every slice idempotent: overlaps and Sidekiq retries never rewrite points that already belong to a track.
- The generator's existing per-user lock serializes overlapping slices naturally.
- The cursor for the next slice is `MAX(timestamp)` below the previous slice, so multi-year gaps in history are skipped in a single hop.
- A Redis `SET NX` key (12h TTL, refreshed per slice, deleted on completion) prevents the every-few-hours daily job from stacking multiple walkers for the same user.

The daily job's guard schedules the walker instead of reporting and giving up; since the condition self-heals, the Sentry report is replaced by a log line.

Net effect: recent tracks appear within minutes (newest-first), a ~10-year, 1M-point history completes in roughly two hours, and the write rate stays flat instead of spiking.

## Testing

- 23 examples across both job specs, 0 failures: slice anchoring, cursor advancement, gap skipping, completion cleanup, schedule dedup, guard handoff, no-stacking on repeated daily runs, and the self-hosted direct-rebuild bypass.
- RuboCop clean.
