### PR TITLE
fix: clarify the geocoding provider pane

### DIFF
--- a/app/javascript/controllers/geocoding_settings_controller.js
+++ b/app/javascript/controllers/geocoding_settings_controller.js
@@ -14,6 +14,7 @@ export default class extends Controller {
     "httpsLockedHint",
     "rpsInput",
     "rpsHint",
+    "apiKeyWrapper",
   ]
   static values = {
     chibigeoHost: String,
@@ -65,6 +66,10 @@ export default class extends Controller {
     const kind = this.hostKind()
     this.chibigeoPanelTarget.hidden = kind !== "chibigeo"
     this.komootWarningTarget.hidden = kind !== "komoot"
+    // komoot's public server takes no key; the field would only invite one.
+    if (this.hasApiKeyWrapperTarget) {
+      this.apiKeyWrapperTarget.hidden = kind === "komoot"
+    }
 
     const locked = this.httpsOnlyHostsValue.includes(this.bareHost())
     if (locked) this.httpsToggleTarget.checked = true

--- a/app/views/settings/integrations/_geocoding.html.erb
+++ b/app/views/settings/integrations/_geocoding.html.erb
@@ -36,6 +36,9 @@
      'chibigeo' => t('settings.geocoding.show.rps_hint_chibigeo'),
      'custom' => t('settings.geocoding.show.rps_hint_custom')
    } %>
+<% chibigeo_utm = 'utm_source=dawarich&utm_medium=app&utm_campaign=geocoding_settings' %>
+<% chibigeo_site_url = "https://chibigeo.com/?#{chibigeo_utm}" %>
+<% chibigeo_docs_url = "https://chibigeo.com/docs/guides/dawarich?#{chibigeo_utm}" %>
 
 <div class="rounded-box border border-base-content/10 bg-base-200 max-w-3xl"
      data-controller="geocoding-settings"
@@ -67,7 +70,8 @@
         <div class="space-y-2" role="radiogroup" aria-label="<%= t('settings.geocoding.show.host_choice') %>">
           <span class="label-text font-medium"><%= t('settings.geocoding.show.host_choice') %></span>
           <% [
-            { value: 'chibigeo', title: t('settings.geocoding.show.choice_chibigeo'), desc: t('settings.geocoding.show.choice_chibigeo_desc'), badge: t('settings.geocoding.show.recommended') },
+            { value: 'chibigeo', title: t('settings.geocoding.show.choice_chibigeo'), desc: t('settings.geocoding.show.choice_chibigeo_desc'), badge: t('settings.geocoding.show.recommended'),
+              link: { label: t('settings.geocoding.show.chibigeo_site_link'), url: chibigeo_site_url } },
             { value: 'komoot', title: t('settings.geocoding.show.choice_komoot'), desc: t('settings.geocoding.show.choice_komoot_desc'), badge: nil },
             { value: 'custom', title: t('settings.geocoding.show.choice_custom'), desc: t('settings.geocoding.show.choice_custom_desc'), badge: nil }
           ].each do |option| %>
@@ -84,7 +88,14 @@
                     <span class="badge badge-primary badge-outline badge-sm"><%= option[:badge] %></span>
                   <% end %>
                 </span>
-                <span class="block text-sm text-base-content/60 mt-0.5"><%= option[:desc] %></span>
+                <span class="block text-sm text-base-content/60 mt-0.5">
+                  <%= option[:desc] %>
+                  <% if option[:link] %>
+                    <%= link_to option[:link][:label], option[:link][:url],
+                                target: '_blank', rel: 'noopener',
+                                class: 'link link-primary whitespace-nowrap' %>
+                  <% end %>
+                </span>
               </span>
             </label>
           <% end %>
@@ -96,9 +107,11 @@
             <div class="text-sm space-y-1">
               <p><%= t('settings.geocoding.show.chibigeo_message') %></p>
               <p><%= t('settings.geocoding.show.chibigeo_limits') %></p>
-              <p>
-                <%= link_to t('settings.geocoding.show.chibigeo_key_link'),
-                            'https://chibigeo.com/docs/guides/dawarich?utm_source=dawarich&utm_medium=app&utm_campaign=geocoding_settings',
+              <p class="flex flex-wrap gap-x-4 gap-y-1">
+                <%= link_to t('settings.geocoding.show.chibigeo_key_link'), chibigeo_docs_url,
+                            target: '_blank', rel: 'noopener',
+                            class: 'link link-primary font-medium' %>
+                <%= link_to t('settings.geocoding.show.chibigeo_site_link'), chibigeo_site_url,
                             target: '_blank', rel: 'noopener',
                             class: 'link link-primary font-medium' %>
               </p>
@@ -108,7 +121,10 @@
         <div data-geocoding-settings-target="komootWarning" <%= 'hidden' unless photon_choice == 'komoot' %>>
           <div class="flex items-start gap-3 rounded-lg border border-warning/40 bg-warning/10 p-4">
             <%= icon 'triangle-alert', class: 'w-5 h-5 shrink-0 text-warning mt-0.5' %>
-            <span class="text-sm"><%= t('settings.geocoding.show.komoot_warning') %></span>
+            <div class="text-sm space-y-1">
+              <p><%= t('settings.geocoding.show.komoot_warning') %></p>
+              <p><%= t('settings.geocoding.show.komoot_no_api_key') %></p>
+            </div>
           </div>
         </div>
 
@@ -124,57 +140,62 @@
           </div>
         </div>
 
-        <div class="form-control">
-          <label class="label cursor-pointer justify-start gap-3">
-            <%= hidden_field_tag 'photon[use_https]', photon_https_locked ? '1' : '0',
-                                 data: { geocoding_settings_target: 'httpsHidden' } %>
-            <%= check_box_tag 'photon[use_https]', '1',
-                              photon_setting ? photon_setting.use_https : true,
-                              class: 'toggle toggle-primary',
-                              disabled: photon_https_locked,
-                              data: { geocoding_settings_target: 'httpsToggle' } %>
-            <span class="label-text"><%= t('settings.geocoding.show.use_https') %></span>
-          </label>
-          <span class="label-text-alt text-base-content/60 ml-1"
-                data-geocoding-settings-target="httpsLockedHint"
-                <%= 'hidden' unless photon_https_locked %>><%= t('settings.geocoding.show.https_locked') %></span>
-        </div>
-
-        <div class="form-control w-full max-w-md">
-          <label class="label"><span class="label-text font-medium"><%= t('settings.geocoding.show.rps') %></span></label>
-          <%= number_field_tag 'photon[rps]', photon_setting&.rps,
-                               class: 'input input-bordered w-full',
-                               step: 'any',
-                               min: rps_rules[photon_choice].min,
-                               max: rps_rules[photon_choice].max,
-                               disabled: rps_rules[photon_choice].locked,
-                               data: { geocoding_settings_target: 'rpsInput' } %>
-          <span class="label-text-alt mt-1 text-base-content/60"
-                data-geocoding-settings-target="rpsHint"><%= rps_hints[photon_choice] %></span>
-        </div>
-
-        <div class="form-control w-full max-w-md">
-          <label class="label"><span class="label-text font-medium"><%= t('settings.geocoding.show.api_key') %></span></label>
-          <%= password_field_tag 'photon[api_key]', nil,
-                                 class: 'input input-bordered w-full',
-                                 autocomplete: 'off',
-                                 placeholder: photon_setting&.api_key.present? ? '••••••••' : '' %>
-          <span class="label-text-alt mt-1 text-base-content/60">
-            <% if photon_setting&.api_key.present? %>
-              <%= t('settings.geocoding.show.api_key_saved') %> <%= t('settings.geocoding.show.api_key_hint') %>
-            <% else %>
-              <%= t('settings.geocoding.show.api_key_hint') %>
-            <% end %>
-          </span>
-        </div>
-        <% if photon_setting&.api_key.present? %>
+        <div class="grid gap-4 sm:grid-cols-2 max-w-md">
           <div class="form-control">
-            <label class="label cursor-pointer justify-start gap-3">
-              <%= check_box_tag 'photon[clear_api_key]', '1', false, class: 'checkbox checkbox-sm' %>
-              <span class="label-text"><%= t('settings.geocoding.show.clear_api_key') %></span>
+            <label class="label"><span class="label-text font-medium"><%= t('settings.geocoding.show.use_https') %></span></label>
+            <label class="label cursor-pointer justify-start gap-3 py-1">
+              <%= hidden_field_tag 'photon[use_https]', photon_https_locked ? '1' : '0',
+                                   data: { geocoding_settings_target: 'httpsHidden' } %>
+              <%= check_box_tag 'photon[use_https]', '1',
+                                photon_setting ? photon_setting.use_https : true,
+                                class: 'toggle toggle-primary',
+                                disabled: photon_https_locked,
+                                data: { geocoding_settings_target: 'httpsToggle' } %>
             </label>
+            <span class="label-text-alt mt-1 text-base-content/60"
+                  data-geocoding-settings-target="httpsLockedHint"
+                  <%= 'hidden' unless photon_https_locked %>><%= t('settings.geocoding.show.https_locked') %></span>
           </div>
-        <% end %>
+
+          <div class="form-control">
+            <label class="label"><span class="label-text font-medium"><%= t('settings.geocoding.show.rps') %></span></label>
+            <%= number_field_tag 'photon[rps]', photon_setting&.rps,
+                                 class: 'input input-bordered w-full',
+                                 step: 'any',
+                                 min: rps_rules[photon_choice].min,
+                                 max: rps_rules[photon_choice].max,
+                                 disabled: rps_rules[photon_choice].locked,
+                                 data: { geocoding_settings_target: 'rpsInput' } %>
+            <span class="label-text-alt mt-1 text-base-content/60"
+                  data-geocoding-settings-target="rpsHint"><%= rps_hints[photon_choice] %></span>
+          </div>
+        </div>
+
+        <div data-geocoding-settings-target="apiKeyWrapper" class="space-y-4"
+             <%= 'hidden' if photon_choice == 'komoot' %>>
+          <div class="form-control w-full max-w-md">
+            <label class="label"><span class="label-text font-medium"><%= t('settings.geocoding.show.api_key') %></span></label>
+            <%= password_field_tag 'photon[api_key]', nil,
+                                   class: 'input input-bordered w-full',
+                                   autocomplete: 'off',
+                                   placeholder: photon_setting&.api_key.present? ? '••••••••' : '' %>
+            <span class="label-text-alt mt-1 text-base-content/60">
+              <% if photon_setting&.api_key.present? %>
+                <%= t('settings.geocoding.show.api_key_saved') %> <%= t('settings.geocoding.show.api_key_hint') %>
+              <% else %>
+                <%= t('settings.geocoding.show.api_key_hint') %>
+              <% end %>
+            </span>
+          </div>
+          <% if photon_setting&.api_key.present? %>
+            <div class="form-control">
+              <label class="label cursor-pointer justify-start gap-3">
+                <%= check_box_tag 'photon[clear_api_key]', '1', false, class: 'checkbox checkbox-sm' %>
+                <span class="label-text"><%= t('settings.geocoding.show.clear_api_key') %></span>
+              </label>
+            </div>
+          <% end %>
+        </div>
       </div>
 
       <% (Geocoding::Providers::CHAIN - ['photon']).each do |provider| %>
@@ -192,22 +213,26 @@
                                  placeholder: "#{provider}.example.com" %>
               <span class="label-text-alt mt-1 text-base-content/60"><%= t('settings.geocoding.show.host_hint') %></span>
             </div>
-            <div class="form-control">
-              <label class="label cursor-pointer justify-start gap-3">
-                <%= hidden_field_tag "#{provider}[use_https]", '0' %>
-                <%= check_box_tag "#{provider}[use_https]", '1', setting ? setting.use_https : true,
-                                  class: 'toggle toggle-primary' %>
-                <span class="label-text"><%= t('settings.geocoding.show.use_https') %></span>
-              </label>
-            </div>
           <% end %>
           <% rule = Geocoding::RateLimits.for(provider, setting&.host) %>
-          <div class="form-control w-full max-w-md">
-            <label class="label"><span class="label-text font-medium"><%= t('settings.geocoding.show.rps') %></span></label>
-            <%= number_field_tag "#{provider}[rps]", setting&.rps,
-                                 class: 'input input-bordered w-full',
-                                 step: 'any', min: rule.min, max: rule.max %>
-            <span class="label-text-alt mt-1 text-base-content/60"><%= t('settings.geocoding.show.rps_hint_custom') %></span>
+          <div class="grid gap-4 sm:grid-cols-2 max-w-md">
+            <% if with_host %>
+              <div class="form-control">
+                <label class="label"><span class="label-text font-medium"><%= t('settings.geocoding.show.use_https') %></span></label>
+                <label class="label cursor-pointer justify-start gap-3 py-1">
+                  <%= hidden_field_tag "#{provider}[use_https]", '0' %>
+                  <%= check_box_tag "#{provider}[use_https]", '1', setting ? setting.use_https : true,
+                                    class: 'toggle toggle-primary' %>
+                </label>
+              </div>
+            <% end %>
+            <div class="form-control">
+              <label class="label"><span class="label-text font-medium"><%= t('settings.geocoding.show.rps') %></span></label>
+              <%= number_field_tag "#{provider}[rps]", setting&.rps,
+                                   class: 'input input-bordered w-full',
+                                   step: 'any', min: rule.min, max: rule.max %>
+              <span class="label-text-alt mt-1 text-base-content/60"><%= t('settings.geocoding.show.rps_hint_custom') %></span>
+            </div>
           </div>
           <div class="form-control w-full max-w-md">
             <label class="label"><span class="label-text font-medium"><%= t('settings.geocoding.show.api_key') %></span></label>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1376,6 +1376,7 @@ de:
         chibigeo_message: ChibiGeo is a flat-rate, privacy-first geocoding service that works with Dawarich out of the box. An API key is required.
         chibigeo_limits: The free Hobby plan includes 2,500 lookups per day at 1 request per second — hard caps, no overage.
         chibigeo_key_link: Get your free API key
+        chibigeo_site_link: What is ChibiGeo?
         disabled: Disabled
         env_managed_notice: Geocoding is currently managed by environment variables set by your instance operator. The settings below take effect only if those variables are removed.
         host: Host
@@ -1390,6 +1391,7 @@ de:
         rps_hint_chibigeo: Match your ChibiGeo plan - Hobby 1, Self-Hoster 5, Builder 10, Scale 25. Asking for more than your plan allows only earns rejected lookups.
         rps_hint_komoot: komoot enforces one request per second for everyone, so this is fixed.
         komoot_warning: photon.komoot.io is a shared public instance with strict rate limits. Requests are throttled to one per second, and bulk geocoding will be slow. Please consider hosting your own Photon instance.
+        komoot_no_api_key: The public komoot server takes no API key — leave it unset.
         save: Save
         test: Test my provider
         test_hint: Save your settings first, then test. The test runs one lookup against your own provider configuration, even when environment variables are active.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1373,6 +1373,7 @@ en:
         chibigeo_message: ChibiGeo is a flat-rate, privacy-first geocoding service that works with Dawarich out of the box. An API key is required.
         chibigeo_limits: The free Hobby plan includes 2,500 lookups per day at 1 request per second — hard caps, no overage.
         chibigeo_key_link: Get your free API key
+        chibigeo_site_link: What is ChibiGeo?
         disabled: Disabled
         env_managed_notice: Geocoding is currently managed by environment variables set by your instance operator. The settings below take effect only if those variables are removed.
         host: Host
@@ -1387,6 +1388,7 @@ en:
         rps_hint_chibigeo: Match your ChibiGeo plan - Hobby 1, Self-Hoster 5, Builder 10, Scale 25. Asking for more than your plan allows only earns rejected lookups.
         rps_hint_komoot: komoot enforces one request per second for everyone, so this is fixed.
         komoot_warning: photon.komoot.io is a shared public instance with strict rate limits. Requests are throttled to one per second, and bulk geocoding will be slow. Please consider hosting your own Photon instance.
+        komoot_no_api_key: The public komoot server takes no API key — leave it unset.
         save: Save
         test: Test my provider
         test_hint: Save your settings first, then test. The test runs one lookup against your own provider configuration, even when environment variables are active.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1376,6 +1376,7 @@ es:
         chibigeo_message: ChibiGeo is a flat-rate, privacy-first geocoding service that works with Dawarich out of the box. An API key is required.
         chibigeo_limits: The free Hobby plan includes 2,500 lookups per day at 1 request per second — hard caps, no overage.
         chibigeo_key_link: Get your free API key
+        chibigeo_site_link: What is ChibiGeo?
         disabled: Disabled
         env_managed_notice: Geocoding is currently managed by environment variables set by your instance operator. The settings below take effect only if those variables are removed.
         host: Host
@@ -1390,6 +1391,7 @@ es:
         rps_hint_chibigeo: Match your ChibiGeo plan - Hobby 1, Self-Hoster 5, Builder 10, Scale 25. Asking for more than your plan allows only earns rejected lookups.
         rps_hint_komoot: komoot enforces one request per second for everyone, so this is fixed.
         komoot_warning: photon.komoot.io is a shared public instance with strict rate limits. Requests are throttled to one per second, and bulk geocoding will be slow. Please consider hosting your own Photon instance.
+        komoot_no_api_key: The public komoot server takes no API key — leave it unset.
         save: Save
         test: Test my provider
         test_hint: Save your settings first, then test. The test runs one lookup against your own provider configuration, even when environment variables are active.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2106,6 +2106,7 @@ fr:
         chibigeo_message: ChibiGeo is a flat-rate, privacy-first geocoding service that works with Dawarich out of the box. An API key is required.
         chibigeo_limits: The free Hobby plan includes 2,500 lookups per day at 1 request per second — hard caps, no overage.
         chibigeo_key_link: Get your free API key
+        chibigeo_site_link: What is ChibiGeo?
         disabled: Disabled
         env_managed_notice: Geocoding is currently managed by environment variables set by your instance operator. The settings below take effect only if those variables are removed.
         host: Host
@@ -2120,6 +2121,7 @@ fr:
         rps_hint_chibigeo: Match your ChibiGeo plan - Hobby 1, Self-Hoster 5, Builder 10, Scale 25. Asking for more than your plan allows only earns rejected lookups.
         rps_hint_komoot: komoot enforces one request per second for everyone, so this is fixed.
         komoot_warning: photon.komoot.io is a shared public instance with strict rate limits. Requests are throttled to one per second, and bulk geocoding will be slow. Please consider hosting your own Photon instance.
+        komoot_no_api_key: The public komoot server takes no API key — leave it unset.
         save: Save
         test: Test my provider
         test_hint: Save your settings first, then test. The test runs one lookup against your own provider configuration, even when environment variables are active.


### PR DESCRIPTION
Three fixes on Settings → Integrations → Geocoding.

- **ChibiGeo link.** The ChibiGeo choice now carries a "What is ChibiGeo?" link to chibigeo.com, so the service is explainable before it is selected; the same link joins the existing API-key link inside the ChibiGeo panel. Both carry the existing utm parameters.
- **komoot takes no API key.** Selecting the komoot public server hides the API key field (and the clear-key checkbox) and says so in the komoot notice, instead of inviting a key the server ignores. A stored key is left untouched — the hidden field submits blank, which the controller already reads as "keep what is saved".
- **HTTPS and rate limit share a row.** Both were full-width stacked blocks; they are now a two-column grid that collapses back to stacked below `sm`. Applied to the Photon fieldset and to the other providers' fieldsets.

Verified in the running app: ChibiGeo links render in both places; selecting komoot hides the key field, shows the notice and pins the rate to 1/s; on custom host the two controls sit side by side (x=358 vs x=586) and the key field returns; at 390px they stack with no new page overflow.

Note: the settings tab strip (`tabs min-w-max flex-nowrap`) already overflows a 390px viewport by ~32px on this page. Pre-existing and untouched here.

304 RSpec examples green (geocoding + integrations requests + French locale coverage), JS suite 161 green, Biome clean.