### PR TITLE
feat: report AirTrail flight distance separately from tracked distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Trip note text now uses consistent left alignment on every line (#3104).
 
+## Added
+
+- AirTrail flights now show as their own figure on the monthly stats page and in the monthly digest. Flight distance is reported next to the distance Dawarich tracked rather than added into it, so neither number changes meaning.
+
 ## [1.14.0] - 2026-08-27, Berlin
 
 ### Changed

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -28,10 +28,11 @@ module StatsHelper
   end
 
   def distance_traveled(user, stat)
-    distance_unit = user.safe_settings.distance_unit
-    value = Stat.convert_distance(stat.distance, distance_unit).round
+    formatted_distance(user, stat.distance)
+  end
 
-    I18n.t('helpers.stats.distance', value: number_with_delimiter(value), unit: distance_unit)
+  def flight_distance_traveled(user, stat)
+    formatted_distance(user, stat.flight_distance)
   end
 
   def active_days(stat)
@@ -74,6 +75,13 @@ module StatsHelper
   end
 
   private
+
+  def formatted_distance(user, meters)
+    distance_unit = user.safe_settings.distance_unit
+    value = Stat.convert_distance(meters, distance_unit).round
+
+    I18n.t('helpers.stats.distance', value: number_with_delimiter(value), unit: distance_unit)
+  end
 
   def collect_countries_and_cities(year_stats)
     countries = []

--- a/app/queries/stats/flight_distance_query.rb
+++ b/app/queries/stats/flight_distance_query.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class Stats::FlightDistanceQuery
+  LOCAL_FLIGHT_DATE = <<~SQL.squish
+    COALESCE(
+      flights.flight_date,
+      (flights.departure_time AT TIME ZONE 'UTC' AT TIME ZONE :timezone)::date
+    )
+  SQL
+
+  def initialize(user, year, month)
+    @user = user
+    @year = year.to_i
+    @month = month.to_i
+  end
+
+  def call
+    (flights_in_month.sum(:distance_km) * 1000).round
+  end
+
+  private
+
+  attr_reader :user, :year, :month
+
+  def flights_in_month
+    user.flights.where(
+      "#{LOCAL_FLIGHT_DATE} BETWEEN :first_day AND :last_day",
+      timezone: user.timezone_iana,
+      first_day: Date.new(year, month, 1),
+      last_day: Date.new(year, month, -1)
+    )
+  end
+end

--- a/app/services/air_trail/import_flights.rb
+++ b/app/services/air_trail/import_flights.rb
@@ -16,12 +16,25 @@ module AirTrail
         url, api_key, skip_ssl_verification: @settings.airtrail_skip_ssl_verification
       ).flights
 
+      months_before_sync = affected_months
       counts = upsert(payload)
       record_synced_at
+      recalculate_stats(months_before_sync | affected_months)
       counts
     end
 
     private
+
+    def affected_months
+      @user.flights.pluck(:flight_date, :departure_time).filter_map do |flight_date, departure_time|
+        local_date = flight_date || departure_time&.in_time_zone(@user.timezone_iana)&.to_date
+        [local_date.year, local_date.month] if local_date
+      end.uniq
+    end
+
+    def recalculate_stats(months)
+      months.each { |year, month| Stats::CalculatingJob.perform_later(@user.id, year, month) }
+    end
 
     def upsert(payload)
       created = 0

--- a/app/services/stats/calculate_month.rb
+++ b/app/services/stats/calculate_month.rb
@@ -37,6 +37,7 @@ class Stats::CalculateMonth
       stat.assign_attributes(
         daily_distance: distance_by_day,
         distance: distance(distance_by_day),
+        flight_distance: flight_distance,
         toponyms: toponyms,
         h3_hex_ids: calculate_h3_hex_ids
       )
@@ -72,6 +73,10 @@ class Stats::CalculateMonth
     distance_by_day.sum { |day| day[1] }
   end
 
