### PR TITLE
Make live-share freshness window configurable

### DIFF
--- a/app/controllers/api/v1/shared/points_controller.rb
+++ b/app/controllers/api/v1/shared/points_controller.rb
@@ -5,7 +5,10 @@ module Api
     module Shared
       class PointsController < BaseController
         MAX_POINTS = 10_000
-        LIVE_FRESHNESS_SECONDS = 15 * 60
+        # Configurable so distance-based location trackers (e.g. GPSlogger)
+        # that go quiet while stationary don't make a live share link say
+        # "location unknown" just because no point arrived in the last 15min.
+        LIVE_FRESHNESS_SECONDS = ENV.fetch('LIVE_SHARE_FRESHNESS_SECONDS', 15 * 60).to_i
 
         def index
           if link.resource_type.to_sym == :live

--- a/spec/requests/api/v1/shared/points_spec.rb
+++ b/spec/requests/api/v1/shared/points_spec.rb
@@ -177,6 +177,16 @@ RSpec.describe 'Api::V1::Shared::Points', type: :request do
       get "/api/v1/shared/#{link.id}/points"
       expect(JSON.parse(response.body)).to eq([])
     end
+
+    it 'honors a longer freshness window via LIVE_SHARE_FRESHNESS_SECONDS' do
+      stub_const('Api::V1::Shared::PointsController::LIVE_FRESHNESS_SECONDS', 1.hour.to_i)
+      create(:point, user: owner, timestamp: 30.minutes.ago.to_i, latitude: 60.0, longitude: 10.0)
+
+      get "/api/v1/shared/#{link.id}/points"
+      body = JSON.parse(response.body)
+      expect(body.size).to eq(1)
+      expect(body.first[1]).to be_within(0.0001).of(60.0)
+    end
   end
 
   context 'for a timeline share' do


### PR DESCRIPTION
So, this solves a problem to me where I would like people to know my live or last known location even if I do not update it for 15+ minutes. Please feel free to comment, reject or accept, I have currently deployed my own fork on my cluster anyway, but thought maybe others would appreciate that too :) 

Everything below is AI generated:

## Summary

The live share endpoint (`Api::V1::Shared::PointsController#live_points`) hardcodes a 15-minute staleness window (`LIVE_FRESHNESS_SECONDS`). If the sharing user's latest point is older than that, the endpoint returns `[]` and the share link shows "location unknown" — even though a valid last-known point exists.

This is especially noticeable with trackers that log by distance rather than time (e.g. GPSlogger's default mode), which go quiet for long stretches while the device is stationary, even though it's still online and reachable.

## Change

Reads the window from `LIVE_SHARE_FRESHNESS_SECONDS`, defaulting to the existing 15 minutes so behavior is unchanged unless explicitly configured:

```ruby
LIVE_FRESHNESS_SECONDS = ENV.fetch('LIVE_SHARE_FRESHNESS_SECONDS', 15 * 60).to_i
```

## Test plan

- [x] Added a request spec covering a longer configured window
- [x] Existing spec for the default 15-minute staleness cutoff still passes unchanged