### PR TITLE
Adding a test-email button + Hiding email preference options if email is not configured (self-hosting)

### DIFF
--- a/app/controllers/settings/general_controller.rb
+++ b/app/controllers/settings/general_controller.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 class Settings::GeneralController < ApplicationController
+  include FlashStreamable
+
   self.page_refresh_morphing = true
 
   before_action :authenticate_user!
+  before_action :authenticate_self_hosted!, only: :test_email
 
   def index; end
 
@@ -17,6 +20,18 @@ class Settings::GeneralController < ApplicationController
       redirect_to settings_general_index_path, notice: I18n.t('controllers.settings.general.settings_updated')
     else
       redirect_to settings_general_index_path, alert: I18n.t('controllers.settings.general.failed_to_update_settings')
+    end
+  end
+
+  def test_email
+    type, message = run_email_test
+
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: stream_flash(type, message) }
+      format.html do
+        flash_key = type == :notice ? :notice : :alert
+        redirect_to settings_general_index_path, flash_key => message
+      end
     end
   end
 
@@ -52,6 +67,27 @@ class Settings::GeneralController < ApplicationController
   end
 
   private
+
+  def run_email_test
+    return [:alert, t('controllers.settings.general.smtp_not_configured')] if ENV['SMTP_SERVER'].blank?
+
+    message = UsersMailer.with(user: current_user).test_email.message
+    message.raise_delivery_errors = true
+    message.deliver
+    [:notice, t('controllers.settings.general.test_email_sent', email: current_user.email)]
+  rescue StandardError => e
+    Rails.logger.error("Test email delivery failed: #{e.class}: #{e.message}")
+    [:alert, t('controllers.settings.general.test_email_failed', error: test_email_error_description(e))]
+  end
+
+  def test_email_error_description(error)
+    safe = error.is_a?(SocketError) || error.is_a?(Timeout::Error) ||
+           error.is_a?(OpenSSL::SSL::SSLError) || error.is_a?(SystemCallError) ||
+           error.is_a?(ArgumentError) ||
+           error.class.name.start_with?('Net::SMTP')
+
+    safe ? "#{error.class}: #{error.message}" : error.class.name
+  end
 
   # Written here rather than left to the locale around_action: that one saves
   # with `update_all`, which the `current_user.save` below would overwrite with

--- a/app/controllers/settings/general_controller.rb
+++ b/app/controllers/settings/general_controller.rb
@@ -69,7 +69,7 @@ class Settings::GeneralController < ApplicationController
   private
 
   def run_email_test
-    return [:alert, t('controllers.settings.general.smtp_not_configured')] if ENV['SMTP_SERVER'].blank?
+    return [:alert, t('controllers.settings.general.smtp_not_configured')] unless DawarichSettings.email_configured?
 
     message = UsersMailer.with(user: current_user).test_email.message
     message.raise_delivery_errors = true

--- a/app/mailers/users_mailer.rb
+++ b/app/mailers/users_mailer.rb
@@ -51,6 +51,12 @@ class UsersMailer < ApplicationMailer
     mail(to: @user.email, subject: I18n.t('mailers.users.otp_account_locked.subject'))
   end
 
+  def test_email
+    @user = params[:user]
+
+    mail(to: @user.email, subject: I18n.t('mailers.users.test_email.subject'))
+  end
+
   def trial_expired; end
 
   def trial_expires_soon; end

--- a/app/views/settings/general/index.html.erb
+++ b/app/views/settings/general/index.html.erb
@@ -14,6 +14,7 @@
               <h2 class="text-2xl font-bold mb-4 flex items-center">
                 <%= icon 'mail', class: "text-primary mr-2" %> <%= t('.email_preferences') %>
               </h2>
+              <% if DawarichSettings.email_configured? %>
               <div class="bg-base-100 p-5 rounded-lg shadow-sm space-y-4">
                 <div class="form-control">
                   <label class="label cursor-pointer justify-start gap-4">
@@ -66,6 +67,16 @@
                   </div>
                 <% end %>
               </div>
