### PR TITLE
Trim memory and query overhead in point workflows

### DIFF
--- a/app/controllers/api/v1/points_controller.rb
+++ b/app/controllers/api/v1/points_controller.rb
@@ -4,6 +4,7 @@ class Api::V1::PointsController < ApiController
   include SafeTimestampParser
 
   BULK_DESTROY_MAX = 5_000
+  MAX_PER_PAGE = 10_000
 
   before_action :authenticate_active_api_user!, only: %i[create update destroy bulk_destroy reapply_anomaly_filter]
   before_action :require_write_api!, only: %i[update destroy bulk_destroy reapply_anomaly_filter]
@@ -55,6 +56,7 @@ class Api::V1::PointsController < ApiController
 
     per_page = params[:per_page].to_i
     per_page = 100 unless per_page.positive?
+    per_page = [per_page, MAX_PER_PAGE].min
     points = points
              .order(timestamp: order)
              .page(params[:page])

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -7,7 +7,6 @@ class TripsController < ApplicationController
   before_action :authenticate_user!
   before_action :authenticate_active_user!, only: %i[new create recalculate]
   before_action :set_trip, only: %i[show edit update destroy recalculate export]
-  before_action :set_coordinates, only: %i[show edit]
 
   def index
     @trips = current_user.trips.order(started_at: :desc).page(params[:page]).per(6)
@@ -29,7 +28,6 @@ class TripsController < ApplicationController
 
   def new
     @trip = Trip.new
-    @coordinates = []
   end
 
   def edit; end
@@ -140,13 +138,6 @@ class TripsController < ApplicationController
 
   def set_trip
     @trip = current_user.trips.find(params[:id])
-  end
-
-  def set_coordinates
-    @coordinates = @trip.points.pluck(
-      Arel.sql('ST_Y(lonlat::geometry)'), Arel.sql('ST_X(lonlat::geometry)'),
-      :battery, :altitude, :timestamp, :velocity, :id, :country
-    ).map { [_1.to_f, _2.to_f, _3.to_s, _4.to_s, _5.to_s, _6.to_s, _7.to_s, _8.to_s] }
   end
 
   def trip_params

--- a/app/jobs/data_migrations/start_settings_points_country_ids_job.rb
+++ b/app/jobs/data_migrations/start_settings_points_country_ids_job.rb
@@ -4,8 +4,10 @@ class DataMigrations::StartSettingsPointsCountryIdsJob < ApplicationJob
   queue_as :data_migrations
 
   def perform
-    Point.where(country_id: nil).find_each do |point|
-      DataMigrations::SetPointsCountryIdsJob.perform_later(point.id)
+    Point.where(country_id: nil).in_batches do |batch|
+      batch.pluck(:id).each do |point_id|
+        DataMigrations::SetPointsCountryIdsJob.perform_later(point_id)
+      end
     end
   end
 end

--- a/app/jobs/places/bulk_name_fetching_job.rb
+++ b/app/jobs/places/bulk_name_fetching_job.rb
@@ -4,8 +4,10 @@ class Places::BulkNameFetchingJob < ApplicationJob
   queue_as :places
 
   def perform
-    Place.where(name: Place::DEFAULT_NAME).find_each do |place|
-      Places::NameFetchingJob.perform_later(place.id)
+    Place.where(name: Place::DEFAULT_NAME).in_batches do |batch|
+      batch.pluck(:id).each do |place_id|
+        Places::NameFetchingJob.perform_later(place_id)
+      end
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -317,7 +317,7 @@ class User < ApplicationRecord
   def countries_visited_uncached
     countries = Set.new
 
-    stats.find_each do |stat|
+    stats.select(:id, :toponyms).find_each do |stat|
       toponyms = stat.toponyms
       next unless toponyms.is_a?(Array)
 
@@ -338,7 +338,7 @@ class User < ApplicationRecord
   def cities_visited_uncached
     cities = Set.new
 
