### PR TITLE
fix: stop a replayed cached fix inflating distance by tens of thousands of km

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- A phone that replays a stale cached position after landing no longer bills the trip as dozens of instant intercontinental flights. Bursts of identical coordinates reached and left at impossible speed are now flagged however long they run, and monthly distance ignores any leg faster than 1,200 km/h. Stored anomaly flags, tracks and statistics are re-evaluated by a background job after upgrading, so existing months change once it has run.
 - Saving family sharing settings without picking a duration no longer turns a timed share into a permanent one, and re-enabling a lapsed share restores its duration.
 - Each account can now pick its own geocoding provider — Photon, Geoapify, Nominatim or LocationIQ — under Settings → Integrations, with a button to test it. The `PHOTON_API_HOST`, `GEOAPIFY_API_KEY`, `NOMINATIM_API_HOST` and `LOCATIONIQ_API_KEY` variables keep working and take precedence.
 - A custom basemap that covers only part of the world can now fill the gaps with the built-in tiles. Turn on "Fill gaps with the default basemap" under Custom Basemap URL. It is off by default, because filling the gaps means requesting tiles from Dawarich's tile server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- A phone that replays a stale cached position after landing no longer bills the trip as dozens of instant intercontinental flights. Bursts of identical coordinates reached and left at impossible speed are now flagged however long they run, and monthly distance ignores any leg faster than 1,200 km/h. Stored anomaly flags, tracks and statistics are re-evaluated by a background job after upgrading; it runs on the lowest-priority queue and does not interrupt tracking, and your existing monthly totals will change once it reaches them.
+
 ## [1.13.1] - 2026-08-22, Berlin
 
 ### Added
@@ -13,7 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- A phone that replays a stale cached position after landing no longer bills the trip as dozens of instant intercontinental flights. Bursts of identical coordinates reached and left at impossible speed are now flagged however long they run, and monthly distance ignores any leg faster than 1,200 km/h. Stored anomaly flags, tracks and statistics are re-evaluated by a background job after upgrading, so existing months change once it has run.
 - Saving family sharing settings without picking a duration no longer turns a timed share into a permanent one, and re-enabling a lapsed share restores its duration.
 - Each account can now pick its own geocoding provider — Photon, Geoapify, Nominatim or LocationIQ — under Settings → Integrations, with a button to test it. The `PHOTON_API_HOST`, `GEOAPIFY_API_KEY`, `NOMINATIM_API_HOST` and `LOCATIONIQ_API_KEY` variables keep working and take precedence.
 - A custom basemap that covers only part of the world can now fill the gaps with the built-in tiles. Turn on "Fill gaps with the default basemap" under Custom Basemap URL. It is off by default, because filling the gaps means requesting tiles from Dawarich's tile server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- A phone that replays a stale cached position after landing no longer bills the trip as dozens of instant intercontinental flights. Bursts of identical coordinates reached and left at impossible speed are now flagged however long they run, and monthly distance ignores any leg faster than 1,200 km/h. Stored anomaly flags, tracks and statistics are re-evaluated by a background job after upgrading; it runs on the lowest-priority queue and does not interrupt tracking, and your existing monthly totals will change once it reaches them.
+- A phone that replays a stale cached position after landing no longer bills the trip as dozens of instant intercontinental flights. Bursts of identical coordinates reached and left at impossible speed are now flagged however long they run, and monthly distance ignores any leg faster than 1,200 km/h. Stored anomaly flags, tracks and statistics are re-evaluated by a background job after upgrading; it runs on the lowest-priority queue and does not interrupt tracking, and your existing monthly totals will change once it reaches them. A track drawn through such a burst can still read longer than the day it belongs to, because the speed ceiling applies to distance totals rather than to stored tracks.
 
 ## [1.13.1] - 2026-08-22, Berlin
 

--- a/app/queries/stats/daily_distance_query.rb
+++ b/app/queries/stats/daily_distance_query.rb
@@ -6,6 +6,7 @@ class Stats::DailyDistanceQuery
   SNAPSHOT_IMPORT_SOURCES = %w[immich_api photoprism_api google_photos].freeze
 
   MAX_PLAUSIBLE_SPEED_MPS = 1_200 / 3.6
+  TELEPORT_METERS = Points::AnomalyFilter::TELEPORT_METERS
 
   def initialize(monthly_points, timespan, timezone = nil, minutes_between_routes: nil)
     @monthly_points = monthly_points
@@ -49,24 +50,35 @@ class Stats::DailyDistanceQuery
           ORDER BY timestamp, id
         )
       ),
+      measured_points AS (
+        SELECT
+          local_date,
+          import_id,
+          prev_import_id,
+          snapshot_import,
+          prev_snapshot_import,
+          (timestamp - prev_timestamp) AS elapsed_seconds,
+          ST_Distance(lonlat::geography, prev_lonlat::geography) AS segment_meters
+        FROM ordered_points
+      ),
       points_with_distances AS (
         SELECT
           local_date,
           CASE
-            WHEN prev_lonlat IS NULL THEN 0
+            WHEN segment_meters IS NULL THEN 0
             WHEN (
               import_id IS NULL
               OR prev_import_id IS NULL
               OR import_id != prev_import_id
               OR snapshot_import
               OR prev_snapshot_import
-            ) AND (timestamp - prev_timestamp) > $4 THEN 0
-            WHEN (timestamp - prev_timestamp) > 0
-              AND ST_Distance(lonlat::geography, prev_lonlat::geography) >
-                  (timestamp - prev_timestamp) * $5::double precision THEN 0
-            ELSE ST_Distance(lonlat::geography, prev_lonlat::geography)
+            ) AND elapsed_seconds > $4 THEN 0
+            WHEN elapsed_seconds > 0
+              AND segment_meters > elapsed_seconds * $5::double precision THEN 0
+            WHEN elapsed_seconds = 0 AND segment_meters > $6::double precision THEN 0
+            ELSE segment_meters
           END AS segment_distance
-        FROM ordered_points
+        FROM measured_points
       )
       SELECT
         EXTRACT(day FROM local_date)::int AS day_of_month,
@@ -85,6 +97,8 @@ class Stats::DailyDistanceQuery
       ActiveRecord::Relation::QueryAttribute.new('month', target.month, ActiveRecord::Type::Integer.new),
       ActiveRecord::Relation::QueryAttribute.new('time_gap_seconds', time_gap_seconds, ActiveRecord::Type::Integer.new),
       ActiveRecord::Relation::QueryAttribute.new('max_speed_mps', MAX_PLAUSIBLE_SPEED_MPS,
+                                                 ActiveRecord::Type::Float.new),
+      ActiveRecord::Relation::QueryAttribute.new('teleport_meters', TELEPORT_METERS,
                                                  ActiveRecord::Type::Float.new)
     ]
 

--- a/app/queries/stats/daily_distance_query.rb
+++ b/app/queries/stats/daily_distance_query.rb
@@ -5,15 +5,6 @@ class Stats::DailyDistanceQuery
   # snapshots rather than a continuous track.
   SNAPSHOT_IMPORT_SOURCES = %w[immich_api photoprism_api google_photos].freeze
 
-  # Fastest a leg may imply and still be counted, in m/s (1,200 km/h — above
-  # any airliner's cruise, with margin). Points::AnomalyFilter is what cleans
-  # displaced fixes, but it cannot catch every one, and a leg it misses is
-  # reported to the user as distance they travelled. Refusing to sum a leg no
-  # vehicle could have flown costs nothing real — a genuine long-haul flight
-  # is an order of magnitude below this — and stops one stale fix inflating a
-  # month. Pairs sharing a timestamp are left alone: they carry no elapsed time
-  # to derive a speed from, and an instantaneous displacement between them is
-  # already Points::AnomalyFilter::TELEPORT_METERS' question, not this one.
   MAX_PLAUSIBLE_SPEED_MPS = 1_200 / 3.6
 
   def initialize(monthly_points, timespan, timezone = nil, minutes_between_routes: nil)

