### PR TITLE
Use renamed import filename for downloads

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -10,8 +10,8 @@ class ImportsController < ApplicationController
 
   before_action :authenticate_user!
   before_action :authenticate_active_user!, only: %i[create]
-  before_action :set_import, only: %i[show edit update destroy]
-  before_action :authorize_import, only: %i[show edit update destroy]
+  before_action :set_import, only: %i[show edit update destroy download]
+  before_action :authorize_import, only: %i[show edit update destroy download]
   before_action :validate_points_limit, only: %i[new create]
 
   after_action :verify_authorized, except: %i[index]
@@ -27,6 +27,10 @@ class ImportsController < ApplicationController
   end
 
   def show; end
+
+  def download
+    redirect_to @import.file.url(filename: @import.name, disposition: :attachment), allow_other_host: true
+  end
 
   def edit; end
 

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -36,7 +36,7 @@ class ImportsController < ApplicationController
     archive_path = Imports::SecureFileDownloader.new(@import.file).download_to_temp_file
     archive = Archive::Unzipper.inspect_archive(archive_path)
 
-    return redirect_to_stored_file(filename: @import.file.blob.filename.to_s) unless wrapped_archive?(archive)
+    return redirect_to_stored_file unless wrapped_archive?(archive)
 
     extracted_path = Archive::Unzipper.extract_single(archive_path)
     stream_extracted_file(extracted_path, archive_path)

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -7,6 +7,8 @@ class ImportsController < ApplicationController
   self.page_refresh_morphing = true
 
   SORTABLE_COLUMNS = %w[name status created_at processed byte_size].freeze
+  CLIENT_WRAPPED_METADATA_KEY = 'dawarich_client_wrapped'
+  ORIGINAL_FILENAME_METADATA_KEY = 'dawarich_original_filename'
 
   before_action :authenticate_user!
   before_action :authenticate_active_user!, only: %i[create]
@@ -29,7 +31,19 @@ class ImportsController < ApplicationController
   def show; end
 
   def download
-    redirect_to @import.file.url(filename: @import.name, disposition: :attachment), allow_other_host: true
+    return redirect_to_stored_file unless wrapped_file_candidate?
+
+    archive_path = Imports::SecureFileDownloader.new(@import.file).download_to_temp_file
+    archive = Archive::Unzipper.inspect_archive(archive_path)
+
+    return redirect_to_stored_file(filename: @import.file.blob.filename.to_s) unless wrapped_archive?(archive)
+
+    extracted_path = Archive::Unzipper.extract_single(archive_path)
+    stream_extracted_file(extracted_path, archive_path)
+    extracted_path = archive_path = nil
+  ensure
+    cleanup_download_file(extracted_path)
+    cleanup_download_file(archive_path)
   end
 
   def edit; end
@@ -130,18 +144,111 @@ status: :unprocessable_content and return
     ExceptionReporter.call(error)
   end
 
-  def create_import_from_signed_id(signed_id)
+  def create_import_from_signed_id(item)
+    descriptor = upload_descriptor(item)
+    signed_id = descriptor.fetch('signed_id')
     Rails.logger.debug "Creating import from signed ID: #{signed_id[0..20]}..."
 
     blob = ActiveStorage::Blob.find_signed(signed_id)
+    original_filename = verified_original_filename(blob, descriptor)
+    mark_client_wrapped(blob, original_filename.present?) if descriptor.key?('client_wrapped')
 
-    import_name = generate_unique_import_name(blob.filename.to_s)
+    import_name = generate_unique_import_name(original_filename || blob.filename.to_s)
     import = current_user.imports.build(name: import_name)
     import.file.attach(blob)
 
     import.save!
 
     import
