### PR TITLE
Retry track generation after cache pool timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Four scheduled jobs (app version check, cache preheat, family location request expiry, points counter correction) were queued onto `default` instead of the queues their job classes declare, so they competed with higher-priority work — the cache preheat in particular could hold up imports, track generation and stats for minutes at a time. They now run on `app_version_checking`, `cache`, `families` and `low_priority` respectively.
 
+### Fixed
+
+- Track generation now retries when the cache connection pool is temporarily busy instead of dropping the job and reporting an error.
+
 ## [1.12.2] - 2026-08-15, Berlin
 
 ### Added

--- a/app/services/tracks/session_manager.rb
+++ b/app/services/tracks/session_manager.rb
@@ -27,10 +27,11 @@ class Tracks::SessionManager
     }
 
     Rails.cache.write(cache_key, session_data, expires_in: DEFAULT_TTL)
-    # Initialize counters atomically using Redis SET
-    Rails.cache.redis.with do |redis|
-      redis.set(counter_key('completed_chunks'), 0, ex: DEFAULT_TTL.to_i)
-      redis.set(counter_key('tracks_created'), 0, ex: DEFAULT_TTL.to_i)
+    with_cache_connection_retry do
+      Rails.cache.redis.with do |redis|
+        redis.set(counter_key('completed_chunks'), 0, ex: DEFAULT_TTL.to_i)
+        redis.set(counter_key('tracks_created'), 0, ex: DEFAULT_TTL.to_i)
+      end
     end
 
     self
@@ -172,6 +173,19 @@ class Tracks::SessionManager
   end
 
   private
+
+  def with_cache_connection_retry
+    attempts = 0
+
+    begin
+      yield
+    rescue ConnectionPool::TimeoutError
+      attempts += 1
+      retry if attempts < 3
+
+      raise
+    end
+  end
 
   def cache_key
     "#{CACHE_KEY_PREFIX}:user:#{user_id}:session:#{session_id}"

--- a/spec/jobs/tracks/parallel_generator_job_spec.rb
+++ b/spec/jobs/tracks/parallel_generator_job_spec.rb
@@ -83,6 +83,22 @@ RSpec.describe Tracks::ParallelGeneratorJob do
       end
     end
 
+    context 'when cache pool retries are exhausted' do
+      let(:timeout_error) { ConnectionPool::TimeoutError.new('Waited 5.0 sec, 0/5 available') }
+
+      before do
+        allow(Tracks::ParallelGenerator).to receive(:new).and_raise(timeout_error)
+      end
+
+      it 'reports the terminal timeout without retrying the full generator' do
+        expect(ExceptionReporter).to receive(:call)
+          .with(timeout_error, 'Failed to start parallel track generation')
+
+        expect { described_class.perform_now(user_id) }
+          .not_to have_enqueued_job(described_class)
+      end
+    end
+
     context 'when an error occurs' do
       let(:error_message) { 'Something went wrong' }
 

--- a/spec/services/tracks/session_manager_spec.rb
+++ b/spec/services/tracks/session_manager_spec.rb
@@ -49,6 +49,36 @@ RSpec.describe Tracks::SessionManager do
       # Check that the key exists and will expire
       expect(Rails.cache.exist?(manager.send(:cache_key))).to be true
     end
+
+    it 'retries transient cache pool timeouts while initializing counters' do
+      pool = instance_double(ConnectionPool)
+      redis = instance_double(Redis)
+      attempts = 0
+      allow(Rails.cache).to receive(:write).and_return(true)
+      allow(Rails.cache).to receive(:redis).and_return(pool)
+      allow(pool).to receive(:with) do |&block|
+        attempts += 1
+        raise ConnectionPool::TimeoutError, 'Waited 5.0 sec, 0/5 available' if attempts < 3
+
+        block.call(redis)
+      end
+      allow(redis).to receive(:set)
+
+      expect(manager.create_session(metadata)).to eq(manager)
+      expect(attempts).to eq(3)
+    end
+
+    it 'raises after cache pool retries are exhausted' do
+      pool = instance_double(ConnectionPool)
+      allow(Rails.cache).to receive(:write).and_return(true)
+      allow(Rails.cache).to receive(:redis).and_return(pool)
+      allow(pool).to receive(:with).and_raise(ConnectionPool::TimeoutError, 'Waited 5.0 sec, 0/5 available')
+
+      expect { manager.create_session(metadata) }
+        .to raise_error(ConnectionPool::TimeoutError)
+
+      expect(pool).to have_received(:with).exactly(3).times
+    end
   end
 
   describe '#get_session_data' do


### PR DESCRIPTION
## Summary
- Ports the fix onto the current `dev` branch.

## Validation
- `git diff --check`
- Patch applied cleanly to the freshly fetched `origin/dev` base.
