### PR TITLE
feat: consider airtrail recordings for stats

### DIFF
--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -200,7 +200,8 @@ class Stat < ApplicationRecord
       monthly_points,
       timespan,
       user.timezone_iana,
-      minutes_between_routes: user.safe_settings.minutes_between_routes
+      minutes_between_routes: user.safe_settings.minutes_between_routes,
+      user_id: user.id
     ).call
   end
 

--- a/app/queries/stats/daily_distance_query.rb
+++ b/app/queries/stats/daily_distance_query.rb
@@ -82,7 +82,7 @@ class Stats::DailyDistanceQuery
           END AS segment_distance
         FROM gapped_points gp
         LEFT JOIN LATERAL (
-          SELECT f.distance_km
+          SELECT SUM(f.distance_km) AS distance_km
           FROM flights f
           WHERE f.user_id = $5
             AND f.distance_km IS NOT NULL
@@ -90,8 +90,6 @@ class Stats::DailyDistanceQuery
             AND f.arrival_time IS NOT NULL
             AND f.departure_time < to_timestamp(gp.timestamp)
             AND f.arrival_time   > to_timestamp(gp.prev_timestamp)
-          ORDER BY f.departure_time
-          LIMIT 1
         ) flight ON gp.gap_excluded
       )
       SELECT

--- a/app/queries/stats/daily_distance_query.rb
+++ b/app/queries/stats/daily_distance_query.rb
@@ -5,11 +5,12 @@ class Stats::DailyDistanceQuery
   # snapshots rather than a continuous track.
   SNAPSHOT_IMPORT_SOURCES = %w[immich_api photoprism_api google_photos].freeze
 
-  def initialize(monthly_points, timespan, timezone = nil, minutes_between_routes: nil)
+  def initialize(monthly_points, timespan, timezone = nil, minutes_between_routes: nil, user_id: nil)
     @monthly_points = monthly_points
     @timespan = timespan
     @timezone = validate_timezone(timezone)
     @time_gap_seconds = validate_minutes_between_routes(minutes_between_routes) * 60
+    @user_id = user_id
   end
 
   def call
@@ -21,7 +22,7 @@ class Stats::DailyDistanceQuery
 
   private
 
-  attr_reader :monthly_points, :timespan, :timezone, :time_gap_seconds
+  attr_reader :monthly_points, :timespan, :timezone, :time_gap_seconds, :user_id
 
   def daily_distances(monthly_points)
     sql = <<~SQL.squish
@@ -47,21 +48,51 @@ class Stats::DailyDistanceQuery
           ORDER BY timestamp, id
         )
       ),
-      points_with_distances AS (
+      gapped_points AS (
         SELECT
           local_date,
-          CASE
-            WHEN prev_lonlat IS NULL THEN 0
-            WHEN (
+          timestamp,
+          lonlat,
+          prev_lonlat,
+          prev_timestamp,
+          (
+            prev_lonlat IS NOT NULL
+            AND (
               import_id IS NULL
               OR prev_import_id IS NULL
               OR import_id != prev_import_id
               OR snapshot_import
               OR prev_snapshot_import
-            ) AND (timestamp - prev_timestamp) > $4 THEN 0
-            ELSE ST_Distance(lonlat::geography, prev_lonlat::geography)
-          END AS segment_distance
+            )
+            AND (timestamp - prev_timestamp) > $4
+          ) AS gap_excluded
         FROM ordered_points
+      ),
+      points_with_distances AS (
+        SELECT
+          gp.local_date,
+          CASE
+            WHEN gp.prev_lonlat IS NULL THEN 0
+            /* A gap this long usually means the tracker lost signal (e.g. a
+               flight) rather than the points being unrelated. If a synced
+               AirTrail flight covers the gap, trust its known distance
+               instead of silently dropping it. */
+            WHEN gp.gap_excluded THEN COALESCE(flight.distance_km * 1000, 0)
+            ELSE ST_Distance(gp.lonlat::geography, gp.prev_lonlat::geography)
+          END AS segment_distance
+        FROM gapped_points gp
+        LEFT JOIN LATERAL (
+          SELECT f.distance_km
+          FROM flights f
+          WHERE f.user_id = $5
+            AND f.distance_km IS NOT NULL
+            AND f.departure_time IS NOT NULL
+            AND f.arrival_time IS NOT NULL
+            AND f.departure_time < to_timestamp(gp.timestamp)
+            AND f.arrival_time   > to_timestamp(gp.prev_timestamp)
+          ORDER BY f.departure_time
+          LIMIT 1
+        ) flight ON gp.gap_excluded
       )
       SELECT
         EXTRACT(day FROM local_date)::int AS day_of_month,
@@ -78,7 +109,8 @@ class Stats::DailyDistanceQuery
       ActiveRecord::Relation::QueryAttribute.new('timezone', timezone, ActiveRecord::Type::String.new),
       ActiveRecord::Relation::QueryAttribute.new('year', target.year, ActiveRecord::Type::Integer.new),
       ActiveRecord::Relation::QueryAttribute.new('month', target.month, ActiveRecord::Type::Integer.new),
-      ActiveRecord::Relation::QueryAttribute.new('time_gap_seconds', time_gap_seconds, ActiveRecord::Type::Integer.new)
+      ActiveRecord::Relation::QueryAttribute.new('time_gap_seconds', time_gap_seconds, ActiveRecord::Type::Integer.new),
+      ActiveRecord::Relation::QueryAttribute.new('user_id', user_id, ActiveRecord::Type::Integer.new)
     ]
 
     Stat.connection.exec_query(sql, 'DailyDistanceQuery', binds).to_a