+  end
+
+  def upload_descriptor(item)
+    parsed = JSON.parse(item.to_s)
+    return parsed if parsed.is_a?(Hash) && parsed['signed_id'].present?
+
+    { 'signed_id' => item.to_s }
+  rescue JSON::ParserError
+    { 'signed_id' => item.to_s }
+  end
+
+  def verified_original_filename(blob, descriptor)
+    return unless ActiveModel::Type::Boolean.new.cast(descriptor['client_wrapped'])
+
+    original_filename = File.basename(descriptor['original_filename'].to_s)
+    return if original_filename.blank?
+    return unless blob.filename.to_s == "#{original_filename}.zip"
+
+    original_filename
+  end
+
+  def mark_client_wrapped(blob, wrapped)
+    metadata = blob.metadata.merge(CLIENT_WRAPPED_METADATA_KEY => wrapped)
+    metadata[ORIGINAL_FILENAME_METADATA_KEY] = blob.filename.to_s.delete_suffix('.zip') if wrapped
+    blob.update!(metadata:)
+  end
+
+  def wrapped_file_candidate?
+    metadata = @import.file.blob.metadata
+    return metadata[CLIENT_WRAPPED_METADATA_KEY] if metadata.key?(CLIENT_WRAPPED_METADATA_KEY)
+
+    legacy_wrapped_filename.present?
+  end
+
+  def wrapped_archive?(archive)
+    return false unless archive.kind == :single_entry
+
+    expected_filename = @import.file.blob.metadata[ORIGINAL_FILENAME_METADATA_KEY] || legacy_wrapped_filename
+    archive.entry_name == expected_filename
+  end
+
+  def legacy_wrapped_filename
+    filename = @import.file.blob.filename.to_s
+    return unless filename.end_with?('.zip')
+
+    inner_filename = filename.delete_suffix('.zip')
+    return unless Imports::ZipExtractor::SUPPORTED_EXTENSIONS.include?(File.extname(inner_filename).downcase)
+
+    inner_filename
+  end
+
+  def redirect_to_stored_file(filename: @import.name)
+    redirect_to @import.file.url(filename:, disposition: :attachment), allow_other_host: true
+  end
+
+  def stream_extracted_file(extracted_path, archive_path)
+    filename = extracted_download_filename
+    send_file_headers!(
+      filename:,
+      type: Marcel::MimeType.for(Pathname.new(extracted_path), name: filename),
+      disposition: :attachment
+    )
+    self.status = :ok
+
+    stream = Enumerator.new do |output|
+      File.open(extracted_path, 'rb') do |file|
+        while (chunk = file.read(64.kilobytes))
+          output << chunk
+        end
+      end
+    ensure
+      cleanup_download_file(extracted_path)
+      cleanup_download_file(archive_path)
+    end
+
+    self.response_body = Rack::BodyProxy.new(stream) do
+      cleanup_download_file(extracted_path)
+      cleanup_download_file(archive_path)
+    end
+  end
+
+  def cleanup_download_file(path)
+    File.unlink(path) if path && File.exist?(path)
+  end
+
+  def extracted_download_filename
+    return @import.name unless @import.name == @import.file.blob.filename.to_s
+
+    @import.file.blob.metadata[ORIGINAL_FILENAME_METADATA_KEY] || legacy_wrapped_filename
   end
 
   def generate_unique_import_name(original_name)