--- a/app/queries/stats/daily_distance_query.rb
+++ b/app/queries/stats/daily_distance_query.rb
@@ -5,6 +5,17 @@ class Stats::DailyDistanceQuery
   # snapshots rather than a continuous track.
   SNAPSHOT_IMPORT_SOURCES = %w[immich_api photoprism_api google_photos].freeze
 
+  # Fastest a leg may imply and still be counted, in m/s (1,200 km/h — above
+  # any airliner's cruise, with margin). Points::AnomalyFilter is what cleans
+  # displaced fixes, but it cannot catch every one, and a leg it misses is
+  # reported to the user as distance they travelled. Refusing to sum a leg no
+  # vehicle could have flown costs nothing real — a genuine long-haul flight
+  # is an order of magnitude below this — and stops one stale fix inflating a
+  # month. Pairs sharing a timestamp are left alone: they carry no elapsed time
+  # to derive a speed from, and an instantaneous displacement between them is
+  # already Points::AnomalyFilter::TELEPORT_METERS' question, not this one.
+  MAX_PLAUSIBLE_SPEED_MPS = 1_200 / 3.6
+
   def initialize(monthly_points, timespan, timezone = nil, minutes_between_routes: nil)
     @monthly_points = monthly_points
     @timespan = timespan
@@ -59,6 +70,9 @@ class Stats::DailyDistanceQuery
               OR snapshot_import
               OR prev_snapshot_import
             ) AND (timestamp - prev_timestamp) > $4 THEN 0
+            WHEN (timestamp - prev_timestamp) > 0
+              AND ST_Distance(lonlat::geography, prev_lonlat::geography) >
+                  (timestamp - prev_timestamp) * $5::double precision THEN 0
             ELSE ST_Distance(lonlat::geography, prev_lonlat::geography)
           END AS segment_distance
         FROM ordered_points
@@ -78,7 +92,9 @@ class Stats::DailyDistanceQuery
       ActiveRecord::Relation::QueryAttribute.new('timezone', timezone, ActiveRecord::Type::String.new),
       ActiveRecord::Relation::QueryAttribute.new('year', target.year, ActiveRecord::Type::Integer.new),
       ActiveRecord::Relation::QueryAttribute.new('month', target.month, ActiveRecord::Type::Integer.new),
-      ActiveRecord::Relation::QueryAttribute.new('time_gap_seconds', time_gap_seconds, ActiveRecord::Type::Integer.new)
+      ActiveRecord::Relation::QueryAttribute.new('time_gap_seconds', time_gap_seconds, ActiveRecord::Type::Integer.new),
+      ActiveRecord::Relation::QueryAttribute.new('max_speed_mps', MAX_PLAUSIBLE_SPEED_MPS,
+                                                 ActiveRecord::Type::Float.new)
     ]
 
     Stat.connection.exec_query(sql, 'DailyDistanceQuery', binds).to_a

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -18,6 +18,7 @@ class Points::AnomalyFilter
   MAX_DISPLACED_RUN_POINTS = 5
   FROZEN_FIX_EXTENT_METERS = 1
   MAX_FROZEN_FIX_SPAN_SECONDS = 3_600
+  FROZEN_FIX_CONTEXT_POINTS = 240
   # Accuracy radius beyond which a reading carries no usable position at all.
   # Deliberately far above any plausible GPS/wifi/cell error: a reported radius
   # is a confidence estimate, not proof the position is wrong. Google Timeline
@@ -285,7 +286,7 @@ class Points::AnomalyFilter
     # generation groups by tracker_id (Tracks::TimeChunkProcessorJob).
     anomaly_ids = points.group_by { |point| point.tracker_id.to_s }.values.flat_map do |stream|
       displaced_run_ids(stream, speeds_by_point, threshold, main_range_ids) +
-        frozen_fix_run_ids(stream, speeds_by_point, threshold, main_range_ids)
+        frozen_fix_run_ids(stream, speeds_by_point, threshold, frozen_range_ids(points, chunk_start, chunk_end))
     end
 
     return 0 if anomaly_ids.empty?
@@ -338,16 +339,30 @@ class Points::AnomalyFilter
     displaced.to_a
   end
 
-  def frozen_fix_run_ids(stream, speeds_by_point, threshold, main_range_ids)
+  def frozen_range_ids(points, chunk_start, chunk_end)
+    lower = chunk_start - MAX_FROZEN_FIX_SPAN_SECONDS
+
+    points.each_with_object(Set.new) do |point, ids|
+      ids << point.id if point.timestamp >= lower && point.timestamp <= chunk_end
+    end
+  end
+
+  def frozen_fix_run_ids(stream, speeds_by_point, threshold, range_ids)
     frozen = []
 
-    each_frozen_run(stream) do |run|
+    each_frozen_run(stream) do |run, previous_point, next_point|
       next unless both_legs_impossible?(run, speeds_by_point, threshold)
+      next unless departs_far_from?(run, previous_point, next_point)
 
-      run.each { |point| frozen << point.id if main_range_ids.include?(point.id) }
+      run.each { |point| frozen << point.id if range_ids.include?(point.id) }
     end
 
     frozen
+  end
+
+  def departs_far_from?(run, previous_point, next_point)
+    distance_meters(previous_point, run.first) > MIN_EXCURSION_METERS &&
+      distance_meters(run.last, next_point) > MIN_EXCURSION_METERS
   end
 
   def each_frozen_run(stream)
@@ -363,7 +378,7 @@ class Points::AnomalyFilter
       next unless run.length > MAX_DISPLACED_RUN_POINTS
       next if run.last.timestamp - run.first.timestamp > MAX_FROZEN_FIX_SPAN_SECONDS
 
-      yield(run)
+      yield(run, stream[start - 1], stream[index])
     end
   end
 
@@ -440,10 +455,7 @@ class Points::AnomalyFilter
     # Tie order must match the per-device window in calculate_all_speeds
     # (ORDER BY timestamp, id), or points sharing a timestamp get speeds
     # attached to the wrong neighbour.
-    before_ctx = Point.where(user_id: @user_id).not_anomaly
-                      .where('timestamp < ?', start_time)
-                      .order(timestamp: :desc, id: :desc).limit(CONTEXT_POINTS)
-                      .select(:id, :timestamp, :tracker_id, :lonlat).to_a.reverse
+    before_ctx = before_context(start_time)
 
     main = Point.where(user_id: @user_id, timestamp: start_time..end_time)
                 .not_anomaly.order(:timestamp, :id)
@@ -455,6 +467,19 @@ class Points::AnomalyFilter
                      .select(:id, :timestamp, :tracker_id, :lonlat).to_a
 
     [before_ctx + main + after_ctx, main]
+  end
+
+  def before_context(start_time)
+    scope = Point.where(user_id: @user_id).not_anomaly
+                 .where('timestamp < ?', start_time)
+                 .order(timestamp: :desc, id: :desc)
+                 .select(:id, :timestamp, :tracker_id, :lonlat)
+
+    widened = scope.where('timestamp >= ?', start_time - MAX_FROZEN_FIX_SPAN_SECONDS)
+                   .limit(FROZEN_FIX_CONTEXT_POINTS).to_a
+    widened = scope.limit(CONTEXT_POINTS).to_a if widened.size < CONTEXT_POINTS
+
+    widened.reverse
   end
 
   # Single CTE query: compute distance and time diff for ALL consecutive pairs

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -16,6 +16,16 @@ class Points::AnomalyFilter
   # and flagging it wholesale would erase real history. Under-flagging a long
   # noise burst is the safer failure.
   MAX_DISPLACED_RUN_POINTS = 5