-    stats.find_each do |stat|
+    stats.select(:id, :toponyms).find_each do |stat|
       toponyms = stat.toponyms
       next unless toponyms.is_a?(Array)
 

--- a/app/serializers/stats_serializer.rb
+++ b/app/serializers/stats_serializer.rb
@@ -31,7 +31,7 @@ class StatsSerializer
   end
 
   def yearly_stats
-    user.stats.group_by(&:year).sort.reverse.map do |year, stats|
+    user.stats.select(:id, :year, :month, :distance, :toponyms).group_by(&:year).sort.reverse.map do |year, stats|
       countries, cities = countries_and_cities_from_stats(stats)
 
       {

--- a/app/services/exports/create.rb
+++ b/app/services/exports/create.rb
@@ -35,10 +35,16 @@ class Exports::Create
   attr_reader :user, :export, :start_at, :end_at, :file_format
 
   def time_framed_points
-    user
-      .points
-      .select(Point.column_names - %w[raw_data])
-      .where(timestamp: start_at.to_i..end_at.to_i)
+    points = user.points.where(timestamp: start_at.to_i..end_at.to_i)
+
+    case file_format.to_sym
+    when :gpx
+      points.select(:id, :lonlat, :altitude, :altitude_decimal, :velocity, :timestamp, :course)
+    when :json
+      points.select(Point.column_names - %w[raw_data])
+    else
+      points
+    end
   end
 
   def build_export_tempfile

--- a/app/services/immich/enrich_scan.rb
+++ b/app/services/immich/enrich_scan.rb
@@ -64,6 +64,7 @@ class Immich::EnrichScan
     points = user.points
                  .where(timestamp: min_ts..max_ts)
                  .where.not(lonlat: nil)
+                 .select(:id, :timestamp, :lonlat)
                  .order(:timestamp)
                  .to_a
 

--- a/app/services/imports/secure_file_downloader.rb
+++ b/app/services/imports/secure_file_downloader.rb
@@ -159,8 +159,7 @@ class Imports::SecureFileDownloader
 
     # Verify checksum
     expected_checksum = storage_attachment.blob.checksum
-    temp_file.rewind
-    actual_checksum = Base64.strict_encode64(Digest::MD5.digest(temp_file.read))
+    actual_checksum = Base64.strict_encode64(Digest::MD5.file(temp_file.path).digest)
     temp_file.rewind
 
     return unless expected_checksum != actual_checksum

--- a/app/services/users/export_data/points.rb
+++ b/app/services/users/export_data/points.rb
@@ -36,8 +36,8 @@ class Users::ExportData::Points
     Rails.logger.info "Streaming #{total_count} points to monthly files..."
     Rails.logger.debug "Starting export of #{total_count} points..."
 
-    user.points.find_in_batches(batch_size: BATCH_SIZE).with_index do |batch, _batch_index|
-      point_ids = batch.map(&:id)
+    user.points.in_batches(of: BATCH_SIZE) do |batch|
+      point_ids = batch.pluck(:id)
       batch_sql = ActiveRecord::Base.sanitize_sql_array([build_batch_query, point_ids])
       result = ActiveRecord::Base.connection.exec_query(batch_sql, 'Points Export Batch')
 

--- a/spec/jobs/data_migrations/start_settings_points_country_ids_job_spec.rb
+++ b/spec/jobs/data_migrations/start_settings_points_country_ids_job_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe DataMigrations::StartSettingsPointsCountryIdsJob, type: :job do
         have_enqueued_job(DataMigrations::SetPointsCountryIdsJob)
         .with(point_with_country.id)
     end
+
+    it 'selects only point IDs while enqueueing' do
+      queries = []
+      callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+
+      ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+        described_class.perform_now
+      end
+
+      point_queries = queries.select { |sql| sql.include?('FROM "points"') }
+      expect(point_queries).not_to be_empty
+      expect(point_queries).to all(include('"points"."id"'))
+      expect(point_queries).to all(satisfy { |sql| !sql.include?('"points"."accuracy"') })
+      expect(point_queries).to all(satisfy { |sql| !sql.include?('"points"."lonlat"') })
+    end
   end
 
   describe 'queue' do

--- a/spec/jobs/places/bulk_name_fetching_job_spec.rb
+++ b/spec/jobs/places/bulk_name_fetching_job_spec.rb
@@ -18,6 +18,20 @@ RSpec.describe Places::BulkNameFetchingJob, type: :job do
         have_enqueued_job(Places::NameFetchingJob).with(place3.id)
     end
 
+    it 'selects only place IDs while enqueueing' do
+      queries = []
+      callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+
+      ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+        described_class.perform_now
+      end
+
+      place_queries = queries.select { |sql| sql.include?('FROM "places"') }
+      expect(place_queries).not_to be_empty
+      expect(place_queries).to all(include('"places"."id"'))
+      expect(place_queries).to all(satisfy { |sql| !sql.include?('"places".*') })
+    end
+
     it 'can be enqueued' do
       expect { described_class.perform_later }.to have_enqueued_job(described_class)
         .on_queue('places')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -587,6 +587,20 @@ RSpec.describe User, type: :model do
       it 'excludes drive-through countries with no qualifying cities' do
         expect(subject).not_to include('Belgium')
       end
+
+      it 'selects only fields required for toponym aggregation' do
+        queries = []
+        callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+          user.countries_visited
+        end
+
+        row_query = queries.find { |sql| sql.include?('FROM "stats"') }
+        expect(row_query).to include('"stats"."id", "stats"."toponyms"')
+        expect(row_query).not_to include('"stats".*')
+        expect(row_query).not_to include('h3_hex_ids')
+      end
     end
 
     describe '#cities_visited' do
@@ -610,6 +624,20 @@ RSpec.describe User, type: :model do
 
       it 'excludes nil and empty city names' do
         expect(subject).not_to include(nil, '')
+      end
+
+      it 'selects only fields required for toponym aggregation' do
+        queries = []
+        callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+          user.cities_visited
+        end
+
+        row_query = queries.find { |sql| sql.include?('FROM "stats"') }
+        expect(row_query).to include('"stats"."id", "stats"."toponyms"')
+        expect(row_query).not_to include('"stats".*')
+        expect(row_query).not_to include('h3_hex_ids')
       end
     end
 

--- a/spec/requests/api/v1/points_caching_spec.rb
+++ b/spec/requests/api/v1/points_caching_spec.rb
@@ -64,6 +64,29 @@ RSpec.describe 'Api::V1::Points conditional GET caching', type: :request do
     expect(response.headers['X-Total-Pages']).to eq('2')
   end
 
+  it 'caps oversized page requests at 10,000 points' do
+    start_at = 2.days.ago.to_i
+    end_at = Time.current.to_i
+    base_timestamp = start_at + 1
+    now = Time.current
+    rows = 9_998.times.map do |offset|
+      {
+        user_id: user.id,
+        timestamp: base_timestamp + offset,
+        lonlat: 'POINT(13.4 52.5)',
+        created_at: now,
+        updated_at: now
+      }
+    end
+    Point.insert_all!(rows)
+
+    get "/api/v1/points?api_key=#{user.api_key}&slim=true&start_at=#{start_at}&end_at=#{end_at}&per_page=999999"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.size).to eq(10_000)
+    expect(response.headers['X-Total-Pages']).to eq('2')
+  end
+
   it 'falls back to the default page size when per_page is zero' do
     get "/api/v1/points?api_key=#{user.api_key}&#{range}&per_page=0"
 