--- a/app/javascript/controllers/upload_controller.js
+++ b/app/javascript/controllers/upload_controller.js
@@ -30,6 +30,7 @@ export default class extends Controller {
     userTrial: { type: Boolean, default: false },
     maxImports: { type: Number, default: 0 },
     currentImportsCount: { type: Number, default: 0 },
+    preserveOriginalFilename: { type: Boolean, default: false },
   }
 
   connect() {
@@ -83,11 +84,15 @@ export default class extends Controller {
 
     const prepared = await this.prepareForUpload(filesToUpload)
 
-    this.totalBytes = prepared.reduce((sum, f) => sum + f.size, 0)
+    this.totalBytes = prepared.reduce(
+      (sum, upload) => sum + upload.file.size,
+      0,
+    )
     this.fileProgress = {}
 
     let completed = 0
-    prepared.forEach((file, index) => {
+    prepared.forEach((preparedUpload, index) => {
+      const { file } = preparedUpload
       this.fileProgress[index] = 0
       const upload = new DirectUpload(file, this.urlValue, {
         directUploadWillStoreFileWithXHR: (request) => {
@@ -109,7 +114,7 @@ export default class extends Controller {
           )
         } else {
           this.fileProgress[index] = file.size
-          this.addHiddenField(blob.signed_id)
+          this.addHiddenField(blob.signed_id, preparedUpload)
         }
         if (completed === prepared.length) this.uploadComplete()
       })
@@ -120,12 +125,20 @@ export default class extends Controller {
     const result = []
     for (const original of files) {
       if (!shouldZip(original)) {
-        result.push(original)
+        result.push({
+          file: original,
+          originalFilename: original.name,
+          clientWrapped: false,
+        })
         continue
       }
       try {
         const zipped = await zipSingleFile(original)
-        result.push(zipped)
+        result.push({
+          file: zipped,
+          originalFilename: original.name,
+          clientWrapped: true,
+        })
       } catch (err) {
         console.error(
           "Client-side zip failed, uploading raw:",
@@ -136,7 +149,11 @@ export default class extends Controller {
           "warning",
           translate("upload.compression_failed", { name: original.name }),
         )
-        result.push(original)
+        result.push({
+          file: original,
+          originalFilename: original.name,
+          clientWrapped: false,
+        })
       }
     }
     return result
@@ -248,11 +265,17 @@ export default class extends Controller {
     if (pct) pct.textContent = `${percent.toFixed(1)}%`
   }
 
-  addHiddenField(signedId) {
+  addHiddenField(signedId, preparedUpload) {
     const field = document.createElement("input")
     field.type = "hidden"
     field.name = this.fieldNameValue
-    field.value = signedId
+    field.value = this.preserveOriginalFilenameValue
+      ? JSON.stringify({
+          signed_id: signedId,
+          original_filename: preparedUpload.originalFilename,
+          client_wrapped: preparedUpload.clientWrapped,
+        })
+      : signedId
     this.element.appendChild(field)
   }
 

--- a/app/policies/import_policy.rb
+++ b/app/policies/import_policy.rb
@@ -11,6 +11,10 @@ class ImportPolicy < ApplicationPolicy
     user.present? && record.user == user
   end
 
+  def download?
+    show?
+  end
+
   # Users can create new imports if they are active or trial
   def new?
     create?

--- a/app/views/imports/_form.html.erb
+++ b/app/views/imports/_form.html.erb
@@ -41,6 +41,7 @@
   upload_user_trial_value: current_user.legacy_trial?,
   upload_max_imports_value: 5,
   upload_current_imports_count_value: current_user.imports.count,
+  upload_preserve_original_filename_value: true,
   upload_target: "form"
 } do |form| %>
   <label class="form-control w-full max-w-xs my-5">

--- a/app/views/imports/_table_row.html.erb
+++ b/app/views/imports/_table_row.html.erb
@@ -62,7 +62,7 @@
         </div>
         <% if import.file.present? %>
           <div class="tooltip" data-tip="<%= t('.download_file') %>">
-            <%= link_to rails_blob_path(import.file, disposition: 'attachment'), class: "btn btn-ghost btn-xs", download: import.name do %>
+            <%= link_to download_import_path(import), class: "btn btn-ghost btn-xs" do %>
               <%= icon 'arrow-big-down', class: 'w-4 h-4' %>
             <% end %>
           </div>

--- a/app/views/map/_onboarding_modal.html.erb
+++ b/app/views/map/_onboarding_modal.html.erb
@@ -111,6 +111,7 @@
           upload_user_trial_value: current_user.legacy_trial?,
           upload_max_imports_value: 5,
           upload_current_imports_count_value: current_user.imports.count,
+          upload_preserve_original_filename_value: true,
           upload_target: "form"
         } do |form| %>
           <label class="form-control w-full mb-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@ Rails.application.routes.draw do
   get 'trial/welcome', to: 'trial/welcome#show', as: :trial_welcome
 
   resources :imports do
+    get :download, on: :member
     resource :extraction, only: %i[create destroy], controller: 'imports/extractions'
   end
   resources :tracks, only: [] do

--- a/spec/requests/imports_spec.rb
+++ b/spec/requests/imports_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'zip'
 
 RSpec.describe 'Imports', type: :request do
   describe 'GET /imports' do
@@ -74,25 +75,24 @@ RSpec.describe 'Imports', type: :request do
 
   describe 'GET /imports/:id/download' do
     let(:user) { create(:user) }
-    let(:import) { create(:import, user:, name: 'renamed-import.gpx') }
+    let(:import) { create(:import, user:, name: 'holiday.gpx') }
+    let(:gpx_content) { '<gpx><trk><name>Holiday</name></trk></gpx>' }
+    let(:zip_path) { create_zip('original.gpx' => gpx_content) }
 
-    before do
-      import.file.attach(
-        io: StringIO.new('file contents'),
-        filename: 'original-import.gpx.zip',
-        content_type: 'application/zip'
-      )
-    end
+    before { attach_file(import, zip_path, 'original.gpx.zip', client_wrapped: true) }
+
+    after { File.delete(zip_path) if File.exist?(zip_path) }
 
     context 'when user is logged in' do
       before { sign_in user }
 
-      it 'downloads the file using the current import name' do
+      it 'downloads the extracted inner file using the renamed import name' do
         get download_import_path(import)
-        follow_redirect!
 
         expect(response).to have_http_status(:ok)
-        expect(response.headers['Content-Disposition']).to include('filename="renamed-import.gpx"')
+        expect(response.headers['Content-Disposition']).to include('filename="holiday.gpx"')
+        expect(response.body).to eq(gpx_content)
+        expect(response.body.b).not_to start_with(Archive::Unzipper::ZIP_MAGIC)
       end
 
       it 'prevents downloading another user\'s import' do
@@ -102,6 +102,46 @@ RSpec.describe 'Imports', type: :request do
 
         expect(response).to redirect_to(root_path)
         expect(flash[:alert]).to eq('You are not authorized to perform this action.')
+      end
+    end
+
+    context 'when the import is a genuine zip upload' do
+      let(:import) { create(:import, user:, name: 'tracks.zip') }
+      let(:zip_path) { create_zip('a.gpx' => gpx_content, 'b.gpx' => gpx_content) }
+
+      before do
+        import.file.purge
+        attach_file(import, zip_path, 'tracks.zip', client_wrapped: false)
+        sign_in user
+      end
+
+      it 'downloads the original zip without extracting an entry' do
+        get download_import_path(import)
+        follow_redirect!
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers['Content-Disposition']).to include('filename="tracks.zip"')
+        expect(response.body.b).to start_with(Archive::Unzipper::ZIP_MAGIC)
+      end
+    end
+
+    context 'when the import is a legacy unmarked KML wrapper' do
+      let(:import) { create(:import, user:, name: 'route.kml.zip') }
+      let(:kml_content) { '<kml><Document><name>Route</name></Document></kml>' }
+      let(:zip_path) { create_zip('route.kml' => kml_content) }
+
+      before do
+        import.file.purge
+        import.file.attach(io: File.open(zip_path), filename: 'route.kml.zip', content_type: 'application/zip')
+        sign_in user
+      end
+
+      it 'detects the wrapper and downloads the inner KML with its original filename' do
+        get download_import_path(import)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers['Content-Disposition']).to include('filename="route.kml"')
+        expect(response.body).to eq(kml_content)
       end
     end
 
@@ -202,6 +242,36 @@ RSpec.describe 'Imports', type: :request do
           end.to change(user.imports, :count).by(1)
 
           expect(response).to redirect_to(imports_path)
+        end
+      end
+
+      context 'when importing client-wrapped files' do
+        it 'uses the original GPX filename as the visible import name' do
+          blob = create_blob_from_zip('track.gpx.zip', 'track.gpx' => '<gpx/>')
+
+          post imports_path, params: { import: { files: [upload_descriptor(blob, 'track.gpx', true)] } }
+
+          created_import = user.imports.order(:id).last
+          expect(created_import.name).to eq('track.gpx')
+          expect(created_import.file.blob.metadata['dawarich_client_wrapped']).to be(true)
+        end
+
+        it 'uses the original KML filename as the visible import name' do
+          blob = create_blob_from_zip('route.kml.zip', 'route.kml' => '<kml/>')
+
+          post imports_path, params: { import: { files: [upload_descriptor(blob, 'route.kml', true)] } }
+
+          expect(user.imports.order(:id).last.name).to eq('route.kml')
+        end
+
+        it 'keeps a genuine zip filename and marks it as unwrapped' do
+          blob = create_blob_from_zip('tracks.zip', 'a.gpx' => '<gpx/>', 'b.gpx' => '<gpx/>')
+
+          post imports_path, params: { import: { files: [upload_descriptor(blob, 'tracks.zip', false)] } }
+
+          created_import = user.imports.order(:id).last
+          expect(created_import.name).to eq('tracks.zip')
+          expect(created_import.file.blob.metadata['dawarich_client_wrapped']).to be(false)
         end
       end
 
@@ -330,5 +400,42 @@ RSpec.describe 'Imports', type: :request do
 
   def generate_signed_id_for_blob(blob)
     blob.signed_id
+  end
+
+  def create_zip(entries)
+    path = Rails.root.join('tmp', "request_import_#{SecureRandom.hex(4)}.zip").to_s
+    ::Zip::File.open(path, create: true) do |zip|
+      entries.each do |filename, content|
+        zip.get_output_stream(filename) { |entry| entry.write(content) }
+      end
+    end
+    path
+  end
+
+  def create_blob_from_zip(filename, entries)
+    path = create_zip(entries)
+    ActiveStorage::Blob.create_and_upload!(
+      io: File.open(path), filename:, content_type: 'application/zip'
+    )
+  ensure
+    File.delete(path) if path && File.exist?(path)
+  end
+
+  def upload_descriptor(blob, original_filename, client_wrapped)
+    {
+      signed_id: blob.signed_id,
+      original_filename:,
+      client_wrapped:
+    }.to_json
+  end
+
+  def attach_file(import, path, filename, client_wrapped:)
+    import.file.attach(io: File.open(path), filename:, content_type: 'application/zip')
+    import.file.blob.update!(
+      metadata: import.file.blob.metadata.merge(
+        'dawarich_client_wrapped' => client_wrapped,
+        'dawarich_original_filename' => filename.delete_suffix('.zip')
+      )
+    )
   end
 end

--- a/spec/requests/imports_spec.rb
+++ b/spec/requests/imports_spec.rb
@@ -72,6 +72,48 @@ RSpec.describe 'Imports', type: :request do
     end
   end
 
+  describe 'GET /imports/:id/download' do
+    let(:user) { create(:user) }
+    let(:import) { create(:import, user:, name: 'renamed-import.gpx') }
+
+    before do
+      import.file.attach(
+        io: StringIO.new('file contents'),
+        filename: 'original-import.gpx.zip',
+        content_type: 'application/zip'
+      )
+    end
+
+    context 'when user is logged in' do
+      before { sign_in user }
+
+      it 'downloads the file using the current import name' do
+        get download_import_path(import)
+        follow_redirect!
+
+        expect(response).to have_http_status(:ok)
+        expect(response.headers['Content-Disposition']).to include('filename="renamed-import.gpx"')
+      end
+
+      it 'prevents downloading another user\'s import' do
+        sign_in create(:user)
+
+        get download_import_path(import)
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq('You are not authorized to perform this action.')
+      end
+    end
+
+    context 'when user is not logged in' do
+      it 'redirects to login' do
+        get download_import_path(import)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
   describe 'GET /imports/new' do
     let(:user) { create(:user) }
 

--- a/spec/requests/imports_spec.rb
+++ b/spec/requests/imports_spec.rb
@@ -125,6 +125,29 @@ RSpec.describe 'Imports', type: :request do
       end
     end
 
+    context 'when a genuine multi-entry legacy zip import has been renamed' do
+      let(:import) { create(:import, user:, name: 'original.gpx.zip') }
+      let(:zip_path) { create_zip('a.gpx' => gpx_content, 'b.gpx' => gpx_content) }
+
+      before do
+        import.file.purge
+        import.file.attach(io: File.open(zip_path), filename: 'original.gpx.zip', content_type: 'application/zip')
+        import.update!(name: 'renamed.gpx.zip')
+        sign_in user
+      end
+
+      it 'downloads the intact zip using the current import name' do
+        get download_import_path(import)
+        follow_redirect!
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body.b).to start_with(Archive::Unzipper::ZIP_MAGIC)
+        expect(response.body.b).to eq(File.binread(zip_path))
+        expect(response.headers['Content-Disposition']).to include('filename="renamed.gpx.zip"')
+        expect(response.headers['Content-Disposition']).not_to include('original.gpx.zip')
+      end
+    end
+
     context 'when the import is a legacy unmarked KML wrapper' do
       let(:import) { create(:import, user:, name: 'route.kml.zip') }
       let(:kml_content) { '<kml><Document><name>Route</name></Document></kml>' }


### PR DESCRIPTION
## Summary

* preserve the original filename for client-side wrapped imports
* use the current import name as the download filename
* route import downloads through an authenticated and authorized controller action
* transparently extract client-side generated single-file ZIP wrappers when downloading
* preserve genuine ZIP uploads as ZIP files
* support legacy GPX/KML wrapper downloads
* store metadata indicating whether an uploaded file was client-wrapped
* keep renamed import downloads consistent with the name shown in Dawarich
* cover renamed filenames, genuine ZIP uploads, legacy wrappers, cross-user authorization, and unauthenticated access

Closes #3455

Also addresses the filename/download portion of #3062.

## Details

Dawarich compresses supported single-file imports such as GPX and KML files client-side before uploading them.

Previously, the generated `.zip` filename could become the visible import name and was also used when downloading the import. This meant users could receive a ZIP archive instead of the original GPX/KML file and renamed imports could still download using the old filename.

This change keeps the storage format unchanged while preserving information about the original uploaded filename.

For client-wrapped imports, Dawarich now:

* stores metadata identifying the file as a client-generated wrapper
* keeps the original filename as the visible import name
* extracts the wrapped file when downloading
* uses the current import name as the downloaded filename

Genuine ZIP uploads remain ZIP files and are not automatically extracted.

Legacy single-file GPX/KML wrappers are also detected where possible.

## Security

Downloads now go through `ImportsController#download`.

The endpoint requires:

* an authenticated user
* authorization through `ImportPolicy`

Users cannot download imports belonging to another user.

## Verification

Successfully tested after rebasing onto the latest `dev` branch:

* `bundle exec rspec spec/requests/imports_spec.rb`
* `bundle exec rubocop app/controllers/imports_controller.rb app/policies/import_policy.rb spec/requests/imports_spec.rb`
* `bundle exec rspec`

The request specs cover:

* renamed import downloads
* extraction of client-generated ZIP wrappers
* preservation of genuine ZIP uploads
* legacy wrapper handling
* cross-user authorization
* unauthenticated access
* preservation of original GPX/KML filenames during import creation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Uploads preserve original filenames and support client-wrapped files.
  - Added a dedicated import download option.
  - Wrapped archives are automatically unpacked so the contained file downloads directly.
  - Genuine ZIP files continue downloading without extraction.
  - Downloaded files use the import’s current name when applicable.

- **Bug Fixes**
  - Download access is restricted to authorized import owners.
  - Legacy wrapped KML files are recognized and handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->