+  # How far a run may wander and still count as one frozen position. A cached
+  # fix repeats its coordinates exactly, so this is a tolerance for float
+  # round-tripping through PostGIS, not a cluster radius — anything that
+  # actually moves, however slightly, is a real reading and is kept.
+  FROZEN_FIX_EXTENT_METERS = 1
+  # Longest a frozen burst may run before it is read as a device genuinely
+  # parked somewhere rather than a position being replayed. A stale fix is
+  # flushed within minutes of the provider recovering; a phone left on a desk
+  # reports the same position for hours, and that is real history.
+  MAX_FROZEN_FIX_SPAN_SECONDS = 3_600
   # Accuracy radius beyond which a reading carries no usable position at all.
   # Deliberately far above any plausible GPS/wifi/cell error: a reported radius
   # is a confidence estimate, not proof the position is wrong. Google Timeline
@@ -282,7 +292,8 @@ class Points::AnomalyFilter
     # journeys between devices that nobody made — the same reason track
     # generation groups by tracker_id (Tracks::TimeChunkProcessorJob).
     anomaly_ids = points.group_by { |point| point.tracker_id.to_s }.values.flat_map do |stream|
-      displaced_run_ids(stream, speeds_by_point, threshold, main_range_ids)
+      displaced_run_ids(stream, speeds_by_point, threshold, main_range_ids) +
+        frozen_fix_run_ids(stream, speeds_by_point, threshold, main_range_ids)
     end
 
     return 0 if anomaly_ids.empty?
@@ -333,6 +344,60 @@ class Points::AnomalyFilter
     end
 
     displaced.to_a
+  end
+
+  # A cached position is replayed verbatim: every reading in the burst carries
+  # identical coordinates, because nothing re-measured it. Real GPS always
+  # jitters, so a run that never moves at all, is reached impossibly fast and
+  # left impossibly fast is a stale fix being replayed rather than a place
+  # anyone was — and that holds however long the burst runs.
+  #
+  # This is why it may exceed MAX_DISPLACED_RUN_POINTS. Run length is what
+  # protects a genuine stay in #displaced_run_ids; here immobility does that
+  # job instead, and does it better: a real stay moves, so it is kept no
+  # matter how impossible the hops either side of it look.
+  #
+  # Seen on a GPX import where a frozen Heathrow fix interleaved with live LAX
+  # fixes for 30 minutes after landing. The bursts ran 6 to 54 points, so every
+  # one of them outran the displaced-run bound, and the alternation billed 14
+  # Atlantic crossings — roughly 44,000 km — to a single month.
+  def frozen_fix_run_ids(stream, speeds_by_point, threshold, main_range_ids)
+    frozen = []
+
+    each_frozen_run(stream) do |run|
+      next unless both_legs_impossible?(run, speeds_by_point, threshold)
+
+      run.each { |point| frozen << point.id if main_range_ids.include?(point.id) }
+    end
+
+    frozen
+  end
+
+  # Walks maximal runs of points that never leave FROZEN_FIX_EXTENT_METERS of
+  # where the run started. Only runs that outlast the displaced-run bound and
+  # stay within the burst span are yielded — a device genuinely parked in one
+  # place reports the same position for hours, and that is real history.
+  # Bounded to runs with a fix either side, so every run yielded has both an
+  # incoming and an outgoing speed to be judged on.
+  def each_frozen_run(stream)
+    index = 1
+    last = stream.length - 1
+
+    while index < last
+      start = index
+      index += 1
+      index += 1 while index < last && frozen_with?(stream[start], stream[index])
+
+      run = stream[start...index]
+      next unless run.length > MAX_DISPLACED_RUN_POINTS
+      next if run.last.timestamp - run.first.timestamp > MAX_FROZEN_FIX_SPAN_SECONDS
+
+      yield(run)
+    end
+  end
+
+  def frozen_with?(anchor, point)
+    distance_meters(anchor, point) <= FROZEN_FIX_EXTENT_METERS
   end
 
   # Impossible on both sides convicts on its own: nothing legitimate arrives and

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -16,15 +16,7 @@ class Points::AnomalyFilter
   # and flagging it wholesale would erase real history. Under-flagging a long
   # noise burst is the safer failure.
   MAX_DISPLACED_RUN_POINTS = 5
-  # How far a run may wander and still count as one frozen position. A cached
-  # fix repeats its coordinates exactly, so this is a tolerance for float
-  # round-tripping through PostGIS, not a cluster radius — anything that
-  # actually moves, however slightly, is a real reading and is kept.
   FROZEN_FIX_EXTENT_METERS = 1
-  # Longest a frozen burst may run before it is read as a device genuinely
-  # parked somewhere rather than a position being replayed. A stale fix is
-  # flushed within minutes of the provider recovering; a phone left on a desk
-  # reports the same position for hours, and that is real history.
   MAX_FROZEN_FIX_SPAN_SECONDS = 3_600
   # Accuracy radius beyond which a reading carries no usable position at all.
   # Deliberately far above any plausible GPS/wifi/cell error: a reported radius
@@ -346,21 +338,6 @@ class Points::AnomalyFilter
     displaced.to_a
   end
 
-  # A cached position is replayed verbatim: every reading in the burst carries
-  # identical coordinates, because nothing re-measured it. Real GPS always
-  # jitters, so a run that never moves at all, is reached impossibly fast and
-  # left impossibly fast is a stale fix being replayed rather than a place
-  # anyone was — and that holds however long the burst runs.
-  #
-  # This is why it may exceed MAX_DISPLACED_RUN_POINTS. Run length is what
-  # protects a genuine stay in #displaced_run_ids; here immobility does that
-  # job instead, and does it better: a real stay moves, so it is kept no
-  # matter how impossible the hops either side of it look.
-  #
-  # Seen on a GPX import where a frozen Heathrow fix interleaved with live LAX
-  # fixes for 30 minutes after landing. The bursts ran 6 to 54 points, so every
-  # one of them outran the displaced-run bound, and the alternation billed 14
-  # Atlantic crossings — roughly 44,000 km — to a single month.
   def frozen_fix_run_ids(stream, speeds_by_point, threshold, main_range_ids)
     frozen = []
 
@@ -373,12 +350,6 @@ class Points::AnomalyFilter
     frozen
   end
 
-  # Walks maximal runs of points that never leave FROZEN_FIX_EXTENT_METERS of
-  # where the run started. Only runs that outlast the displaced-run bound and
-  # stay within the burst span are yielded — a device genuinely parked in one
-  # place reports the same position for hours, and that is real history.
-  # Bounded to runs with a fix either side, so every run yielded has both an
-  # incoming and an outgoing speed to be judged on.
   def each_frozen_run(stream)
     index = 1
     last = stream.length - 1

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -409,8 +409,7 @@ class Points::AnomalyFilter
     dwell = run.last.timestamp - run.first.timestamp
     return false if dwell > MAX_EXCURSION_SPAN_SECONDS
 
-    distance_meters(previous_point, run.first) > MIN_EXCURSION_METERS &&
-      distance_meters(run.last, next_point) > MIN_EXCURSION_METERS
+    departs_far_from?(run, previous_point, next_point)
   end
 
   # An excursion has to arrive or leave faster than any ground travel to be worth

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -280,13 +280,14 @@ class Points::AnomalyFilter
 
     # Only check points in the main range (not context points)
     main_range_ids = main_points.map(&:id).to_set
