### PR TITLE
fix: guard orphan track deletion with a points foreign key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Trip note text now uses consistent left alignment on every line (#3104).
 - Existing saved places now appear in Map v2 visit searches and can be assigned to visits (#3083)
+- Orphaned track cleanup no longer removes a track that still owns points, and a database foreign key now backs that guarantee.
 
 ## [1.14.0] - 2026-08-27, Berlin
 

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -71,12 +71,21 @@ class Track < ApplicationRecord
     ids = Array(ids).uniq
     return 0 if ids.empty?
 
-    rows = where(id: ids).pluck(:id, :user_id, :start_at, :end_at)
+    rows = []
+    transaction do
+      rows = where(id: ids).where.missing(:points)
+                           .lock('FOR UPDATE OF tracks')
+                           .pluck(:id, :user_id, :start_at, :end_at)
+      next if rows.empty?
+
+      orphan_ids = rows.map(&:first)
+      TrackSegment.where(track_id: orphan_ids).delete_all
+      where(id: orphan_ids).delete_all
+    end
     return 0 if rows.empty?
 
     owners = rows.map { |id, user_id, _, _| [id, user_id] }
-    TrackSegment.where(track_id: ids).delete_all
-    deleted = where(id: ids).delete_all
+    deleted = rows.size
     # delete_all skips after_commit, so the epoch bump (like the broadcast
     # below) must be replayed explicitly or deleted tracks 304 forever.
     rows.group_by { |_, user_id, _, _| user_id }.each do |user_id, user_rows|
@@ -86,6 +95,9 @@ class Track < ApplicationRecord
     end
     broadcast_destroyed(owners)
     deleted
+  rescue ActiveRecord::InvalidForeignKey
+    Rails.logger.info("event=tracks.orphan_delete_aborted count=#{ids.size}")
+    0
   end
 
   def self.broadcast_destroyed(track_owner_pairs)

--- a/app/services/tracks/deduplicator.rb
+++ b/app/services/tracks/deduplicator.rb
@@ -20,6 +20,7 @@ class Tracks::Deduplicator
 
     deleted = ActiveRecord::Base.transaction do
       delete_orphaned_segments
+      detach_duplicate_points
       delete_duplicate_tracks
     end
 
@@ -56,6 +57,19 @@ class Tracks::Deduplicator
     ActiveRecord::Base.connection.execute(
       ActiveRecord::Base.sanitize_sql([<<~SQL.squish, { user_id: user.id }])
         DELETE FROM track_segments
+        WHERE track_id IN (
+          SELECT id FROM tracks
+          WHERE user_id = :user_id
+            AND id NOT IN (#{keeper_ids_subquery})
+        )
+      SQL
+    )
+  end
+
+  def detach_duplicate_points
+    ActiveRecord::Base.connection.execute(
+      ActiveRecord::Base.sanitize_sql([<<~SQL.squish, { user_id: user.id }])
+        UPDATE points SET track_id = NULL
         WHERE track_id IN (
           SELECT id FROM tracks
           WHERE user_id = :user_id

--- a/db/migrate/20260827200000_add_points_track_foreign_key.rb
+++ b/db/migrate/20260827200000_add_points_track_foreign_key.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AddPointsTrackForeignKey < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  LOCK_TIMEOUT = '5s'
+  MAX_ATTEMPTS = 5
+
+  def up
+    return if foreign_key_exists?(:points, :tracks, column: :track_id)
+
+    attempts = 0
+    begin
+      attempts += 1
+      transaction do
+        connection.execute("SET LOCAL lock_timeout = '#{LOCK_TIMEOUT}'")
+        add_foreign_key :points, :tracks, column: :track_id, validate: false
+      end
+    rescue ActiveRecord::LockWaitTimeout
+      raise if attempts >= MAX_ATTEMPTS
+
+      sleep(attempts * 5)
+      retry
+    end
+  end
+
+  def down
+    remove_foreign_key :points, :tracks, column: :track_id, if_exists: true
+  end
+end

--- a/db/migrate/20260827200100_validate_points_track_foreign_key.rb
+++ b/db/migrate/20260827200100_validate_points_track_foreign_key.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class ValidatePointsTrackForeignKey < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  BATCH_SIZE = 10_000
+
+  def up
+    return unless foreign_key_exists?(:points, :tracks, column: :track_id)
+
+    detach_dangling_points
+    validate_foreign_key :points, :tracks, column: :track_id
+  end
+
+  def down; end
+
+  private
+
+  def detach_dangling_points
+    loop do
+      detached = connection.update(<<~SQL.squish)
+        UPDATE points SET track_id = NULL
+        WHERE id IN (
+          SELECT p.id FROM points p
+          LEFT JOIN tracks t ON t.id = p.track_id
+          WHERE p.track_id IS NOT NULL AND t.id IS NULL
+          LIMIT #{BATCH_SIZE}
+        )
+      SQL
+
+      break if detached.zero?
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_25_120100) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_27_200100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -684,6 +684,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_25_120100) do
   add_foreign_key "place_visits", "places"
   add_foreign_key "place_visits", "visits"
   add_foreign_key "points", "points_raw_data_archives", column: "raw_data_archive_id", on_delete: :restrict
+  add_foreign_key "points", "tracks"
   add_foreign_key "points", "users"
   add_foreign_key "points", "visits"
   add_foreign_key "points_raw_data_archives", "users"

--- a/lib/tasks/e2e.rake
+++ b/lib/tasks/e2e.rake
@@ -377,8 +377,8 @@ namespace :e2e do
     PlaceVisit.where(visit_id: user.visits.select(:id)).delete_all
     PlaceVisit.where(place_id: user.places.select(:id)).delete_all
     TrackSegment.where(track_id: Track.where(user_id: user.id).select(:id)).delete_all
-    Track.where(user_id: user.id).delete_all
     user.points.delete_all
+    Track.where(user_id: user.id).delete_all
     user.visits.delete_all
     user.places.destroy_all
     user.areas.delete_all if user.respond_to?(:areas)

--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -35,9 +35,49 @@ RSpec.describe Track, type: :model do
       expect(Track.delete_orphaned(orphans.map(&:id))).to eq(2)
     end
 
+    it 'spares tracks that still have points' do
+      track = create(:track, user: user)
+      segment = create(:track_segment, track: track)
+      create(:point, user: user, track: track)
+
+      expect(Track.delete_orphaned([track.id])).to eq(0)
+      expect(Track.exists?(track.id)).to be true
+      expect(TrackSegment.exists?(segment.id)).to be true
+    end
+
+    it 'deletes only the point-less tracks in a mixed batch' do
+      orphan = create(:track, user: user)
+      kept = create(:track, user: user)
+      create(:point, user: user, track: kept)
+
+      expect(Track.delete_orphaned([orphan.id, kept.id])).to eq(1)
+      expect(Track.exists?(orphan.id)).to be false
+      expect(Track.exists?(kept.id)).to be true
+    end
+
     it 'does not broadcast for empty input' do
       expect { Track.delete_orphaned([]) }
         .not_to have_broadcasted_to(user).from_channel(TracksChannel)
+    end
+  end
+
+  describe 'points foreign key' do
+    let(:user) { create(:user) }
+
+    it 'refuses to delete a track that still has points' do
+      track = create(:track, user: user)
+      create(:point, user: user, track: track)
+
+      expect { Track.where(id: track.id).delete_all }
+        .to raise_error(ActiveRecord::InvalidForeignKey)
+    end
+
+    it 'allows destroy, which nullifies the points first' do
+      track = create(:track, user: user)
+      point = create(:point, user: user, track: track)
+
+      expect { track.destroy }.not_to raise_error
+      expect(point.reload.track_id).to be_nil
     end
   end
 

--- a/spec/services/tracks/deduplicator_spec.rb
+++ b/spec/services/tracks/deduplicator_spec.rb
@@ -79,6 +79,24 @@ RSpec.describe Tracks::Deduplicator do
       end
     end
 
+    context 'when duplicate tracks still own points' do
+      let(:start_time) { 2.hours.ago }
+      let(:end_time) { 1.hour.ago }
+
+      let!(:older) { create(:track, user: user, start_at: start_time, end_at: end_time, tracker_id: 'a') }
+      let!(:newer) { create(:track, user: user, start_at: start_time, end_at: end_time, tracker_id: 'b') }
+
+      it 'detaches their points instead of aborting on the foreign key' do
+        point = create(:point, user: user, track: older)
+
+        expect { described_class.new(user).call }.not_to raise_error
+
+        expect(Track.exists?(older.id)).to be false
+        expect(Track.exists?(newer.id)).to be true
+        expect(point.reload.track_id).to be_nil
+      end
+    end
+
     context 'when another user has tracks with the same timestamps' do
       let(:other_user) { create(:user) }
       let(:start_time) { 2.hours.ago }


### PR DESCRIPTION
Rebased, corrected replacement for #3229, which forked 550 commits ago and no longer applies.

### What changed vs #3229

**Dropped — already fixed on `dev`.** #3229 added an `unless track.points.exists?` guard to `Tracks::RecalculateJob`. `dev` already destroys tracks with `points.count < 2` (shipped in 1.14.0), which also covers the 1-point husk that `exists?` misses. Merging the old guard would have regressed that case, so the job is untouched here.

**Kept and corrected — the orphan-deletion guard.** `Track.delete_orphaned` deleted every id handed to it. It now re-checks `where.missing(:points)` under `FOR UPDATE` inside the transaction and deletes only genuinely point-less tracks. #3229's rewrite of this method silently dropped the `Tracks::TileEpoch.bump_range` invalidation that landed after it forked; that is preserved here, so deleted tracks stop 304-ing on Map v2.

**Corrected — the exception class.** #3229 used `on_delete: :restrict` and rescued `ActiveRecord::InvalidForeignKey`. RESTRICT raises `PG::RestrictViolation` (SQLSTATE 23001), which Rails maps to `StatementInvalid` — the rescue would never have fired. This uses the default `NO ACTION`, which raises 23503 and maps to `InvalidForeignKey`. A regression spec pins the behaviour.

### The foreign key

`points.track_id → tracks.id`, added `NOT VALID` behind a 5s `lock_timeout` with bounded retry so the DDL cannot stall ingest on the points table, then validated in a separate migration after dangling references are detached in batches.

The FK is load-bearing, not decoration: `FOR UPDATE` only serializes against a concurrent point insert because that insert takes `FOR KEY SHARE` on the parent row. Without the constraint the lock protects nothing.

### Collateral fixes

Two paths deleted tracks with points still attached, which the constraint rejects:

- `Tracks::Deduplicator#delete_duplicate_tracks` — raw `DELETE FROM tracks`, never detached points. Now nullifies them first.
- `lib/tasks/e2e.rake` `reset_user_data!` — deleted tracks before points. Order swapped.

`Users::Destroy` and `Tracks::Merger` were checked and are already safe: both detach points before deleting tracks.

### Verification

`spec/jobs` + `spec/models` — 1676 examples, 0 failures. Plus `spec/services/tracks`, `spec/services/imports/destroy_spec.rb`, `spec/services/users/destroy_spec.rb` — 340 examples, 0 failures. RuboCop clean on all changed files.

Closes #3229.