+              <% else %>
+                <div class="bg-base-100 p-5 rounded-lg shadow-sm">
+                  <p class="text-sm text-base-content/70">
+                    <%= t('controllers.settings.general.smtp_not_configured_html',
+                          link: link_to(t('controllers.settings.general.smtp_not_configured_link'),
+                                        'https://dawarich.app/docs/self-hosting/configuration/smtp/',
+                                        target: '_blank', rel: 'noopener', class: 'link link-primary')) %>
+                  </p>
+                </div>
+              <% end %>
             </div>
 
             <!-- Language Section -->

--- a/app/views/settings/general/index.html.erb
+++ b/app/views/settings/general/index.html.erb
@@ -54,6 +54,17 @@
                     </div>
                   </label>
                 </div>
+
+                <% if DawarichSettings.self_hosted? %>
+                  <div class="border-t border-base-content/10 pt-4">
+                    <div class="flex flex-wrap items-center gap-3">
+                      <%= link_to t('.send_test_email'), settings_test_email_path,
+                                  data: { turbo: true, turbo_method: :post },
+                                  class: 'btn btn-outline btn-sm' %>
+                      <span class="text-sm text-base-content/70"><%= t('.test_email_hint') %></span>
+                    </div>
+                  </div>
+                <% end %>
               </div>
             </div>
 

--- a/app/views/users_mailer/test_email.html.erb
+++ b/app/views/users_mailer/test_email.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+    .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <p><%= t('.body') %></p>
+
+    <p><%= t('.sent_at') %>: <%= l(Time.current.in_time_zone(@user.timezone), format: :long) rescue Time.current %></p>
+  </div>
+</body>
+</html>

--- a/config/initializers/03_dawarich_settings.rb
+++ b/config/initializers/03_dawarich_settings.rb
@@ -41,6 +41,10 @@ class DawarichSettings
       ENV['PROMETHEUS_EXPORTER_ENABLED'].to_s == 'true'
     end
 
+    def email_configured?
+      ENV['SMTP_SERVER'].present?
+    end
+
     def nominatim_enabled?
       @nominatim_enabled ||= NOMINATIM_API_HOST.present?
     end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3057,6 +3057,8 @@ ca:
         verified_thank_you_for_supporting_dawarich_via_platform: "Verificat! Gràcies per donar suport a Dawarich a través de %{platform}."
         not_found_in_supporter_list_make_sure_you_re_using: No s'ha trobat a la llista de col·laboradors. Assegura't d'utilitzar el mateix correu electrònic o nom d'usuari de GitHub que a la teva plataforma de donació.
         smtp_not_configured: L'enviament de correu electrònic mitjançant SMTP no està configurat. Configura els paràmetres SMTP d'autoallotjament per establir les preferències de correu electrònic.
+        smtp_not_configured_html: L'enviament de correu electrònic mitjançant SMTP no està configurat. Configura %{link} per establir les preferències de correu electrònic.
+        smtp_not_configured_link: els paràmetres SMTP d'autoallotjament
         test_email_sent: Correu de prova enviat a %{email}. Comprova la teva bústia d'entrada (i la carpeta de correu no desitjat).
         test_email_failed: 'El correu de prova ha fallat: %{error}'
       onboardings:

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1462,6 +1462,8 @@ ca:
         receive_an_annual_summary_on_january_2nd_with_your_year: Rep un resum anual el 2 de gener amb el teu any en retrospectiva.
         news_updates: Notícies i actualitzacions
         receive_occasional_emails_about_new_features_and_important_updates: Rep correus electrònics ocasionals sobre noves funcions i actualitzacions importants
+        send_test_email: Envia un correu de prova
+        test_email_hint: Envia un missatge de prova al correu electrònic del teu compte per verificar els paràmetres SMTP
         timezone: Fus horari
         your_timezone: El teu fus horari
         all_dates_and_times_will_be_displayed_in_this_timezone: Totes les dates i hores es mostraran en aquest fus horari
@@ -2479,6 +2481,9 @@ ca:
       the_lock_will_automatically_lift_after_30_minutes_no_action: El bloqueig es desactivarà automàticament d'aquí a 30 minuts. No cal fer res si has estat tu.
       didn_t_recognise_this_activity_someone_may_be_trying_to: No reconeixes aquesta activitat? És possible que algú estigui intentant accedir al teu compte. Et recomanem restablir la teva contrasenya immediatament.
       reset_your_password_2: 'Restableix la teva contrasenya:'