+    frozen_ids = frozen_range_ids(points, chunk_start, chunk_end)
 
     # Each device is its own stream. Interleaving them by timestamp invents
     # journeys between devices that nobody made — the same reason track
     # generation groups by tracker_id (Tracks::TimeChunkProcessorJob).
     anomaly_ids = points.group_by { |point| point.tracker_id.to_s }.values.flat_map do |stream|
       displaced_run_ids(stream, speeds_by_point, threshold, main_range_ids) +
-        frozen_fix_run_ids(stream, speeds_by_point, threshold, frozen_range_ids(points, chunk_start, chunk_end))
+        frozen_fix_run_ids(stream, speeds_by_point, threshold, frozen_ids)
     end
 
     return 0 if anomaly_ids.empty?
@@ -383,7 +384,8 @@ class Points::AnomalyFilter
   end
 
   def frozen_with?(anchor, point)
-    distance_meters(anchor, point) <= FROZEN_FIX_EXTENT_METERS
+    anchor.accuracy == point.accuracy &&
+      distance_meters(anchor, point) <= FROZEN_FIX_EXTENT_METERS
   end
 
   # Impossible on both sides convicts on its own: nothing legitimate arrives and
@@ -459,12 +461,12 @@ class Points::AnomalyFilter
 
     main = Point.where(user_id: @user_id, timestamp: start_time..end_time)
                 .not_anomaly.order(:timestamp, :id)
-                .select(:id, :timestamp, :tracker_id, :lonlat).to_a
+                .select(:id, :timestamp, :tracker_id, :lonlat, :accuracy).to_a
 
     after_ctx = Point.where(user_id: @user_id).not_anomaly
                      .where('timestamp > ?', end_time)
                      .order(:timestamp, :id).limit(CONTEXT_POINTS)
-                     .select(:id, :timestamp, :tracker_id, :lonlat).to_a
+                     .select(:id, :timestamp, :tracker_id, :lonlat, :accuracy).to_a
 
     [before_ctx + main + after_ctx, main]
   end
@@ -473,7 +475,7 @@ class Points::AnomalyFilter
     scope = Point.where(user_id: @user_id).not_anomaly
                  .where('timestamp < ?', start_time)
                  .order(timestamp: :desc, id: :desc)
-                 .select(:id, :timestamp, :tracker_id, :lonlat)
+                 .select(:id, :timestamp, :tracker_id, :lonlat, :accuracy)
 
     widened = scope.where('timestamp >= ?', start_time - MAX_FROZEN_FIX_SPAN_SECONDS)
                    .limit(FROZEN_FIX_CONTEXT_POINTS).to_a

--- a/db/migrate/20260823190000_enqueue_frozen_fix_anomaly_recalculation.rb
+++ b/db/migrate/20260823190000_enqueue_frozen_fix_anomaly_recalculation.rb
@@ -8,7 +8,7 @@ class EnqueueFrozenFixAnomalyRecalculation < ActiveRecord::Migration[8.0]
   ].freeze
 
   def up
-    clear_previous_run
+    return if clear_previous_run.zero?
 
     DataMigrations::RecalculateAnomaliesJob.perform_later
   rescue NameError
@@ -33,6 +33,6 @@ class EnqueueFrozenFixAnomalyRecalculation < ActiveRecord::Migration[8.0]
           { keys: KEYS }
         ]
       )
-    )
+    ).cmd_tuples
   end
 end

--- a/db/migrate/20260823190000_enqueue_frozen_fix_anomaly_recalculation.rb
+++ b/db/migrate/20260823190000_enqueue_frozen_fix_anomaly_recalculation.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class EnqueueFrozenFixAnomalyRecalculation < ActiveRecord::Migration[8.0]
+  KEYS = %w[
+    anomaly_rules_recalculation_queued_at
+    anomaly_rules_recalculated_at
+    anomaly_rules_recalculation_failed_at
+  ].freeze
+
+  def up
+    clear_previous_run
+
+    DataMigrations::RecalculateAnomaliesJob.perform_later
+  rescue NameError
+    raise
+  rescue StandardError => e
+    Rails.logger.error(
+      "[EnqueueFrozenFixAnomalyRecalculation] could not enqueue the recalculation: #{e.class}: #{e.message}. " \
+      'Start it later with: DataMigrations::RecalculateAnomaliesJob.perform_later'
+    )
+  end
+
+  def down; end
+
+  private
+
+  def clear_previous_run
+    execute(
+      ActiveRecord::Base.sanitize_sql_array(
+        [
+          "UPDATE users SET settings = COALESCE(settings, '{}'::jsonb) - ARRAY[:keys]::text[] " \
+          'WHERE settings ?| ARRAY[:keys]::text[]',
+          { keys: KEYS }
+        ]
+      )
+    )
+  end
+end

--- a/db/migrate/20260823190000_enqueue_frozen_fix_anomaly_recalculation.rb
+++ b/db/migrate/20260823190000_enqueue_frozen_fix_anomaly_recalculation.rb
@@ -1,38 +1,50 @@
 # frozen_string_literal: true
 
 class EnqueueFrozenFixAnomalyRecalculation < ActiveRecord::Migration[8.0]
-  KEYS = %w[
-    anomaly_rules_recalculation_queued_at
-    anomaly_rules_recalculated_at
-    anomaly_rules_recalculation_failed_at
-  ].freeze
+  # Sidekiq receives the job the moment perform_later runs, and a worker from
+  # the still-running old deployment can pop it before a wrapping migration
+  # transaction commits the stamp-clearing UPDATE. The dispatcher would then
+  # see every user still stamped, hand out nobody, and — having found no work
+  # — never reschedule itself: the fleet sweep silently never happens. Without
+  # the transaction the UPDATE is committed before the job exists.
+  disable_ddl_transaction!
 
   def up
-    return if clear_previous_run.zero?
-
-    DataMigrations::RecalculateAnomaliesJob.perform_later
-  rescue NameError
-    raise
-  rescue StandardError => e
-    Rails.logger.error(
-      "[EnqueueFrozenFixAnomalyRecalculation] could not enqueue the recalculation: #{e.class}: #{e.message}. " \
-      'Start it later with: DataMigrations::RecalculateAnomaliesJob.perform_later'
-    )
+    clear_completion_stamps
+    enqueue_recalculation
   end
 
   def down; end
 
   private
 