+  def flight_distance
+    Stats::FlightDistanceQuery.new(user, year, month).call
+  end
+
   def toponyms
     CountriesAndCities.new(
       points_in_local_month,
@@ -99,6 +104,7 @@ class Stats::CalculateMonth
     stat.update!(
       daily_distance: {},
       distance: 0,
+      flight_distance: flight_distance,
       toponyms: [],
       h3_hex_ids: {}
     )

--- a/app/services/users/digests/calculate_month.rb
+++ b/app/services/users/digests/calculate_month.rb
@@ -21,6 +21,7 @@ module Users
 
           digest.assign_attributes(
             distance: stat.distance,
+            flight_distance: stat.flight_distance,
             toponyms: stat.toponyms || [],
             monthly_distances: (stat.daily_distance || []).to_h.transform_keys(&:to_s),
             time_spent_by_location: calculate_time_spent,

--- a/app/views/stats/_month.html.erb
+++ b/app/views/stats/_month.html.erb
@@ -25,6 +25,16 @@
     <div class="stat-desc"><%= x_than_average_distance(stat, @average_distance_this_year) %></div>
   </div>
 
+  <% if stat.flight_distance.positive? %>
+    <div class="stat place-items-center text-center">
+      <div class="stat-title flex items-center justify-center gap-1">
+        <%= icon 'plane' %> <%= t('.flight_distance') %>
+      </div>
+      <div class="stat-value text-info"><%= flight_distance_traveled(current_user, stat) %></div>
+      <div class="stat-desc"><%= t('.from_airtrail_not_counted_in_distance') %></div>
+    </div>
+  <% end %>
+
   <div class="stat place-items-center text-center">
     <div class="stat-title flex items-center justify-center gap-1">
       <%= icon 'calendar-check-2' %> <%= t('.active_days') %>

--- a/app/views/stats/public_month.html.erb
+++ b/app/views/stats/public_month.html.erb
@@ -14,12 +14,20 @@
     </div>
   </div>
 
-  <div class="stats shadow mx-auto mb-8 w-full">
+  <div class="stats stats-vertical lg:stats-horizontal shadow mx-auto mb-8 w-full">
     <div class="stat place-items-center text-center">
       <div class="stat-title"><%= t('.distance_traveled') %></div>
       <div class="stat-value"><%= distance_traveled(@user, @stat) %></div>
       <div class="stat-desc"><%= t('.total_distance_for_this_month') %></div>
     </div>
+
+    <% if @stat.flight_distance.positive? %>
+      <div class="stat place-items-center text-center">
+        <div class="stat-title"><%= t('.flight_distance') %></div>
+        <div class="stat-value text-info"><%= flight_distance_traveled(@user, @stat) %></div>
+        <div class="stat-desc"><%= t('.from_airtrail_not_counted_in_distance') %></div>
+      </div>
+    <% end %>
 
     <div class="stat place-items-center text-center">
       <div class="stat-title"><%= t('.active_days') %></div>

--- a/app/views/users/digests_mailer/monthly_digest.html.erb
+++ b/app/views/users/digests_mailer/monthly_digest.html.erb
@@ -24,6 +24,9 @@
   <h2><%= t('.overview') %></h2>
   <pre class="ascii" style="<%= pre_style %>">
 <%= t('.distance') %>       <%= distance_with_unit(@digest.distance, @distance_unit) %>
+<% if @digest.flight_distance.positive? %>
+<%= t('.flights') %>        <%= distance_with_unit(@digest.flight_distance, @distance_unit) %>
+<% end %>
 <%= t('.active_days') %>    <%= @active_days %>
 <%= t('.countries') %>      <%= @digest.time_spent_by_location.to_h['countries'].to_a.size %>
 <%= t('.cities') %>         <%= @digest.time_spent_by_location.to_h['cities'].to_a.size %>

--- a/app/views/users/digests_mailer/monthly_digest.text.erb
+++ b/app/views/users/digests_mailer/monthly_digest.text.erb
@@ -5,6 +5,9 @@
 
 <%= t('.overview') %>
   <%= t('.distance') %>       <%= distance_with_unit(@digest.distance, @distance_unit) %>
+<% if @digest.flight_distance.positive? %>
+  <%= t('.flights') %>        <%= distance_with_unit(@digest.flight_distance, @distance_unit) %>
+<% end %>
   <%= t('.active_days') %>    <%= @active_days %>
   <%= t('.countries') %>      <%= @digest.time_spent_by_location.to_h['countries'].to_a.size %>
   <%= t('.cities') %>         <%= @digest.time_spent_by_location.to_h['cities'].to_a.size %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1990,6 +1990,8 @@ ca:
       available_on_pro: Disponible a Pro
       upgrade_to_pro: Millora a Pro
     month:
+      flight_distance: Distància de vol
+      from_airtrail_not_counted_in_distance: D'AirTrail, no comptat a la distància
       monthly_digest: Resum mensual
       share: Comparteix
       distance_traveled: Distància recorreguda
@@ -2041,6 +2043,8 @@ ca:
       distance: Distància
       countries_count_countries_cities_count_cities: "%{countries_count} països, %{cities_count} ciutats"
     public_month:
+      flight_distance: Distància de vol
+      from_airtrail_not_counted_in_distance: D'AirTrail, no comptat a la distància
       monthly_digest: Resum mensual
       distance_traveled: Distància recorreguda
       total_distance_for_this_month: Distància total d'aquest mes
@@ -2321,6 +2325,7 @@ ca:
           other: "%{count} ciutats"
     digests_mailer:
       monthly_digest:
+        flights: Vols
         your: El teu
         in_review: en retrospectiva
         here_s_what_your_location_history_looked_like_last_month: Així és com va ser el teu historial d'ubicacions el mes passat.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1995,6 +1995,8 @@ de:
       available_on_pro: Verfügbar auf Pro
       upgrade_to_pro: Auf Pro upgraden
     month:
+      flight_distance: Flugdistanz
+      from_airtrail_not_counted_in_distance: Aus AirTrail, nicht in der Distanz enthalten
       monthly_digest: Monatsrückblick
       share: Teilen
       distance_traveled: Gefahrene Strecke
@@ -2046,6 +2048,8 @@ de:
       distance: Distanz
       countries_count_countries_cities_count_cities: "%{countries_count} Länder, %{cities_count} Städte"
     public_month:
+      flight_distance: Flugdistanz
+      from_airtrail_not_counted_in_distance: Aus AirTrail, nicht in der Distanz enthalten
       monthly_digest: Monatlicher Überblick
       distance_traveled: Gesamtstrecke
       total_distance_for_this_month: Gesamtstrecke für diesen Monat
@@ -2326,6 +2330,7 @@ de:
           other: "%{count} Städte"
     digests_mailer:
       monthly_digest:
+        flights: Flüge
         your: Dein
         in_review: im Rückblick
         here_s_what_your_location_history_looked_like_last_month: Hier ist ein Überblick, wie dein Standortverlauf im letzten Monat aussah.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1990,6 +1990,8 @@ en:
       available_on_pro: Available on Pro
       upgrade_to_pro: Upgrade to Pro
     month:
+      flight_distance: Flight distance
+      from_airtrail_not_counted_in_distance: From AirTrail, not counted in distance
       monthly_digest: Monthly Digest
       share: Share
       distance_traveled: Distance traveled
@@ -2041,6 +2043,8 @@ en:
       distance: Distance
       countries_count_countries_cities_count_cities: "%{countries_count} countries, %{cities_count} cities"
     public_month:
+      flight_distance: Flight distance
+      from_airtrail_not_counted_in_distance: From AirTrail, not counted in distance
       monthly_digest: Monthly Digest
       distance_traveled: Distance traveled
       total_distance_for_this_month: Total distance for this month
@@ -2321,6 +2325,7 @@ en:
           other: "%{count} cities"
     digests_mailer:
       monthly_digest:
+        flights: Flights
         your: Your
         in_review: in review
         here_s_what_your_location_history_looked_like_last_month: Here's what your location history looked like last month.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1995,6 +1995,8 @@ es:
       available_on_pro: Disponible en Pro
       upgrade_to_pro: Actualizar a Pro
     month:
+      flight_distance: Distancia de vuelo
+      from_airtrail_not_counted_in_distance: Desde AirTrail, no incluido en la distancia
       monthly_digest: Resumen mensual
       share: Compartir
       distance_traveled: Distancia recorrida
@@ -2046,6 +2048,8 @@ es:
       distance: Distancia
       countries_count_countries_cities_count_cities: "%{countries_count} países, %{cities_count} ciudades"
     public_month:
+      flight_distance: Distancia de vuelo
+      from_airtrail_not_counted_in_distance: Desde AirTrail, no incluido en la distancia
       monthly_digest: Resumen mensual
       distance_traveled: Distancia recorrida
       total_distance_for_this_month: Distancia total para este mes
@@ -2326,6 +2330,7 @@ es:
           other: "%{count} ciudades"
     digests_mailer:
       monthly_digest:
+        flights: Vuelos
         your: Tu
         in_review: en revisión
         here_s_what_your_location_history_looked_like_last_month: Aquí está cómo se veía tu historia de ubicación el mes pasado.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2859,6 +2859,8 @@ fr:
       available_on_pro: Disponible sur Pro
       upgrade_to_pro: Passez à Pro
     month:
+      flight_distance: Distance en vol
+      from_airtrail_not_counted_in_distance: Depuis AirTrail, non compté dans la distance
       monthly_digest: Récapitulatif mensuel
       share: Partager
       distance_traveled: Distance parcourue
@@ -2914,6 +2916,8 @@ fr:
       countries_count_countries_cities_count_cities: "%{countries_count} pays, %{cities_count}
         villes"
     public_month:
+      flight_distance: Distance en vol
+      from_airtrail_not_counted_in_distance: Depuis AirTrail, non compté dans la distance
       monthly_digest: Récapitulatif mensuel
       distance_traveled: Distance parcourue
       total_distance_for_this_month: Distance totale pour ce mois
@@ -3219,6 +3223,7 @@ fr:
           other: "%{count} villes"
     digests_mailer:
       monthly_digest:
+        flights: Vols
         your: Votre
         in_review: en revue
         here_s_what_your_location_history_looked_like_last_month: Voici à quoi ressemblait

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1990,6 +1990,8 @@ pl:
       available_on_pro: Dostępne w planie Pro
       upgrade_to_pro: Przejdź na Pro
     month:
+      flight_distance: Dystans lotów
+      from_airtrail_not_counted_in_distance: Z AirTrail, nieliczony do dystansu
       monthly_digest: Podsumowanie miesięczne
       share: Udostępnij
       distance_traveled: Przebyty dystans
@@ -2041,6 +2043,8 @@ pl:
       distance: Dystans
       countries_count_countries_cities_count_cities: "%{countries_count} krajów, %{cities_count} miast"
     public_month:
+      flight_distance: Dystans lotów
+      from_airtrail_not_counted_in_distance: Z AirTrail, nieliczony do dystansu
       monthly_digest: Podsumowanie miesięczne
       distance_traveled: Przebyty dystans
       total_distance_for_this_month: Całkowity dystans w tym miesiącu
@@ -2321,6 +2325,7 @@ pl:
           other: "%{count} miast"
     digests_mailer:
       monthly_digest:
+        flights: Loty
         your: Twoje
         in_review: podsumowanie
         here_s_what_your_location_history_looked_like_last_month: Tak wyglądała historia Twojej lokalizacji w poprzednim miesiącu.

--- a/db/migrate/20260827120000_add_flight_distance_to_stats_and_digests.rb
+++ b/db/migrate/20260827120000_add_flight_distance_to_stats_and_digests.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddFlightDistanceToStatsAndDigests < ActiveRecord::Migration[8.0]
+  def change
+    add_column :stats, :flight_distance, :bigint, default: 0, null: false, if_not_exists: true
+    add_column :digests, :flight_distance, :bigint, default: 0, null: false, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_25_120100) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -86,6 +86,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_120100) do
     t.datetime "created_at", null: false
     t.bigint "distance", default: 0, null: false
     t.jsonb "first_time_visits", default: {}
