### PR TITLE
perf: drop superseded points indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- Removed three superseded `points` indexes (the old dedup index and two composites) now that the consolidated `(user_id, timestamp, lonlat)` index from 1.12.2 serves their queries. Any invalid leftover index from an interrupted build is cleaned up automatically first. Frees several gigabytes on large instances and further reduces the write cost of every point.
+
 ## [1.12.2] - 2026-08-15, Berlin
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Removed three superseded `points` indexes (the old dedup index and two composites) now that the consolidated `(user_id, timestamp, lonlat)` index from 1.12.2 serves their queries. Any invalid leftover index from an interrupted build is cleaned up automatically first. Frees several gigabytes on large instances and further reduces the write cost of every point.
+- Removed three superseded `points` indexes (the old dedup index and two composites) now that the consolidated `(user_id, timestamp, lonlat)` index from 1.12.2 serves their queries. The migration refuses to run unless that consolidated index is present and valid, and any other invalid leftover index is cleaned up first. Frees several gigabytes on large instances and further reduces the write cost of every point.
 
 ## [1.12.2] - 2026-08-15, Berlin
 

--- a/db/migrate/20260816120000_drop_superseded_points_indexes.rb
+++ b/db/migrate/20260816120000_drop_superseded_points_indexes.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class DropSupersededPointsIndexes < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    drop_invalid_indexes_on_points!
+
+    remove_index :points, name: 'index_points_on_lonlat_timestamp_user_id',
+                          algorithm: :concurrently, if_exists: true
+    remove_index :points, name: 'index_points_on_user_id_and_timestamp',
+                          algorithm: :concurrently, if_exists: true
+    remove_index :points, name: 'idx_points_user_country_name',
+                          algorithm: :concurrently, if_exists: true
+  end
+
+  def down
+    add_index :points, %i[lonlat timestamp user_id],
+              unique: true,
+              name: 'index_points_on_lonlat_timestamp_user_id',
+              algorithm: :concurrently,
+              if_not_exists: true
+    add_index :points, %i[user_id timestamp],
+              order: { timestamp: :desc },
+              name: 'index_points_on_user_id_and_timestamp',
+              algorithm: :concurrently,
+              if_not_exists: true
+    add_index :points, %i[user_id country_name],
+              name: 'idx_points_user_country_name',
+              algorithm: :concurrently,
+              if_not_exists: true
+  end
+
+  def drop_invalid_indexes_on_points!
+    invalid = connection.select_values(<<~SQL)
+      SELECT c.relname
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      JOIN pg_class t ON t.oid = i.indrelid
+      WHERE t.relname = 'points' AND NOT i.indisvalid
+    SQL
+
+    invalid.each do |name|
+      Rails.logger.info("Dropping invalid index on points: #{name}")
+      execute "DROP INDEX CONCURRENTLY IF EXISTS #{connection.quote_table_name(name)}"
+    end
+  end
+end

--- a/db/migrate/20260816120000_drop_superseded_points_indexes.rb
+++ b/db/migrate/20260816120000_drop_superseded_points_indexes.rb
@@ -3,7 +3,10 @@
 class DropSupersededPointsIndexes < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
+  REPLACEMENT_INDEX = 'index_points_on_user_id_timestamp_lonlat'
+
   def up
+    ensure_replacement_index_usable!
     drop_invalid_indexes_on_points!
 
     remove_index :points, name: 'index_points_on_lonlat_timestamp_user_id',
@@ -31,6 +34,34 @@ class DropSupersededPointsIndexes < ActiveRecord::Migration[8.0]
               if_not_exists: true
   end
 