+    test_email:
+      body: Si pots llegir això, la configuració SMTP de la teva instància funciona.
+      sent_at: Enviat el
     welcome:
       welcome_to_dawarich: Benvingut/da a Dawarich!
       hi: Hola
@@ -3051,6 +3056,9 @@ ca:
         please_enter_an_email_address_or_github_username: Introdueix una adreça de correu electrònic o un nom d'usuari de GitHub
         verified_thank_you_for_supporting_dawarich_via_platform: "Verificat! Gràcies per donar suport a Dawarich a través de %{platform}."
         not_found_in_supporter_list_make_sure_you_re_using: No s'ha trobat a la llista de col·laboradors. Assegura't d'utilitzar el mateix correu electrònic o nom d'usuari de GitHub que a la teva plataforma de donació.
+        smtp_not_configured: L'enviament de correu electrònic mitjançant SMTP no està configurat. Configura els paràmetres SMTP d'autoallotjament per establir les preferències de correu electrònic.
+        test_email_sent: Correu de prova enviat a %{email}. Comprova la teva bústia d'entrada (i la carpeta de correu no desitjat).
+        test_email_failed: 'El correu de prova ha fallat: %{error}'
       onboardings:
         demo_data_loaded: Dades de demostració carregades.
         demo_data_is_already_loaded: Les dades de demostració ja estan carregades.
@@ -3256,6 +3264,8 @@ ca:
         subject: Confirma la supressió del compte de Dawarich
       otp_account_locked:
         subject: Compte de Dawarich bloquejat temporalment
+      test_email:
+        subject: Correu de prova de Dawarich
       digests:
         year_end:
           subject: El teu any %{year} en retrospectiva - Dawarich

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1514,6 +1514,8 @@ de:
         receive_an_annual_summary_on_january_2nd_with_your_year: Erhalte eine jährliche Zusammenfassung am 2. Januar mit einem Überblick über dein Jahr.
         news_updates: Nachrichten & Updates
         receive_occasional_emails_about_new_features_and_important_updates: Erhalte gelegentliche E-Mails zu neuen Funktionen und wichtigen Updates
+        send_test_email: Test-E-Mail senden
+        test_email_hint: Sendet eine Testnachricht an die E-Mail-Adresse deines Kontos, um die SMTP-Einstellungen zu überprüfen
         timezone: Zeitzone
         your_timezone: Deine Zeitzone
         all_dates_and_times_will_be_displayed_in_this_timezone: Alle Daten und Uhrzeiten werden in dieser Zeitzone angezeigt
@@ -2484,6 +2486,9 @@ de:
       the_lock_will_automatically_lift_after_30_minutes_no_action: Die Sperre wird nach 30 Minuten automatisch aufgehoben. Wenn du das warst, musst du nichts unternehmen.
       didn_t_recognise_this_activity_someone_may_be_trying_to: Warst du das nicht? Möglicherweise versucht jemand, auf dein Konto zuzugreifen. Wir empfehlen dir, dein Passwort sofort zurückzusetzen.
       reset_your_password_2: 'Passwort zurücksetzen:'
+    test_email:
+      body: Wenn du dies lesen kannst, funktioniert die SMTP-Konfiguration deiner Instanz.
+      sent_at: Gesendet um
     welcome:
       welcome_to_dawarich: Willkommen bei Dawarich!
       hi: Hallo
@@ -3111,6 +3116,9 @@ de:
         please_enter_an_email_address_or_github_username: Gib bitte eine E-Mail-Adresse oder GitHub-Nutzername ein
         verified_thank_you_for_supporting_dawarich_via_platform: Verifiziert! Danke für deine Unterstützung von Dawarich über %{platform}.
         not_found_in_supporter_list_make_sure_you_re_using: Nicht in der Unterstützerliste gefunden. Stelle sicher, dass du dieselbe E-Mail-Adresse oder GitHub-Nutzername verwendest, wie dein Spenden-Plattform.
+        smtp_not_configured: Der E-Mail-Versand über SMTP ist nicht konfiguriert. Konfiguriere die selbst gehosteten SMTP-Einstellungen, um E-Mail-Präferenzen festzulegen.
+        test_email_sent: Test-E-Mail an %{email} gesendet. Prüfe deinen Posteingang (und den Spam-Ordner).
+        test_email_failed: 'Test-E-Mail fehlgeschlagen: %{error}'
       onboardings:
         demo_data_loaded: Demo-Daten geladen.
         demo_data_is_already_loaded: Demo-Daten sind bereits geladen.