+    t.bigint "flight_distance", default: 0, null: false
     t.integer "month"
     t.jsonb "monthly_distances", default: {}
     t.integer "period_type", default: 0, null: false
@@ -467,6 +468,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_120100) do
     t.datetime "created_at", null: false
     t.jsonb "daily_distance", default: {}
     t.bigint "distance", null: false
+    t.bigint "flight_distance", default: 0, null: false
     t.jsonb "h3_hex_ids", default: {}
     t.integer "month", null: false
     t.jsonb "sharing_settings", default: {}

--- a/spec/queries/stats/flight_distance_query_spec.rb
+++ b/spec/queries/stats/flight_distance_query_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::FlightDistanceQuery do
+  let(:user) { create(:user) }
+
+  subject(:flight_meters) { described_class.new(user, 2026, 4).call }
+
+  context 'without any flights' do
+    it 'returns zero' do
+      expect(flight_meters).to eq(0)
+    end
+  end
+
+  context 'with flights dated inside the month' do
+    before do
+      create(:flight, user: user, flight_date: Date.new(2026, 4, 3), distance_km: 633.4)
+      create(:flight, user: user, flight_date: Date.new(2026, 4, 28), distance_km: 120.6)
+    end
+
+    it 'sums their distance in meters' do
+      expect(flight_meters).to eq(754_000)
+    end
+  end
+
+  context 'with flights dated outside the month' do
+    before do
+      create(:flight, user: user, flight_date: Date.new(2026, 3, 31), distance_km: 500.0)
+      create(:flight, user: user, flight_date: Date.new(2026, 5, 1), distance_km: 500.0)
+    end
+
+    it 'excludes them' do
+      expect(flight_meters).to eq(0)
+    end
+  end
+
+  context 'with a flight belonging to another user' do
+    before do
+      create(:flight, user: create(:user), flight_date: Date.new(2026, 4, 10), distance_km: 900.0)
+    end
+
+    it 'does not borrow it' do
+      expect(flight_meters).to eq(0)
+    end
+  end
+
+  context 'with a flight whose distance is unknown' do
+    before { create(:flight, user: user, flight_date: Date.new(2026, 4, 10), distance_km: nil) }
+
+    it 'skips it instead of failing' do
+      expect(flight_meters).to eq(0)
+    end
+  end
+
+  context 'with a dateless flight that departs in the new month only in the user timezone' do
+    let(:user) { create(:user, settings: { 'timezone' => 'Europe/Berlin' }) }
+
+    before do
+      create(:flight, user: user, flight_date: nil,
+                      departure_time: Time.utc(2026, 3, 31, 23, 0), distance_km: 300.0)
+    end
+
+    it 'counts it, because locally it departed on April 1st' do
+      expect(flight_meters).to eq(300_000)
+    end
+  end
+
+  context 'with a dateless flight that departs in the previous month only in the user timezone' do
+    let(:user) { create(:user, settings: { 'timezone' => 'America/Los_Angeles' }) }
+
+    before do
+      create(:flight, user: user, flight_date: nil,
+                      departure_time: Time.utc(2026, 4, 1, 3, 0), distance_km: 300.0)
+    end
+
+    it 'excludes it, because locally it departed on March 31st' do
+      expect(flight_meters).to eq(0)
+    end
+  end
+
+  context 'with a flight that has neither a date nor a departure time' do
+    before do
+      create(:flight, user: user, flight_date: nil, departure_time: nil,
+                      arrival_time: nil, distance_km: 300.0)
+    end
+
+    it 'skips it instead of failing' do
+      expect(flight_meters).to eq(0)
+    end
+  end
+end