--- a/spec/requests/trips_spec.rb
+++ b/spec/requests/trips_spec.rb
@@ -3,6 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe '/trips', type: :request do
+  def capture_sql(&block)
+    queries = []
+    callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+    ActiveSupport::Notifications.subscribed(callback, 'sql.active_record', &block)
+    queries
+  end
+
   let(:valid_attributes) do
     {
       name: 'Summer Vacation 2024',
@@ -51,6 +58,14 @@ RSpec.describe '/trips', type: :request do
       get trip_url(trip)
 
       expect(response).to be_successful
+    end
+
+    it 'does not load the unused raw point coordinate projection' do
+      queries = capture_sql { get trip_url(trip) }
+
+      expect(
+        queries.none? { |sql| sql.include?('ST_Y(lonlat::geometry)') && sql.include?('"points"."battery"') }
+      ).to be(true)
     end
 
     it 'renders the recalculate button' do
@@ -200,6 +215,14 @@ RSpec.describe '/trips', type: :request do
       get edit_trip_url(trip)
 
       expect(response).to be_successful
+    end
+
+    it 'does not load the unused raw point coordinate projection' do
+      queries = capture_sql { get edit_trip_url(trip) }
+
+      expect(
+        queries.none? { |sql| sql.include?('ST_Y(lonlat::geometry)') && sql.include?('"points"."battery"') }
+      ).to be(true)
     end
   end
 

--- a/spec/serializers/stats_serializer_spec.rb
+++ b/spec/serializers/stats_serializer_spec.rb
@@ -103,6 +103,18 @@ RSpec.describe StatsSerializer do
       it 'returns the expected JSON' do
         expect(serializer).to eq(expected_json)
       end
+
+      it 'does not load H3 payloads while aggregating stats' do
+        queries = []
+        callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { serializer }
+
+        row_queries = queries.select { |sql| sql.include?('FROM "stats"') && !sql.include?('SUM(') }
+        expect(row_queries).not_to be_empty
+        expect(row_queries).to all(satisfy { |sql| !sql.include?('"stats".*') })
+        expect(row_queries).to all(satisfy { |sql| !sql.include?('h3_hex_ids') })
+      end
     end
 
     context 'when years have different countries' do

--- a/spec/services/exports/create_spec.rb
+++ b/spec/services/exports/create_spec.rb
@@ -82,6 +82,21 @@ RSpec.describe Exports::Create do
         expect(inner).to include('<trkpt')
       end
 
+      it 'selects only fields required by GPX serialization' do
+        queries = []
+        callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { create_export }
+
+        point_query = queries.find { |sql| sql.include?('FROM "points"') && sql.include?('"points"."lonlat"') }
+        expect(point_query).to include(
+          '"points"."id"', '"points"."lonlat"', '"points"."altitude"',
+          '"points"."altitude_decimal"', '"points"."velocity"',
+          '"points"."timestamp"', '"points"."course"'
+        )
+        expect(point_query).not_to include('raw_data', 'geodata', 'motion_data')
+      end
+
       it 'updates the export status to completed' do
         create_export
 

--- a/spec/services/immich/enrich_scan_spec.rb
+++ b/spec/services/immich/enrich_scan_spec.rb
@@ -148,6 +148,19 @@ RSpec.describe Immich::EnrichScan do
           :latitude, :longitude, :time_delta_seconds, :match_method
         )
       end