@@ -3318,6 +3326,8 @@ de:
         subject: Bestätige die Löschung deines Dawarich-Kontos
       otp_account_locked:
         subject: Dawarich-Konto vorübergehend gesperrt
+      test_email:
+        subject: Dawarich Test-E-Mail
       digests:
         year_end:
           subject: Dein %{year} Jahresrückblick – Dawarich

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3117,6 +3117,8 @@ de:
         verified_thank_you_for_supporting_dawarich_via_platform: Verifiziert! Danke für deine Unterstützung von Dawarich über %{platform}.
         not_found_in_supporter_list_make_sure_you_re_using: Nicht in der Unterstützerliste gefunden. Stelle sicher, dass du dieselbe E-Mail-Adresse oder GitHub-Nutzername verwendest, wie dein Spenden-Plattform.
         smtp_not_configured: Der E-Mail-Versand über SMTP ist nicht konfiguriert. Konfiguriere die selbst gehosteten SMTP-Einstellungen, um E-Mail-Präferenzen festzulegen.
+        smtp_not_configured_html: 'Der E-Mail-Versand über SMTP ist nicht konfiguriert. Konfiguriere %{link}, um E-Mail-Präferenzen festzulegen.'
+        smtp_not_configured_link: die selbst gehosteten SMTP-Einstellungen
         test_email_sent: Test-E-Mail an %{email} gesendet. Prüfe deinen Posteingang (und den Spam-Ordner).
         test_email_failed: 'Test-E-Mail fehlgeschlagen: %{error}'
       onboardings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1511,6 +1511,8 @@ en:
         receive_an_annual_summary_on_january_2nd_with_your_year: Receive an annual summary on January 2nd with your year in review.
         news_updates: News & Updates
         receive_occasional_emails_about_new_features_and_important_updates: Receive occasional emails about new features and important updates
+        send_test_email: Send test email
+        test_email_hint: Sends a test message to your account email to verify SMTP settings
         timezone: Timezone
         your_timezone: Your timezone
         all_dates_and_times_will_be_displayed_in_this_timezone: All dates and times will be displayed in this timezone
@@ -2479,6 +2481,9 @@ en:
       the_lock_will_automatically_lift_after_30_minutes_no_action: The lock will automatically lift after 30 minutes. No action is required if this was you.
       didn_t_recognise_this_activity_someone_may_be_trying_to: Didn't recognise this activity? Someone may be trying to access your account. We recommend resetting your password immediately.
       reset_your_password_2: 'Reset your password:'
+    test_email:
+      body: If you can read this, your instance's SMTP configuration works.
+      sent_at: Sent at
     welcome:
       welcome_to_dawarich: Welcome to Dawarich!
       hi: Hi
@@ -3039,6 +3044,9 @@ en:
         please_enter_an_email_address_or_github_username: Please enter an email address or GitHub username
         verified_thank_you_for_supporting_dawarich_via_platform: Verified! Thank you for supporting Dawarich via %{platform}.
         not_found_in_supporter_list_make_sure_you_re_using: Not found in supporter list. Make sure you're using the same email or GitHub username as your donation platform.
+        smtp_not_configured: Email sending via SMTP is not configured. Configure self-hosted SMTP settings in order to set email preferences.
+        test_email_sent: Test email sent to %{email}. Check your inbox (and spam folder).
+        test_email_failed: 'Test email failed: %{error}'
       onboardings:
         demo_data_loaded: Demo data loaded.
         demo_data_is_already_loaded: Demo data is already loaded.
@@ -3244,6 +3252,8 @@ en:
         subject: Confirm Dawarich account deletion
       otp_account_locked:
         subject: Dawarich account temporarily locked
+      test_email:
+        subject: Dawarich test email
       digests:
         year_end:
           subject: Your %{year} Year in Review - Dawarich

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3045,6 +3045,8 @@ en:
         verified_thank_you_for_supporting_dawarich_via_platform: Verified! Thank you for supporting Dawarich via %{platform}.
         not_found_in_supporter_list_make_sure_you_re_using: Not found in supporter list. Make sure you're using the same email or GitHub username as your donation platform.
         smtp_not_configured: Email sending via SMTP is not configured. Configure self-hosted SMTP settings in order to set email preferences.