--- a/spec/regressions/flight_distance_shown_separately_spec.rb
+++ b/spec/regressions/flight_distance_shown_separately_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Flight distance is shown separately from tracked distance' do
+  let(:user) { create(:user, settings: { 'distance_unit' => 'km' }) }
+
+  describe 'the monthly stats page', type: :request do
+    before { sign_in user }
+
+    it 'shows the flight figure alongside the tracked one' do
+      create(:stat, user: user, year: 2026, month: 4, distance: 120_000,
+                    flight_distance: 633_400, daily_distance: [[1, 120_000]])
+
+      get '/stats/2026/4'
+
+      expect(response.body).to include('Flight distance')
+      expect(response.body).to include('633')
+      expect(response.body).to include('120')
+      expect(response.body).to include('not counted in distance')
+    end
+
+    it 'hides the flight figure when the month has no flights' do
+      create(:stat, user: user, year: 2026, month: 4, distance: 120_000,
+                    flight_distance: 0, daily_distance: [[1, 120_000]])
+
+      get '/stats/2026/4'
+
+      expect(response.body).not_to include('Flight distance')
+    end
+  end
+
+  describe 'the monthly digest email', type: :mailer do
+    let(:digest) do
+      create(:users_digest, :monthly, user: user, year: 2026, month: 4,
+                                      distance: 120_000, flight_distance: 633_400)
+    end
+    let(:mail) { Users::DigestsMailer.with(user: user, digest: digest).monthly_digest }
+
+    it 'lists flights as their own line in both parts' do
+      expect(mail.html_part.body.to_s).to include('Flights')
+      expect(mail.text_part.body.to_s).to include('Flights')
+      expect(mail.text_part.body.to_s).to include('633')
+    end
+
+    context 'when the month has no flights' do
+      let(:digest) do
+        create(:users_digest, :monthly, user: user, year: 2026, month: 4,
+                                        distance: 120_000, flight_distance: 0)
+      end
+
+      it 'omits the line' do
+        expect(mail.text_part.body.to_s).not_to include('Flights')
+      end
+    end
+  end
+end

