### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ Check the documentation on the [website](https://dawarich.app/docs/environment-v
 
 As you could probably guess, I like statistics.
 
-<a href="https://star-history.com/#Freika/dawarich&Date">
+<a href="https://star-history.dera.page/#Freika/dawarich&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Freika/dawarich&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Freika/dawarich&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Freika/dawarich&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Freika/dawarich&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Freika/dawarich&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Freika/dawarich&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This change switches it to a working alternative at star-history.dera.page so the chart renders correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History embed links in the README to use the current hosting URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->