+        smtp_not_configured_html: 'Email sending via SMTP is not configured. Configure %{link} in order to set email preferences.'
+        smtp_not_configured_link: self-hosted SMTP settings
         test_email_sent: Test email sent to %{email}. Check your inbox (and spam folder).
         test_email_failed: 'Test email failed: %{error}'
       onboardings:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3062,6 +3062,8 @@ es:
         verified_thank_you_for_supporting_dawarich_via_platform: Verificado! ¡Gracias por apoyar a Dawarich mediante %{platform}!
         not_found_in_supporter_list_make_sure_you_re_using: No encontrado en la lista de apoyo. Asegúrate de que estás utilizando el mismo correo electrónico o nombre de usuario de GitHub que tu plataforma de donación.
         smtp_not_configured: El envío de correo electrónico mediante SMTP no está configurado. Configura los ajustes SMTP de autoalojamiento para establecer las preferencias de correo electrónico.
+        smtp_not_configured_html: 'El envío de correo electrónico mediante SMTP no está configurado. Configura %{link} para establecer las preferencias de correo electrónico.'
+        smtp_not_configured_link: los ajustes SMTP de autoalojamiento
         test_email_sent: Correo de prueba enviado a %{email}. Revisa tu bandeja de entrada (y la carpeta de spam).
         test_email_failed: 'El correo de prueba falló: %{error}'
       onboardings:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1514,6 +1514,8 @@ es:
         receive_an_annual_summary_on_january_2nd_with_your_year: Recibir un resumen anual el 2 de enero con tu año en revisión.
         news_updates: Noticias y actualizaciones
         receive_occasional_emails_about_new_features_and_important_updates: Recibir correos electrónicos ocasionales sobre nuevas características y actualizaciones importantes.
+        send_test_email: Enviar correo de prueba
+        test_email_hint: Envía un mensaje de prueba al correo electrónico de tu cuenta para verificar la configuración SMTP
         timezone: Zona horaria
         your_timezone: Tu zona horaria
         all_dates_and_times_will_be_displayed_in_this_timezone: Todos los fechas y horas se mostrarán en esta zona horaria.
@@ -2484,6 +2486,9 @@ es:
       the_lock_will_automatically_lift_after_30_minutes_no_action: El bloqueo se levantará automáticamente después de 30 minutos. Si has sido tú, no tienes que hacer nada.
       didn_t_recognise_this_activity_someone_may_be_trying_to: "¿No reconoces esta actividad? Es posible que alguien esté intentando acceder a tu cuenta. Te recomendamos restablecer tu contraseña de inmediato."
       reset_your_password_2: 'Reinicia tu contraseña:'
+    test_email:
+      body: Si puedes leer esto, la configuración SMTP de tu instancia funciona.
+      sent_at: Enviado el
     welcome:
       welcome_to_dawarich: "¡Te damos la bienvenida a Dawarich!"
       hi: Hola
@@ -3056,6 +3061,9 @@ es:
         please_enter_an_email_address_or_github_username: Por favor, introduce una dirección de correo electrónico o un nombre de usuario de GitHub
         verified_thank_you_for_supporting_dawarich_via_platform: Verificado! ¡Gracias por apoyar a Dawarich mediante %{platform}!
         not_found_in_supporter_list_make_sure_you_re_using: No encontrado en la lista de apoyo. Asegúrate de que estás utilizando el mismo correo electrónico o nombre de usuario de GitHub que tu plataforma de donación.
+        smtp_not_configured: El envío de correo electrónico mediante SMTP no está configurado. Configura los ajustes SMTP de autoalojamiento para establecer las preferencias de correo electrónico.
+        test_email_sent: Correo de prueba enviado a %{email}. Revisa tu bandeja de entrada (y la carpeta de spam).
+        test_email_failed: 'El correo de prueba falló: %{error}'
       onboardings:
         demo_data_loaded: Datos de demostración cargados.
         demo_data_is_already_loaded: Los datos de demostración ya están cargados.
