### PR TITLE
Keep curated places on the manual source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Fixed
 
+- Places you created and named yourself keep their manual attribution when reverse geocoding refreshes them, so they stay ranked ahead of auto-created address places and stay visible on the map (#3418).
 - Trip note text now uses consistent left alignment on every line (#3104).
 - Existing saved places now appear in Map v2 visit searches and can be assigned to visits (#3083)
 - Orphaned track cleanup no longer removes a track that still owns points, and a database foreign key now backs that guarantee.

--- a/app/services/reverse_geocoding/places/fetch_data.rb
+++ b/app/services/reverse_geocoding/places/fetch_data.rb
@@ -46,7 +46,7 @@ class ReverseGeocoding::Places::FetchData
 
     unless place.name_locked?
       attributes[:name] = place_name(data)
-      attributes[:source] = Place.sources[:photon]
+      attributes[:source] = :photon
     end
 
     place.machine_named = true

--- a/app/services/reverse_geocoding/places/fetch_data.rb
+++ b/app/services/reverse_geocoding/places/fetch_data.rb
@@ -41,10 +41,13 @@ class ReverseGeocoding::Places::FetchData
       city:       data['properties']['city'],
       country:    data['properties']['country'],
       geodata:    data,
-      source:     Place.sources[:photon],
       reverse_geocoded_at: Time.current
     }
-    attributes[:name] = place_name(data) unless place.name_locked?
+
+    unless place.name_locked?
+      attributes[:name] = place_name(data)
+      attributes[:source] = Place.sources[:photon]
+    end
 
     place.machine_named = true
     place.update!(attributes)
@@ -130,11 +133,14 @@ class ReverseGeocoding::Places::FetchData
   end
 
   def populate_place_attributes(place, data)
-    place.name = place_name(data) unless place.name_locked?
+    unless place.name_locked?
+      place.name = place_name(data)
+      place.source = :photon
+    end
+
     place.city = data['properties']['city']
     place.country = data['properties']['country']
     place.geodata = data
-    place.source = :photon
 
     return if place.lonlat.present?
 

--- a/spec/regressions/curated_place_keeps_manual_source_spec.rb
+++ b/spec/regressions/curated_place_keeps_manual_source_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe 'Curated places keep their manual source through reverse geocodin
 
   context 'when the user created and named the place' do
     let(:place) do
-      create(:place, user: user, name: 'Home', source: :manual, user_named: true)
+      create(:place, user: user, name: 'Home', source: :manual, user_named: true,
+                     latitude: 54.28, longitude: 13.08)
     end
 
     it 'keeps the manual source' do
@@ -39,14 +40,14 @@ RSpec.describe 'Curated places keep their manual source through reverse geocodin
       expect(place.reload).to be_manual
     end
 
-    it 'keeps the place ranked ahead of machine-minted neighbours' do
+    it 'outranks a machine-minted neighbour that sits closer to the visit' do
       create(:place, user: user, name: 'Greifswalder Chaussee 1', source: :photon,
-                     latitude: place.latitude, longitude: place.longitude)
+                     latitude: 54.280050, longitude: 13.080050)
 
       service.call
 
       found = Visits::PlaceFinder.new(user).find_or_create_place(
-        center_lat: place.latitude.to_f, center_lon: place.longitude.to_f, suggested_name: nil
+        center_lat: 54.280045, center_lon: 13.080045, suggested_name: nil
       )
 
       expect(found.id).to eq(place.id)
@@ -58,13 +59,11 @@ RSpec.describe 'Curated places keep their manual source through reverse geocodin
     end
   end
 
-  context 'when the place was minted by the detector' do
-    let(:place) { create(:place, user: user, name: Place::DEFAULT_NAME, source: :photon) }
+  context 'when the place is unlocked and still on the schema-default source' do
+    let(:place) { create(:place, user: user, name: Place::DEFAULT_NAME, source: :manual) }
 
-    it 'stays on the photon source' do
-      service.call
-
-      expect(place.reload).to be_photon
+    it 'is still stamped photon' do
+      expect { service.call }.to change { place.reload.source }.from('manual').to('photon')
     end
   end
 

--- a/spec/regressions/curated_place_keeps_manual_source_spec.rb
+++ b/spec/regressions/curated_place_keeps_manual_source_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Curated places keep their manual source through reverse geocoding' do
+  subject(:service) { ReverseGeocoding::Places::FetchData.new(place.id) }
+
+  let(:user) { create(:user) }
+  let(:geocoded_place) do
+    double(
+      data: {
+        'geometry' => { 'coordinates' => [13.0948638, 54.2905245] },
+        'properties' => {
+          'osm_id' => 12_345,
+          'name' => 'Some Cafe',
+          'osm_value' => 'cafe',
+          'city' => 'Berlin',
+          'country' => 'Germany',
+          'postcode' => '10115',
+          'street' => 'Test Street',
+          'housenumber' => '1'
+        }
+      }
+    )
+  end
+
+  before do
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+    allow(Geocoder).to receive(:search).and_return([geocoded_place])
+  end
+
+  context 'when the user created and named the place' do
+    let(:place) do
+      create(:place, user: user, name: 'Home', source: :manual, user_named: true)
+    end
+
+    it 'keeps the manual source' do
+      expect { service.call }.not_to(change { place.reload.source })
+      expect(place.reload).to be_manual
+    end
+
+    it 'keeps the place ranked ahead of machine-minted neighbours' do
+      create(:place, user: user, name: 'Greifswalder Chaussee 1', source: :photon,
+                     latitude: place.latitude, longitude: place.longitude)
+
+      service.call
+
+      found = Visits::PlaceFinder.new(user).find_or_create_place(
+        center_lat: place.latitude.to_f, center_lon: place.longitude.to_f, suggested_name: nil
+      )
+
+      expect(found.id).to eq(place.id)
+    end
+
+    it 'still refreshes the geocoded payload' do
+      expect { service.call }.to change { place.reload.reverse_geocoded_at }.from(nil)
+      expect(place.reload.city).to eq('Berlin')
+    end
+  end
+
+  context 'when the place was minted by the detector' do
+    let(:place) { create(:place, user: user, name: Place::DEFAULT_NAME, source: :photon) }
+
+    it 'stays on the photon source' do
+      service.call
+
+      expect(place.reload).to be_photon
+    end
+  end
+
+  describe 'sibling places returned by the same lookup' do
+    let(:place) { create(:place, user: user, name: Place::DEFAULT_NAME, source: :photon) }
+    let(:sibling_payload) do
+      {
+        'geometry' => { 'coordinates' => [13.1, 54.3] },
+        'properties' => {
+          'osm_id' => 67_890,
+          'name' => 'Second Place',
+          'osm_value' => 'cafe',
+          'city' => 'Berlin',
+          'country' => 'Germany'
+        }
+      }
+    end
+
+    before do
+      allow(Geocoder).to receive(:search).and_return([geocoded_place, double(data: sibling_payload)])
+    end
+
+    it 'does not downgrade a curated sibling' do
+      sibling = create(
+        :place,
+        user: user,
+        name: 'Corner Shop',
+        source: :manual,
+        user_named: true,
+        geodata: { 'properties' => { 'osm_id' => 67_890 } }
+      )
+
+      service.call
+
+      expect(sibling.reload).to be_manual
+      expect(sibling.name).to eq('Corner Shop')
+    end
+  end
+end


### PR DESCRIPTION
GitHub issue: https://github.com/Freika/dawarich/issues/3418

## Summary
- `ReverseGeocoding::Places::FetchData` wrote `source: photon` on every place it refreshed, including places a user created and named. Only `name` was guarded.
- Losing the manual source costs a place its manual-first ranking in `Visits::PlaceFinder` and `Visits::Detection::PlaceAttributor`, and drops it out of `Place.map_visible` until it gains a confirmed visit or a tag — so curated places quietly stop absorbing visits and disappear from the map.
- `Visits::Suggest` enqueues `ReverseGeocodingJob('place', id)` for every fresh visit's place, so this fires on manual places routinely.
- Name and source now share the existing `name_locked?` guard, in both `#update_place` and the bulk sibling path `#populate_place_attributes`. Geodata, city, country and `reverse_geocoded_at` still refresh for every place.

## Why `name_locked?` and not `manual?`
`places.source` defaults to `0` (manual) in the schema, so `Place.new.manual?` is true — a `manual?` guard would stop newly minted sibling places from ever being stamped photon. Both user-facing creation paths (`PlacesController#create`, `Visits::Create#create_new_place`) set `user_named: true`, so `lock_name_on_user_edit` stamps `name_locked_at`; that is the codebase's existing "the user curated this" signal.

## Verification
- New regression spec fails before the fix (3 of 5 examples, `source ... did change from "manual" to "photon"`) and passes after.
- 232 + 372 examples green across `spec/regressions`, `spec/services/reverse_geocoding` and `spec/services/visits`, re-run after rebasing onto current `dev`.
- rubocop clean; CHANGELOG updated.

## Not covered
- Places already flipped to photon in existing installs stay flipped; a backfill would be a separate change.
- A user place left on the default name `Suggested place` never gets `name_locked_at`, so it remains unguarded.