-  def clear_previous_run
-    execute(
-      ActiveRecord::Base.sanitize_sql_array(
-        [
-          "UPDATE users SET settings = COALESCE(settings, '{}'::jsonb) - ARRAY[:keys]::text[] " \
-          'WHERE settings ?| ARRAY[:keys]::text[]',
-          { keys: KEYS }
-        ]
-      )
-    ).cmd_tuples
+  def stamp_keys
+    [
+      DataMigrations::RecalculateAnomaliesUserJob::QUEUED_SETTINGS_KEY,
+      DataMigrations::RecalculateAnomaliesUserJob::RECALCULATED_SETTINGS_KEY,
+      DataMigrations::RecalculateAnomaliesUserJob::FAILED_SETTINGS_KEY
+    ]
+  end
+
+  def clear_completion_stamps
+    quoted = stamp_keys.map { |key| connection.quote(key) }.join(', ')
+
+    execute(<<~SQL.squish)
+      UPDATE users
+      SET settings = settings - ARRAY[#{quoted}]::text[]
+      WHERE settings ?| ARRAY[#{quoted}]::text[]
+    SQL
+  end
+
+  def enqueue_recalculation
+    DataMigrations::RecalculateAnomaliesJob.perform_later
+  rescue NameError
+    raise
+  rescue StandardError => e
+    Rails.logger.error(
+      '[EnqueueFrozenFixAnomalyRecalculation] could not enqueue the anomaly recalculation: ' \
+      "#{e.class}: #{e.message}. " \
+      'Start it later with: DataMigrations::RecalculateAnomaliesJob.perform_later'
+    )
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_19_120100) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_23_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"

--- a/spec/migrations/enqueue_frozen_fix_anomaly_recalculation_spec.rb
+++ b/spec/migrations/enqueue_frozen_fix_anomaly_recalculation_spec.rb
@@ -17,16 +17,19 @@ RSpec.describe EnqueueFrozenFixAnomalyRecalculation do
   end
 
   it 'hands the work to a background job instead of doing it inline' do
-    user = create(:user)
-    user.update!(settings: (user.settings || {}).merge(done_key => '2026-08-02T01:00:00Z'))
+    stamped_user
 
     expect { migration.up }.to have_enqueued_job(DataMigrations::RecalculateAnomaliesJob)
   end
 
-  it 'does not enqueue a second dispatcher when no previous run had to be cleared' do
+  it 'still sweeps an instance that carries no stamps from the previous run' do
     create(:user)
 
-    expect { migration.up }.not_to have_enqueued_job(DataMigrations::RecalculateAnomaliesJob)
+    expect { migration.up }.to have_enqueued_job(DataMigrations::RecalculateAnomaliesJob)
+  end
+
+  it 'runs without a wrapping transaction so stamps are committed before the job can see them' do
+    expect(described_class.disable_ddl_transaction).to be true
   end
 
   it 'clears the stamps left by the previous recalculation so the user is picked up again' do
@@ -68,8 +71,6 @@ RSpec.describe EnqueueFrozenFixAnomalyRecalculation do
   end
 
   it 'does not abort the migration when the job queue is unreachable' do
-    stamped_user
-
     allow(DataMigrations::RecalculateAnomaliesJob)
       .to receive(:perform_later).and_raise(StandardError, 'Connection refused')
 
@@ -77,8 +78,6 @@ RSpec.describe EnqueueFrozenFixAnomalyRecalculation do
   end
 
   it 'aborts on a missing constant instead of hiding a broken deploy' do
-    stamped_user
-
     allow(DataMigrations::RecalculateAnomaliesJob)
       .to receive(:perform_later).and_raise(NameError, 'uninitialized constant')
 
@@ -86,8 +85,6 @@ RSpec.describe EnqueueFrozenFixAnomalyRecalculation do
   end
 
   it 'logs how to start the recalculation by hand when enqueueing failed' do
-    stamped_user
-
     allow(DataMigrations::RecalculateAnomaliesJob)
       .to receive(:perform_later).and_raise(StandardError, 'Connection refused')
     allow(Rails.logger).to receive(:error)

--- a/spec/migrations/enqueue_frozen_fix_anomaly_recalculation_spec.rb
+++ b/spec/migrations/enqueue_frozen_fix_anomaly_recalculation_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260823190000_enqueue_frozen_fix_anomaly_recalculation.rb')
+
+RSpec.describe EnqueueFrozenFixAnomalyRecalculation do
+  subject(:migration) { described_class.new }
+
+  let(:queued_key) { DataMigrations::RecalculateAnomaliesUserJob::QUEUED_SETTINGS_KEY }
+  let(:done_key) { DataMigrations::RecalculateAnomaliesUserJob::RECALCULATED_SETTINGS_KEY }
+  let(:failed_key) { DataMigrations::RecalculateAnomaliesUserJob::FAILED_SETTINGS_KEY }
+
+  def stamped_user
+    create(:user).tap do |user|
+      user.update!(settings: (user.settings || {}).merge(done_key => '2026-08-02T01:00:00Z'))
+    end
+  end
+
+  it 'hands the work to a background job instead of doing it inline' do
+    user = create(:user)
+    user.update!(settings: (user.settings || {}).merge(done_key => '2026-08-02T01:00:00Z'))
+
+    expect { migration.up }.to have_enqueued_job(DataMigrations::RecalculateAnomaliesJob)
+  end
+
+  it 'does not enqueue a second dispatcher when no previous run had to be cleared' do
+    create(:user)
+
+    expect { migration.up }.not_to have_enqueued_job(DataMigrations::RecalculateAnomaliesJob)
+  end
+
+  it 'clears the stamps left by the previous recalculation so the user is picked up again' do
+    user = create(:user)
+    user.update!(settings: (user.settings || {}).merge(queued_key => '2026-08-02T00:00:00Z',
+                                                       done_key => '2026-08-02T01:00:00Z'))
+
+    migration.up
+
+    expect(user.reload.settings.keys).not_to include(queued_key, done_key)
+  end
+
+  it 'clears a failure stamp so an account that gave up is retried' do
+    user = create(:user)
+    user.update!(settings: (user.settings || {}).merge(failed_key => '2026-08-02T02:00:00Z'))
+
+    migration.up
+
+    expect(user.reload.settings.keys).not_to include(failed_key)
+  end
+
+  it 'leaves unrelated settings untouched' do
+    user = create(:user)
+    user.update!(settings: (user.settings || {}).merge(done_key => '2026-08-02T01:00:00Z',
+                                                       'timezone' => 'Europe/Berlin'))
+
+    migration.up
+
+    expect(user.reload.settings).to include('timezone' => 'Europe/Berlin')
+  end
+
+  it 'is a no-op for a user that was never recalculated' do
+    user = create(:user)
+    before_settings = user.reload.settings
+
+    migration.up
+
+    expect(user.reload.settings).to eq(before_settings)
+  end
+
+  it 'does not abort the migration when the job queue is unreachable' do
+    stamped_user
+
+    allow(DataMigrations::RecalculateAnomaliesJob)
+      .to receive(:perform_later).and_raise(StandardError, 'Connection refused')
+
+    expect { migration.up }.not_to raise_error
+  end
+
+  it 'aborts on a missing constant instead of hiding a broken deploy' do
+    stamped_user
+
+    allow(DataMigrations::RecalculateAnomaliesJob)
+      .to receive(:perform_later).and_raise(NameError, 'uninitialized constant')
+
+    expect { migration.up }.to raise_error(NameError)
+  end
+
+  it 'logs how to start the recalculation by hand when enqueueing failed' do
+    stamped_user
+
+    allow(DataMigrations::RecalculateAnomaliesJob)
+      .to receive(:perform_later).and_raise(StandardError, 'Connection refused')
+    allow(Rails.logger).to receive(:error)
+
+    migration.up
+
+    expect(Rails.logger)
+      .to have_received(:error).with(/DataMigrations::RecalculateAnomaliesJob\.perform_later/)
+  end
+end

--- a/spec/queries/stats/daily_distance_query_spec.rb
+++ b/spec/queries/stats/daily_distance_query_spec.rb
@@ -67,18 +67,11 @@ RSpec.describe Stats::DailyDistanceQuery do
       end
     end
 
-    # Anomaly detection cleans the data, but it cannot be relied on to catch
-    # every displaced fix, and a leg it misses is reported to the user as
-    # distance they travelled. A statistic should refuse to report a leg no
-    # vehicle could have flown regardless of what upstream filtering did.
-    # Observed on a GPX import that reported 55,646 km for one month, 44,044 km
-    # of which was fourteen instantaneous Heathrow-to-LAX hops.
     context 'with a leg no aircraft could have flown' do
       let!(:heathrow) do
         create(:point, user: user, lonlat: 'POINT(-0.4803 51.4693)',
                        timestamp: DateTime.new(2021, 1, 5, 12, 0, 0).to_i)
       end
-      # 8,780 km away, 15 seconds later: about 2,100,000 km/h.
       let!(:lax) do
         create(:point, user: user, lonlat: 'POINT(-118.4103 33.9429)',
                        timestamp: DateTime.new(2021, 1, 5, 12, 0, 15).to_i)
@@ -91,14 +84,11 @@ RSpec.describe Stats::DailyDistanceQuery do
       end
     end
 
-    # The guard on the rule above: the same 8,780 km covered in the time a real
-    # flight takes is ordinary long-haul travel and must still be counted.
     context 'with a genuine long-haul flight' do
       let!(:lax) do
         create(:point, user: user, lonlat: 'POINT(-118.4103 33.9429)',
                        timestamp: DateTime.new(2021, 1, 6, 0, 30, 0).to_i)
       end
-      # Same distance, 10 hours later: about 880 km/h.
       let!(:heathrow) do
         create(:point, user: user, lonlat: 'POINT(-0.4803 51.4693)',
                        timestamp: DateTime.new(2021, 1, 6, 10, 30, 0).to_i)

--- a/spec/queries/stats/daily_distance_query_spec.rb
+++ b/spec/queries/stats/daily_distance_query_spec.rb
@@ -67,6 +67,50 @@ RSpec.describe Stats::DailyDistanceQuery do
       end
     end
 
+    # Anomaly detection cleans the data, but it cannot be relied on to catch
+    # every displaced fix, and a leg it misses is reported to the user as
+    # distance they travelled. A statistic should refuse to report a leg no
+    # vehicle could have flown regardless of what upstream filtering did.
+    # Observed on a GPX import that reported 55,646 km for one month, 44,044 km
+    # of which was fourteen instantaneous Heathrow-to-LAX hops.
+    context 'with a leg no aircraft could have flown' do
+      let!(:heathrow) do
+        create(:point, user: user, lonlat: 'POINT(-0.4803 51.4693)',
+                       timestamp: DateTime.new(2021, 1, 5, 12, 0, 0).to_i)
+      end
+      # 8,780 km away, 15 seconds later: about 2,100,000 km/h.
+      let!(:lax) do
+        create(:point, user: user, lonlat: 'POINT(-118.4103 33.9429)',
+                       timestamp: DateTime.new(2021, 1, 5, 12, 0, 15).to_i)
+      end
+
+      subject { described_class.new(monthly_points, timespan, 'Etc/UTC').call }
+
+      it 'excludes the impossible leg from the day' do
+        expect(subject.find { |day, _| day == 5 }.last).to eq(0)
+      end
+    end
+
+    # The guard on the rule above: the same 8,780 km covered in the time a real
+    # flight takes is ordinary long-haul travel and must still be counted.
+    context 'with a genuine long-haul flight' do
+      let!(:lax) do
+        create(:point, user: user, lonlat: 'POINT(-118.4103 33.9429)',
+                       timestamp: DateTime.new(2021, 1, 6, 0, 30, 0).to_i)
+      end
+      # Same distance, 10 hours later: about 880 km/h.
+      let!(:heathrow) do
+        create(:point, user: user, lonlat: 'POINT(-0.4803 51.4693)',
+                       timestamp: DateTime.new(2021, 1, 6, 10, 30, 0).to_i)
+      end
+
+      subject { described_class.new(monthly_points, timespan, 'Etc/UTC', minutes_between_routes: 1000).call }
+
+      it 'counts the flight' do
+        expect(subject.find { |day, _| day == 6 }.last).to be > 8_000_000
+      end
+    end
+
     context 'with points from different imports separated by a long gap' do
       # Morning activity in Vienna and afternoon activity in Salzburg imported
       # as two separate GPX files. The cross-import jump must NOT be counted.

--- a/spec/queries/stats/daily_distance_query_spec.rb
+++ b/spec/queries/stats/daily_distance_query_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe Stats::DailyDistanceQuery do
                timestamp: DateTime.new(2021, 1, 1, 6, 1, 0).to_i)
       end
       let!(:point3) do