@@ -3263,6 +3271,8 @@ es:
         subject: Confirma la eliminación de la cuenta de Dawarich
       otp_account_locked:
         subject: La cuenta de Dawarich está temporalmente bloqueada
+      test_email:
+        subject: Correo de prueba de Dawarich
       digests:
         year_end:
           subject: Tu %{year} Año en Resumen - Dawarich

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4037,6 +4037,8 @@ fr:
           des donateurs. Assurez-vous d'utiliser la même adresse e-mail ou le même
           nom d'utilisateur GitHub que votre plateforme de dons.
         smtp_not_configured: L'envoi d'e-mails via SMTP n'est pas configuré. Configurez les paramètres SMTP auto-hébergés pour définir vos préférences d'e-mail.
+        smtp_not_configured_html: L'envoi d'e-mails via SMTP n'est pas configuré. Configurez %{link} pour définir vos préférences d'e-mail.
+        smtp_not_configured_link: les paramètres SMTP auto-hébergés
         test_email_sent: E-mail de test envoyé à %{email}. Vérifiez votre boîte de
           réception (et le dossier spam).
         test_email_failed: "L'e-mail de test a échoué : %{error}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2280,6 +2280,9 @@ fr:
         receive_occasional_emails_about_new_features_and_important_updates: Recevoir
           des emails occasionnels sur les nouvelles fonctionnalités et les mises à
           jour importantes
+        send_test_email: Envoyer un e-mail de test
+        test_email_hint: Envoie un message de test à l'adresse e-mail de votre compte
+          pour vérifier les paramètres SMTP
         timezone: Fuseau horaire
         your_timezone: Votre fuseau horaire
         all_dates_and_times_will_be_displayed_in_this_timezone: Toutes les dates et
@@ -3510,6 +3513,9 @@ fr:
         cette activité ? Quelqu'un pourrait essayer d'accéder à votre compte. Nous
         recommandons de réinitialiser votre mot de passe immédiatement.
       reset_your_password_2: 'Réinitialisez votre mot de passe :'
+    test_email:
+      body: Si vous pouvez lire ceci, la configuration SMTP de votre instance fonctionne.
+      sent_at: Envoyé le
     welcome:
       welcome_to_dawarich: Bienvenue chez Dawarich !
       hi: Bonjour
@@ -4030,6 +4036,10 @@ fr:
         not_found_in_supporter_list_make_sure_you_re_using: Non trouvé dans la liste
           des donateurs. Assurez-vous d'utiliser la même adresse e-mail ou le même
           nom d'utilisateur GitHub que votre plateforme de dons.
+        smtp_not_configured: L'envoi d'e-mails via SMTP n'est pas configuré. Configurez les paramètres SMTP auto-hébergés pour définir vos préférences d'e-mail.
+        test_email_sent: E-mail de test envoyé à %{email}. Vérifiez votre boîte de
+          réception (et le dossier spam).
+        test_email_failed: "L'e-mail de test a échoué : %{error}"
       onboardings:
         demo_data_loaded: Données de démo chargées.
         demo_data_is_already_loaded: Les données de démo sont déjà chargées.
@@ -4309,6 +4319,8 @@ fr:
         subject: Confirmez la suppression du compte Dawarich
       otp_account_locked:
         subject: Compte Dawarich verrouillé temporairement
+      test_email:
+        subject: E-mail de test Dawarich
       digests:
         year_end:
           subject: Bilan annuel %{year} — Dawarich

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1511,6 +1511,8 @@ pl:
         receive_an_annual_summary_on_january_2nd_with_your_year: Otrzymuj roczne podsumowanie 2 stycznia z przeglądem całego roku.
         news_updates: Aktualności i nowości
         receive_occasional_emails_about_new_features_and_important_updates: Otrzymuj okazjonalne wiadomości o nowych funkcjach i ważnych aktualizacjach
+        send_test_email: Wyślij testowego e-maila
+        test_email_hint: Wysyła testową wiadomość na adres e-mail Twojego konta, aby zweryfikować ustawienia SMTP
         timezone: Strefa czasowa
         your_timezone: Twoja strefa czasowa
         all_dates_and_times_will_be_displayed_in_this_timezone: Wszystkie daty i godziny będą wyświetlane w tej strefie czasowej