+
+      it 'selects only fields required for temporal matching' do
+        queries = []
+        callback = ->(_name, _start, _finish, _id, payload) { queries << payload[:sql] }
+
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { service.call }
+
+        point_query = queries.find { |sql| sql.include?('FROM "points"') }
+        expect(point_query).to include(
+          '"points"."id"', '"points"."timestamp"', '"points"."lonlat"'
+        )
+        expect(point_query).not_to include('"points".*', 'raw_data', 'geodata', 'motion_data')
+      end
     end
 
     context 'when no Dawarich points exist in the time range' do

--- a/spec/services/imports/secure_file_downloader_spec.rb
+++ b/spec/services/imports/secure_file_downloader_spec.rb
@@ -133,5 +133,25 @@ RSpec.describe Imports::SecureFileDownloader do
       expect(File.exist?(path)).to be(true)
       File.unlink(path) if File.exist?(path)
     end
+
+    context 'with a file larger than the digest read buffer' do
+      let(:file_content) { 'x' * 1.megabyte }
+
+      it 'never reads the complete tempfile into one Ruby String' do
+        read_sizes = []
+        trace = TracePoint.new(:c_return) do |event|
+          next unless event.method_id == :read
+          next unless event.return_value.is_a?(String)
+
+          read_sizes << event.return_value.bytesize
+        end
+
+        path = trace.enable { subject.download_to_temp_file }
+
+        expect(read_sizes).not_to include(file_content.bytesize)
+      ensure
+        File.unlink(path) if path && File.exist?(path)
+      end
+    end
   end
 end