--- a/spec/services/air_trail/import_flights_spec.rb
+++ b/spec/services/air_trail/import_flights_spec.rb
@@ -99,4 +99,34 @@ RSpec.describe AirTrail::ImportFlights do
     expect(user.reload.settings['other_key']).to eq('x')
     expect(user.settings['airtrail_last_synced_at']).to be_present
   end
+  describe 'stats recalculation' do
+    it 'enqueues a stats recalculation for the month a synced flight falls in' do
+      allow_any_instance_of(AirTrail::Client).to receive(:flights).and_return([airtrail_flight(id: 1)])
+
+      expect { described_class.new(user).call }
+        .to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2026, 4)
+    end
+
+    it 'enqueues a recalculation for the month of a flight that the sync removed' do
+      create(:flight, user: user, external_id: 99, flight_date: Date.new(2025, 11, 3))
+      allow_any_instance_of(AirTrail::Client).to receive(:flights).and_return([airtrail_flight(id: 1)])
+
+      expect { described_class.new(user).call }
+        .to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2025, 11)
+    end
+
+    it 'enqueues each affected month once' do
+      allow_any_instance_of(AirTrail::Client).to receive(:flights)
+        .and_return([airtrail_flight(id: 1), airtrail_flight(id: 2)])
+
+      expect { described_class.new(user).call }
+        .to have_enqueued_job(Stats::CalculatingJob).with(user.id, 2026, 4).exactly(:once)
+    end
+
+    it 'does not enqueue anything when the integration is not configured' do
+      user.update!(settings: user.settings.merge('airtrail_url' => '', 'airtrail_api_key' => ''))
+
+      expect { described_class.new(user).call }.not_to have_enqueued_job(Stats::CalculatingJob)
+    end
+  end
 end