-        create(:point, user: user, lonlat: 'POINT(16.39 48.23)',
+        create(:point, user: user, lonlat: 'POINT(16.381 48.221)',
                timestamp: DateTime.new(2021, 1, 1, 6, 1, 0).to_i)
       end
 
@@ -278,7 +278,29 @@ RSpec.describe Stats::DailyDistanceQuery do
 
       it 'orders tied timestamps deterministically and sums both segments' do
         day1_distance = subject.find { |day, _| day == 1 }&.last
-        expect(day1_distance).to be_between(2_000, 3_500)
+        expect(day1_distance).to be_between(1_400, 1_600)
+      end
+    end
+
+    context 'with two points sharing a timestamp far enough apart to be a teleport' do
+      let!(:point1) do
+        create(:point, user: user, lonlat: 'POINT(16.37 48.21)',
+               timestamp: DateTime.new(2021, 1, 3, 6, 0, 0).to_i)
+      end
+      let!(:point2) do
+        create(:point, user: user, lonlat: 'POINT(16.38 48.22)',
+               timestamp: DateTime.new(2021, 1, 3, 6, 1, 0).to_i)
+      end
+      let!(:point3) do
+        create(:point, user: user, lonlat: 'POINT(13.405 52.52)',
+               timestamp: DateTime.new(2021, 1, 3, 6, 1, 0).to_i)
+      end
+
+      subject { described_class.new(monthly_points, timespan, 'Etc/UTC', minutes_between_routes: 30).call }
+
+      it 'counts the real segment and drops the instantaneous jump' do
+        day3_distance = subject.find { |day, _| day == 3 }&.last
+        expect(day3_distance).to be_between(1_000, 1_600)
       end
     end
 

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -351,6 +351,40 @@ RSpec.describe Points::AnomalyFilter do
       end
     end
 
+    context 'Pass 2: a frozen run no longer than a displaced run' do
+      let(:start_time) { 2.hours.ago.to_i }
+      let(:end_time) { Time.current.to_i }
+      let(:base_time) { 1.hour.ago.to_i }
+      def lax(idx) = "POINT(#{-118.4103 + (idx * 0.0001)} #{33.9429 + (idx * 0.0001)})"
+
+      let!(:live_before) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + (i * 15), lonlat: lax(i))
+        end
+      end
+      let!(:stale_burst) do
+        (0..4).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 45 + (i * 15),
+                         lonlat: 'POINT(-0.4803 51.4693)')
+        end
+      end
+      let!(:live_after) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 150 + (i * 15), lonlat: lax(i + 3))
+        end
+      end
+
+      before { described_class.new(user.id, start_time, end_time).call }
+
+      it 'is still caught by the displaced-run pass' do
+        stale_burst.each { |point| expect(point.reload.anomaly).to be true }
+      end
+
+      it 'leaves the live fixes alone' do
+        (live_before + live_after).each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
+
     context 'Pass 2: a frozen burst delivered as single-point live batches' do
       let(:start_time) { 3.hours.ago.to_i }
       let(:end_time) { Time.current.to_i }

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -317,20 +317,11 @@ RSpec.describe Points::AnomalyFilter do
       end
     end
 