--- a/spec/services/users/export_data/points_spec.rb
+++ b/spec/services/users/export_data/points_spec.rb
@@ -316,6 +316,19 @@ RSpec.describe Users::ExportData::Points, type: :service do
 
           expect(result).to eq(result.sort)
         end
+
+        it 'does not instantiate Point models before running the export query' do
+          instantiated = 0
+          callback = lambda do |_name, _start, _finish, _id, payload|
+            instantiated += payload[:record_count] if payload[:class_name] == 'Point'
+          end
+
+          ActiveSupport::Notifications.subscribed(callback, 'instantiation.active_record') do
+            monthly_service.call
+          end
+
+          expect(instantiated).to eq(0)
+        end
       end
 
       context 'with no points' do


### PR DESCRIPTION
## Summary

Narrows queries and avoids model instantiation on paths that read points and stats. No public API or payload changes beyond a new page-size ceiling.

This is the backend salvage from #3103, re-cut against current `dev`. That PR sat 722 commits behind and conflicting; its map/JS half is now stale (`data_loader.js` gates the bulk fetch behind `tiledPointsActive()` / `bulkPointsRequired()`, and `onBatch` is deliberate progressive rendering), so none of it is carried over here.

## Changes

- **Trips** — remove the dead `set_coordinates` before_action. Trip views read `@trip.path&.coordinates`; the 8-column pluck over every trip point on `show` and `edit` had no remaining consumer.
- **Imports** — stream the tempfile checksum with `Digest::MD5.file` instead of reading the whole download into a Ruby String.
- **Enqueue sweeps and points export** — `in_batches` + `pluck(:id)` instead of instantiating every record.
- **Narrow projections** — GPX export, `StatsSerializer#yearly_stats`, the countries/cities toponym caches, and the Immich temporal matcher now select only the columns they read.
- **Points API** — clamp `per_page` at 10,000. The existing 100-record default is unchanged.

## Notes on the salvage

Two specs carried over from #3103 were vacuous against current `dev` and were rewritten:

- The trips assertion matched `"points"."latitude", "points"."longitude"`, but `set_coordinates` moved to `ST_Y/ST_X(lonlat::geometry)` after that PR was opened — so it passed with or without the fix.
- The country-ids job assertion checked for the absence of `"points".*`, but the `Point` model expands `*` into an explicit column list, so it could never fail. It now asserts the absence of `"points"."accuracy"` and `"points"."lonlat"`.

## Testing

Run against an isolated test database.

- Red/green verified: with the production changes reverted and the specs in place, 12 of the 12 new examples fail; with the changes applied, all pass.
- `bundle exec rspec` over the touched specs — 268 examples, 0 failures.
- Wider sweep over `spec/requests/api/v1/points_spec.rb`, `spec/services/exports`, `spec/services/users/export_data`, `spec/serializers`, `spec/services/immich`, `spec/services/imports` — 548 examples, 0 failures.
- RuboCop on all 20 changed files — 0 offenses.
