### PR TITLE
Implement place show page

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -12,9 +12,7 @@ class PlacesController < ApplicationController
 
   def show
     @place = current_user.places.includes(:tags).find(params[:id])
-    @recent_visits = @place.visits.active.order(started_at: :desc).limit(5)
-
-    render layout: false
+    @visits = @place.visits.active.order(started_at: :desc).page(params[:page]).per(10)
   end
 
   def create
@@ -49,6 +47,7 @@ class PlacesController < ApplicationController
       @place = current_user.places.includes(:tags, :active_visits).find(@place.id)
 
       respond_to do |format|
+        format.json { render json: { name: @place.name }, status: :ok }
         format.turbo_stream do
           if drawer_request?
             recent_visits = @place.visits.active.order(started_at: :desc).limit(5)
@@ -70,6 +69,7 @@ class PlacesController < ApplicationController
       end
     else
       respond_to do |format|
+        format.json { render json: { error: @place.errors.full_messages.join(', ') }, status: :unprocessable_entity }
         format.turbo_stream do
           render turbo_stream: stream_flash(:error, @place.errors.full_messages.join(', '))
         end

--- a/app/javascript/controllers/place_map_controller.js
+++ b/app/javascript/controllers/place_map_controller.js
@@ -1,0 +1,73 @@
+import { Controller } from "@hotwired/stimulus"
+import maplibregl from "maplibre-gl"
+import { getCurrentTheme } from "maps_maplibre/utils/popup_theme"
+import { getMapStyle } from "maps_maplibre/utils/style_manager"
+
+export default class extends Controller {
+  static values = {
+    lat: Number,
+    lng: Number,
+    name: String,
+  }
+
+  connect() {
+    this.initializeMap()
+  }
+
+  disconnect() {
+    if (this.map) {
+      this.map.remove()
+      this.map = null
+    }
+  }
+
+  async initializeMap() {
+    try {
+      const style = await getMapStyle(getCurrentTheme())
+
+      if (this.map) return
+
+      this.map = new maplibregl.Map({
+        container: this.element,
+        style,
+        center: [this.lngValue, this.latValue],
+        zoom: 14,
+        attributionControl: false,
+      })
+
+      this.map.addControl(
+        new maplibregl.NavigationControl({ showCompass: false }),
+        "top-right",
+      )
+
+      this.map.on("load", () => this.addMarker())
+    } catch (error) {
+      console.error("Error initializing place map:", error)
+    }
+  }
+
+  addMarker() {
+    // Create a custom marker element
+    const el = document.createElement("div")
+    el.className = "place-map-marker"
+    el.innerHTML = `
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#ef4444" class="w-8 h-8 drop-shadow-lg">
+        <path fill-rule="evenodd" d="m11.54 22.351.07.04.028.016a.76.76 0 0 0 .723 0l.028-.015.071-.041a16.975 16.975 0 0 0 1.144-.742 19.58 19.58 0 0 0 2.683-2.282c1.944-1.99 3.963-4.98 3.963-8.827a8.25 8.25 0 0 0-16.5 0c0 3.846 2.02 6.837 3.963 8.827a19.58 19.58 0 0 0 2.682 2.282 16.975 16.975 0 0 0 1.145.742Z" clip-rule="evenodd" />
+      </svg>`
+
+    new maplibregl.Marker({ element: el })
+      .setLngLat([this.lngValue, this.latValue])
+      .setPopup(
+        new maplibregl.Popup({ offset: 25 }).setHTML(
+          `<strong>${escapeHtml(this.nameValue)}</strong><br/>${this.latValue.toFixed(6)}, ${this.lngValue.toFixed(6)}`,
+        ),
+      )
+      .addTo(this.map)
+  }
+}
+
+function escapeHtml(str) {
+  const div = document.createElement("div")
+  div.textContent = str
+  return div.innerHTML
+}

