### PR TITLE
Keep every map control reachable on narrow viewports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Fixed
 
+- The map control cluster keeps Search, Create and Settings on phone-sized screens instead of hiding them; on short viewports it scrolls within the map area rather than running off the bottom (#3421).
 - Trip note text now uses consistent left alignment on every line (#3104).
 - Existing saved places now appear in Map v2 visit searches and can be assigned to visits (#3083)
 - Orphaned track cleanup no longer removes a track that still owns points, and a database foreign key now backs that guarantee.

--- a/app/assets/stylesheets/maps_maplibre_panel.css
+++ b/app/assets/stylesheets/maps_maplibre_panel.css
@@ -424,6 +424,15 @@
   padding: 6px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
   transition: left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  max-height: calc(100% - 24px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: none;
+}
+
+.map-button-cluster::-webkit-scrollbar {
+  width: 0;
+  height: 0;
 }
 
 .maps-maplibre-container.panel-open ~ .map-button-cluster {
@@ -462,6 +471,7 @@
   position: relative;
   width: 40px;
   height: 40px;
+  flex: none;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -530,6 +540,7 @@
 
 .map-button-cluster__divider {
   height: 1px;
+  flex: none;
   background: oklch(var(--bc) / 0.1);
   margin: 2px 4px;
 }
@@ -550,14 +561,4 @@
   text-align: center;
   border: 1.5px solid oklch(var(--b1));
   white-space: nowrap;
-}
-
-/* Mobile — collapse to Timeline + Layers + overflow */
-@media (max-width: 640px) {
-  .map-button-cluster__btn[data-tab="search"],
-  .map-button-cluster__btn[data-tab="tools"],
-  .map-button-cluster__btn[data-tab="settings"],
-  .map-button-cluster__divider {
-    display: none;
-  }
 }


### PR DESCRIPTION
GitHub issue: https://github.com/Freika/dawarich/issues/3421

## Summary
- A `max-width: 640px` rule in `maps_maplibre_panel.css` hid the Search, Create and Settings buttons plus the divider. Its own comment promised "collapse to Timeline + Layers + overflow", but no overflow menu was ever built — so on a phone those three controls had **no** entry point, and the cluster is their only one.
- Removed the hiding rule. The cluster now clamps with `max-height: calc(100% - 24px)` + `overflow-y: auto` and scrolls when it runs out of room.
- The clamp is deliberately **not** width-gated: running out of vertical room is a function of viewport height, not width. A first pass behind `max-width: 640px` measured as a no-op for landscape phones.
- `flex: none` on `.map-button-cluster__btn` and `__divider` is load-bearing — without it the flex column shrinks the 40px buttons to ~29px to fit the clamp instead of scrolling, silently breaking touch targets.

## Verification
Measured the real stylesheet against the real cluster markup in headless Chrome, before and after:

| Viewport | Before | After |
|---|---|---|
| 390x844 (portrait phone) | 5/8 buttons; `search`, `create`, `settings` hidden | 8/8, buttons 40px, no overflow |
| 740x360 (landscape phone) | 8/8 but cluster bottom 81px past the map area | 8/8, clamped to 292px, genuinely scrollable, buttons 40px, no overflow |
| 1440x900 (desktop) | 8/8, no overflow | unchanged |

The landscape overflow was pre-existing and above the old 640px breakpoint, so it is not the reported symptom — the height-based clamp fixes it as a side effect.

## Paired e2e branch
`fix/mobile-map-cluster-buttons` in `e2e-dawarich-playwright` adds `v2/map/button-cluster-mobile.spec.js` (3 tests). They ship together.

⚠️ That spec is lint-clean and Playwright collects all 3, but it has **not been executed** — no local dawarich server was up when it was written. Worth a `scripts/run-against.sh` pass before merging.
