### PR TITLE
Fix blank map when the public volume carries stale assets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,11 @@ docs/
 screenshots/
 .ruby-lsp/
 
+# Compiled assets and the sprockets manifest are regenerated inside the image;
+# never bake host-side leftovers into it
+/public/assets/
+/config/sprockets-manifest.json
+
 # Node deps are installed inside the image (npm ci), never from the host
 node_modules/
 

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/config/sprockets-manifest.json
 /coverage
 /node_modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- The map no longer stays blank after an upgrade when the `dawarich_public` Docker volume still holds precompiled assets from an older version. The asset manifest now ships inside the app image instead of the public volume, and the container logs a warning when the boot-time asset sync cannot run. (#3346)
+- The map no longer stays blank after an upgrade when the `dawarich_public` Docker volume still holds precompiled assets from an older version. The asset manifest now ships inside the app image instead of the public volume, the boot-time asset sync stages from inside the app directory (a tmpfs-mounted `/tmp` can no longer skip it), and the container logs a warning if the sync still cannot run. (#3346)
 
 ## [1.12.1] - 2026-08-13, Berlin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- The map no longer stays blank after an upgrade when the `dawarich_public` Docker volume still holds precompiled assets from an older version. The asset manifest now ships inside the app image instead of the public volume, and the container logs a warning when the boot-time asset sync cannot run. (#3346)
+
 ## [1.12.1] - 2026-08-13, Berlin
 
 ### Fixed

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,5 +5,7 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
 
+Rails.application.config.assets.manifest = Rails.root.join('config/sprockets-manifest.json')
+
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -121,9 +121,10 @@ RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rake assets:precompile \
 RUN mkdir -p tmp/pids tmp/cache tmp/sockets \
     && chmod -R 777 tmp
 
-# Copy public directory to temp location for syncing with volume at runtime
-# This allows new static files to be added to the persistent volume
-RUN cp -r public /tmp/public_assets
+# Stage a pristine copy of public/ for the entrypoint to sync into the
+# persistent volume at runtime. Lives under the app dir, not /tmp, so
+# tmpfs-mounted /tmp cannot make the sync silently skip.
+RUN cp -r public $APP_PATH/public_dist
 
 # Copy entrypoint scripts and grant execution permissions
 COPY ./docker/entrypoint-env-guard.sh /usr/local/bin/entrypoint-env-guard.sh

--- a/docker/web-entrypoint.sh
+++ b/docker/web-entrypoint.sh
@@ -68,6 +68,8 @@ if [ -d "/tmp/public_assets" ]; then
   rm -rf $APP_PATH/public/assets
   cp -r /tmp/public_assets/* $APP_PATH/public/
   echo "✅ Static assets synced!"
+else
+  echo "⚠️ /tmp/public_assets not found — static assets were NOT synced. The public volume may keep serving assets from a previous version."
 fi
 
 # Function to check and create a PostgreSQL database

--- a/docker/web-entrypoint.sh
+++ b/docker/web-entrypoint.sh
@@ -62,14 +62,15 @@ rm -f "$APP_PATH/tmp/pids/server.pid"
 
 # Sync static assets from image to volume
 # This ensures new and updated files are copied to the persistent volume
-if [ -d "/tmp/public_assets" ]; then
+ASSETS_DIST="$APP_PATH/public_dist"
+if [ -d "$ASSETS_DIST" ]; then
   echo "📦 Syncing static assets to public volume..."
   # Remove old compiled assets to prevent stale files from persisting
   rm -rf $APP_PATH/public/assets
-  cp -r /tmp/public_assets/* $APP_PATH/public/
+  cp -r "$ASSETS_DIST"/* $APP_PATH/public/
   echo "✅ Static assets synced!"
 else
-  echo "⚠️ /tmp/public_assets not found — static assets were NOT synced. The public volume may keep serving assets from a previous version."
+  echo "⚠️ $ASSETS_DIST not found — static assets were NOT synced. The public volume may keep serving assets from a previous version."
 fi
 
 # Function to check and create a PostgreSQL database

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :assets do
+  task remove_manifest: :environment do
+    manifest = Rails.application.config.assets.manifest
+
+    FileUtils.rm_f(manifest) if manifest
+  end
+end
+
+if Rake::Task.task_defined?('assets:clobber')
+  Rake::Task['assets:clobber'].enhance do
+    Rake::Task['assets:remove_manifest'].invoke
+  end
+end

--- a/spec/regressions/sprockets_manifest_location_spec.rb
+++ b/spec/regressions/sprockets_manifest_location_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Sprockets asset manifest' do
+  it 'is stored outside the public directory' do
+    expect(Rails.application.assets_manifest.filename)
+      .not_to start_with(Rails.public_path.to_s)
+  end
+end

--- a/spec/tasks/assets_clobber_spec.rb
+++ b/spec/tasks/assets_clobber_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'assets:remove_manifest' do
+  let(:manifest_path) { Rails.application.config.assets.manifest.to_s }
+
+  after do
+    FileUtils.rm_f(manifest_path)
+  end
+
+  it 'removes the sprockets manifest file' do
+    FileUtils.mkdir_p(File.dirname(manifest_path))
+    File.write(manifest_path, '{}')
+
+    Rake::Task['assets:remove_manifest'].reenable
+    Rake::Task['assets:remove_manifest'].invoke
+
+    expect(File).not_to exist(manifest_path)
+  end
+
+  it 'runs as part of assets:clobber' do
+    sources = Rake::Task['assets:clobber'].actions.filter_map(&:source_location).map(&:first)
+
+    expect(sources).to include(Rails.root.join('lib/tasks/assets.rake').to_s)
+  end
+end


### PR DESCRIPTION
Closes #3346. Likely also resolves the remaining reports in #1767.

## Problem

Self-hosted setups mount `dawarich_public` as a persistent volume. `web-entrypoint.sh` refreshes it from a staging copy on every boot, but the copy lived in `/tmp` — with `tmpfs: /tmp` container hardening it vanished and the sync skipped silently. The volume then keeps the previous version's sprockets manifest and digested files forever.

Because bare imports resolve through the stale manifest while new files live-compile fresh (`config.assets.compile = true`), the browser receives a mix of old and new modules in one graph. Since 1.10.0 that mix fails with `SyntaxError: The requested module 'maps_maplibre/utils/geometry' does not provide an export named 'trimOutlierCoords'`, killing the `maps--maplibre` controller — blank map, zero server-side errors.

Reproduced with the published images: the failing digest in the issue report (`geometry-…781244bb…fb6ecc.js`) is byte-identical to the 1.9.2 image's geometry.js.

## Fix

- The sprockets manifest now lives at `config/sprockets-manifest.json` inside the image (`config.assets.manifest`). Both the precompile task and the runtime reader honor this path; compiled files still go to `public/assets`. Asset resolution therefore always matches the running code, no matter what the volume contains — existing broken installs heal on their next upgrade even if their sync stays skipped.
- The boot-time sync stages from `$APP_PATH/public_dist` inside the app directory instead of `/tmp`, so a tmpfs-mounted `/tmp` can no longer skip it; if staging is still missing, the entrypoint logs a warning instead of skipping silently.
- `assets:clobber` now also removes the relocated manifest, and `.dockerignore` excludes host-side `public/assets/` and the manifest so local leftovers can never be baked into an image.

## Verification

- New regression spec `spec/regressions/sprockets_manifest_location_spec.rb` — red before, green after — plus `spec/tasks/assets_clobber_spec.rb` covering the clobber enhancement (real task run verified).
- Production `assets:precompile` writes the manifest to `config/`, nothing under `public/assets`.
- Booted a production server with the real 1.9.2 manifest + old `geometry.js` planted in `public/assets`: the importmap emits the current digest and the map loads.
- Both entrypoint sync branches exercised in a sandbox (sync replaces stale assets; warning fires when staging is absent).

Trade-off: after downgrading from a fixed image, older versions find no manifest in the volume and live-compile all assets (works, slower first boot).