### PR TITLE
fix: accept both aff and via as the Partnero referral param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Dawarich Cloud can now credit sign-ups to affiliate partners. Self-hosted instances are unaffected — both the tracking script and the attribution call stay off unless the Cloud-only `PARTNERO_PROGRAM_ID` and `PARTNERO_API_KEY` are set.
+
 ### Changed
 
 - Consolidated `points` table indexes: a new `(user_id, timestamp, lonlat)` unique index replaces three redundant indexes, roughly halving the write cost of every point. The index is built concurrently at boot during the upgrade; on instances with millions of points this can take several minutes — the app stays usable while it builds.

--- a/app/controllers/concerns/partnero_trackable.rb
+++ b/app/controllers/concerns/partnero_trackable.rb
@@ -4,13 +4,17 @@
 # creates.
 #
 # PartneroJS scopes its cookie to the host that set it, so a key captured on
-# dawarich.app never reaches this app. The marketing site forwards it as a `via`
+# dawarich.app never reaches this app. The marketing site forwards it as a query
 # param instead (see site/src/utils/utm.js); this concern parks that key in the
 # session until a signup actually happens, on whichever page the visitor lands.
 module PartneroTrackable
   extend ActiveSupport::Concern
 
-  REFERRAL_PARAM = :via
+  # Partnero's referral param is configured per program — their docs describe
+  # `via`, the snippet generated for this program emits `aff`. Both are read so
+  # a dashboard setting cannot silently cost every commission; `aff` wins because
+  # that is what the program's own snippet writes.
+  REFERRAL_PARAMS = %i[aff via].freeze
   MAX_KEY_LENGTH = 255
 
   included do
@@ -18,11 +22,12 @@ module PartneroTrackable
   end
 
   def store_partnero_referral
-    return if params[REFERRAL_PARAM].blank?
+    key = REFERRAL_PARAMS.filter_map { |param| params[param].presence }.first
+    return if key.blank?
 
     # truncate, not byteslice: cutting a multi-byte character in half yields a
     # string the JSON cookie serializer refuses, which would 500 the page.
-    session[:partnero_referral] = params[REFERRAL_PARAM].to_s.truncate(MAX_KEY_LENGTH, omission: '')
+    session[:partnero_referral] = key.to_s.truncate(MAX_KEY_LENGTH, omission: '')
   end
 
   # Spends the referral: a key credits exactly one account, so it is deleted from

--- a/spec/requests/users/registrations_partnero_spec.rb
+++ b/spec/requests/users/registrations_partnero_spec.rb
@@ -24,6 +24,27 @@ RSpec.describe 'Users::Registrations Partnero attribution', type: :request do
     }
   end
 
+  # Partnero's referral param is configured per program: their docs use `via`,
+  # the snippet generated for this program uses `aff`. Both are accepted so the
+  # attribution cannot be silently lost to a dashboard setting.
+  %i[aff via].each do |param|
+    it "attributes a signup referred via ?#{param}=" do
+      get new_user_registration_path(param => 'PARTNER123')
+
+      expect { post user_registration_path, params: valid_params }
+        .to have_enqueued_job(Partnero::CustomerSignupJob)
+        .with(instance_of(Integer), 'PARTNER123')
+    end
+  end
+
+  it 'prefers aff when a link carries both' do
+    get new_user_registration_path(aff: 'FROM_AFF', via: 'FROM_VIA')
+
+    expect { post user_registration_path, params: valid_params }
+      .to have_enqueued_job(Partnero::CustomerSignupJob)
+      .with(instance_of(Integer), 'FROM_AFF')
+  end
+
   context 'when the visitor arrived through an affiliate link' do
     it 'attributes the created user to the referring partner' do
       get new_user_registration_path(via: 'PARTNER123')


### PR DESCRIPTION
Partnero's referral param is configured per program. Their tracking docs describe `via`, which is what shipped in #3348 — but the snippet generated for our program emits `aff`.

Reading only one spelling means a dashboard setting we cannot see decides whether every commission is recorded, and both failure directions are silent: `partner_key` arrives blank, `Partnero::CustomerSignupJob` returns at its first guard, and nothing logs. Rather than bet on it, `PartneroTrackable` now reads both.

`aff` wins when a link carries both, since that is what the program's own snippet writes.

Companion change in dawarich-app/site#61 reads both on the marketing site and forwards the key under the param it arrived on.

Also restores the affiliate CHANGELOG entry, which did not survive the 1.12.1 release — the new third-party data flow is currently undocumented.

## Testing

- Parameterised specs cover both spellings plus precedence when a link carries both.
- 229 examples across `spec/requests/users/` and `spec/jobs/partnero/`, 0 failures. RuboCop clean.
