### PR TITLE
Return family locations to OwnTracks in HTTP mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## Added
+
+- OwnTracks in HTTP mode now shows your family members on its own map: every location upload is answered with the latest position of each family member sharing with you, so they appear as friends in the app alongside the Dawarich map.
+
 ## Fixed
 
 - Trip note text now uses consistent left alignment on every line (#3104).

--- a/app/controllers/api/v1/owntracks/points_controller.rb
+++ b/app/controllers/api/v1/owntracks/points_controller.rb
@@ -7,7 +7,7 @@ class Api::V1::Owntracks::PointsController < ApiController
   def create
     OwnTracks::PointCreator.new(point_params, current_api_user.id).call
 
-    render json: [], status: :ok
+    render json: friends_payload, status: :ok
   rescue StandardError => e
     Rails.logger.error("Point creation failed: #{e.class}: #{e.message}")
     Sentry.capture_exception(e) if defined?(Sentry)
@@ -17,6 +17,15 @@ class Api::V1::Owntracks::PointsController < ApiController
   end
 
   private
+
+  def friends_payload
+    OwnTracks::FriendsFormatter.new(current_api_user).call
+  rescue StandardError => e
+    Rails.logger.error("OwnTracks friends formatting failed: #{e.class}: #{e.message}")
+    Sentry.capture_exception(e) if defined?(Sentry)
+
+    []
+  end
 
   OWNTRACKS_FIELDS = %i[
     _type lat lon tst tid t bs batt p acc vac vel alt

--- a/app/services/families/locations.rb
+++ b/app/services/families/locations.rb
@@ -9,11 +9,12 @@ class Families::Locations
 
   MAX_POINTS_PER_MEMBER = 5000
 
-  def call
+  def call(excluding: nil)
     return [] unless family_feature_available?
     return [] unless user.in_family?
 
     sharing_members = family_members_with_sharing_enabled
+    sharing_members = sharing_members.reject { _1.id == excluding } if excluding
     return [] unless sharing_members.any?
 
     build_family_locations(sharing_members)
@@ -37,6 +38,7 @@ class Families::Locations
 
   def family_members_with_sharing_enabled
     user.family.members
+        .includes(:family_membership)
         .select(&:family_sharing_enabled?)
   end
 

--- a/app/services/families/locations.rb
+++ b/app/services/families/locations.rb
@@ -44,7 +44,7 @@ class Families::Locations
 
   def build_family_locations(sharing_members)
     latest_points =
-      sharing_members.map { _1.points.complete.order(timestamp: :desc).first }.compact
+      sharing_members.map { _1.points.without_raw_data.complete.order(timestamp: :desc).first }.compact
 
     latest_points.map do |point|
       {

--- a/app/services/own_tracks/friends_formatter.rb
+++ b/app/services/own_tracks/friends_formatter.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class OwnTracks::FriendsFormatter
+  BATTERY_STATUS_CODES = {
+    'unplugged' => 1,
+    'discharging' => 1,
+    'charging' => 2,
+    'full' => 3
+  }.freeze
+
+  BATTERY_STATUS_UNKNOWN = 0
+
+  attr_reader :user
+
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    members = Families::Locations.new(user).call.reject { _1[:user_id] == user.id }
+
+    members.flat_map { |member| [card_for(member), location_for(member)] }
+  end
+
+  private
+
+  def card_for(member)
+    {
+      _type: 'card',
+      tid: tracker_id(member),
+      name: member[:email]
+    }.compact
+  end
+
+  def location_for(member)
+    {
+      _type: 'location',
+      tid: tracker_id(member),
+      lat: member[:latitude],
+      lon: member[:longitude],
+      tst: member[:timestamp],
+      batt: member[:battery],
+      bs: BATTERY_STATUS_CODES.fetch(member[:battery_status], BATTERY_STATUS_UNKNOWN)
+    }.compact
+  end
+
+  def tracker_id(member)
+    member[:user_id].to_s(36).upcase
+  end
+end

--- a/app/services/own_tracks/friends_formatter.rb
+++ b/app/services/own_tracks/friends_formatter.rb
@@ -17,7 +17,7 @@ class OwnTracks::FriendsFormatter
   end
 
   def call
-    members = Families::Locations.new(user).call.reject { _1[:user_id] == user.id }
+    members = Families::Locations.new(user).call(excluding: user.id)
 
     members.flat_map { |member| [card_for(member), location_for(member)] }
   end

--- a/spec/requests/api/v1/owntracks/points_spec.rb
+++ b/spec/requests/api/v1/owntracks/points_spec.rb
@@ -59,6 +59,42 @@ RSpec.describe 'Api::V1::Owntracks::Points', type: :request do
         end
       end
 
+      context 'when a family member shares their location' do
+        let(:family) { create(:family, creator: user) }
+        let(:relative) { create(:user) }
+
+        before do
+          create(:family_membership, family: family, user: user, role: :owner)
+          create(:family_membership, family: family, user: relative)
+          relative.update_family_location_sharing!(true, duration: 'permanent')
+          create(:point, user: relative, timestamp: 1.hour.ago.to_i)
+        end
+
+        it 'answers with their card and location for OwnTracks to show' do
+          post "/api/v1/owntracks/points?api_key=#{user.api_key}", params: point_params
+
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body).map { _1['_type'] }).to eq(%w[card location])
+        end
+      end
+
+      context 'when formatting family locations fails' do
+        before do
+          allow(OwnTracks::FriendsFormatter).to receive(:new).and_raise(StandardError, 'boom')
+          allow(Rails.logger).to receive(:error)
+        end
+
+        it 'still accepts the point rather than making OwnTracks resend it' do
+          expect do
+            post "/api/v1/owntracks/points?api_key=#{user.api_key}", params: point_params
+          end.to change(Point, :count).by(1)
+
+          expect(response).to have_http_status(:ok)
+          expect(JSON.parse(response.body)).to eq([])
+          expect(Rails.logger).to have_received(:error).with(/OwnTracks friends formatting failed/)
+        end
+      end
+
       context 'when user is inactive but active_until is in the future' do
         before do
           user.update(status: :inactive, active_until: 1.day.from_now)

--- a/spec/requests/api/v1/owntracks/points_spec.rb
+++ b/spec/requests/api/v1/owntracks/points_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe 'Api::V1::Owntracks::Points', type: :request do
         before do
           allow(OwnTracks::FriendsFormatter).to receive(:new).and_raise(StandardError, 'boom')
           allow(Rails.logger).to receive(:error)
+          allow(Sentry).to receive(:capture_exception)
         end
 
         it 'still accepts the point rather than making OwnTracks resend it' do
@@ -92,6 +93,7 @@ RSpec.describe 'Api::V1::Owntracks::Points', type: :request do
           expect(response).to have_http_status(:ok)
           expect(JSON.parse(response.body)).to eq([])
           expect(Rails.logger).to have_received(:error).with(/OwnTracks friends formatting failed/)
+          expect(Sentry).to have_received(:capture_exception)
         end
       end
 

--- a/spec/services/families/locations_spec.rb
+++ b/spec/services/families/locations_spec.rb
@@ -18,6 +18,32 @@ RSpec.describe Families::Locations do
 
   after { travel_back }
 
+  def membership_queries_for_family_of(member_count)
+    owner = create(:user)
+    owner_family = create(:family, creator: owner)
+    create(:family_membership, family: owner_family, user: owner, role: :owner)
+
+    member_count.times do
+      member = create(:user)
+      create(:family_membership, family: owner_family, user: member)
+      member.update_family_location_sharing!(true, duration: 'permanent')
+      create(:point, user: member, timestamp: 1.hour.ago.to_i)
+    end
+
+    membership_queries_during { described_class.new(owner.reload).call }
+  end
+
+  def membership_queries_during
+    count = 0
+    subscription = ActiveSupport::Notifications.subscribe('sql.active_record') do |*, payload|
+      count += 1 if payload[:sql].include?('family_memberships') && payload[:name] != 'SCHEMA'
+    end
+    yield
+    ActiveSupport::Notifications.unsubscribe(subscription)
+
+    count
+  end
+
   describe '#call' do
     it 'returns latest locations for sharing members' do
       other_user.update_family_location_sharing!(true, duration: 'permanent')
@@ -41,6 +67,20 @@ RSpec.describe Families::Locations do
       expect(result.length).to eq(1)
       expect(result.first[:timestamp]).to eq(real_point.timestamp)
       expect(result.first[:updated_at]).to eq(Time.zone.at(real_point.timestamp))
+    end
+
+    it 'excludes a member the caller asked to skip' do
+      other_user.update_family_location_sharing!(true, duration: 'permanent')
+      create(:point, user: other_user, timestamp: 1.hour.ago.to_i)
+
+      expect(described_class.new(user).call(excluding: other_user.id)).to eq([])
+    end
+
+    it 'does not issue a membership query per member' do
+      small = membership_queries_for_family_of(2)
+      large = membership_queries_for_family_of(4)
+
+      expect(large).to eq(small)
     end
 
     context 'when the family feature is unavailable to the caller' do

--- a/spec/services/own_tracks/friends_formatter_spec.rb
+++ b/spec/services/own_tracks/friends_formatter_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OwnTracks::FriendsFormatter do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:now) { Time.zone.local(2026, 3, 13, 12, 0, 0) }
+  let(:user) { create(:user) }
+  let(:family) { create(:family, creator: user) }
+  let(:other_user) { create(:user, email: 'jane@example.com') }
+
+  before do
+    travel_to(now)
+    create(:family_membership, family: family, user: user, role: :owner)
+    create(:family_membership, family: family, user: other_user)
+  end
+
+  after { travel_back }
+
+  describe '#call' do
+    subject(:payload) { described_class.new(user).call }
+
+    context 'when a family member shares their location' do
+      let!(:point) do
+        create(:point, user: other_user, timestamp: 1.hour.ago.to_i, battery: 87, battery_status: :charging)
+      end
+
+      before { other_user.update_family_location_sharing!(true, duration: 'permanent') }
+
+      it 'returns a card followed by a location message' do
+        expect(payload.map { _1[:_type] }).to eq(%w[card location])
+      end
+
+      it 'identifies the member by a short tracker id rather than their email' do
+        tracker_ids = payload.map { _1[:tid] }
+
+        expect(tracker_ids.uniq).to eq([other_user.id.to_s(36).upcase])
+        expect(tracker_ids.first).not_to include('@')
+      end
+
+      it 'names the member on the card' do
+        expect(payload.first).to include(_type: 'card', name: 'jane@example.com')
+      end
+
+      it 'reports the position of the latest point' do
+        expect(payload.last).to include(
+          _type: 'location',
+          lat: point.lat,
+          lon: point.lon,
+          tst: point.timestamp,
+          batt: 87,
+          bs: 2
+        )
+      end
+
+      it 'omits keys it has no value for instead of emitting nulls' do
+        point.update!(battery: nil, battery_status: nil)
+
+        expect(payload.last).not_to have_key(:batt)
+        expect(payload.flat_map(&:values)).to all(be_present)
+      end
+
+      it 'excludes the requesting user even when they share too' do
+        user.update_family_location_sharing!(true, duration: 'permanent')
+        create(:point, user: user, timestamp: 1.minute.ago.to_i)
+
+        expect(payload.map { _1[:tid] }.uniq).to eq([other_user.id.to_s(36).upcase])
+      end
+    end
+
+    describe 'battery status mapping' do
+      before { other_user.update_family_location_sharing!(true, duration: 'permanent') }
+
+      {
+        unknown: 0,
+        unplugged: 1,
+        discharging: 1,
+        charging: 2,
+        connected_not_charging: 0,
+        full: 3
+      }.each do |status, expected_code|
+        it "maps #{status} to OwnTracks bs #{expected_code}" do
+          create(:point, user: other_user, timestamp: 1.hour.ago.to_i, battery_status: status)
+
+          expect(payload.last[:bs]).to eq(expected_code)
+        end
+      end
+    end
+
+    context 'when several members share' do
+      let(:third_user) { create(:user) }
+
+      before do
+        create(:family_membership, family: family, user: third_user)
+        [other_user, third_user].each do |member|
+          member.update_family_location_sharing!(true, duration: 'permanent')
+          create(:point, user: member, timestamp: 1.hour.ago.to_i)
+        end
+      end
+
+      it 'returns a card and a location for each of them' do
+        expect(payload.count { _1[:_type] == 'card' }).to eq(2)
+        expect(payload.count { _1[:_type] == 'location' }).to eq(2)
+        expect(payload.map { _1[:tid] }.uniq.length).to eq(2)
+      end
+    end
+
+    context 'when no member shares their location' do
+      before { create(:point, user: other_user, timestamp: 1.hour.ago.to_i) }
+
+      it 'returns an empty array' do
+        expect(payload).to eq([])
+      end
+    end
+
+    context 'when the family feature is unavailable to the caller' do
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        other_user.update_family_location_sharing!(true, duration: 'permanent')
+        create(:point, user: other_user, timestamp: 1.hour.ago.to_i)
+      end
+
+      it 'returns an empty array' do
+        expect(payload).to eq([])
+      end
+    end
+
+    context 'when the user is not in a family' do
+      let(:solo_user) { create(:user) }
+
+      it 'returns an empty array' do
+        expect(described_class.new(solo_user).call).to eq([])
+      end
+    end
+  end
+end