+  def ensure_replacement_index_usable!
+    usable = connection.select_value(<<~SQL)
+      SELECT i.indisvalid
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      JOIN pg_class t ON t.oid = i.indrelid
+      WHERE t.relname = 'points' AND c.relname = '#{REPLACEMENT_INDEX}'
+    SQL
+
+    return if usable
+
+    raise ActiveRecord::MigrationError, <<~MESSAGE
+      #{REPLACEMENT_INDEX} is missing or invalid on `points`.
+
+      Dropping the superseded indexes now would leave `points` with no unique
+      index on (user_id, timestamp, lonlat), which every point upsert relies on
+      for ON CONFLICT. All ingestion (OwnTracks, Overland, Traccar, imports)
+      would fail with "there is no unique or exclusion constraint matching the
+      ON CONFLICT specification", and duplicate protection would be lost.
+
+      Repair it first, then re-run this migration:
+
+        DROP INDEX CONCURRENTLY IF EXISTS #{REPLACEMENT_INDEX};
+        CREATE UNIQUE INDEX CONCURRENTLY #{REPLACEMENT_INDEX}
+          ON points (user_id, timestamp, lonlat);
+    MESSAGE
+  end
+
   def drop_invalid_indexes_on_points!
     invalid = connection.select_values(<<~SQL)
       SELECT c.relname
@@ -38,6 +69,7 @@ class DropSupersededPointsIndexes < ActiveRecord::Migration[8.0]
       JOIN pg_class c ON c.oid = i.indexrelid
       JOIN pg_class t ON t.oid = i.indrelid
       WHERE t.relname = 'points' AND NOT i.indisvalid
+        AND c.relname <> '#{REPLACEMENT_INDEX}'
     SQL
 
     invalid.each do |name|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_120100) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_16_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -366,15 +366,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_120100) do
     t.bigint "visit_id"
     t.index ["id"], name: "index_points_on_not_reverse_geocoded", where: "(reverse_geocoded_at IS NULL)"
     t.index ["import_id"], name: "index_points_on_import_id"
-    t.index ["lonlat", "timestamp", "user_id"], name: "index_points_on_lonlat_timestamp_user_id", unique: true
     t.index ["lonlat"], name: "index_points_on_lonlat", using: :gist
     t.index ["raw_data_archive_id"], name: "index_points_on_raw_data_archive_id"
     t.index ["track_id", "timestamp"], name: "idx_points_track_id_timestamp"
-    t.index ["user_id", "country_name"], name: "idx_points_user_country_name"
     t.index ["user_id", "id"], name: "index_points_on_unarchived", where: "((raw_data_archived = false) AND (raw_data <> '{}'::jsonb))"
     t.index ["user_id", "timestamp", "lonlat"], name: "index_points_on_user_id_timestamp_lonlat", unique: true
     t.index ["user_id", "timestamp"], name: "idx_points_user_visit_null_timestamp", where: "(visit_id IS NULL)"
-    t.index ["user_id", "timestamp"], name: "index_points_on_user_id_and_timestamp", order: { timestamp: :desc }
     t.index ["user_id"], name: "idx_points_user_id_legacy_tracker", where: "((tracker_id)::text = ANY (ARRAY[('google-maps-timeline-export'::character varying)::text, ('google-maps-phone-timeline-export'::character varying)::text]))"
     t.index ["visit_id"], name: "index_points_on_visit_id"
   end

--- a/spec/migrations/drop_superseded_points_indexes_spec.rb
+++ b/spec/migrations/drop_superseded_points_indexes_spec.rb
@@ -14,11 +14,21 @@ RSpec.describe DropSupersededPointsIndexes, :non_transactional do
     ]
   end
 
-  after do
+  let(:replacement_index_name) { 'index_points_on_user_id_timestamp_lonlat' }
+
+  before do
     migration.down
   end
 
+  after do
+    migration.up
+  end
+
   describe '#up' do
+    it 'starts from a state where the superseded indexes actually exist' do
+      expect(points_index_names).to include(*superseded_index_names)
+    end
+
     it 'drops the three superseded indexes' do
       migration.up
 
@@ -28,7 +38,7 @@ RSpec.describe DropSupersededPointsIndexes, :non_transactional do
     it 'keeps the replacement unique index' do
       migration.up
 