-    # A cached position is replayed verbatim: every reading in the burst carries
-    # byte-identical coordinates because nothing re-measured it. Real GPS always
-    # jitters, so a run that never moves at all, arrives impossibly fast and
-    # leaves impossibly fast is a stale fix being replayed — however long the
-    # burst runs. Observed on a real GPX import where a frozen Heathrow fix
-    # interleaved with live LAX fixes for 30 minutes after landing, billing 14
-    # Atlantic crossings (~44,000 km) to a single month.
     context 'Pass 2: a frozen cached fix replayed for longer than a displaced run' do
       let(:start_time) { 2.hours.ago.to_i }
       let(:end_time) { Time.current.to_i }
       let(:base_time) { 1.hour.ago.to_i }
-      # Live fixes at LAX, jittering as real GPS does.
       def lax(idx) = "POINT(#{-118.4103 + (idx * 0.0001)} #{33.9429 + (idx * 0.0001)})"
-      # The stale fix: identical every single time.
       let(:frozen) { 'POINT(-0.4803 51.4693)' }
 
       let!(:live_before) do
@@ -338,7 +329,6 @@ RSpec.describe Points::AnomalyFilter do
           create(:point, user: user, accuracy: 10, timestamp: base_time + (i * 15), lonlat: lax(i))
         end
       end
-      # Eight identical readings — beyond MAX_DISPLACED_RUN_POINTS.
       let!(:stale_burst) do
         (0..7).map do |i|
           create(:point, user: user, accuracy: 10, timestamp: base_time + 45 + (i * 15), lonlat: frozen)
@@ -361,10 +351,6 @@ RSpec.describe Points::AnomalyFilter do
       end
     end
 
-    # The guard on the rule above: length alone must never convict. A run of the
-    # same length, arriving and leaving just as impossibly, is kept when it
-    # actually moves — that is a genuine stay reached through bad data, not a
-    # position being replayed. Same shape as the frozen-fix case, one difference.
     context 'Pass 2: a long run that moves is not treated as a frozen fix' do
       let(:start_time) { 2.hours.ago.to_i }
       let(:end_time) { Time.current.to_i }
@@ -376,7 +362,6 @@ RSpec.describe Points::AnomalyFilter do
           create(:point, user: user, accuracy: 10, timestamp: base_time + (i * 15), lonlat: lax(i))
         end
       end
-      # Eight readings around Heathrow that drift like a real walk.
       let!(:moving_stay) do
         (0..7).map do |i|
           create(:point, user: user, accuracy: 10, timestamp: base_time + 45 + (i * 15),

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -351,6 +351,76 @@ RSpec.describe Points::AnomalyFilter do
       end
     end
 
+    context 'Pass 2: a frozen burst delivered as single-point live batches' do
+      let(:start_time) { 3.hours.ago.to_i }
+      let(:end_time) { Time.current.to_i }
+      let(:base_time) { 2.hours.ago.to_i }
+      def lax(idx) = "POINT(#{-118.4103 + (idx * 0.0001)} #{33.9429 + (idx * 0.0001)})"
+      let(:frozen) { 'POINT(-0.4803 51.4693)' }
+
+      let!(:live_before) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + (i * 15), lonlat: lax(i))
+        end
+      end
+      let!(:stale_burst) do
+        (0..7).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 45 + (i * 15), lonlat: frozen)
+        end
+      end
+      let!(:live_after) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 180 + (i * 15), lonlat: lax(i + 3))
+        end
+      end
+
+      before do
+        newest = live_after.last
+        described_class.new(user.id, newest.timestamp, newest.timestamp).call
+      end
+
+      it 'flags the burst that arrived in earlier batches' do
+        stale_burst.each { |point| expect(point.reload.anomaly).to be true }
+      end
+
+      it 'leaves the live fixes alone' do
+        (live_before + live_after).each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
+
+    context 'Pass 2: a frozen burst older than the re-judged window' do
+      let(:start_time) { 8.hours.ago.to_i }
+      let(:end_time) { Time.current.to_i }
+      let(:base_time) { 6.hours.ago.to_i }
+      def lax(idx) = "POINT(#{-118.4103 + (idx * 0.0001)} #{33.9429 + (idx * 0.0001)})"
+
+      let!(:live_before) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + (i * 15), lonlat: lax(i))
+        end
+      end
+      let!(:stale_burst) do
+        (0..7).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 45 + (i * 15),
+                         lonlat: 'POINT(-0.4803 51.4693)')
+        end
+      end
+      let!(:live_after) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 180 + (i * 15), lonlat: lax(i + 3))
+        end
+      end
+      let!(:much_later) do
+        create(:point, user: user, accuracy: 10, timestamp: base_time + 20_000, lonlat: lax(9))
+      end
+
+      before { described_class.new(user.id, much_later.timestamp, much_later.timestamp).call }
+
+      it 'leaves a burst beyond the lookback untouched' do
+        stale_burst.each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
+
     context 'Pass 2: a long run that moves is not treated as a frozen fix' do
       let(:start_time) { 2.hours.ago.to_i }
       let(:end_time) { Time.current.to_i }

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -317,6 +317,85 @@ RSpec.describe Points::AnomalyFilter do
       end
     end
 
+    # A cached position is replayed verbatim: every reading in the burst carries
+    # byte-identical coordinates because nothing re-measured it. Real GPS always
+    # jitters, so a run that never moves at all, arrives impossibly fast and
+    # leaves impossibly fast is a stale fix being replayed — however long the
+    # burst runs. Observed on a real GPX import where a frozen Heathrow fix
+    # interleaved with live LAX fixes for 30 minutes after landing, billing 14
+    # Atlantic crossings (~44,000 km) to a single month.
+    context 'Pass 2: a frozen cached fix replayed for longer than a displaced run' do
+      let(:start_time) { 2.hours.ago.to_i }
+      let(:end_time) { Time.current.to_i }
+      let(:base_time) { 1.hour.ago.to_i }
+      # Live fixes at LAX, jittering as real GPS does.
+      def lax(idx) = "POINT(#{-118.4103 + (idx * 0.0001)} #{33.9429 + (idx * 0.0001)})"
+      # The stale fix: identical every single time.
+      let(:frozen) { 'POINT(-0.4803 51.4693)' }
+
+      let!(:live_before) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + (i * 15), lonlat: lax(i))
+        end
+      end
+      # Eight identical readings — beyond MAX_DISPLACED_RUN_POINTS.
+      let!(:stale_burst) do
+        (0..7).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 45 + (i * 15), lonlat: frozen)
+        end
+      end
+      let!(:live_after) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 180 + (i * 15), lonlat: lax(i + 3))
+        end
+      end
+
+      before { described_class.new(user.id, start_time, end_time).call }
+
+      it 'flags the whole frozen burst' do
+        stale_burst.each { |point| expect(point.reload.anomaly).to be true }
+      end
+
+      it 'leaves the live fixes either side alone' do
+        (live_before + live_after).each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
+
+    # The guard on the rule above: length alone must never convict. A run of the
+    # same length, arriving and leaving just as impossibly, is kept when it
+    # actually moves — that is a genuine stay reached through bad data, not a
+    # position being replayed. Same shape as the frozen-fix case, one difference.
+    context 'Pass 2: a long run that moves is not treated as a frozen fix' do
+      let(:start_time) { 2.hours.ago.to_i }
+      let(:end_time) { Time.current.to_i }
+      let(:base_time) { 1.hour.ago.to_i }
+      def lax(idx) = "POINT(#{-118.4103 + (idx * 0.0001)} #{33.9429 + (idx * 0.0001)})"
+
+      let!(:live_before) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + (i * 15), lonlat: lax(i))
+        end
+      end
+      # Eight readings around Heathrow that drift like a real walk.
+      let!(:moving_stay) do
+        (0..7).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 45 + (i * 15),
+                         lonlat: "POINT(#{-0.4803 + (i * 0.0009)} #{51.4693 + (i * 0.0009)})")
+        end
+      end
+      let!(:live_after) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 180 + (i * 15), lonlat: lax(i + 3))
+        end
+      end
+
+      before { described_class.new(user.id, start_time, end_time).call }
+
+      it 'keeps the run that moves' do
+        moving_stay.each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
+
     # The real shape of a stale cached position: it jumps hundreds of km away
     # and comes straight back. Only the arrival is impossibly fast — the return
     # leg looks merely plane-like — so a test requiring both sides to be extreme

