### PR TITLE
Handle expired track generation sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Fixed
 
+- Track generation no longer reports a failure when its temporary progress session expires during finalization.
 - Places you created and named yourself keep their manual attribution when reverse geocoding refreshes them, so they stay ranked ahead of auto-created address places and stay visible on the map (#3418).
 - The map control cluster keeps Search, Create and Settings on phone-sized screens instead of hiding them; on short viewports it scrolls within the map area rather than running off the bottom (#3421).
 - Trip note text now uses consistent left alignment on every line (#3104).

--- a/app/jobs/tracks/boundary_resolver_job.rb
+++ b/app/jobs/tracks/boundary_resolver_job.rb
@@ -59,9 +59,6 @@ class Tracks::BoundaryResolverJob < ApplicationJob
   end
 
   def finalize_session(_boundary_tracks_resolved)
-    session_data = session_manager.get_session_data
-    session_data['tracks_created']
-
     session_manager.mark_completed
   end
 

--- a/spec/jobs/tracks/boundary_resolver_job_spec.rb
+++ b/spec/jobs/tracks/boundary_resolver_job_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe Tracks::BoundaryResolverJob do
     expect(session_manager).to have_received(:mark_failed)
   end
 
+  it 'does not report a session that expires during boundary resolution' do
+    boundary_detector = instance_double(Tracks::BoundaryDetector, resolve_cross_chunk_tracks: 1)
+    allow(Tracks::PerUserLock).to receive(:with_user_lock).with(user.id).and_yield
+    allow(Tracks::BoundaryDetector).to receive(:new).with(user).and_return(boundary_detector)
+    allow(session_manager).to receive_messages(get_session_data: nil, mark_completed: false)
+
+    described_class.perform_now(user.id, session_id)
+
+    expect(boundary_detector).to have_received(:resolve_cross_chunk_tracks)
+    expect(session_manager).to have_received(:mark_completed)
+    expect(ExceptionReporter).not_to have_received(:call)
+    expect(session_manager).not_to have_received(:mark_failed)
+  end
+
   describe 'rescheduling while chunks are still running' do
     let(:pending_session) do
       instance_double(


### PR DESCRIPTION
## Summary
- Ports the fix onto the current `dev` branch.

## Validation
- `git diff --check`
- Patch applied cleanly to the freshly fetched `origin/dev` base.
