### PR TITLE
DISABLE_FAMILY_FEATURE Environment Flag

### DIFF
--- a/config/initializers/03_dawarich_settings.rb
+++ b/config/initializers/03_dawarich_settings.rb
@@ -56,6 +56,7 @@ class DawarichSettings
     # Deliberately not memoized: the answer depends on the user, and
     # DawarichSettings is a process-wide singleton.
     def family_feature_available_for?(user)
+      return false if ENV['DISABLE_FAMILY_FEATURE'].to_s == 'true'
       return true if self_hosted?
       return false if user.nil?
 


### PR DESCRIPTION
Would be nice to allow disabling the Family Feature for self-hosters, I for one have no need for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for disabling the family feature through the `DISABLE_FAMILY_FEATURE` configuration setting.
  * When enabled, the family feature is consistently unavailable regardless of account type or entitlement status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->