--- a/spec/queries/stats/daily_distance_query_spec.rb
+++ b/spec/queries/stats/daily_distance_query_spec.rb
@@ -314,6 +314,79 @@ RSpec.describe Stats::DailyDistanceQuery do
       end
     end
 
+    context 'with a synced AirTrail flight covering a large real-time tracking gap' do
+      # No GPS signal during the flight (e.g. no wifi/cellular in the air),
+      # but AirTrail already knows the real distance for that leg.
+      let!(:point1) do
+        create(:point, user: user, lonlat: 'POINT(12.5211 55.7603)',
+               timestamp: DateTime.new(2021, 1, 1, 6, 0, 0).to_i)
+      end
+      let!(:point2) do
+        create(:point, user: user, lonlat: 'POINT(4.4960 52.1576)',
+               timestamp: DateTime.new(2021, 1, 1, 12, 0, 0).to_i)
+      end
+      let!(:flight) do
+        create(:flight, user: user,
+               departure_time: DateTime.new(2021, 1, 1, 6, 30, 0),
+               arrival_time: DateTime.new(2021, 1, 1, 8, 0, 0),
+               distance_km: 633.4)
+      end
+
+      subject do
+        described_class.new(monthly_points, timespan, 'Etc/UTC', minutes_between_routes: 30, user_id: user.id).call
+      end
+
+      it 'uses the flight distance instead of dropping the gap' do
+        day1_distance = subject.find { |day, _| day == 1 }&.last
+        expect(day1_distance).to eq(633_400)
+      end
+    end
+
+    context 'with a large real-time tracking gap and no matching flight' do
+      let!(:point1) do
+        create(:point, user: user, lonlat: 'POINT(12.5211 55.7603)',
+               timestamp: DateTime.new(2021, 1, 1, 6, 0, 0).to_i)
+      end
+      let!(:point2) do
+        create(:point, user: user, lonlat: 'POINT(4.4960 52.1576)',
+               timestamp: DateTime.new(2021, 1, 1, 12, 0, 0).to_i)
+      end
+
+      subject do
+        described_class.new(monthly_points, timespan, 'Etc/UTC', minutes_between_routes: 30, user_id: user.id).call
+      end
+
+      it 'still drops the gap' do
+        expect(subject.find { |day, _| day == 1 }&.last).to eq(0)
+      end
+    end
+
+    context 'with a large real-time tracking gap and a flight belonging to a different user' do
+      let!(:other_user) { create(:user) }
+      let!(:point1) do
+        create(:point, user: user, lonlat: 'POINT(12.5211 55.7603)',
+               timestamp: DateTime.new(2021, 1, 1, 6, 0, 0).to_i)
+      end
+      let!(:point2) do
+        create(:point, user: user, lonlat: 'POINT(4.4960 52.1576)',
+               timestamp: DateTime.new(2021, 1, 1, 12, 0, 0).to_i)
+      end
+      let!(:flight) do
+        create(:flight, user: other_user,
+               departure_time: DateTime.new(2021, 1, 1, 6, 30, 0),
+               arrival_time: DateTime.new(2021, 1, 1, 8, 0, 0),
+               distance_km: 633.4)
+      end
+
+      subject do
+        described_class.new(monthly_points, timespan, 'Etc/UTC', minutes_between_routes: 30, user_id: user.id).call
+      end
+
+      it 'does not borrow another user\'s flight distance' do
+        expect(subject.find { |day, _| day == 1 }&.last).to eq(0)
+      end
+    end
+
     context 'with a blank minutes_between_routes setting' do
       let!(:point1) do
         create(:point, user: user, lonlat: 'POINT(16.37 48.21)',


### PR DESCRIPTION
This PR enables counting the airtrail flights into the stats page / digests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily distance calculations across extended tracking or import gaps.
  * Recorded flight distances are now included when matching flights are found.
  * Gaps without matching flights remain excluded, and flights belonging to other users are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->