--- a/spec/services/points/anomaly_filter_spec.rb
+++ b/spec/services/points/anomaly_filter_spec.rb
@@ -351,6 +351,36 @@ RSpec.describe Points::AnomalyFilter do
       end
     end
 
+    context 'Pass 2: a stationary run whose accuracy keeps being re-measured' do
+      let(:start_time) { 2.hours.ago.to_i }
+      let(:end_time) { Time.current.to_i }
+      let(:base_time) { 1.hour.ago.to_i }
+      def lax(idx) = "POINT(#{-118.4103 + (idx * 0.0001)} #{33.9429 + (idx * 0.0001)})"
+
+      let!(:live_before) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + (i * 15), lonlat: lax(i))
+        end
+      end
+      let!(:indoor_stay) do
+        (0..7).map do |i|
+          create(:point, user: user, accuracy: 10 + i, timestamp: base_time + 45 + (i * 15),
+                         lonlat: 'POINT(-0.4803 51.4693)')
+        end
+      end
+      let!(:live_after) do
+        (0..2).map do |i|
+          create(:point, user: user, accuracy: 10, timestamp: base_time + 180 + (i * 15), lonlat: lax(i + 3))
+        end
+      end
+
+      before { described_class.new(user.id, start_time, end_time).call }
+
+      it 'keeps a run that is re-measured rather than replayed' do
+        indoor_stay.each { |point| expect(point.reload.anomaly).not_to be true }
+      end
+    end
+
     context 'Pass 2: a frozen run no longer than a displaced run' do
       let(:start_time) { 2.hours.ago.to_i }
       let(:end_time) { Time.current.to_i }


### PR DESCRIPTION
## The bug

A GPX import covering one month reported **55,646 km**. Only **11,596 km** of it was physically possible — **44,044 km (79%)** came from fourteen instantaneous Heathrow↔LAX hops generated inside a thirty-minute window on 9 Nov.

After landing at LAX the location provider replayed a **frozen Heathrow fix** (byte-identical coordinates, zero drift) interleaved with live LAX fixes. Sorted by timestamp — which is how distance is measured — every switch bills another Atlantic crossing. The fastest implied 2,107,147 km/h: 8,780 km in 15 seconds.

Every hop over 50 km in that month:

| # | From (UTC) | To (UTC) | km | Δt | km/h | |
|---|---|---|---|---|---|---|
| 1 | 11-08 09:45 | 11-08 11:31 | 788 | 6,357s | 446 | real flight |
| 2 | 11-09 00:22 | 11-09 00:23 | 8,780 | 28s | 1,128,841 | **impossible** |
| 3 | 11-09 00:25 | 11-09 00:27 | 8,780 | 113s | 279,710 | **impossible** |
| 4 | 11-09 00:42 | 11-09 00:42 | 8,780 | 15s | 2,107,147 | **impossible** |
| 5 | 11-09 00:45 | 11-09 00:46 | 8,780 | 56s | 564,417 | **impossible** |
| 6 | 11-09 00:52 | 11-09 00:52 | 8,780 | 19s | 1,663,512 | **impossible** |
| 7 | 11-17 06:39 | 11-17 16:31 | 8,781 | 35,518s | 890 | real flight |
| 8 | 11-17 17:50 | 11-17 19:00 | 757 | 4,207s | 648 | real flight |

Hop 7 is a genuine 8,781 km flight covering the same distance as the phantoms. Distance alone cannot separate them — only speed can.

## Why the filter missed it

`Points::AnomalyFilter` did fire, flagging 97 points and cutting the month from ~128,000 km to 55,646 km. It stalls on `MAX_DISPLACED_RUN_POINTS = 5`: the run lengths in that window were 21, 6, 4, 1, 13, 1, 11, 2, 9, 5, 6, 10, 17, 54 — **nine of fourteen exceed five**, so no sliding window was ever wide enough to bracket them.

**The bound cannot simply be raised.** A genuine stay bracketed by two impossible hops satisfies *both* `contradicts_stay?` and `both_legs_impossible?`, so unbounding either erases real history — what the existing `a long genuine stay bracketed by impossible hops` spec guards.

## The fix

**1. `Points::AnomalyFilter#frozen_fix_run_ids`** — what separates a replayed fix from a genuine stay is *movement*. A cached position repeats verbatim because nothing re-measured it; real GPS always jitters. The pass convicts a run of **any length** that never moves, keeps an identical accuracy reading, departs `MIN_EXCURSION_METERS` from the fixes either side, and is reached and left impossibly fast — capped at an hour so a device genuinely parked somewhere is kept. Immobility does the job run length was doing, and does it better.

Because a burst is only judged once a later fix contradicts it — and that fix routinely arrives in its own single-point batch — `before_context` reaches back over the burst span and the pass may flag inside it, mirroring `filter_sentinel_fixes`, which re-judges the recent past for the same reason. Without this the pass could never fire on the live-ingest path at all.

**2. `Stats::DailyDistanceQuery`** — refuses to sum any leg implying more than 1,200 km/h, or a tied-timestamp pair displaced further than the filter's own `TELEPORT_METERS`. Anomaly detection cannot catch every displaced fix, and a leg it misses is reported as distance the user travelled. A genuine long-haul flight is an order of magnitude below the ceiling.

**3. Existing data** — stored flags, tracks and stats stay wrong until something recalculates them, and `Stats::BulkCalculator` only revisits months containing points newer than the last run, so a historical month never comes back on its own. The migration clears the 1.11.0 recalculation stamps and hands the work to the existing dispatcher; it enqueues only when it actually cleared something, so an upgrade that runs both recalculation migrations does not start two dispatchers.

## Verification

TDD throughout. RuboCop clean.

**Regression against real data** — two unrelated real datasets A/B'd, pristine vs patched:

| dataset | flagged | raw km | gated km |
|---|---|---|---|
| 18,700 pts / 2 trackers / 9 months | 2 → 2 | 1036.9 → 1036.9 | 1030.1 → 1030.1 |
| 17,988 pts / 1 tracker / 1 month | 0 → 0 | 944.4 → 944.4 | 938.0 → 938.0 |

Bit-identical. The change is inert on data without frozen-fix bursts.

**On the file that prompted this:**

| | before | after |
|---|---|---|
| Monthly stat | 55,646 km | **11,602 km** |
| Phantom day (Nov 9) | 44,112 km | **139 km** |
| Real flight day (Nov 17) | 9,697 km | 9,697 km |
| Real flight day (Nov 8) | 869 km | 869 km |
| Track total | 89,843 km | **54,808 km** |
| Largest track | 43,990 km | **26,472 km** |
| The 37 real tracks | 1,887 km | 1,887 km |
| Points flagged | 97 | 136 of 104,907 (0.13%) |

Real flights and real tracks survive untouched; only the phantom shrank.

## Known divergence

The 1,200 km/h ceiling applies to monthly distance, not to stored track distance, so a leg the filter still misses shows as 0 km in stats while the track it belongs to keeps it. On this file the phantom day reads 139 km while its track is 26,472 km. Narrowing that means applying the same ceiling in track building, which is a larger change and deliberately not attempted here.
