### PR TITLE
fix(api): lock the user row while merging mobile settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- `PATCH /api/v1/settings/mobile` now takes a row lock around its read-merge-write, so a mobile settings change no longer discards a concurrent write to another settings section or from another device.
+
 ### Fixed
 
 - A phone that replays a stale cached position after landing no longer bills the trip as dozens of instant intercontinental flights. Bursts of identical coordinates reached and left at impossible speed are now flagged however long they run, and monthly distance ignores any leg faster than 1,200 km/h. Stored anomaly flags, tracks and statistics are re-evaluated by a background job after upgrading; it runs on the lowest-priority queue and does not interrupt tracking, and your existing monthly totals will change once it reaches them. A track drawn through such a burst can still read longer than the day it belongs to, because the speed ceiling applies to distance totals rather than to stored tracks.

--- a/app/controllers/api/v1/settings/mobile_controller.rb
+++ b/app/controllers/api/v1/settings/mobile_controller.rb
@@ -23,13 +23,21 @@ class Api::V1::Settings::MobileController < ApiController
 
   def update
     sanitized = sanitized_params
-    settings = current_api_user.settings || {}
-    existing = settings['mobile'] || {}
-    settings['mobile'] = existing
-                         .merge(sanitized)
-                         .merge('updated_at' => Time.current.iso8601)
 
-    if current_api_user.update(settings: settings)
+    # The settings column holds every section, so a read-merge-write here races
+    # any other write to the same row: two devices, or the web UI changing an
+    # unrelated section. The row lock makes the merge see the latest value.
+    updated = current_api_user.with_lock do
+      settings = current_api_user.settings || {}
+      existing = settings['mobile'] || {}
+      settings['mobile'] = existing
+                           .merge(sanitized)
+                           .merge('updated_at' => Time.current.iso8601)
+
+      current_api_user.update(settings: settings)
+    end
+
+    if updated
       Rails.logger.info(
         "Mobile settings updated for user #{current_api_user.id}: #{sanitized.keys.join(', ')}"
       )

--- a/spec/regressions/mobile_settings_concurrent_write_spec.rb
+++ b/spec/regressions/mobile_settings_concurrent_write_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Mobile settings concurrent writes', type: :request do
+  let(:user) { create(:user) }
+  let(:headers) { { 'Authorization' => "Bearer #{user.api_key}" } }
+
+  # A second request commits between this request loading the user and merging
+  # its own change into the settings column.
+  def interleave_concurrent_write
+    allow_any_instance_of(Api::V1::Settings::MobileController)
+      .to receive(:sanitized_params).and_wrap_original do |original, *args|
+        unless @interleaved
+          @interleaved = true
+          concurrent = User.find(user.id)
+          concurrent.update!(
+            settings: concurrent.settings.merge('maps' => { 'distance_unit' => 'mi' })
+          )
+        end
+        original.call(*args)
+      end
+  end
+
+  it 'does not discard a concurrent write to another settings section' do
+    user.update!(settings: (user.settings || {}).merge('maps' => { 'distance_unit' => 'km' }))
+    interleave_concurrent_write
+
+    patch '/api/v1/settings/mobile',
+          params: { settings: { batch_size: 300 } },
+          headers: headers
+
+    expect(response).to have_http_status(:ok)
+    user.reload
+    expect(user.settings.dig('mobile', 'batch_size')).to eq(300)
+    expect(user.settings.dig('maps', 'distance_unit')).to eq('mi')
+  end
+
+  it 'does not discard a concurrent mobile field written by another device' do
+    user.update!(settings: (user.settings || {}).merge('mobile' => { 'tracking_mode' => 'precise' }))
+    allow_any_instance_of(Api::V1::Settings::MobileController)
+      .to receive(:sanitized_params).and_wrap_original do |original, *args|
+        unless @interleaved
+          @interleaved = true
+          concurrent = User.find(user.id)
+          mobile = concurrent.settings['mobile'].merge('tracking_mode' => 'significant')
+          concurrent.update!(settings: concurrent.settings.merge('mobile' => mobile))
+        end
+        original.call(*args)
+      end
+
+    patch '/api/v1/settings/mobile',
+          params: { settings: { batch_size: 300 } },
+          headers: headers
+
+    user.reload
+    expect(user.settings.dig('mobile', 'batch_size')).to eq(300)
+    expect(user.settings.dig('mobile', 'tracking_mode')).to eq('significant')
+  end
+end


### PR DESCRIPTION
`PATCH /api/v1/settings/mobile` read the `settings` column, merged its own section, and wrote the whole column back with no lock. Two overlapping writes each read the pre-write value, so the later one silently discarded the earlier one.

The blast is wider than mobile-vs-mobile: that column holds **every** settings section, so a mobile write could also drop a concurrent change to `maps.distance_unit` made from the web UI.

The merge now runs inside `with_lock`, so it always sees the latest value.

## Verification

Two regression specs in `spec/regressions/mobile_settings_concurrent_write_spec.rb`, each interleaving a concurrent write at the point a real second request would commit — after this request loads the user, before it merges:

- a concurrent write to another settings section (`maps.distance_unit`) survives
- a concurrent write to another mobile field (`tracking_mode`) survives

Both fail without the lock (`Expected "km" to eq "mi"`, `Expected "precise" to eq "significant"`) and pass with it. `spec/requests/api/v1/settings` 215 examples and the 17 mobile request examples pass; rubocop clean.

Found while reviewing the client-side settings sync work in dawarich-app/multiplatform-app#60 — the client now sends only changed fields, which fixes the common stale-device case, but end-to-end conflict safety needs the server side too.