@@ -2479,6 +2481,9 @@ pl:
       the_lock_will_automatically_lift_after_30_minutes_no_action: Blokada zostanie automatycznie zdjęta po 30 minutach. Jeśli to była Twoja aktywność, nie musisz nic robić.
       didn_t_recognise_this_activity_someone_may_be_trying_to: Nie rozpoznajesz tej aktywności? Ktoś może próbować uzyskać dostęp do Twojego konta. Zalecamy natychmiastową zmianę hasła.
       reset_your_password_2: 'Zmień hasło:'
+    test_email:
+      body: Jeśli możesz to przeczytać, konfiguracja SMTP Twojej instancji działa.
+      sent_at: Wysłano
     welcome:
       welcome_to_dawarich: Witamy w Dawarich!
       hi: Cześć
@@ -3106,6 +3111,9 @@ pl:
         please_enter_an_email_address_or_github_username: Podaj adres e-mail lub nazwę użytkownika GitHub
         verified_thank_you_for_supporting_dawarich_via_platform: Zweryfikowano! Dziękujemy za wspieranie Dawarich przez %{platform}.
         not_found_in_supporter_list_make_sure_you_re_using: Nie znaleziono na liście wspierających. Upewnij się, że używasz tego samego e-maila lub loginu GitHub co na platformie wsparcia.
+        smtp_not_configured: Wysyłanie e-maili przez SMTP nie jest skonfigurowane. Skonfiguruj ustawienia SMTP dla self-hostingu, aby ustawić preferencje e-mail.
+        test_email_sent: Testowy e-mail wysłano na adres %{email}. Sprawdź swoją skrzynkę odbiorczą (i folder spam).
+        test_email_failed: 'Nie udało się wysłać testowego e-maila: %{error}'
       onboardings:
         demo_data_loaded: Dane demo zostały załadowane.
         demo_data_is_already_loaded: Dane demo są już załadowane.
@@ -3311,6 +3319,8 @@ pl:
         subject: Potwierdź usunięcie konta Dawarich
       otp_account_locked:
         subject: Konto Dawarich zostało tymczasowo zablokowane
+      test_email:
+        subject: Testowy e-mail Dawarich
       digests:
         year_end:
           subject: Twoje podsumowanie roku %{year} - Dawarich

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -3112,6 +3112,8 @@ pl:
         verified_thank_you_for_supporting_dawarich_via_platform: Zweryfikowano! Dziękujemy za wspieranie Dawarich przez %{platform}.
         not_found_in_supporter_list_make_sure_you_re_using: Nie znaleziono na liście wspierających. Upewnij się, że używasz tego samego e-maila lub loginu GitHub co na platformie wsparcia.
         smtp_not_configured: Wysyłanie e-maili przez SMTP nie jest skonfigurowane. Skonfiguruj ustawienia SMTP dla self-hostingu, aby ustawić preferencje e-mail.
+        smtp_not_configured_html: 'Wysyłanie e-maili przez SMTP nie jest skonfigurowane. Skonfiguruj %{link}, aby ustawić preferencje e-mail.'
+        smtp_not_configured_link: ustawienia SMTP dla self-hostingu
         test_email_sent: Testowy e-mail wysłano na adres %{email}. Sprawdź swoją skrzynkę odbiorczą (i folder spam).
         test_email_failed: 'Nie udało się wysłać testowego e-maila: %{error}'
       onboardings:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
     resources :general, only: [:index]
     patch 'general', to: 'general#update'
     post 'general/verify_supporter', to: 'general#verify_supporter', as: :verify_supporter
+    post 'general/test_email', to: 'general#test_email', as: :test_email
 
     resources :integrations, only: [:index]
     patch 'integrations', to: 'integrations#update'

--- a/spec/requests/settings/general_spec.rb
+++ b/spec/requests/settings/general_spec.rb
@@ -11,6 +11,11 @@ RSpec.describe 'settings/general', type: :request do
     end
 
     describe 'GET /index' do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('SMTP_SERVER').and_return('smtp.example.com')
+      end
+
       it 'returns a success response' do
         get settings_general_index_url
 
@@ -23,6 +28,17 @@ RSpec.describe 'settings/general', type: :request do
         expect(response.body).to include('id="email-digests"')
         expect(response.body).to include('name="monthly_digest_emails_enabled"')
         expect(response.body).to include('name="yearly_digest_emails_enabled"')