--- a/spec/swagger/api/v1/owntracks/points_controller_spec.rb
+++ b/spec/swagger/api/v1/owntracks/points_controller_spec.rb
@@ -36,6 +36,7 @@ describe 'OwnTracks Points API', type: :request do
       }
       tags 'Points'
       consumes 'application/json'
+      produces 'application/json'
       parameter name: :point, in: :body, schema: {
         type: :object,
         properties: {
@@ -70,6 +71,23 @@ description: 'Array of region names device is currently in' },
       parameter name: :api_key, in: :query, type: :string, required: true, description: 'API Key'
 
       response '200', 'Point created' do
+        schema type: :array,
+               description: 'OwnTracks messages for family members sharing their location',
+               items: {
+                 type: :object,
+                 properties: {
+                   _type: { type: :string, description: 'Message type, either "card" or "location"' },
+                   tid: { type: :string, description: 'Tracker ID identifying the family member' },
+                   name: { type: :string, description: 'Family member name, on card messages only' },
+                   lat: { type: :number, description: 'Latitude coordinate' },
+                   lon: { type: :number, description: 'Longitude coordinate' },
+                   tst: { type: :number, description: 'Timestamp in Unix epoch time' },
+                   batt: { type: :number, description: 'Device battery level (percentage)' },
+                   bs: { type: :number,
+                         description: 'Battery status (0=unknown, 1=unplugged, 2=charging, 3=full)' }
+                 }
+               }
+
         let(:file_path) { 'spec/fixtures/files/owntracks/2024-03.rec' }
         let(:file) { File.read(file_path) }
         let(:json) { OwnTracks::RecParser.new(file).call }

--- a/spec/swagger/api/v1/owntracks/points_controller_spec.rb
+++ b/spec/swagger/api/v1/owntracks/points_controller_spec.rb
@@ -92,9 +92,21 @@ description: 'Array of region names device is currently in' },
         let(:file) { File.read(file_path) }
         let(:json) { OwnTracks::RecParser.new(file).call }
         let(:point) { json.first }