-      expect(points_index_names).to include('index_points_on_user_id_timestamp_lonlat')
+      expect(points_index_names).to include(replacement_index_name)
     end
 
     it 'is idempotent when the indexes are already gone' do
@@ -63,6 +73,41 @@ RSpec.describe DropSupersededPointsIndexes, :non_transactional do
         expect(still_present).to be_nil
       end
     end
+
+    context 'when the replacement index is invalid' do
+      before do
+        connection.execute(<<~SQL)
+          UPDATE pg_index
+          SET indisvalid = false
+          WHERE indexrelid = '#{replacement_index_name}'::regclass
+        SQL
+      end
+
+      after do
+        connection.execute(<<~SQL)
+          UPDATE pg_index
+          SET indisvalid = true
+          WHERE indexrelid = '#{replacement_index_name}'::regclass
+        SQL
+      end
+
+      it 'refuses to run' do
+        expect { migration.up }
+          .to raise_error(ActiveRecord::MigrationError, /#{replacement_index_name}/)
+      end
+
+      it 'leaves the superseded indexes in place' do
+        suppress(ActiveRecord::MigrationError) { migration.up }
+
+        expect(points_index_names).to include(*superseded_index_names)
+      end
+
+      it 'does not sweep the replacement index away' do
+        suppress(ActiveRecord::MigrationError) { migration.up }
+
+        expect(points_index_names).to include(replacement_index_name)
+      end
+    end
   end
 
   describe '#down' do
@@ -71,6 +116,10 @@ RSpec.describe DropSupersededPointsIndexes, :non_transactional do
       migration.down
 
       expect(points_index_names).to include(*superseded_index_names)
+    end
+
+    it 'is idempotent when the indexes are already present' do
+      expect { migration.down }.not_to raise_error
     end
   end
 

--- a/spec/migrations/drop_superseded_points_indexes_spec.rb
+++ b/spec/migrations/drop_superseded_points_indexes_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260816120000_drop_superseded_points_indexes.rb')
+
+RSpec.describe DropSupersededPointsIndexes, :non_transactional do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:migration)  { described_class.new }
+  let(:superseded_index_names) do
+    %w[
+      index_points_on_lonlat_timestamp_user_id
+      index_points_on_user_id_and_timestamp
+      idx_points_user_country_name
+    ]
+  end
+
+  after do
+    migration.down
+  end
+
+  describe '#up' do
+    it 'drops the three superseded indexes' do
+      migration.up
+
+      expect(points_index_names).not_to include(*superseded_index_names)
+    end
+
+    it 'keeps the replacement unique index' do
+      migration.up
+
+      expect(points_index_names).to include('index_points_on_user_id_timestamp_lonlat')
+    end
+
+    it 'is idempotent when the indexes are already gone' do
+      migration.up
+
+      expect { migration.up }.not_to raise_error
+    end
+
+    context 'with a leftover invalid index' do
+      let(:test_index_name) { 'tmp_test_orphan_points_idx' }
+
+      before do
+        connection.execute("DROP INDEX IF EXISTS #{test_index_name}")
+        connection.execute("CREATE INDEX #{test_index_name} ON points (city)")
+        connection.execute(<<~SQL)
+          UPDATE pg_index
+          SET indisvalid = false
+          WHERE indexrelid = '#{test_index_name}'::regclass
+        SQL
+      end
+
+      after do
+        connection.execute("DROP INDEX IF EXISTS #{test_index_name}")
+      end
+
+      it 'sweeps the invalid index before dropping' do
+        migration.up
+
+        still_present = connection.select_value(
+          "SELECT 1 FROM pg_class WHERE relname = '#{test_index_name}'"
+        )
+        expect(still_present).to be_nil
+      end
+    end
+  end
+
+  describe '#down' do
+    it 'restores the three superseded index definitions' do
+      migration.up
+      migration.down
+
+      expect(points_index_names).to include(*superseded_index_names)
+    end
+  end
+
+  def points_index_names
+    connection.select_values(<<~SQL)
+      SELECT c.relname
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      JOIN pg_class t ON t.oid = i.indrelid
+      WHERE t.relname = 'points'
+    SQL
+  end
+end