--- a/spec/services/stats/calculate_month_spec.rb
+++ b/spec/services/stats/calculate_month_spec.rb
@@ -247,5 +247,56 @@ RSpec.describe Stats::CalculateMonth do
         end
       end
     end
+
+    context 'with AirTrail flights in the month' do
+      let!(:point1) { create(:point, user: user, timestamp: DateTime.new(year, month, 5, 12).to_i) }
+      let!(:point2) do
+        create(:point, user: user, lonlat: 'POINT(13.5 52.5)', timestamp: DateTime.new(year, month, 5, 13).to_i)
+      end
+      let!(:flight) do
+        create(:flight, user: user, flight_date: Date.new(year, month, 5),
+                        departure_time: DateTime.new(year, month, 5, 15),
+                        arrival_time: DateTime.new(year, month, 5, 17), distance_km: 633.4)
+      end
+
+      it 'records the flight distance separately' do
+        calculate_stats
+
+        expect(Stat.last.flight_distance).to eq(633_400)
+      end
+
+      it 'leaves the tracked distance untouched' do
+        calculate_stats
+        distance_with_flight = Stat.last.distance
+
+        Flight.delete_all
+        described_class.new(user.id, year, month).call
+
+        expect(Stat.last.distance).to eq(distance_with_flight)
+        expect(distance_with_flight).to be < 633_400
+      end
+
+      it 'ignores flights belonging to another user' do
+        create(:flight, user: create(:user), flight_date: Date.new(year, month, 6), distance_km: 900.0)
+
+        calculate_stats
+
+        expect(Stat.last.flight_distance).to eq(633_400)
+      end
+    end
+
+    context 'when there are no points but the month has flights and an existing stat' do
+      let!(:stat) { create(:stat, user: user, year: year, month: month, distance: 5000, flight_distance: 1) }
+      let!(:flight) do
+        create(:flight, user: user, flight_date: Date.new(year, month, 5), distance_km: 633.4)
+      end
+
+      it 'keeps the flight distance current instead of zeroing it' do
+        calculate_stats
+
+        expect(stat.reload.flight_distance).to eq(633_400)
+        expect(stat.distance).to eq(0)
+      end
+    end
   end
 end

