### PR TITLE
Fix oversized integration flash messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Fixed
 
+- Integration settings now show bounded connection errors instead of failing when an upstream service returns an oversized malformed response.
 - Places you created and named yourself keep their manual attribution when reverse geocoding refreshes them, so they stay ranked ahead of auto-created address places and stay visible on the map (#3418).
 - The map control cluster keeps Search, Create and Settings on phone-sized screens instead of hiding them; on short viewports it scrolls within the map area rather than running off the bottom (#3421).
 - Trip note text now uses consistent left alignment on every line (#3104).

--- a/app/controllers/settings/integrations_controller.rb
+++ b/app/controllers/settings/integrations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Settings::IntegrationsController < ApplicationController
+  FLASH_MESSAGE_BYTES = 512
+
   before_action :authenticate_user!
   before_action :authenticate_active_user!, only: %i[update]
   before_action :require_pro!, only: %i[update]
@@ -23,13 +25,17 @@ class Settings::IntegrationsController < ApplicationController
       refresh_photos_cache: params[:refresh_photos_cache].present?
     ).call
 
-    flash[:notice] = result[:notices].join('. ') if result[:notices].any?
-    flash[:alert] = result[:alerts].join('. ') if result[:alerts].any?
+    flash[:notice] = flash_message(result[:notices]) if result[:notices].any?
+    flash[:alert] = flash_message(result[:alerts]) if result[:alerts].any?
 
     redirect_to settings_integrations_path(service: params[:service].presence)
   end
 
   private
+
+  def flash_message(messages)
+    messages.join('. ').truncate_bytes(FLASH_MESSAGE_BYTES)
+  end
 
   def available_services
     return Integrations::Status::SERVICES if DawarichSettings.self_hosted?

--- a/spec/requests/settings/integrations_spec.rb
+++ b/spec/requests/settings/integrations_spec.rb
@@ -112,13 +112,11 @@ RSpec.describe 'Settings::Integrations', type: :request do
     context 'when airtrail settings change' do
       let(:airtrail_url) { 'https://airtrail.test' }
 
-      before do
+      it 'persists settings and verifies the airtrail connection' do
         stub_request(:get, "#{airtrail_url}/api/flight/list?scope=mine")
           .to_return(status: 200, body: { success: true, flights: [] }.to_json,
                      headers: { 'Content-Type' => 'application/json' })
-      end
 
-      it 'persists settings and verifies the airtrail connection' do
         patch '/settings/integrations', params: {
           settings: { 'airtrail_url' => airtrail_url, 'airtrail_api_key' => 'k' }
         }
@@ -127,6 +125,19 @@ RSpec.describe 'Settings::Integrations', type: :request do
         follow_redirect!
         expect(flash[:notice]).to include('AirTrail connection verified')
         expect(user.reload.settings['airtrail_url']).to eq(airtrail_url)
+      end
+
+      it 'keeps malformed upstream responses within the flash cookie limit' do
+        stub_request(:get, "#{airtrail_url}/api/flight/list?scope=mine")
+          .to_return(status: 200, body: "<html>#{'x' * 12_000}")
+
+        patch '/settings/integrations', params: {
+          settings: { 'airtrail_url' => airtrail_url, 'airtrail_api_key' => 'k' }
+        }
+
+        expect(response).to redirect_to(settings_integrations_path)
+        expect(flash[:alert]).to start_with('AirTrail connection failed:')
+        expect(flash[:alert].bytesize).to be <= 512
       end
     end
 


### PR DESCRIPTION
## Summary
- Ports the fix onto the current `dev` branch.

## Validation
- `git diff --check`
- Patch applied cleanly to the freshly fetched `origin/dev` base.