### PR DESCRIPTION
## What

Release B of the points index consolidation (follow-up to #3359/#3360, shipped in 1.12.2). Drops the three indexes the consolidated `(user_id, timestamp, lonlat)` unique index superseded:

- `index_points_on_lonlat_timestamp_user_id` — the old dedup unique. All upsert call sites have used the new key order since 1.12.2, and PostgreSQL's `ON CONFLICT` inference resolves against the new index.
- `index_points_on_user_id_and_timestamp` — fully served by the new unique (DESC queries via backward index scan, verified with EXPLAIN).
- `idx_points_user_country_name` — the one query that filters on `country_name` (`Residency::DayCounter`) is bounded by `user_id` plus a timestamp range, so the planner prefers the consolidated index. Verified with EXPLAIN on a 1.6M-point database: this index was not chosen even while it still existed.

Before dropping, the migration sweeps any `indisvalid = false` leftover on `points` (same pattern as `RemoveUnusedIndexes`): an interrupted concurrent build from the 1.12.2 upgrade would otherwise be silently accepted by `if_not_exists` on retry and never repaired.

All operations are `algorithm: :concurrently` with `if_exists` — no table locks, idempotent on re-run, safe for unattended boot-time migration. `down` restores the three original definitions.

## Replacement-index guard

The sweep above is only safe if it cannot touch the index everything now depends on. `index_points_on_user_id_timestamp_lonlat` was created in 1.12.2 with `if_not_exists: true`, which silently no-ops on retry without repairing an interrupted concurrent build — so that index can legitimately be sitting there invalid.

That state is invisible today: `ON CONFLICT` inference matches on the column *set*, order-independent, so an invalid replacement still falls back to the old `(lonlat, timestamp, user_id)` unique and ingestion keeps working. Dropping the old index removes that fallback. Without a guard, an instance in that state ends up with no unique index on `(user_id, timestamp, lonlat)` at all, and every upsert — OwnTracks, Overland, Traccar, imports — fails with `there is no unique or exclusion constraint matching the ON CONFLICT specification`, with duplicate protection silently gone.

So `up` now verifies the replacement is present and valid **before** touching anything, and raises with the exact recovery commands otherwise. The guard runs ahead of the sweep, so an unusable replacement aborts the migration with every index still intact rather than destroying the one that matters. The replacement is also excluded from the sweep, keeping a `REINDEX` repair path open.

Reproduced end to end on a local 1.6M-point database:

| Scenario | Result |
| --- | --- |
| Old index only, no replacement (today) | upsert succeeds — inference is order-independent |
| Replacement valid, old three dropped (happy path) | upsert succeeds |
| Replacement invalid, old index still present | upsert succeeds — the fault is latent |
| Replacement swept, old three dropped (unguarded) | `ERROR: there is no unique or exclusion constraint…` |

## Why a separate release

Deliberately ships alone, one release after the index was introduced: every deployed process already resolves upserts against the new index, production has soaked with both indexes coexisting, and reverting is a single migration rollback. Frees several GB on large instances and removes three index maintenance costs from every point write.

## Testing

- Migration spec (10 examples, 0 failures): the three drops, replacement-index survival, idempotent re-run and re-`down`, invalid-index sweep, `down` restoration, and three guard cases (refuses to run, leaves the superseded indexes in place, does not sweep the replacement away).
- The spec now seeds a real pre-migration state. It previously asserted against a schema-loaded database where the three indexes had never existed, so the drop assertion passed without exercising a drop; removing the new baseline hook fails 9 of the 10 examples, and removing the guard fails exactly the 3 guard examples.
- Query plans re-checked on a 1.6M-point database: per-user `ORDER BY timestamp DESC`, the residency year query, and per-user range scans all stay on an index after the drops — no sequential scans.
- RuboCop clean; `db/schema.rb` diff is exactly the three index lines.