+      end
+
+      it 'shows a not-configured notice instead of preferences when SMTP is unset' do
+        allow(ENV).to receive(:[]).with('SMTP_SERVER').and_return(nil)
+
+        get settings_general_index_url
+
+        expect(response.body).to include('Email sending via SMTP is not configured')
+        expect(response.body).to include('https://dawarich.app/docs/self-hosting/configuration/smtp/')
+        expect(response.body).not_to include('name="monthly_digest_emails_enabled"')
+        expect(response.body).not_to include('name="news_emails_enabled"')
       end
     end
 

--- a/spec/requests/settings/general_spec.rb
+++ b/spec/requests/settings/general_spec.rb
@@ -117,6 +117,91 @@ RSpec.describe 'settings/general', type: :request do
       end
     end
 
+    describe 'POST /test_email' do
+      around do |example|
+        original_from = UsersMailer.default_params[:from]
+        UsersMailer.default from: 'hi@dawarich.app'
+        example.run
+      ensure
+        UsersMailer.default from: original_from
+      end
+
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(true)
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('SMTP_SERVER').and_return('smtp.example.com')
+        ActionMailer::Base.deliveries.clear
+      end
+
+      it 'delivers a test email to the current user' do
+        expect do
+          post settings_test_email_path
+        end.to change { ActionMailer::Base.deliveries.size }.by(1)
+
+        expect(ActionMailer::Base.deliveries.last.to).to include(user.email)
+        expect(response).to redirect_to(settings_general_index_path)
+        expect(flash[:notice]).to include(user.email)
+      end
+
+      it 'shows an alert when SMTP is not configured' do
+        allow(ENV).to receive(:[]).with('SMTP_SERVER').and_return(nil)
+
+        post settings_test_email_path
+
+        expect(ActionMailer::Base.deliveries).to be_empty
+        expect(response).to redirect_to(settings_general_index_path)
+        expect(flash[:alert]).to be_present
+      end
+
+      it 'shows an alert with the error when delivery fails' do
+        allow_any_instance_of(Mail::Message).to receive(:deliver)
+          .and_raise(Net::SMTPAuthenticationError.new('authentication failed'))
+
+        post settings_test_email_path
+
+        expect(response).to redirect_to(settings_general_index_path)
+        expect(flash[:alert]).to include('Net::SMTPAuthenticationError')
+      end
+
+      it 'responds with turbo stream when requested' do
+        post settings_test_email_path, headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+        expect(response.media_type).to eq('text/vnd.turbo-stream.html')
+        expect(response.body).to include(user.email)
+      end
+
+      it 'renders the button as a Turbo POST link' do
+        get settings_general_index_path
+
+        link = response.body.scan(/<a[^>]*settings\/general\/test_email[^>]*>/).first
+        expect(link).to be_present
+        expect(link).to include('data-turbo="true"')
+        expect(link).to include('data-turbo-method="post"')
+        expect(response.body).to include(
+          '>Sends a test message to your account email to verify SMTP settings</span>'
+        )
+      end
+
+      context 'when not self-hosted' do
+        before do
+          allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        end
+
+        it 'is not authorized' do
+          post settings_test_email_path
+
+          expect(ActionMailer::Base.deliveries).to be_empty
+          expect(response).to redirect_to(root_path)
+        end
+
+        it 'does not render the test email button' do
+          get settings_general_index_path
+
+          expect(response.body).not_to include('test_email')
+        end
+      end
+    end
+
     describe 'POST /verify_supporter' do
       context 'when both email and github username are blank' do
         it 'redirects with alert' do


### PR DESCRIPTION
See discussion:
https://github.com/Freika/dawarich/discussions/3460

<img width="645" height="370" alt="Screenshot from 2026-08-29 23-04-08" src="https://github.com/user-attachments/assets/647e5f95-189f-4475-91e3-0c43638042a7" />

<img width="699" height="144" alt="Screenshot from 2026-08-29 23-05-39" src="https://github.com/user-attachments/assets/a5a519d3-de3f-45d4-aa62-612349f48697" />

Email test:
<img width="541" height="270" alt="image" src="https://github.com/user-attachments/assets/1b4e0e8f-6d3a-4482-b27c-6d49719b78cc" />

