### PR TITLE
perf: fan out the nightly cache preheat and fix four cron queue routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Consolidated `points` table indexes: a new `(user_id, timestamp, lonlat)` unique index replaces three redundant indexes, roughly halving the write cost of every point. The index is built by the boot-time migration; on instances with millions of points this can take several minutes, during which the container waits before serving requests. The `points` table itself stays fully usable while the index builds.
 - Automatic daily track generation no longer rebuilds a user's entire history when their tracks are missing and their history exceeds 100k points. On Dawarich Cloud such histories are backfilled automatically at a throttled rate; self-hosted instances still rebuild directly, as fast as their own hardware allows.
+- The nightly cache preheat now runs as one background job per user instead of a single job looping over every user. Its duration is bounded by the slowest individual user rather than by the sum of all of them, so one account with a large history no longer delays the preheat for everyone else.
 
 ### Fixed
+
+- Four scheduled jobs (app version check, cache preheat, family location request expiry, points counter correction) were queued onto `default` instead of the queues their job classes declare, so they competed with higher-priority work — the cache preheat in particular could hold up imports, track generation and stats for minutes at a time. They now run on `app_version_checking`, `cache`, `families` and `low_priority` respectively.
 
 - The map no longer stays blank after an upgrade when the `dawarich_public` Docker volume still holds precompiled assets from an older version. The asset manifest now ships inside the app image instead of the public volume, the boot-time asset sync stages from inside the app directory (a tmpfs-mounted `/tmp` can no longer skip it), and the container logs a warning if the sync still cannot run. (#3346)
 - User data exports no longer fail when a legacy place has no spatial coordinates. (#3344)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Consolidated `points` table indexes: a new `(user_id, timestamp, lonlat)` unique index replaces three redundant indexes, roughly halving the write cost of every point. The index is built by the boot-time migration; on instances with millions of points this can take several minutes, during which the container waits before serving requests. The `points` table itself stays fully usable while the index builds.
 - Automatic daily track generation no longer rebuilds a user's entire history when their tracks are missing and their history exceeds 100k points. On Dawarich Cloud such histories are backfilled automatically at a throttled rate; self-hosted instances still rebuild directly, as fast as their own hardware allows.
-- The nightly cache preheat now runs as one background job per user instead of a single job looping over every user. Its duration is bounded by the slowest individual user rather than by the sum of all of them, so one account with a large history no longer delays the preheat for everyone else.
+- The nightly cache preheat now runs as one background job per user instead of a single job looping over every user. Its duration is bounded by the slowest individual user rather than by the sum of all of them, so one account with a large history no longer delays the preheat for everyone else. On Dawarich Cloud it now only preheats active and trial accounts; self-hosted instances continue to preheat every user.
 
 ### Fixed
 

--- a/app/jobs/cache/preheating_job.rb
+++ b/app/jobs/cache/preheating_job.rb
@@ -11,12 +11,21 @@ class Cache::PreheatingJob < ApplicationJob
   def perform
     preheat_country_borders
 
-    User.select(:id).find_in_batches(batch_size: BATCH_SIZE) do |batch|
+    target_users.find_in_batches(batch_size: BATCH_SIZE) do |batch|
       ActiveJob.perform_all_later(batch.map { |user| Cache::UserPreheatingJob.new(user.id) })
     end
   end
 
   private
+
+  # Self-hosted instances have no subscription lifecycle, so every user is
+  # worth preheating. On Cloud, warming caches for lapsed accounts that will
+  # never load a page is wasted queue time.
+  def target_users
+    scope = User.select(:id)
+
+    DawarichSettings.self_hosted? ? scope : scope.active_or_trial
+  end
 
   def preheat_country_borders
     Rails.cache.write(

--- a/app/jobs/cache/preheating_job.rb
+++ b/app/jobs/cache/preheating_job.rb
@@ -1,51 +1,28 @@
 # frozen_string_literal: true
 
+# Nightly cache preheat. Writes the one global cache entry inline, then fans
+# out per-user work so the run is bounded by the slowest single user rather
+# than by the sum of every user.
 class Cache::PreheatingJob < ApplicationJob
   queue_as :cache
 
+  BATCH_SIZE = 500
+
   def perform
-    # Preheat country borders GeoJSON (global, not per-user)
+    preheat_country_borders
+
+    User.select(:id).find_in_batches(batch_size: BATCH_SIZE) do |batch|
+      ActiveJob.perform_all_later(batch.map { |user| Cache::UserPreheatingJob.new(user.id) })
+    end
+  end
+
+  private
+
+  def preheat_country_borders
     Rails.cache.write(
       'dawarich/countries_codes',
       Oj.load(File.read(Rails.root.join('lib/assets/countries.geojson'))),
-      expires_in: 1.day
+      expires_in: Cache::UserPreheatingJob::EXPIRES_IN
     )
-
-    User.find_each do |user|
-      Rails.cache.write(
-        "dawarich/user_#{user.id}_years_tracked",
-        user.years_tracked,
-        expires_in: 1.day
-      )
-
-      Rails.cache.write(
-        "dawarich/user_#{user.id}_points_geocoded_stats",
-        StatsQuery.new(user).cached_points_geocoded_stats,
-        expires_in: 1.day
-      )
-
-      Rails.cache.write(
-        "dawarich/user_#{user.id}_countries_visited",
-        user.countries_visited_uncached,
-        expires_in: 1.day
-      )
-
-      Rails.cache.write(
-        "dawarich/user_#{user.id}_cities_visited",
-        user.cities_visited_uncached,
-        expires_in: 1.day
-      )
-
-      # Preheat total_distance cache
-      total_distance_meters = user.stats.sum(:distance)
-      Rails.cache.write(
-        "dawarich/user_#{user.id}_total_distance",
-        Stat.convert_distance(total_distance_meters, user.safe_settings.distance_unit),
-        expires_in: 1.day
-      )
-
-      # Preheat insights yearly digest cache
-      Cache::PreheatInsightsDigests.new(user).call
-    end
   end
 end

--- a/app/jobs/cache/user_preheating_job.rb
+++ b/app/jobs/cache/user_preheating_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Preheats the per-user caches read by the dashboard and Insights pages.
+# Fanned out one-per-user by Cache::PreheatingJob so a single slow user
+# cannot stall the whole nightly preheat.
+class Cache::UserPreheatingJob < ApplicationJob
+  queue_as :cache
+
+  EXPIRES_IN = 1.day
+
+  def perform(user_id)
+    user = User.find_by(id: user_id)
+    return if user.nil?
+
+    write("dawarich/user_#{user.id}_years_tracked", user.years_tracked)
+    write("dawarich/user_#{user.id}_points_geocoded_stats", StatsQuery.new(user).cached_points_geocoded_stats)
+    write("dawarich/user_#{user.id}_countries_visited", user.countries_visited_uncached)
+    write("dawarich/user_#{user.id}_cities_visited", user.cities_visited_uncached)
+    write("dawarich/user_#{user.id}_total_distance", total_distance(user))
+
+    Cache::PreheatInsightsDigests.new(user).call
+  end
+
+  private
+
+  def write(key, value)
+    Rails.cache.write(key, value, expires_in: EXPIRES_IN)
+  end
+
+  def total_distance(user)
+    Stat.convert_distance(user.stats.sum(:distance), user.safe_settings.distance_unit)
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -23,12 +23,12 @@ airtrail_flight_import_job:
 app_version_checking_job:
   cron: "0 */6 * * *" # every 6 hours
   class: "AppVersionCheckingJob"
-  queue: default
+  queue: app_version_checking
 
 cache_preheating_job:
   cron: "0 0 * * *" # every day at 0:00
   class: "Cache::PreheatingJob"
-  queue: default
+  queue: cache
 
 daily_track_generation_job:
   cron: "0 */12 * * *" # every 12 hours (real-time generation handles most cases)
@@ -53,12 +53,12 @@ stale_jobs_recovery_job:
 family_location_requests_expiry_job:
   cron: "30 * * * *" # every hour at :30
   class: "Families::ExpireLocationRequestsJob"
-  queue: default
+  queue: families
 
 points_counter_correction_job:
   cron: "0 */6 * * *" # every 6 hours
   class: "Users::PointsCounterCorrectionJob"
-  queue: default
+  queue: low_priority
 
 lite_archival_warning_job:
   cron: "0 3 * * *" # every day at 03:00

--- a/spec/config/schedule_spec.rb
+++ b/spec/config/schedule_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Guards the three-way contract described in .claude/rules/background-jobs.md:
+# a cron entry's queue, the job class's `queue_as`, and the queue list in
+# config/sidekiq.yml must all agree. A drift in any of them means the job
+# either never runs or runs at the wrong priority, and neither failure mode
+# surfaces as an exception.
+RSpec.describe 'config/schedule.yml' do
+  schedule = YAML.load_file(Rails.root.join('config/schedule.yml'))
+  sidekiq_queues = YAML.load_file(Rails.root.join('config/sidekiq.yml')).fetch(:queues).map(&:to_s)
+
+  it 'is not empty' do
+    expect(schedule).not_to be_empty
+  end
+
+  schedule.each do |entry_name, config|
+    context "entry #{entry_name}" do
+      let(:job_class) { config.fetch('class') }
+      let(:scheduled_queue) { config['queue'] }
+
+      it 'references a job class that exists' do
+        expect { job_class.constantize }.not_to raise_error
+      end
+
+      it 'declares a queue' do
+        expect(scheduled_queue).to be_present
+      end
+
+      it 'schedules onto the queue the job class declares' do
+        expect(scheduled_queue).to eq(job_class.constantize.new.queue_name)
+      end
+
+      it 'schedules onto a queue Sidekiq actually processes' do
+        expect(sidekiq_queues).to include(scheduled_queue)
+      end
+    end
+  end
+end

--- a/spec/jobs/cache/preheating_job_spec.rb
+++ b/spec/jobs/cache/preheating_job_spec.rb
@@ -6,8 +6,13 @@ RSpec.describe Cache::PreheatingJob do
   before { Rails.cache.clear }
 
   describe '#perform' do
-    let!(:user1) { create(:user) }
-    let!(:user2) { create(:user) }
+    # skip_auto_trial pins the factory status: the after_commit :activate /
+    # :start_trial hooks would otherwise rewrite it based on self_hosted?,
+    # which these examples stub per context.
+    let!(:active_user) { create(:user, skip_auto_trial: true) }
+    let!(:trial_user) { create(:user, :trial, skip_auto_trial: true) }
+    let!(:inactive_user) { create(:user, :inactive, skip_auto_trial: true) }
+    let!(:pending_payment_user) { create(:user, status: :pending_payment, skip_auto_trial: true) }
 
     it 'runs on the cache queue' do
       expect(described_class.new.queue_name).to eq('cache')
@@ -19,29 +24,69 @@ RSpec.describe Cache::PreheatingJob do
       expect(Rails.cache.exist?('dawarich/countries_codes')).to be true
     end
 
-    it 'fans out one job per user instead of preheating inline' do
-      described_class.new.perform
-
-      expect(Cache::UserPreheatingJob).to have_been_enqueued.with(user1.id)
-      expect(Cache::UserPreheatingJob).to have_been_enqueued.with(user2.id)
-    end
-
-    it 'enqueues exactly one job per user' do
-      expect { described_class.new.perform }
-        .to have_enqueued_job(Cache::UserPreheatingJob).exactly(User.count).times
-    end
-
     it 'does not write per-user caches itself' do
       described_class.new.perform
 
-      expect(Rails.cache.exist?("dawarich/user_#{user1.id}_years_tracked")).to be false
+      expect(Rails.cache.exist?("dawarich/user_#{active_user.id}_years_tracked")).to be false
     end
 
-    it 'preheats every user once the fanned-out jobs run' do
-      perform_enqueued_jobs { described_class.new.perform }
+    context 'on Dawarich Cloud' do
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
 
-      expect(Rails.cache.exist?("dawarich/user_#{user1.id}_years_tracked")).to be true
-      expect(Rails.cache.exist?("dawarich/user_#{user2.id}_years_tracked")).to be true
+      it 'fans out to active users' do
+        described_class.new.perform
+
+        expect(Cache::UserPreheatingJob).to have_been_enqueued.with(active_user.id)
+      end
+
+      it 'fans out to trial users' do
+        described_class.new.perform
+
+        expect(Cache::UserPreheatingJob).to have_been_enqueued.with(trial_user.id)
+      end
+
+      it 'skips inactive users' do
+        described_class.new.perform
+
+        expect(Cache::UserPreheatingJob).not_to have_been_enqueued.with(inactive_user.id)
+      end
+
+      it 'skips users pending payment' do
+        described_class.new.perform
+
+        expect(Cache::UserPreheatingJob).not_to have_been_enqueued.with(pending_payment_user.id)
+      end
+
+      it 'enqueues exactly one job per active or trial user' do
+        expect { described_class.new.perform }
+          .to have_enqueued_job(Cache::UserPreheatingJob).exactly(2).times
+      end
+
+      it 'preheats the fanned-out users once their jobs run' do
+        perform_enqueued_jobs { described_class.new.perform }
+
+        expect(Rails.cache.exist?("dawarich/user_#{active_user.id}_years_tracked")).to be true
+        expect(Rails.cache.exist?("dawarich/user_#{trial_user.id}_years_tracked")).to be true
+        expect(Rails.cache.exist?("dawarich/user_#{inactive_user.id}_years_tracked")).to be false
+      end
+    end
+
+    context 'when self-hosted' do
+      before { allow(DawarichSettings).to receive(:self_hosted?).and_return(true) }
+
+      it 'fans out to every user regardless of status' do
+        described_class.new.perform
+
+        expect(Cache::UserPreheatingJob).to have_been_enqueued.with(active_user.id)
+        expect(Cache::UserPreheatingJob).to have_been_enqueued.with(trial_user.id)
+        expect(Cache::UserPreheatingJob).to have_been_enqueued.with(inactive_user.id)
+        expect(Cache::UserPreheatingJob).to have_been_enqueued.with(pending_payment_user.id)
+      end
+
+      it 'enqueues exactly one job per user' do
+        expect { described_class.new.perform }
+          .to have_enqueued_job(Cache::UserPreheatingJob).exactly(User.count).times
+      end
     end
   end
 end

--- a/spec/jobs/cache/preheating_job_spec.rb
+++ b/spec/jobs/cache/preheating_job_spec.rb
@@ -8,85 +8,40 @@ RSpec.describe Cache::PreheatingJob do
   describe '#perform' do
     let!(:user1) { create(:user) }
     let!(:user2) { create(:user) }
-    let!(:import1) { create(:import, user: user1) }
-    let!(:import2) { create(:import, user: user2) }
-    let(:user_1_years_tracked_key) { "dawarich/user_#{user1.id}_years_tracked" }
-    let(:user_2_years_tracked_key) { "dawarich/user_#{user2.id}_years_tracked" }
-    let(:user_1_points_geocoded_stats_key) { "dawarich/user_#{user1.id}_points_geocoded_stats" }
-    let(:user_2_points_geocoded_stats_key) { "dawarich/user_#{user2.id}_points_geocoded_stats" }
-    let(:user_1_countries_visited_key) { "dawarich/user_#{user1.id}_countries_visited" }
-    let(:user_2_countries_visited_key) { "dawarich/user_#{user2.id}_countries_visited" }
-    let(:user_1_cities_visited_key) { "dawarich/user_#{user1.id}_cities_visited" }
-    let(:user_2_cities_visited_key) { "dawarich/user_#{user2.id}_cities_visited" }
 
-    before do
-      create_list(:point, 3, user: user1, import: import1, reverse_geocoded_at: Time.current)
-      create_list(:point, 2, user: user2, import: import2, reverse_geocoded_at: Time.current)
+    it 'runs on the cache queue' do
+      expect(described_class.new.queue_name).to eq('cache')
     end
 
-    it 'preheats years_tracked cache for all users' do
-      # Clear cache before test to ensure clean state
-      Rails.cache.clear
-
+    it 'preheats the global country borders cache' do
       described_class.new.perform
 
-      # Verify that cache keys exist after job runs
-      expect(Rails.cache.exist?(user_1_years_tracked_key)).to be true
-      expect(Rails.cache.exist?(user_2_years_tracked_key)).to be true
-
-      # Verify the cached data is reasonable
-      user1_years = Rails.cache.read(user_1_years_tracked_key)
-      user2_years = Rails.cache.read(user_2_years_tracked_key)
-
-      expect(user1_years).to be_an(Array)
-      expect(user2_years).to be_an(Array)
+      expect(Rails.cache.exist?('dawarich/countries_codes')).to be true
     end
 
-    it 'preheats points_geocoded_stats cache for all users' do
-      # Clear cache before test to ensure clean state
-      Rails.cache.clear
-
+    it 'fans out one job per user instead of preheating inline' do
       described_class.new.perform
 
-      # Verify that cache keys exist after job runs
-      expect(Rails.cache.exist?(user_1_points_geocoded_stats_key)).to be true
-      expect(Rails.cache.exist?(user_2_points_geocoded_stats_key)).to be true
-
-      # Verify the cached data has the expected structure
-      user1_stats = Rails.cache.read(user_1_points_geocoded_stats_key)
-      user2_stats = Rails.cache.read(user_2_points_geocoded_stats_key)
-
-      expect(user1_stats).to be_a(Hash)
-      expect(user1_stats).to have_key(:geocoded)
-      expect(user1_stats).to have_key(:without_data)
-      expect(user1_stats[:geocoded]).to eq(3)
-
-      expect(user2_stats).to be_a(Hash)
-      expect(user2_stats).to have_key(:geocoded)
-      expect(user2_stats).to have_key(:without_data)
-      expect(user2_stats[:geocoded]).to eq(2)
+      expect(Cache::UserPreheatingJob).to have_been_enqueued.with(user1.id)
+      expect(Cache::UserPreheatingJob).to have_been_enqueued.with(user2.id)
     end
 
-    it 'actually writes to cache' do
+    it 'enqueues exactly one job per user' do
+      expect { described_class.new.perform }
+        .to have_enqueued_job(Cache::UserPreheatingJob).exactly(User.count).times
+    end
+
+    it 'does not write per-user caches itself' do
       described_class.new.perform
 
-      expect(Rails.cache.exist?(user_1_years_tracked_key)).to be true
-      expect(Rails.cache.exist?(user_1_points_geocoded_stats_key)).to be true
-      expect(Rails.cache.exist?(user_1_countries_visited_key)).to be true
-      expect(Rails.cache.exist?(user_1_cities_visited_key)).to be true
-      expect(Rails.cache.exist?(user_2_years_tracked_key)).to be true
-      expect(Rails.cache.exist?(user_2_points_geocoded_stats_key)).to be true
-      expect(Rails.cache.exist?(user_2_countries_visited_key)).to be true
-      expect(Rails.cache.exist?(user_2_cities_visited_key)).to be true
+      expect(Rails.cache.exist?("dawarich/user_#{user1.id}_years_tracked")).to be false
     end
 
-    it 'handles users with no points gracefully' do
-      user_no_points = create(:user)
+    it 'preheats every user once the fanned-out jobs run' do
+      perform_enqueued_jobs { described_class.new.perform }
 
-      expect { described_class.new.perform }.not_to raise_error
-
-      cached_stats = Rails.cache.read("dawarich/user_#{user_no_points.id}_points_geocoded_stats")
-      expect(cached_stats).to eq({ geocoded: 0, without_data: 0 })
+      expect(Rails.cache.exist?("dawarich/user_#{user1.id}_years_tracked")).to be true
+      expect(Rails.cache.exist?("dawarich/user_#{user2.id}_years_tracked")).to be true
     end
   end
 end

--- a/spec/jobs/cache/user_preheating_job_spec.rb
+++ b/spec/jobs/cache/user_preheating_job_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Cache::UserPreheatingJob do
+  before { Rails.cache.clear }
+
+  describe '#perform' do
+    let!(:user) { create(:user) }
+    let!(:import) { create(:import, user: user) }
+
+    before do
+      create_list(:point, 3, user: user, import: import, reverse_geocoded_at: Time.current)
+    end
+
+    it 'runs on the cache queue' do
+      expect(described_class.new.queue_name).to eq('cache')
+    end
+
+    it 'preheats years_tracked' do
+      described_class.new.perform(user.id)
+
+      expect(Rails.cache.read("dawarich/user_#{user.id}_years_tracked")).to be_an(Array)
+    end
+
+    it 'preheats points_geocoded_stats' do
+      described_class.new.perform(user.id)
+
+      stats = Rails.cache.read("dawarich/user_#{user.id}_points_geocoded_stats")
+
+      expect(stats).to include(geocoded: 3)
+      expect(stats).to have_key(:without_data)
+    end
+
+    it 'preheats countries and cities visited' do
+      described_class.new.perform(user.id)
+
+      expect(Rails.cache.exist?("dawarich/user_#{user.id}_countries_visited")).to be true
+      expect(Rails.cache.exist?("dawarich/user_#{user.id}_cities_visited")).to be true
+    end
+
+    it 'preheats total_distance' do
+      described_class.new.perform(user.id)
+
+      expect(Rails.cache.exist?("dawarich/user_#{user.id}_total_distance")).to be true
+    end
+
+    it 'handles a user with no points gracefully' do
+      user_without_points = create(:user)
+
+      expect { described_class.new.perform(user_without_points.id) }.not_to raise_error
+
+      expect(Rails.cache.read("dawarich/user_#{user_without_points.id}_points_geocoded_stats"))
+        .to eq({ geocoded: 0, without_data: 0 })
+    end
+
+    context 'when the user no longer exists' do
+      it 'does not raise' do
+        deleted_id = create(:user).id
+        User.find(deleted_id).destroy
+
+        expect { described_class.new.perform(deleted_id) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Two background-job findings from a GlitchTip performance review, plus a regression guard.

## Cache preheat fanned out and scoped

`Cache::PreheatingJob` looped over every user in one job, doing six expensive cache writes each (`years_tracked`, geocoded stats, countries, cities, total distance, insights digests). GlitchTip has it averaging **653 s (~11 min)** per run, and that number grows linearly with the user count.

Two changes:

1. **Fan-out.** It now writes only the global country-borders entry inline and dispatches the per-user work to a new `Cache::UserPreheatingJob` via `ActiveJob.perform_all_later` (batched at 500). Runtime becomes *slowest single user* rather than *sum of all users*, so one account with a large history no longer delays everyone else's preheat.
2. **Scoping.** On Cloud it now targets `User.active_or_trial` — the same scope `Tracks::DailyGenerationJob`, `Users::PointsCounterCorrectionJob` and both digest scheduling jobs already use — so lapsed and pending-payment accounts that will never load a page no longer consume queue time. Self-hosted instances have no subscription lifecycle and keep preheating every user.

Otherwise unchanged: same cache keys, same 1-day TTL. The per-user job no-ops if the user was deleted between fan-out and execution.

## Four cron entries were on the wrong queue

```
app_version_checking_job              default -> app_version_checking
cache_preheating_job                  default -> cache
family_location_requests_expiry_job   default -> families
points_counter_correction_job         default -> low_priority
```

Each job class already declared the right queue via `queue_as`; only `config/schedule.yml` disagreed, and the cron entry wins. `default` sits fourth in `config/sidekiq.yml`'s strict-priority list — ahead of `imports`, `tracks` and `stats` — so the 11-minute preheat and the 76-second counter correction were blocking user-facing work.

## Regression guard

`spec/config/schedule_spec.rb` asserts, for all 19 cron entries, the contract from `.claude/rules/background-jobs.md`:

1. the referenced class resolves,
2. a queue is declared,
3. it matches the class's `queue_as`,
4. Sidekiq actually processes that queue (present in `config/sidekiq.yml`).

None of these failure modes raises at runtime — a job scheduled onto a queue absent from `sidekiq.yml` silently never runs — so a test is the only thing that catches the drift. I verified the guard fails (not just passes) by temporarily reverting one entry, and likewise verified the status-scoping specs fail when the scope is removed.

## A note for anyone writing user-status specs here

`User` has `after_commit :activate` / `:start_trial` on create, branching on `DawarichSettings.self_hosted?`. In the test environment that rewrites the factory's `status` to `:active` for every user, so `create(:user, :inactive)` silently yields an active user and any status-filtering assertion passes vacuously. These specs pass `skip_auto_trial: true`, matching the existing idiom in `spec/models/user_spec.rb`.

## Verification

```
bundle exec rspec spec/jobs/cache spec/config/schedule_spec.rb
95 examples, 0 failures

bundle exec rubocop <changed files>
no offenses detected
```

No migrations, no user-visible UI change.
