### PR TITLE
Sync the Tracks layer toggle with saved settings on map load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - The map no longer stays blank after an upgrade when the `dawarich_public` Docker volume still holds precompiled assets from an older version. The asset manifest now ships inside the app image instead of the public volume, the boot-time asset sync stages from inside the app directory (a tmpfs-mounted `/tmp` can no longer skip it), and the container logs a warning if the sync still cannot run. (#3346)
 - User data exports no longer fail when a legacy place has no spatial coordinates. (#3344)
+- The Tracks layer toggle on the map now reflects your saved setting after a page reload; previously it always showed as off even though the setting was saved and tracks were loaded. (#736)
 - The map no longer leaps to a just-left place or a phantom spot off your route: iOS visit reports delivered after departure and coarse cell-tower fixes without motion data are now filtered out as anomalies. Existing histories are re-evaluated automatically after the upgrade, and tracks and stats are rebuilt along the way.
 
 ## [1.12.1] - 2026-08-13, Berlin

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -74,6 +74,7 @@ export default class extends Controller {
     "anomaliesToggle",
     "familyToggle",
     "flightsToggle",
+    "tracksToggle",
     // Speed-colored routes
     "routesOptions",
     "speedColoredToggle",

--- a/spec/javascript/maplibre_target_declarations_test.mjs
+++ b/spec/javascript/maplibre_target_declarations_test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict"
+import { readdir, readFile } from "node:fs/promises"
+import test from "node:test"
+
+const viewsDir = new URL("../../app/views/map/maplibre/", import.meta.url)
+const controllerUrl = new URL(
+  "../../app/javascript/controllers/maps/maplibre_controller.js",
+  import.meta.url,
+)
+
+async function boundTargetNames() {
+  const names = new Set()
+  for (const entry of await readdir(viewsDir)) {
+    if (!entry.endsWith(".erb")) continue
+    const source = await readFile(new URL(entry, viewsDir), "utf8")
+    for (const match of source.matchAll(
+      /data-maps--maplibre-target="([^"]+)"/g,
+    )) {
+      for (const name of match[1].split(/\s+/)) {
+        if (name) names.add(name)
+      }
+    }
+  }
+  return names
+}
+
+async function declaredTargetNames() {
+  const source = await readFile(controllerUrl, "utf8")
+  const block = source.match(/static targets = \[([\s\S]*?)\]/)
+  assert.ok(block, "maplibre_controller.js declares no static targets block")
+  return new Set([...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]))
+}
+
+test("every target bound in the Map v2 views is declared by the controller", async () => {
+  const bound = await boundTargetNames()
+  const declared = await declaredTargetNames()
+  const missing = [...bound].filter((name) => !declared.has(name))
+  assert.deepEqual(
+    missing,
+    [],
+    `Map v2 views bind Stimulus targets the maps--maplibre controller never declares, so their state silently stops syncing: ${missing.join(", ")}`,
+  )
+})


### PR DESCRIPTION
Fixes the Map v2 "layers aren't remembered after reload" report from https://github.com/Freika/dawarich/issues/736#issuecomment-5299478125.

## Problem

The Map Layers panel's Tracks checkbox always rendered unchecked after a page load, regardless of the saved setting. Settings persistence itself was fine: the PATCH saved `enabled_map_layers` correctly, the reloaded page fetched tracks and showed them on the map — only the checkbox disagreed. To the reporter this read as "Dawarich doesn't remember my settings", compounded by the loading badge counting points (fetched for the default-enabled Heatmap layer) while the Points toggle sat off.

## Cause

`"tracksToggle"` was never declared in `static targets` of `maplibre_controller.js` — the only toggle in the panel that wasn't. The view binds it and `syncToggleStates` maps it, but `hasTracksToggleTarget` is undefined for an undeclared target, so the sync silently skipped the checkbox. Present since the panel shipped in #1953.

## Fix

- Add `"tracksToggle"` to `static targets` (one line).
- New `spec/javascript/maplibre_target_declarations_test.mjs`: every `data-maps--maplibre-target` bound in `app/views/map/maplibre/*.erb` must be declared in the controller's `static targets` — this class of bug is silent by construction, and this guards all of it. The test fails on the previous code naming exactly `tracksToggle`.
- CHANGELOG entry under Unreleased.

## Verification

- JS suite 82/82 (new test red before the fix, green after); Biome clean.
- Live red/green on two local stacks: on 1.12.1 the reloaded Tracks checkbox renders unchecked with Tracks saved as enabled; with this branch it renders checked. Full e2e tracks spec 15/15 against the fixed build.

Note for review: users whose saved layers include Tracks (the backend default) will now correctly see the toggle ON after load — a visible change, but the layer was always fetched and rendered.

Companion e2e PR (ship together): https://github.com/Freika/e2e-dawarich-playwright/pull/5 — strengthens the previously vacuous toggle-persistence spec so this can't regress silently.
