### PR TITLE
Stop reporting recovered time-anchor collisions

### DIFF
--- a/app/jobs/track_segments/time_anchor_backfill_job.rb
+++ b/app/jobs/track_segments/time_anchor_backfill_job.rb
@@ -62,8 +62,10 @@ module TrackSegments
         ActiveRecord::Base.transaction(requires_new: true) do
           ActiveRecord::Base.connection.execute(anchor_sql([id]))
         end
-      rescue ActiveRecord::RecordNotUnique => e
-        ExceptionReporter.call(e, "TimeAnchorBackfill: segment #{id} collides with an existing anchor")
+      rescue ActiveRecord::RecordNotUnique
+        Rails.logger.info(
+          "TimeAnchorBackfill: segment #{id} collides with an existing anchor"
+        )
       end
     end
 

--- a/spec/jobs/track_segments/time_anchor_backfill_job_spec.rb
+++ b/spec/jobs/track_segments/time_anchor_backfill_job_spec.rb
@@ -73,10 +73,13 @@ RSpec.describe TrackSegments::TimeAnchorBackfillJob do
     survivor = create(:track_segment, track: track, transportation_mode: :walking,
                       start_index: 6, end_index: 9, start_at: nil, end_at: nil)
 
+    allow(ExceptionReporter).to receive(:call)
+
     expect { described_class.perform_now }.not_to raise_error
 
     expect(TrackSegment.exists?(colliding.id)).to be false
     expect(survivor.reload.start_at).to be_present
+    expect(ExceptionReporter).not_to have_received(:call)
   end
 
   it 'preserves manually-corrected segments even when their slice cannot be anchored' do


### PR DESCRIPTION
## Summary
- Ports the fix onto the current `dev` branch.

## Validation
- `git diff --check`
- Patch applied cleanly to the freshly fetched `origin/dev` base.