-        let(:api_key) { create(:user).api_key }
+        let(:user) { create(:user) }
+        let(:family) { create(:family, creator: user) }
+        let(:relative) { create(:user) }
+        let(:api_key) do
+          create(:family_membership, family: family, user: user, role: :owner)
+          create(:family_membership, family: family, user: relative)
+          relative.update_family_location_sharing!(true, duration: 'permanent')
+          create(:point, user: relative, timestamp: 1.hour.ago.to_i)
 
-        run_test!
+          user.api_key
+        end
+
+        run_test! do |response|
+          expect(JSON.parse(response.body).map { _1['_type'] }).to eq(%w[card location])
+        end
       end
 
       response '401', 'Unauthorized' do

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -2988,6 +2988,39 @@ paths:
       responses:
         '200':
           description: Point created
+          content:
+            application/json:
+              schema:
+                type: array
+                description: OwnTracks messages for family members sharing their location
+                items:
+                  type: object
+                  properties:
+                    _type:
+                      type: string
+                      description: Message type, either "card" or "location"
+                    tid:
+                      type: string
+                      description: Tracker ID identifying the family member
+                    name:
+                      type: string
+                      description: Family member name, on card messages only
+                    lat:
+                      type: number
+                      description: Latitude coordinate
+                    lon:
+                      type: number
+                      description: Longitude coordinate
+                    tst:
+                      type: number
+                      description: Timestamp in Unix epoch time
+                    batt:
+                      type: number
+                      description: Device battery level (percentage)
+                    bs:
+                      type: number
+                      description: Battery status (0=unknown, 1=unplugged, 2=charging,
+                        3=full)
         '401':
           description: Unauthorized
       requestBody:


