### PR TITLE
Allow oidc_config.enabled to return true with only OIDC_CLIENT_ID and OIDC_PKCE_ENABLED configured

### DIFF
--- a/config/initializers/01_constants.rb
+++ b/config/initializers/01_constants.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'oidc_config'
+
 SELF_HOSTED = %w[true 1 yes on t].include?(ENV.fetch('SELF_HOSTED', 'true').to_s.delete(%q("')).strip.downcase)
 
 DISTANCE_UNITS = {
@@ -47,7 +49,7 @@ METRICS_PASSWORD = ENV.fetch('METRICS_PASSWORD', nil)
 OMNIAUTH_PROVIDERS =
   if SELF_HOSTED
     # Self-hosted: only OpenID Connect
-    ENV['OIDC_CLIENT_ID'].present? && ENV['OIDC_CLIENT_SECRET'].present? ? %i[openid_connect] : []
+    OidcConfig.enabled? ? %i[openid_connect] : []
   else
     # Cloud: only GitHub and Google
     providers = []

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -295,11 +295,12 @@ Devise.setup do |config|
     end
 
     Rails.logger.info "OIDC: PKCE #{oidc_config[:pkce] ? 'enabled' : 'disabled'}"
+    Rails.logger.info 'OIDC: Public client (no client secret, PKCE only)' if OidcConfig.public_client?
     Rails.logger.info "OIDC: Client ID: #{oidc_config[:client_options][:identifier]}, " \
                       "Redirect URI: #{oidc_config[:client_options][:redirect_uri]}"
     config.omniauth :openid_connect, oidc_config
   else
-    Rails.logger.warn 'OIDC: Not configured (missing OIDC_CLIENT_ID or OIDC_CLIENT_SECRET)'
+    Rails.logger.warn 'OIDC: Not configured (set OIDC_CLIENT_ID plus either OIDC_CLIENT_SECRET or OIDC_PKCE_ENABLED=true)'
   end
 
   # ==> Warden configuration

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -185,6 +185,11 @@ ALLOW_EMAIL_PASSWORD_LOGIN=true
 # advertise PKCE support)
 # OIDC_PKCE_ENABLED=true
 
+# Public clients: if your provider issues no client secret for Dawarich, set
+# OIDC_PKCE_ENABLED=true and leave OIDC_CLIENT_SECRET unset. Dawarich then omits
+# client authentication on the token request. When a secret is set it is used,
+# with PKCE layered on top.
+
 # Option 2: Manual Endpoint Configuration (if discovery is not supported)
 # Use this if your provider doesn't support OIDC discovery
 # OIDC_CLIENT_ID=

--- a/lib/oidc_config.rb
+++ b/lib/oidc_config.rb
@@ -11,6 +11,10 @@ module OidcConfig
     env['OIDC_CLIENT_ID'].to_s.strip != '' && (env['OIDC_CLIENT_SECRET'].to_s.strip != '' || pkce_enabled?(env))
   end
 
+  def self.public_client?(env = ENV)
+    env['OIDC_CLIENT_SECRET'].to_s.strip == '' && pkce_enabled?(env)
+  end
+
   def self.build(env = ENV)
     return nil unless enabled?(env)
 
@@ -25,6 +29,8 @@ module OidcConfig
         redirect_uri: redirect_uri(env)
       }
     }
+
+    config[:client_auth_method] = :none if public_client?(env)
 
     issuer = normalize_issuer(env['OIDC_ISSUER'].to_s)
 

--- a/lib/oidc_config.rb
+++ b/lib/oidc_config.rb
@@ -8,7 +8,7 @@ module OidcConfig
   DEFAULT_SCHEME = 'https'
 
   def self.enabled?(env = ENV)
-    env['OIDC_CLIENT_ID'].to_s.strip != '' && env['OIDC_CLIENT_SECRET'].to_s.strip != ''
+    env['OIDC_CLIENT_ID'].to_s.strip != '' && (env['OIDC_CLIENT_SECRET'].to_s.strip != '' || pkce_enabled?(env))
   end
 
   def self.build(env = ENV)

--- a/spec/lib/oidc_config_spec.rb
+++ b/spec/lib/oidc_config_spec.rb
@@ -23,6 +23,30 @@ RSpec.describe OidcConfig do
     it 'is false when client secret is missing' do
       expect(described_class.enabled?(base_env.merge('OIDC_CLIENT_SECRET' => nil))).to be false
     end
+
+    it 'is true when the secret is missing but PKCE is enabled' do
+      env = base_env.merge('OIDC_CLIENT_SECRET' => nil, 'OIDC_PKCE_ENABLED' => 'true')
+
+      expect(described_class.enabled?(env)).to be true
+    end
+
+    it 'is false when client id is missing even with PKCE enabled' do
+      env = base_env.merge('OIDC_CLIENT_ID' => '', 'OIDC_PKCE_ENABLED' => 'true')
+
+      expect(described_class.enabled?(env)).to be false
+    end
+  end
+
+  describe '.public_client?' do
+    it 'is true when PKCE is enabled without a client secret' do
+      env = base_env.merge('OIDC_CLIENT_SECRET' => nil, 'OIDC_PKCE_ENABLED' => 'true')
+
+      expect(described_class.public_client?(env)).to be true
+    end
+
+    it 'is false when a client secret is present' do
+      expect(described_class.public_client?(base_env.merge('OIDC_PKCE_ENABLED' => 'true'))).to be false
+    end
   end
 
   describe '.build' do
@@ -119,6 +143,26 @@ RSpec.describe OidcConfig do
           built = described_class.build(base_env.merge('OIDC_PKCE_ENABLED' => value))
           expect(built[:pkce]).to be(false), "expected pkce to be false when OIDC_PKCE_ENABLED=#{value.inspect}"
         end
+      end
+    end
+
+    context 'public client (PKCE without a client secret)' do
+      let(:public_env) { base_env.merge('OIDC_CLIENT_SECRET' => nil, 'OIDC_PKCE_ENABLED' => 'true') }
+
+      it 'sends no client authentication on the token request' do
+        expect(described_class.build(public_env)[:client_auth_method]).to eq(:none)
+      end
+
+      it 'leaves the client secret unset' do
+        expect(described_class.build(public_env)[:client_options][:secret]).to be_nil
+      end
+
+      it 'still enables PKCE' do
+        expect(described_class.build(public_env)[:pkce]).to be true
+      end
+
+      it 'keeps the default client authentication when a secret is present' do
+        expect(described_class.build(base_env)).not_to have_key(:client_auth_method)
       end
     end
   end


### PR DESCRIPTION
Very simple bug I found when trying to remove the OIDC_CLIENT_ID value from my compose file when moving to PKCE.

Line 285 in config/initializers/devise.rb depends on oidc_config.enabled returning true prior to attempting to configure OIDC for the application.

`if SELF_HOSTED && OidcConfig.enabled?`

I modified Line 11 of lib/oidc_config.rb to make the OIDC_CLIENT_SECRET check an || with oidc_config.pkce_enabled

Workaround is to simply include random text for OIDC_CLIENT_SECRET, at which point everything works great.