--- a/spec/services/users/digests/calculate_month_spec.rb
+++ b/spec/services/users/digests/calculate_month_spec.rb
@@ -114,5 +114,16 @@ RSpec.describe Users::Digests::CalculateMonth do
         expect(nz['minutes']).to eq(1_440)
       end
     end
+
+    context 'when the stat carries flight distance' do
+      let!(:stat) { create(:stat, user: user, year: year, month: month, distance: 12_345, flight_distance: 633_400) }
+
+      it 'copies it onto the digest without folding it into the tracked distance' do
+        digest = calculate_digest
+
+        expect(digest.flight_distance).to eq(633_400)
+        expect(digest.distance).to eq(12_345)
+      end
+    end
   end
 end


### PR DESCRIPTION
Another way to do what #3396 set out to do: get AirTrail flights into the stats page and the monthly digest.

## The problem with filling the gap

A flight counts as zero today. You stop tracking when you board and start again when you land, and that gap is thrown away on purpose, so the flight is missing from your total.

#3396 fills the gap with the flight's distance. That sounds right, but the gap it fills is not really "a flight". The code throws away *any* gap longer than `minutes_between_routes`, which is 30 minutes by default. That is also sleep, a flat battery, or an afternoon indoors. So a flight gets added to whatever ordinary gap it happens to touch. Four things follow from that:

- A flight that overlaps a gap by one second still adds its whole distance.
- If the phone gets signal mid-flight, the flight touches two gaps and is counted twice.
- Days are cut at midnight, so no gap crosses midnight. A night flight — the one you most want counted — gets nothing.
- The flight lookup runs once per point, for everyone, including people with no flights at all.

These are not small slips. They come from hanging a second source of distance off a rule that is about tracking gaps in general.

## What this does instead

It counts flights on their own. `Stats::DailyDistanceQuery` is not touched.

- **`Stats::FlightDistanceQuery`** adds up `distance_km` for the month. It dates each flight by AirTrail's own `flight_date`. If that is missing it uses `departure_time`, read through your timezone with an explicit `AT TIME ZONE 'UTC' AT TIME ZONE :timezone` instead of trusting whatever timezone the database session is set to.
- **`flight_distance`** column on `stats` and `digests`. `Stats::CalculateMonth` saves it next to `distance`, never into it. If a month has flights but no points, the number is kept rather than wiped.
- **Syncing AirTrail** now asks for stats to be recalculated for every month it changed, both before and after the sync. Nothing else would notice a change that only touches flights.
- **The stats page, the public month page and both parts of the digest** show it as its own number, only when it is not zero, labelled "From AirTrail, not counted in distance". Translated into all six languages.

Because flights are picked directly instead of matched against gaps, each one is counted exactly once. Overlap stops being a question. Night flights work. People without AirTrail pay nothing.

There is no on/off setting. The tracked number does not change, so there is nothing to switch off. Showing the flight number separately, with a label, is what tells people where it came from.

## Checks

- `1888 examples, 0 failures` across `spec/queries`, `spec/services/{stats,air_trail,users}`, `spec/models/stat_spec.rb`, `spec/helpers`, `spec/mailers`, `spec/requests/stats_spec.rb`, `spec/serializers`, `spec/regressions`
- RuboCop clean on every file touched
- `spec/regressions/flight_distance_shown_separately_spec.rb` loads the real page and the real email, with flights and without. It also deletes the flight, runs again, and checks the tracked distance came out the same.
- Tried outside the tests too: a 633.4 km flight on 12 April, plus one with no date leaving at 23:00 UTC on 31 March, gives 733,400 m for April and 0 for March. The Berlin reading correctly moves the second one into April.

The tile row on the public month page also picked up `stats-vertical lg:stats-horizontal`, because this adds a fourth tile to a row that stayed side-by-side at 390px.

## Not in this PR

There is no per-day split, only a monthly total, so the daily distance chart is unchanged.

`StatsSerializer` is untouched, so `totalDistanceKm` on `/api/v1/stats` still reports tracked distance only. Whether to put flights there is a separate call, not something to slip in with this.