--- a/app/javascript/controllers/place_name_editor_controller.js
+++ b/app/javascript/controllers/place_name_editor_controller.js
@@ -1,0 +1,80 @@
+import { Controller } from "@hotwired/stimulus"
+import Flash from "./flash_controller"
+
+export default class extends Controller {
+  static targets = [
+    "display",
+    "input",
+    "form",
+    "editButton",
+    "saveButton",
+    "cancelButton",
+  ]
+
+  connect() {
+    this.editing = false
+  }
+
+  toggle() {
+    if (this.editing) {
+      this.cancel()
+    } else {
+      this.edit()
+    }
+  }
+
+  edit() {
+    this.editing = true
+    this.inputTarget.value = this.displayTarget.textContent.trim()
+    this.displayTarget.classList.add("hidden")
+    this.formTarget.classList.remove("hidden")
+    this.editButtonTarget.classList.add("hidden")
+    this.inputTarget.focus()
+    this.inputTarget.select()
+  }
+
+  cancel() {
+    this.editing = false
+    this.displayTarget.classList.remove("hidden")
+    this.formTarget.classList.remove("hidden")
+    this.formTarget.classList.add("hidden")
+    this.editButtonTarget.classList.remove("hidden")
+  }
+
+  async save(event) {
+    event.preventDefault()
+
+    const newName = this.inputTarget.value.trim()
+    if (!newName || newName === this.displayTarget.textContent.trim()) {
+      this.cancel()
+      return
+    }
+
+    const url = this.formTarget.action
+    const csrfToken = document.querySelector("[name='csrf-token']")?.content
+
+    try {
+      const response = await fetch(url, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": csrfToken,
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ place: { name: newName } }),
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        Flash.show("error", data.error || "Failed to update name")
+        return
+      }
+
+      this.displayTarget.textContent = newName
+      this.cancel()
+      Flash.show("notice", "Name updated")
+    } catch {
+      Flash.show("error", "Failed to update name")
+    }
+  }
+}

--- a/app/javascript/controllers/place_note_editor_controller.js
+++ b/app/javascript/controllers/place_note_editor_controller.js
@@ -1,0 +1,66 @@
+import { Controller } from "@hotwired/stimulus"
+import Flash from "./flash_controller"
+
+export default class extends Controller {
+  static targets = ["display", "textarea", "form", "editButton", "cancelButton", "saveButton"]
+
+  connect() {
+    this.editing = false
+  }
+
+  edit() {
+    this.editing = true
+    this.textareaTarget.value = this.displayTarget.textContent.trim()
+    this.displayTarget.classList.add("hidden")
+    this.formTarget.classList.remove("hidden")
+    this.editButtonTarget.classList.add("hidden")
+    this.saveButtonTarget.disabled = false
+    this.textareaTarget.focus()
+  }
+
+  cancel() {
+    this.editing = false
+    this.displayTarget.classList.remove("hidden")
+    this.formTarget.classList.add("hidden")
+    this.editButtonTarget.classList.remove("hidden")
+  }
+
+  async save(event) {
+    event.preventDefault()
+
+    const newNote = this.textareaTarget.value.trim()
+    const originalNote = this.displayTarget.textContent.trim()
+
+    if (newNote === originalNote) {
+      this.cancel()
+      return
+    }
+
+    const url = this.formTarget.action
+    const csrfToken = document.querySelector("[name='csrf-token']")?.content
+
+    try {
+      const response = await fetch(url, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": csrfToken,
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ place: { note: newNote } }),
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        Flash.show("error", data.error || "Failed to update note")
+        return
+      }
+
+      this.displayTarget.textContent = newNote
+      this.cancel()
+      Flash.show("notice", "Note updated")
+    } catch {
+      Flash.show("error", "Failed to update note")
+    }
+  }
+}

--- a/app/javascript/controllers/place_tags_editor_controller.js
+++ b/app/javascript/controllers/place_tags_editor_controller.js
@@ -1,0 +1,58 @@
+import { Controller } from "@hotwired/stimulus"
+import Flash from "./flash_controller"
+
+export default class extends Controller {
+  static targets = ["display", "editButton", "form", "cancelButton", "checkbox"]
+
+  connect() {
+    this.editing = false
+  }
+
+  edit() {
+    this.editing = true
+    this.displayTarget.classList.add("hidden")
+    this.formTarget.classList.remove("hidden")
+    this.editButtonTarget.classList.add("hidden")
+  }
+
+  cancel() {
+    this.editing = false
+    this.displayTarget.classList.remove("hidden")
+    this.formTarget.classList.add("hidden")
+    this.editButtonTarget.classList.remove("hidden")
+  }
+
+  async save(event) {
+    event.preventDefault()
+
+    const checked = this.checkboxTargets
+      .filter((cb) => cb.checked)
+      .map((cb) => cb.value)
+
+    const url = this.formTarget.action
+    const csrfToken = document.querySelector("[name='csrf-token']")?.content
+
+    try {
+      const response = await fetch(url, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": csrfToken,
+          Accept: "application/json",
+        },
+        body: JSON.stringify({ place: { tag_ids: checked } }),
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        Flash.show("error", data.error || "Failed to update tags")
+        return
+      }
+
+      // Reload the page to reflect updated tags
+      Turbo.visit(window.location.pathname, { action: "replace" })
+    } catch {
+      Flash.show("error", "Failed to update tags")
+    }
+  }
+}