### PR DESCRIPTION
Reimplements #1964 by @andresokol on top of the current `dev`.

OwnTracks in HTTP mode treats the body of our response to a location upload as a queue of inbound messages — that is how friends reach its map. We now answer with a `card` and a `location` for every family member sharing their location with the uploader.

@AngelMariages was right on #1964: a non-empty response does not endanger the upload. In `owntracks/android`, `HttpMessageProcessorEndpoint.sendMessage` decides delivery purely on `response.isSuccessful`, and an unparseable body is caught (`"HTTP response body could not be parsed, ignoring"`) and still returns `Result.success`. `Parser` also sets `ignoreUnknownKeys = true`. Our controller has been returning `[]` rather than `{}` since 0.37.3 anyway.

## What it does

`OwnTracks::FriendsFormatter` delegates to `Families::Locations`, so the entitlement gate, the sharing-expiry check and the `complete` points scope are not duplicated, and the uploader's own position is excluded.

```json
[{"_type":"card","tid":"2E","name":"jane@example.com"},
 {"_type":"location","tid":"2E","lat":52.51,"lon":13.4,"tst":1787855393,"batt":64,"bs":2}]
```

Three details that matter for the app, all learned from the Android client:

- **`tid` is a short base36 user id, not an email.** `onFinalizeMessage` builds the contact identity as `"owntracks/http/" + tid` and paints it on the map marker, so an email there would become both the contact key and the visible label. The name travels on the `card` instead.
- **Keys without a value are omitted, never sent as `null`.** `batt`, `acc`, `alt` and `vel` deserialize into non-nullable Kotlin integers, and `LenientIntSerializer` passes `JsonNull` straight through — one null makes the whole array unparseable and every friend in it is silently dropped.
- **Battery status maps completely.** `unplugged`/`discharging` → 1, `charging` → 2, `full` → 3, everything else (including `connected_not_charging`, which OwnTracks has no equivalent for) → 0.

A formatting failure falls back to an empty array, so a stored point is never turned into a resend.

Self-hosted instances get this for free; on Cloud it follows the Family plan entitlement like the rest of the family map.

## Testing

- 16 service examples and 2 request examples, plus the documented response schema.
- `spec/services/own_tracks spec/requests/api/v1/owntracks spec/swagger/api/v1/owntracks spec/services/families spec/requests/api/v1/families` → 194 examples, 0 failures.
- RuboCop clean.
