### PR TITLE
Handle legacy place coordinates in user exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- User data exports no longer fail when a legacy place has no spatial coordinates. (#3344)
+
 ## [1.12.1] - 2026-08-13, Berlin
 
 ### Fixed

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -39,11 +39,11 @@ class Place < ApplicationRecord
   }
 
   def lon
-    lonlat.x
+    lonlat&.x || longitude
   end
 
   def lat
-    lonlat.y
+    lonlat&.y || latitude
   end
 
   def name_locked?

--- a/spec/services/users/export_data/visits_spec.rb
+++ b/spec/services/users/export_data/visits_spec.rb
@@ -69,6 +69,22 @@ RSpec.describe Users::ExportData::Visits, type: :service do
         end
       end
 
+      context 'when a legacy place has no spatial coordinates' do
+        let!(:visit) do
+          place = create(:place, name: 'Legacy Place', longitude: 13.405, latitude: 52.52)
+          place.update_column(:lonlat, nil)
+
+          create(:visit, user: user, place: place, name: 'Legacy Visit')
+        end
+
+        it 'exports the stored latitude and longitude' do
+          expect(subject.first['place_reference']).to include(
+            'latitude' => '52.52',
+            'longitude' => '13.405'
+          )
+        end
+      end
+
       context 'when user has visits without places' do
         let!(:visit_without_place) do
           create(:visit,


### PR DESCRIPTION
Closes #3344.

`Place#lat` / `Place#lon` call `lonlat.y` / `lonlat.x` with no nil guard, so any place row with `lonlat IS NULL` raises `NoMethodError: undefined method 'y' for nil`. Places created before the spatial column was introduced have a nil `lonlat`; `DataMigrations::MigratePlacesLonlatJob` only backfilled `user.visited_places`, so anything it missed stays nil. `latitude` and `longitude` have been `null: false` since the original create migration, so the stored decimals are always available as a fallback.

## Summary

- Fall back to stored `latitude` / `longitude` for legacy places without `lonlat`
- Keep user data exports working for affected accounts
- Add regression coverage and a changelog entry

## Verification

- `bundle exec rspec spec/services/users/export_data/visits_spec.rb` — 18 examples, 0 failures
- `bundle exec rubocop app/models/place.rb spec/services/users/export_data/visits_spec.rb` — no offenses

## Notes

The same nil-`lonlat` crash was reported twice before on other call sites and both issues were closed without the fix landing: #2826 (Places page 500) and #2734 (`/api/v1/places` 500). This guard covers all `Place#lat` / `#lon` callers, including the timeline day assembler and the places serializer.

The regression spec exercises the legacy array mode. The production export path uses the streaming mode (`output_directory`); both funnel through `build_visit_hash`, so the fix applies to either.