--- a/app/views/places/index.html.erb
+++ b/app/views/places/index.html.erb
@@ -37,7 +37,7 @@
           <tbody>
             <% @places.each do |place| %>
               <tr>
-                <td><%= place.name %></td>
+                <td><%= link_to place.name, place_path(place) %></td>
                 <td><%= human_datetime(place.created_at, current_user.safe_settings.timezone) %></td>
                 <td><%= "#{place.lat}, #{place.lon}" %></td>
                 <td>

--- a/app/views/places/show.html.erb
+++ b/app/views/places/show.html.erb
@@ -1,3 +1,236 @@
-<%= turbo_frame_tag 'place-drawer' do %>
-  <%= render 'drawer', place: @place, recent_visits: @recent_visits %>
-<% end %>
+<% content_for :title, @place.name %>
+
+<% stats = place_dwell_stats(@place) %>
+
+<div class="container mx-auto px-4 my-5">
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <!-- Left column: Place details -->
+    <div>
+      <div class="flex items-center gap-3 mb-4">
+        <div class="avatar placeholder">
+          <div class="bg-primary text-primary-content rounded-full w-12 h-12 flex items-center justify-center text-xl">
+            <% if stats[:primary_tag]&.icon.present? %>
+              <span><%= stats[:primary_tag].icon %></span>
+            <% else %>
+              <%= icon 'map-pin', class: 'w-6 h-6' %>
+            <% end %>
+          </div>
+        </div>
+        <div class="w-full">
+          <div class="flex items-center gap-2 w-full" data-controller="place-name-editor">
+            <h1 class="card-title text-2xl">
+              <span data-place-name-editor-target="display"><%= @place.name %></span>
+            </h1>
+            <button type="button"
+                    data-place-name-editor-target="editButton"
+                    data-action="click->place-name-editor#toggle"
+                    class="btn btn-ghost btn-xs btn-square"
+                    title="<%= t('.edit_name') %>">
+              <%= icon 'square-pen', class: 'w-4 h-4' %>
+            </button>
+
+            <%= form_with model: @place,
+                          method: :patch,
+                          class: "hidden inline-flex items-center gap-2",
+                          data: { place_name_editor_target: "form", action: "submit->place-name-editor#save" } do |f| %>
+              <%= f.text_field :name,
+                               data: { place_name_editor_target: "input" },
+                               class: "input input-bordered input-sm w-48",
+                               autocomplete: "off" %>
+              <button type="submit"
+                      data-place-name-editor-target="saveButton"
+                      class="btn btn-xs">
+                <%= icon 'save', class: 'w-4 h-4' %>
+              </button>
+              <button type="button"
+                      data-place-name-editor-target="cancelButton"
+                      data-action="click->place-name-editor#cancel"
+                      class="btn btn-ghost btn-xs">
+                <%= icon 'x', class: 'w-4 h-4' %>
+              </button>
+            <% end %>
+
+            <div class="ml-auto">
+              <%= button_to place_path(@place),
+                method: :delete,
+                class: 'ml-auto btn btn-ghost btn-xs btn-square',
+                data: { turbo_confirm: t('places.drawer.delete_this_place_this_cannot_be_undone') } do %>
+                <%= icon 'trash-2', class: 'w-4 h-4' %>
+              <% end %>
+            </div>
+          </div>
+          <% if stats[:location_line].present? %>
+            <p class="text-base-content/70"><%= stats[:location_line] %></p>
+          <% end %>
+        </div>
+      </div>
+
+      <!-- Stats row -->
+      <div class="stats stats-vertical lg:stats-horizontal shadow mb-4 w-full">
+        <div class="stat">
+          <div class="stat-title"><%= t('.visits') %></div>
+          <div class="stat-value text-primary"><%= stats[:visit_count] %></div>
+        </div>
+        <div class="stat">
+          <div class="stat-title"><%= t('places.drawer.total_hours') %></div>
+          <div class="stat-value text-secondary"><%= stats[:total_hours] %></div>
+        </div>
+        <div class="stat">
+          <div class="stat-title"><%= t('places.drawer.avg_dwell') %></div>
+          <div class="stat-value text-accent"><%= stats[:avg_label] %></div>
+        </div>
+      </div>
+
+      <!-- Visits -->
+      <div class="mt-4">
+        <h3 class="font-semibold mb-2"><%= t('.visits') %></h3>
+        <% if @visits.any? %>
+          <div class="border border-base-300 rounded-xl overflow-x-auto">
+            <table class="table table-sm w-full">
+              <thead class="bg-base-200">
+                <tr>
+                  <th class="px-3 py-2.5 text-xs uppercase tracking-wider text-base-content/50"><%= t('.visit_date') %></th>
+                  <th class="px-3 py-2.5 text-xs uppercase tracking-wider text-base-content/50"><%= t('.visit_time') %></th>
+                  <th class="px-3 py-2.5 text-xs uppercase tracking-wider text-base-content/50 text-right"><%= t('.visit_duration') %></th>
+                  <th class="px-3 py-2.5 w-12"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @visits.each do |visit| %>
+                  <% range = place_visit_time_range(visit) %>
+                  <tr id="visit_entry_<%= visit.id %>">
+                    <td class="px-3 py-2.5"><%= range[:date_label] %></td>
+                    <td class="px-3 py-2.5"><%= range[:start_label] %> &rarr; <%= range[:end_label] %></td>
+                    <td class="px-3 py-2.5 text-right"><%= range[:duration_label] %></td>
+                    <td class="px-3 py-2.5 text-center">
+                      <%= button_to visit_path(visit),
+                                    method: :delete,
+                                    class: 'btn btn-ghost btn-xs text-error',
+                                    data: { turbo_confirm: t('visits.buttons.delete_this_visit_your_location_points_stay') } do %>
+                        <%= icon 'trash-2', class: 'w-3.5 h-3.5' %>
+                      <% end %>
+                    </td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="flex justify-center mt-4">
+            <%= paginate @visits %>
+          </div>
+        <% else %>
+          <p class="text-base-content/50 italic"><%= t('places.drawer.no_visits_yet') %></p>
+        <% end %>
+      </div>
+    </div>
+
+    <!-- Right column: Map -->
+    <div class="card bg-base-100">
+      <div class="w-full overflow-hidden" style="height: 500px"
+            data-controller="place-map"
+            data-place-map-lat-value="<%= @place.lat %>"
+            data-place-map-lng-value="<%= @place.lon %>"
+            data-place-map-name-value="<%= @place.name %>">
+      </div>
+
+      <!-- Note -->
+      <div class="mt-4" data-controller="place-note-editor">
+        <div class="flex items-center justify-between mb-2">
+          <h3 class="font-semibold"><%= t('places.drawer.notes') %></h3>
+          <button type="button"
+                  data-place-note-editor-target="editButton"
+                  data-action="click->place-note-editor#edit"
+                  class="btn btn-ghost btn-xs btn-square"
+                  title="<%= t('.edit_note') %>">
+            <%= icon 'square-pen', class: 'w-3.5 h-3.5' %>
+          </button>
+        </div>
+        <div data-place-note-editor-target="display">
+          <%= @place.note %>
+        </div>
+        <%= form_with model: @place,
+                      method: :patch,
+                      class: "hidden",
+                      data: { place_note_editor_target: "form", action: "submit->place-note-editor#save", turbo: false } do |f| %>
+          <%= f.text_area :note,
+                          rows: 4,
+                          data: { place_note_editor_target: "textarea" },
+                          class: "textarea textarea-bordered w-full text-sm mb-2",
+                          placeholder: t('places.drawer.notes') %>
+          <div class="flex gap-2">
+            <%= f.submit t('places.drawer.save'), class: 'btn btn-primary btn-xs', data: { place_note_editor_target: "saveButton" } %>
+            <button type="button"
+                    data-place-note-editor-target="cancelButton"
+                    data-action="click->place-note-editor#cancel"
+                    class="btn btn-ghost btn-xs">
+              <%= icon 'x', class: 'w-3.5 h-3.5' %> <%= t('.cancel') %>
+            </button>
+          </div>
+        <% end %>
+      </div>
+
+      <!-- Tags -->
+      <div class="mt-4" data-controller="place-tags-editor">
+        <div class="flex items-center justify-between mb-2">
+          <h3 class="font-semibold"><%= t('.tags') %></h3>
+          <button type="button"
+                  data-place-tags-editor-target="editButton"
+                  data-action="click->place-tags-editor#edit"
+                  class="btn btn-ghost btn-xs btn-square"
+                  title="<%= t('.edit_tags') %>">
+            <%= icon 'square-pen', class: 'w-3.5 h-3.5' %>
+          </button>
+        </div>
+
+        <!-- Display mode -->
+        <div data-place-tags-editor-target="display" class="flex flex-wrap gap-2">
+          <% if @place.tags.any? %>
+            <% @place.tags.each do |tag| %>
+              <span class="badge badge-lg">
+                <% if tag.color.present? %>
+                  <span class="w-3 h-3 rounded-full" style="margin-right: 5px; background-color: <%= tag.color %>"></span>
+                <% end %>
+                <%= tag.name %>
+              </span>
+            <% end %>
+          <% else %>
+            <span class="text-base-content/50 italic"><%= t('.no_tags') %></span>
+          <% end %>
+        </div>
+
+        <!-- Edit mode -->
+        <%= form_with model: @place,
+                      method: :patch,
+                      class: "hidden",
+                      data: { place_tags_editor_target: "form", action: "submit->place-tags-editor#save" } do |f| %>
+          <div class="space-y-1 mb-3 max-h-60 overflow-y-auto">
+            <% current_user.tags.ordered.each do |tag| %>
+              <label class="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-base-200 cursor-pointer transition-colors">
+                <%= check_box_tag "place[tag_ids][]", tag.id, @place.tags.include?(tag),
+                    class: "checkbox checkbox-sm",
+                    data: { place_tags_editor_target: "checkbox" } %>
+                <span class="text-sm">
+                  <%= tag.icon.present? ? tag.icon : '' %> <%= tag.name %>
+                </span>
+                <% if tag.color.present? %>
+                  <span class="w-3 h-3 rounded-full ml-auto" style="background-color: <%= tag.color %>"></span>
+                <% end %>
+              </label>
+            <% end %>
+          </div>
+          <div class="flex gap-2">
+            <%= f.submit t('places.drawer.save'), class: 'btn btn-primary btn-xs' %>
+            <button type="button"
+                    data-place-tags-editor-target="cancelButton"
+                    data-action="click->place-tags-editor#cancel"
+                    class="btn btn-ghost btn-xs">
+              <%= icon 'x', class: 'w-3.5 h-3.5' %> <%= t('.cancel') %>
+            </button>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1270,6 +1270,23 @@ en:
       places: Places
       delete: Delete
       are_you_sure_deleting_a_place_will_result_in_deleting: Are you sure? Deleting a place will result in deleting all visits for this place.
+    show:
+      coordinates: Coordinates
+      city: City
+      country: Country
+      created_at: Created at
+      updated_at: Updated at
+      tags: Tags
+      no_tags: No tags
+      visits: Visits
+      visit_name: Name
+      visit_date: Date
+      visit_time: Time
+      visit_duration: Duration
+      edit_name: Edit name
+      edit_note: Edit note
+      edit_tags: Edit tags
+      cancel: Cancel
   points:
     address:
       address: 'Address:'


### PR DESCRIPTION
Adds a show page where you can edit place details like name, tags, notes, as well as seeing and deleting visits. 
 
### Points for improvement
It's not visually evident how to access this page, I had considered adding another button to the index table but this would not show on mobile well. For now you just have to click the point name on index.

It would be nice to be able to create visits from the listing, but the change was getting large enough as is.

### Screenshots
Desktop View: 
<img width="1544" height="886" alt="Screenshot 2026-08-30 at 14 01 42" src="https://github.com/user-attachments/assets/d5e25cec-9fb4-43b0-b1cf-d19b846d8e31" />


Mobile:
<img width="1179" height="2556" alt="Screen Shot 2026-08-30 at 14 01 50" src="https://github.com/user-attachments/assets/3acf108a-f099-44a3-a023-e84d579357a0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed place pages with location information, dwell statistics, visits, interactive maps, notes, and tags.
  * Added inline editing for place names, notes, and tags.
  * Added pagination for place visits.
  * Place names in the places list now link to their detail pages.
  * Added JSON feedback for successful and failed place updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->