### PR TITLE
feat(api): accept visits in batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- A place created from a suggested visit no longer has its name locked. Visits detected on a phone arrive with a generated name such as "Visited place", and locking it meant reverse geocoding could never replace it with the real address.
+- Places created from a suggested visit now get their real address. Visits detected on a phone arrive with a generated name such as "Visited place"; that name is no longer locked, reverse geocoding is queued for the new place, and the resolved address now replaces the generated name on the visit as well as the place.
 
 ## [1.14.1] - 2026-08-31, Berlin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.14.2]
+
+### Added
+
+- The API now accepts visits in batches: `POST /api/v1/visits/batch` takes up to 100 visits in one request and reports each one's outcome separately, so a single rejected visit no longer costs the whole sync. The mobile apps previously had to send one request per detected visit.
+
+### Fixed
+
+- A place created from a suggested visit no longer has its name locked. Visits detected on a phone arrive with a generated name such as "Visited place", and locking it meant reverse geocoding could never replace it with the real address.
+
 ## [1.14.1] - 2026-08-31, Berlin
 
 ### Changed

--- a/app/controllers/api/v1/visits_controller.rb
+++ b/app/controllers/api/v1/visits_controller.rb
@@ -113,12 +113,14 @@ class Api::V1::VisitsController < ApiController
     end
 
     results = submitted.each_with_index.map { |attributes, index| create_batched_visit(attributes, index) }
+    failed_count = results.count { |result| result[:status] == 'failed' }
+    report_batch_failures(failed_count, submitted.size)
 
     render json: {
       results: results,
       created_count: results.count { |result| result[:status] == 'created' },
       duplicate_count: results.count { |result| result[:status] == 'duplicate' },
-      failed_count: results.count { |result| result[:status] == 'failed' }
+      failed_count: failed_count
     }
   end
 
@@ -164,13 +166,23 @@ class Api::V1::VisitsController < ApiController
     params.require(:visit).permit(:name, :place_id, :area_id, :status, :latitude, :longitude, :started_at, :ended_at)
   end
 
+  def report_batch_failures(failed_count, submitted_count)
+    return unless failed_count.positive?
+
+    ExceptionReporter.call(
+      "Visits batch rejected #{failed_count} of #{submitted_count} entries",
+      'Batch visit creation rejected entries'
+    )
+  end
+
   def create_batched_visit(attributes, index)
     unless attributes.is_a?(ActionController::Parameters)
       return { index: index, status: 'failed',
                error: I18n.t('controllers.api.v1.visits.invalid_visit_payload') }
     end
 
-    service = Visits::Create.new(current_api_user, attributes.permit(*BATCH_VISIT_ATTRIBUTES))
+    service = Visits::Create.new(current_api_user, attributes.permit(*BATCH_VISIT_ATTRIBUTES),
+                                 report_exceptions: false)
 
     if service.call
       { index: index, status: service.duplicate? ? 'duplicate' : 'created',

--- a/app/controllers/api/v1/visits_controller.rb
+++ b/app/controllers/api/v1/visits_controller.rb
@@ -169,10 +169,8 @@ class Api::V1::VisitsController < ApiController
   def report_batch_failures(failed_count, submitted_count)
     return unless failed_count.positive?
 
-    ExceptionReporter.call(
-      "Visits batch rejected #{failed_count} of #{submitted_count} entries",
-      'Batch visit creation rejected entries'
-    )
+    Rails.logger.warn("Visits batch rejected #{failed_count} of #{submitted_count} entries")
+    ExceptionReporter.call('Batch visit creation rejected entries', 'Visits batch had rejected entries')
   end
 
   def create_batched_visit(attributes, index)
@@ -185,8 +183,9 @@ class Api::V1::VisitsController < ApiController
                                  report_exceptions: false)
 
     if service.call
-      { index: index, status: service.duplicate? ? 'duplicate' : 'created',
-        visit: Api::VisitSerializer.new(service.visit).call }
+      result = { index: index, status: service.duplicate? ? 'duplicate' : 'created' }
+      result[:visit] = Api::VisitSerializer.new(service.visit).call unless service.visit.soft_deleted?
+      result
     else
       { index: index, status: 'failed',
         error: service.errors || I18n.t('controllers.api.v1.visits.failed_to_create_visit') }

--- a/app/controllers/api/v1/visits_controller.rb
+++ b/app/controllers/api/v1/visits_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::V1::VisitsController < ApiController
   BATCH_MAX = 100
+  BATCH_VISIT_ATTRIBUTES = %i[name status latitude longitude started_at ended_at].freeze
 
   def index
     visits = Visits::Finder.new(current_api_user, params).call
@@ -96,9 +97,9 @@ class Api::V1::VisitsController < ApiController
   end
 
   def batch
-    submitted = batch_params[:visits]
+    submitted = params[:visits]
 
-    if submitted.blank?
+    unless submitted.is_a?(Array) && submitted.any?
       return render json: { error: I18n.t('controllers.api.v1.visits.no_visits_provided') },
                     status: :unprocessable_content
     end
@@ -116,6 +117,7 @@ class Api::V1::VisitsController < ApiController
     render json: {
       results: results,
       created_count: results.count { |result| result[:status] == 'created' },
+      duplicate_count: results.count { |result| result[:status] == 'duplicate' },
       failed_count: results.count { |result| result[:status] == 'failed' }
     }
   end
@@ -162,17 +164,17 @@ class Api::V1::VisitsController < ApiController
     params.require(:visit).permit(:name, :place_id, :area_id, :status, :latitude, :longitude, :started_at, :ended_at)
   end
 
-  def batch_params
-    params.permit(
-      visits: %i[name place_id area_id status latitude longitude started_at ended_at]
-    )
-  end
-
   def create_batched_visit(attributes, index)
-    service = Visits::Create.new(current_api_user, attributes)
+    unless attributes.is_a?(ActionController::Parameters)
+      return { index: index, status: 'failed',
+               error: I18n.t('controllers.api.v1.visits.invalid_visit_payload') }
+    end
+
+    service = Visits::Create.new(current_api_user, attributes.permit(*BATCH_VISIT_ATTRIBUTES))
 
     if service.call
-      { index: index, status: 'created', visit: Api::VisitSerializer.new(service.visit).call }
+      { index: index, status: service.duplicate? ? 'duplicate' : 'created',
+        visit: Api::VisitSerializer.new(service.visit).call }
     else
       { index: index, status: 'failed',
         error: service.errors || I18n.t('controllers.api.v1.visits.failed_to_create_visit') }

--- a/app/controllers/api/v1/visits_controller.rb
+++ b/app/controllers/api/v1/visits_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::VisitsController < ApiController
+  BATCH_MAX = 100
+
   def index
     visits = Visits::Finder.new(current_api_user, params).call
 
@@ -93,6 +95,31 @@ class Api::V1::VisitsController < ApiController
     end
   end
 
+  def batch
+    submitted = batch_params[:visits]
+
+    if submitted.blank?
+      return render json: { error: I18n.t('controllers.api.v1.visits.no_visits_provided') },
+                    status: :unprocessable_content
+    end
+
+    if submitted.size > BATCH_MAX
+      return render json: {
+        error: I18n.t('controllers.api.v1.visits.too_many_visits_maximum_is_limit_per_batch', limit: BATCH_MAX),
+        limit: BATCH_MAX,
+        requested: submitted.size
+      }, status: :unprocessable_content
+    end
+
+    results = submitted.each_with_index.map { |attributes, index| create_batched_visit(attributes, index) }
+
+    render json: {
+      results: results,
+      created_count: results.count { |result| result[:status] == 'created' },
+      failed_count: results.count { |result| result[:status] == 'failed' }
+    }
+  end
+
   def bulk_update
     service = Visits::BulkUpdate.new(
       current_api_user,
@@ -133,6 +160,23 @@ class Api::V1::VisitsController < ApiController
 
   def visit_params
     params.require(:visit).permit(:name, :place_id, :area_id, :status, :latitude, :longitude, :started_at, :ended_at)
+  end
+
+  def batch_params
+    params.permit(
+      visits: %i[name place_id area_id status latitude longitude started_at ended_at]
+    )
+  end
+
+  def create_batched_visit(attributes, index)
+    service = Visits::Create.new(current_api_user, attributes)
+
+    if service.call
+      { index: index, status: 'created', visit: Api::VisitSerializer.new(service.visit).call }
+    else
+      { index: index, status: 'failed',
+        error: service.errors || I18n.t('controllers.api.v1.visits.failed_to_create_visit') }
+    end
   end
 
   def merge_params

--- a/app/services/places/name_fetcher.rb
+++ b/app/services/places/name_fetcher.rb
@@ -18,6 +18,7 @@ module Places
       name = ::Visits::Names::Builder.build_from_properties(properties)
 
       ActiveRecord::Base.transaction do
+        previous_name = place.name
         place.machine_named = true
         place.name = name if name.present? && !place.name_locked?
         place.city = properties['city'] if properties['city'].present?
@@ -26,7 +27,10 @@ module Places
         place.save!
 
         propagated_name = place.name
-        place.visits.where(name: Place::DEFAULT_NAME).update_all(name: propagated_name) if propagated_name.present?
+        if propagated_name.present?
+          stale_names = [Place::DEFAULT_NAME, previous_name].uniq - [propagated_name]
+          place.visits.where(name: stale_names).update_all(name: propagated_name) if stale_names.any?
+        end
 
         place
       end

--- a/app/services/visits/create.rb
+++ b/app/services/visits/create.rb
@@ -80,11 +80,16 @@ module Visits
         longitude: lon_f,
         lonlat: "POINT(#{lon_f} #{lat_f})",
         source: :manual,
-        user_named: true
+        user_named: !suggested?,
+        machine_named: suggested?
       )
     rescue ActiveRecord::RecordInvalid => e
       ExceptionReporter.call(e, "Failed to create place: #{e.message}")
       nil
+    end
+
+    def suggested?
+      params[:status].to_s == 'suggested'
     end
 
     def create_visit(place)

--- a/app/services/visits/create.rb
+++ b/app/services/visits/create.rb
@@ -15,6 +15,7 @@ module Visits
 
     def call
       return false unless timestamps_usable?
+      return false unless coordinates_usable?
 
       result = ActiveRecord::Base.transaction do
         place = find_or_create_place
@@ -29,9 +30,7 @@ module Visits
     rescue ActiveRecord::RecordNotUnique
       @duplicate = true
       @visit = existing_visit
-      # Re-creating a visit over its own tombstone (or an old decline) is an
-      # explicit undo: revive the row instead of returning it still hidden.
-      @visit.update!(deleted_at: nil, status: :confirmed) if @visit && (@visit.soft_deleted? || @visit.declined?)
+      @visit.update!(deleted_at: nil, status: :confirmed) if @visit && revivable?(@visit)
       @errors = 'Failed to create visit: duplicate visit' unless @visit
 
       @visit || false
@@ -53,6 +52,46 @@ module Visits
     end
 
     private
+
+    def revivable?(visit)
+      return false if suggested?
+
+      visit.soft_deleted? || visit.declined?
+    end
+
+    def coordinates_usable?
+      if latitude.nil? || longitude.nil?
+        @errors = 'Failed to create visit: invalid coordinates'
+        return false
+      end
+
+      unless latitude.between?(-90, 90) && longitude.between?(-180, 180)
+        @errors = 'Failed to create visit: coordinates out of range'
+        return false
+      end
+
+      true
+    end
+
+    def latitude
+      return @latitude if defined?(@latitude)
+
+      @latitude = parse_coordinate(params[:latitude])
+    end
+
+    def longitude
+      return @longitude if defined?(@longitude)
+
+      @longitude = parse_coordinate(params[:longitude])
+    end
+
+    def parse_coordinate(value)
+      return nil if value.blank?
+
+      Float(value)
+    rescue ArgumentError, TypeError
+      nil
+    end
 
     def timestamps_usable?
       if started_at.nil? || ended_at.nil?
@@ -110,21 +149,17 @@ module Visits
            .where(
              'ST_DWithin(places.lonlat::geography, ' \
              'ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)',
-             params[:longitude].to_f, params[:latitude].to_f, 100
+             longitude, latitude, 100
            ).first
     end
 
     def create_new_place
-      place_name = params[:name]
-      lat_f = params[:latitude].to_f
-      lon_f = params[:longitude].to_f
-
       @created_place = Place.create!(
         user: user,
-        name: place_name,
-        latitude: lat_f,
-        longitude: lon_f,
-        lonlat: "POINT(#{lon_f} #{lat_f})",
+        name: params[:name],
+        latitude: latitude,
+        longitude: longitude,
+        lonlat: "POINT(#{longitude} #{latitude})",
         source: :manual,
         user_named: !suggested?,
         machine_named: suggested?
@@ -140,6 +175,8 @@ module Visits
       return unless Geocoding::Config.for(user).enabled?
 
       Places::NameFetchingJob.perform_later(@created_place.id)
+    rescue StandardError => e
+      ExceptionReporter.call(e, "Failed to enqueue place name fetching: #{e.message}")
     end
 
     def suggested?

--- a/app/services/visits/create.rb
+++ b/app/services/visits/create.rb
@@ -4,9 +4,10 @@ module Visits
   class Create
     attr_reader :user, :params, :errors, :visit
 
-    def initialize(user, params)
+    def initialize(user, params, report_exceptions: true)
       @user = user
       @params = params.respond_to?(:with_indifferent_access) ? params.with_indifferent_access : params
+      @report_exceptions = report_exceptions
       @visit = nil
       @errors = nil
       @duplicate = false
@@ -35,13 +36,13 @@ module Visits
 
       @visit || false
     rescue ActiveRecord::RecordInvalid => e
-      ExceptionReporter.call(e, "Failed to create visit: #{e.message}")
+      report_exception(e, "Failed to create visit: #{e.message}")
 
       @errors = "Failed to create visit: #{e.message}"
 
       false
     rescue StandardError => e
-      ExceptionReporter.call(e, "Failed to create visit: #{e.message}")
+      report_exception(e, "Failed to create visit: #{e.message}")
 
       @errors = "Failed to create visit: #{e.message}"
       false
@@ -52,6 +53,12 @@ module Visits
     end
 
     private
+
+    def report_exception(error, message)
+      return unless @report_exceptions
+
+      ExceptionReporter.call(error, message)
+    end
 
     def revivable?(visit)
       return false if suggested?
@@ -165,7 +172,7 @@ module Visits
         machine_named: suggested?
       )
     rescue ActiveRecord::RecordInvalid => e
-      ExceptionReporter.call(e, "Failed to create place: #{e.message}")
+      report_exception(e, "Failed to create place: #{e.message}")
       nil
     end
 
@@ -176,7 +183,7 @@ module Visits
 
       Places::NameFetchingJob.perform_later(@created_place.id)
     rescue StandardError => e
-      ExceptionReporter.call(e, "Failed to enqueue place name fetching: #{e.message}")
+      report_exception(e, "Failed to enqueue place name fetching: #{e.message}")
     end
 
     def suggested?

--- a/app/services/visits/create.rb
+++ b/app/services/visits/create.rb
@@ -9,17 +9,25 @@ module Visits
       @params = params.respond_to?(:with_indifferent_access) ? params.with_indifferent_access : params
       @visit = nil
       @errors = nil
+      @duplicate = false
+      @created_place = nil
     end
 
     def call
-      ActiveRecord::Base.transaction do
+      return false unless timestamps_usable?
+
+      result = ActiveRecord::Base.transaction do
         place = find_or_create_place
         return false unless place
 
-        visit = create_visit(place)
-        visit
+        create_visit(place)
       end
+
+      enqueue_name_fetching
+
+      result
     rescue ActiveRecord::RecordNotUnique
+      @duplicate = true
       @visit = existing_visit
       # Re-creating a visit over its own tombstone (or an old decline) is an
       # explicit undo: revive the row instead of returning it still hidden.
@@ -40,7 +48,45 @@ module Visits
       false
     end
 
+    def duplicate?
+      @duplicate
+    end
+
     private
+
+    def timestamps_usable?
+      if started_at.nil? || ended_at.nil?
+        @errors = 'Failed to create visit: invalid timestamps'
+        return false
+      end
+
+      if ended_at < started_at
+        @errors = 'Failed to create visit: ended_at is before started_at'
+        return false
+      end
+
+      true
+    end
+
+    def started_at
+      return @started_at if defined?(@started_at)
+
+      @started_at = parse_time(params[:started_at])
+    end
+
+    def ended_at
+      return @ended_at if defined?(@ended_at)
+
+      @ended_at = parse_time(params[:ended_at])
+    end
+
+    def parse_time(value)
+      return nil if value.blank?
+
+      Time.zone.parse(value.to_s)
+    rescue ArgumentError
+      nil
+    end
 
     def find_or_create_place
       existing_place = find_existing_place
@@ -54,7 +100,7 @@ module Visits
       place = find_existing_place
       return nil unless place
 
-      user.visits.find_by(place_id: place.id, started_at: Time.zone.parse(params[:started_at]))
+      user.visits.find_by(place_id: place.id, started_at: started_at)
     end
 
     def find_existing_place
@@ -73,7 +119,7 @@ module Visits
       lat_f = params[:latitude].to_f
       lon_f = params[:longitude].to_f
 
-      Place.create!(
+      @created_place = Place.create!(
         user: user,
         name: place_name,
         latitude: lat_f,
@@ -88,13 +134,19 @@ module Visits
       nil
     end
 
+    def enqueue_name_fetching
+      return unless suggested?
+      return if @created_place.nil?
+      return unless Geocoding::Config.for(user).enabled?
+
+      Places::NameFetchingJob.perform_later(@created_place.id)
+    end
+
     def suggested?
       params[:status].to_s == 'suggested'
     end
 
     def create_visit(place)
-      started_at = Time.zone.parse(params[:started_at])
-      ended_at = Time.zone.parse(params[:ended_at])
       duration_minutes = ((ended_at - started_at) / 60).to_i
 
       @visit = user.visits.create!(

--- a/app/services/visits/create.rb
+++ b/app/services/visits/create.rb
@@ -183,7 +183,7 @@ module Visits
 
       Places::NameFetchingJob.perform_later(@created_place.id)
     rescue StandardError => e
-      report_exception(e, "Failed to enqueue place name fetching: #{e.message}")
+      ExceptionReporter.call(e, "Failed to enqueue place name fetching: #{e.message}")
     end
 
     def suggested?

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -2910,6 +2910,8 @@ ca:
           failed_to_delete_visit: No s'ha pogut suprimir la visita
           visit_not_found: Visita no trobada
           failed_to_create_visit: No s'ha pogut crear la visita
+          no_visits_provided: "No s'ha proporcionat cap visita"
+          too_many_visits_maximum_is_limit_per_batch: "Massa visites, el màxim és %{limit} per lot"
       record_not_found: Registre no trobat
       complete_your_subscription_to_continue: Completa la teva subscripció per continuar.
       this_feature_requires_a_pro_plan: Aquesta funció requereix el pla Pro.

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -2911,6 +2911,7 @@ ca:
           visit_not_found: Visita no trobada
           failed_to_create_visit: No s'ha pogut crear la visita
           no_visits_provided: "No s'ha proporcionat cap visita"
+          invalid_visit_payload: "L'entrada de visita ha de ser un objecte"
           too_many_visits_maximum_is_limit_per_batch: "Massa visites, el màxim és %{limit} per lot"
       record_not_found: Registre no trobat
       complete_your_subscription_to_continue: Completa la teva subscripció per continuar.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2976,6 +2976,8 @@ de:
           failed_to_delete_visit: Aufenthalt konnte nicht gelöscht werden
           visit_not_found: Aufenthalt nicht gefunden
           failed_to_create_visit: Aufenthalt konnte nicht erstellt werden
+          no_visits_provided: "Keine Aufenthalte übermittelt"
+          too_many_visits_maximum_is_limit_per_batch: "Zu viele Aufenthalte, maximal %{limit} pro Stapel"
       record_not_found: Datensatz nicht gefunden
       complete_your_subscription_to_continue: Fertige dein Abonnement ab, um fortzufahren.
       this_feature_requires_a_pro_plan: Diese Funktion erfordert ein Pro-Abonnement.

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2977,6 +2977,7 @@ de:
           visit_not_found: Aufenthalt nicht gefunden
           failed_to_create_visit: Aufenthalt konnte nicht erstellt werden
           no_visits_provided: "Keine Aufenthalte übermittelt"
+          invalid_visit_payload: "Aufenthaltseintrag muss ein Objekt sein"
           too_many_visits_maximum_is_limit_per_batch: "Zu viele Aufenthalte, maximal %{limit} pro Stapel"
       record_not_found: Datensatz nicht gefunden
       complete_your_subscription_to_continue: Fertige dein Abonnement ab, um fortzufahren.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2899,6 +2899,7 @@ en:
           visit_not_found: Visit not found
           failed_to_create_visit: Failed to create visit
           no_visits_provided: "No visits provided"
+          invalid_visit_payload: "Visit entry must be an object"
           too_many_visits_maximum_is_limit_per_batch: "Too many visits selected, maximum is %{limit} per batch"
       record_not_found: Record not found
       complete_your_subscription_to_continue: Complete your subscription to continue.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2898,6 +2898,8 @@ en:
           failed_to_delete_visit: Failed to delete visit
           visit_not_found: Visit not found
           failed_to_create_visit: Failed to create visit
+          no_visits_provided: "No visits provided"
+          too_many_visits_maximum_is_limit_per_batch: "Too many visits selected, maximum is %{limit} per batch"
       record_not_found: Record not found
       complete_your_subscription_to_continue: Complete your subscription to continue.
       this_feature_requires_a_pro_plan: This feature requires a Pro plan.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2922,6 +2922,7 @@ es:
           visit_not_found: No se encontró la visita
           failed_to_create_visit: No se pudo crear la visita
           no_visits_provided: "No se proporcionaron visitas"
+          invalid_visit_payload: "La entrada de visita debe ser un objeto"
           too_many_visits_maximum_is_limit_per_batch: "Demasiadas visitas, el máximo es %{limit} por lote"
       record_not_found: Registro no encontrado
       complete_your_subscription_to_continue: Completa tu suscripción para continuar.

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2921,6 +2921,8 @@ es:
           failed_to_delete_visit: No se pudo eliminar la visita
           visit_not_found: No se encontró la visita
           failed_to_create_visit: No se pudo crear la visita
+          no_visits_provided: "No se proporcionaron visitas"
+          too_many_visits_maximum_is_limit_per_batch: "Demasiadas visitas, el máximo es %{limit} por lote"
       record_not_found: Registro no encontrado
       complete_your_subscription_to_continue: Completa tu suscripción para continuar.
       this_feature_requires_a_pro_plan: Esta función requiere un plan Pro.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3863,6 +3863,7 @@ fr:
           visit_not_found: Visite non trouvée
           failed_to_create_visit: Échec de création de visite
           no_visits_provided: "Aucune visite fournie"
+          invalid_visit_payload: "L'entrée de visite doit être un objet"
           too_many_visits_maximum_is_limit_per_batch: "Trop de visites, le maximum est de %{limit} par lot"
       record_not_found: Enregistrement non trouvé
       complete_your_subscription_to_continue: Terminez votre abonnement pour continuer.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3862,6 +3862,8 @@ fr:
           failed_to_delete_visit: Echec de suppression de visite
           visit_not_found: Visite non trouvée
           failed_to_create_visit: Échec de création de visite
+          no_visits_provided: "Aucune visite fournie"
+          too_many_visits_maximum_is_limit_per_batch: "Trop de visites, le maximum est de %{limit} par lot"
       record_not_found: Enregistrement non trouvé
       complete_your_subscription_to_continue: Terminez votre abonnement pour continuer.
       this_feature_requires_a_pro_plan: Cette fonctionnalité nécessite un plan Pro.

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -2966,6 +2966,7 @@ pl:
           visit_not_found: Nie znaleziono wizyty
           failed_to_create_visit: Nie udało się utworzyć wizyty
           no_visits_provided: "Nie przekazano żadnych wizyt"
+          invalid_visit_payload: "Wpis wizyty musi być obiektem"
           too_many_visits_maximum_is_limit_per_batch: "Zbyt wiele wizyt, maksymalnie %{limit} na partię"
       record_not_found: Nie znaleziono rekordu
       complete_your_subscription_to_continue: Dokończ subskrypcję, aby kontynuować.

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -2965,6 +2965,8 @@ pl:
           failed_to_delete_visit: Nie udało się usunąć wizyty
           visit_not_found: Nie znaleziono wizyty
           failed_to_create_visit: Nie udało się utworzyć wizyty
+          no_visits_provided: "Nie przekazano żadnych wizyt"
+          too_many_visits_maximum_is_limit_per_batch: "Zbyt wiele wizyt, maksymalnie %{limit} na partię"
       record_not_found: Nie znaleziono rekordu
       complete_your_subscription_to_continue: Dokończ subskrypcję, aby kontynuować.
       this_feature_requires_a_pro_plan: Ta funkcja wymaga planu Pro.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -331,6 +331,7 @@ Rails.application.routes.draw do
         collection do
           post 'merge', to: 'visits#merge'
           post 'bulk_update', to: 'visits#bulk_update'
+          post 'batch', to: 'visits#batch'
         end
       end
       resource :plan, only: [:show], controller: 'plan'

--- a/spec/requests/api/v1/visits_spec.rb
+++ b/spec/requests/api/v1/visits_spec.rb
@@ -669,6 +669,37 @@ RSpec.describe 'Api::V1::Visits', type: :request do
       end
     end
 
+    context 'when reporting rejected entries' do
+      it 'groups every batch under the same report regardless of how many failed' do
+        reported = []
+        allow(ExceptionReporter).to receive(:call) { |subject, _| reported << subject }
+
+        post '/api/v1/visits/batch',
+             params: { visits: Array.new(2) { |i| visit_payload(i, name: '') } },
+             headers: auth_headers, as: :json
+        post '/api/v1/visits/batch',
+             params: { visits: Array.new(4) { |i| visit_payload(i + 10, name: '') } },
+             headers: auth_headers, as: :json
+
+        expect(reported.uniq.size).to eq(1)
+      end
+    end
+
+    context 'when a replayed entry matches a visit the user deleted' do
+      it 'reports it as a duplicate without handing back the tombstoned visit' do
+        payload = visit_payload(0, name: 'Home')
+
+        post '/api/v1/visits/batch', params: { visits: [payload] }, headers: auth_headers, as: :json
+        user.visits.last.update!(deleted_at: Time.current)
+
+        post '/api/v1/visits/batch', params: { visits: [payload] }, headers: auth_headers, as: :json
+
+        result = JSON.parse(response.body)['results'].first
+        expect(result['status']).to eq('duplicate')
+        expect(result['visit']).to be_nil
+      end
+    end
+
     context 'without authentication' do
       it 'returns unauthorized' do
         post '/api/v1/visits/batch', params: { visits: [visit_payload(0)] }, as: :json

--- a/spec/requests/api/v1/visits_spec.rb
+++ b/spec/requests/api/v1/visits_spec.rb
@@ -512,7 +512,9 @@ RSpec.describe 'Api::V1::Visits', type: :request do
           post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
         end.not_to(change { user.visits.count })
 
-        expect(JSON.parse(response.body)['created_count']).to eq(2)
+        json_response = JSON.parse(response.body)
+        expect(json_response['created_count']).to eq(0)
+        expect(json_response['duplicate_count']).to eq(2)
       end
     end
 
@@ -563,6 +565,62 @@ RSpec.describe 'Api::V1::Visits', type: :request do
         json_response = JSON.parse(response.body)
         expect(json_response['limit']).to eq(Api::V1::VisitsController::BATCH_MAX)
         expect(json_response['requested']).to eq(Api::V1::VisitsController::BATCH_MAX + 1)
+      end
+    end
+
+    context 'when visits is not an array' do
+      it 'rejects an object whose keys are permitted attributes' do
+        post '/api/v1/visits/batch', params: { visits: { name: 'Home' } }, headers: auth_headers, as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it 'rejects a string' do
+        post '/api/v1/visits/batch', params: { visits: 'Home' }, headers: auth_headers, as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    context 'when the batch contains a non-object element' do
+      let(:params) { { visits: [visit_payload(0, name: 'Home'), 'junk', visit_payload(6, name: 'Office')] } }
+
+      it 'keeps every submitted position addressable by index' do
+        post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['results'].pluck('index')).to eq([0, 1, 2])
+        expect(json_response['results'].pluck('status')).to eq(%w[created failed created])
+      end
+
+      it 'still creates the well-formed visits' do
+        expect do
+          post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+        end.to change { user.visits.count }.by(2)
+      end
+    end
+
+    context 'when a batch is replayed' do
+      let(:params) { { visits: [visit_payload(0, name: 'Home')] } }
+
+      it 'reports the second run as a duplicate rather than created' do
+        post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+        post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['results'].pluck('status')).to eq(%w[duplicate])
+        expect(json_response['created_count']).to eq(0)
+        expect(json_response['duplicate_count']).to eq(1)
+      end
+
+      it 'reports two identical entries in one batch as one created and one duplicate' do
+        post '/api/v1/visits/batch',
+             params: { visits: [visit_payload(0, name: 'Home'), visit_payload(0, name: 'Home')] },
+             headers: auth_headers, as: :json
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['created_count']).to eq(1)
+        expect(json_response['duplicate_count']).to eq(1)
       end
     end
 

--- a/spec/requests/api/v1/visits_spec.rb
+++ b/spec/requests/api/v1/visits_spec.rb
@@ -624,6 +624,51 @@ RSpec.describe 'Api::V1::Visits', type: :request do
       end
     end
 
+    context 'at the batch size boundary' do
+      it 'accepts exactly BATCH_MAX visits' do
+        payloads = Array.new(Api::V1::VisitsController::BATCH_MAX) { |i| visit_payload(i) }
+
+        post '/api/v1/visits/batch', params: { visits: payloads }, headers: auth_headers, as: :json
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['created_count']).to eq(Api::V1::VisitsController::BATCH_MAX)
+      end
+    end
+
+    context 'when an entry ends before it starts' do
+      it 'reports that entry as failed and keeps the rest' do
+        bad = visit_payload(3).merge(started_at: '2023-12-05T10:00:00Z', ended_at: '2023-12-05T09:00:00Z')
+
+        post '/api/v1/visits/batch',
+             params: { visits: [visit_payload(0), bad] }, headers: auth_headers, as: :json
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['results'].pluck('status')).to eq(%w[created failed])
+        expect(json_response['failed_count']).to eq(1)
+      end
+    end
+
+    context 'with a confirmed visit in the batch' do
+      it 'still locks the place name' do
+        post '/api/v1/visits/batch',
+             params: { visits: [visit_payload(0, name: 'Home', status: 'confirmed')] },
+             headers: auth_headers, as: :json
+
+        expect(user.places.reload.pluck(:name_locked_at)).to all(be_present)
+      end
+    end
+
+    context 'when many entries in one batch are rejected' do
+      it 'reports at most one exception for the whole batch' do
+        expect(ExceptionReporter).to receive(:call).at_most(:once)
+
+        payloads = Array.new(5) { |i| visit_payload(i, name: '') }
+        post '/api/v1/visits/batch', params: { visits: payloads }, headers: auth_headers, as: :json
+
+        expect(JSON.parse(response.body)['failed_count']).to eq(5)
+      end
+    end
+
     context 'without authentication' do
       it 'returns unauthorized' do
         post '/api/v1/visits/batch', params: { visits: [visit_payload(0)] }, as: :json

--- a/spec/requests/api/v1/visits_spec.rb
+++ b/spec/requests/api/v1/visits_spec.rb
@@ -452,4 +452,126 @@ RSpec.describe 'Api::V1::Visits', type: :request do
       end
     end
   end
+  describe 'POST /api/v1/visits/batch' do
+    def visit_payload(offset_hours, name: 'Visit', status: 'suggested')
+      {
+        name: name,
+        latitude: 52.52 + (offset_hours / 1000.0),
+        longitude: 13.405 + (offset_hours / 1000.0),
+        started_at: (Time.zone.parse('2023-12-01T10:00:00Z') + offset_hours.hours).iso8601,
+        ended_at: (Time.zone.parse('2023-12-01T11:00:00Z') + offset_hours.hours).iso8601,
+        status: status
+      }
+    end
+
+    context 'with a valid batch' do
+      let(:params) { { visits: [visit_payload(0, name: 'Home'), visit_payload(3, name: 'Office')] } }
+
+      it 'creates every visit in one request' do
+        expect do
+          post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+        end.to change { user.visits.count }.by(2)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'returns a result per submitted visit, in order, with its index' do
+        post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['results'].pluck('index')).to eq([0, 1])
+        expect(json_response['results'].pluck('status')).to eq(%w[created created])
+        expect(json_response['results'].map { |result| result.dig('visit', 'name') }).to eq(%w[Home Office])
+      end
+
+      it 'reports created and failed counts' do
+        post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['created_count']).to eq(2)
+        expect(json_response['failed_count']).to eq(0)
+      end
+
+      it 'leaves place names unlocked for suggested visits' do
+        post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+
+        expect(user.places.reload.pluck(:name_locked_at)).to all(be_nil)
+      end
+
+      it 'assigns every visit to the authenticated user' do
+        post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+
+        expect(user.visits.count).to eq(2)
+        expect(other_user.visits.count).to eq(0)
+      end
+
+      it 'does not duplicate visits when the same batch is replayed' do
+        post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+
+        expect do
+          post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+        end.not_to(change { user.visits.count })
+
+        expect(JSON.parse(response.body)['created_count']).to eq(2)
+      end
+    end
+
+    context 'when one visit in the batch is invalid' do
+      let(:params) do
+        { visits: [visit_payload(0, name: 'Home'), visit_payload(3, name: ''), visit_payload(6, name: 'Office')] }
+      end
+
+      it 'still creates the valid visits' do
+        expect do
+          post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+        end.to change { user.visits.count }.by(2)
+      end
+
+      it 'marks only the offending index as failed' do
+        post '/api/v1/visits/batch', params: params, headers: auth_headers, as: :json
+
+        json_response = JSON.parse(response.body)
+        expect(json_response['results'].pluck('status')).to eq(%w[created failed created])
+        expect(json_response['results'][1]['error']).to be_present
+        expect(json_response['created_count']).to eq(2)
+        expect(json_response['failed_count']).to eq(1)
+      end
+    end
+
+    context 'with an invalid envelope' do
+      it 'rejects a missing visits key' do
+        post '/api/v1/visits/batch', params: {}, headers: auth_headers, as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)['error']).to be_present
+      end
+
+      it 'rejects an empty visits array' do
+        post '/api/v1/visits/batch', params: { visits: [] }, headers: auth_headers, as: :json
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it 'rejects a batch over the maximum size' do
+        oversized = { visits: Array.new(Api::V1::VisitsController::BATCH_MAX + 1) { |i| visit_payload(i) } }
+
+        expect do
+          post '/api/v1/visits/batch', params: oversized, headers: auth_headers, as: :json
+        end.not_to(change { Visit.count })
+
+        expect(response).to have_http_status(:unprocessable_content)
+        json_response = JSON.parse(response.body)
+        expect(json_response['limit']).to eq(Api::V1::VisitsController::BATCH_MAX)
+        expect(json_response['requested']).to eq(Api::V1::VisitsController::BATCH_MAX + 1)
+      end
+    end
+
+    context 'without authentication' do
+      it 'returns unauthorized' do
+        post '/api/v1/visits/batch', params: { visits: [visit_payload(0)] }, as: :json
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
 end

--- a/spec/services/places/name_fetcher_spec.rb
+++ b/spec/services/places/name_fetcher_spec.rb
@@ -68,6 +68,39 @@ RSpec.describe Places::NameFetcher do
         service.call
       end
 
+      context 'when a device-named place gets a real address' do
+        let(:place) do
+          create(
+            :place,
+            name: 'Visited place',
+            city: nil,
+            country: nil,
+            geodata: {},
+            lonlat: 'POINT(10.0 10.0)'
+          )
+        end
+
+        it 'renames the place' do
+          expect { service.call }.to change { place.reload.name }.from('Visited place').to('Central Park, New York')
+        end
+
+        it 'propagates the new name to a visit that carried the old place name' do
+          visit = create(:visit, place: place, user: place.user, name: 'Visited place')
+
+          service.call
+
+          expect(visit.reload.name).to eq('Central Park, New York')
+        end
+
+        it 'leaves a visit the user renamed independently alone' do
+          visit = create(:visit, place: place, user: place.user, name: 'Dentist')
+
+          service.call
+
+          expect(visit.reload.name).to eq('Dentist')
+        end
+      end
+
       context 'when the name is locked by the user' do
         let(:place) do
           create(

--- a/spec/services/visits/create_spec.rb
+++ b/spec/services/visits/create_spec.rb
@@ -190,6 +190,30 @@ RSpec.describe Visits::Create do
       end
     end
 
+    context 'place name locking' do
+      it 'locks the place name when the visit is confirmed' do
+        service = described_class.new(user, valid_params)
+        service.call
+
+        expect(service.visit.place.name_locked_at).to be_present
+      end
+
+      it 'leaves the place name unlocked when the visit is suggested' do
+        service = described_class.new(user, valid_params.merge(status: 'suggested'))
+        service.call
+
+        expect(service.visit.place.name_locked_at).to be_nil
+      end
+
+      it 'lets reverse geocoding rename a place created from a suggested visit' do
+        service = described_class.new(user, valid_params.merge(status: 'suggested'))
+        service.call
+        place = service.visit.place
+
+        expect(place.name_locked?).to be(false)
+      end
+    end
+
     context 'when place creation fails' do
       subject(:service) { described_class.new(user, valid_params) }
 

--- a/spec/services/visits/create_spec.rb
+++ b/spec/services/visits/create_spec.rb
@@ -243,6 +243,15 @@ RSpec.describe Visits::Create do
 
         expect { service.call }.not_to have_enqueued_job(Places::NameFetchingJob)
       end
+
+      it 'does not enqueue for a place the rolled-back transaction discarded' do
+        visits_association = user.visits
+        allow(user).to receive(:visits).and_return(visits_association)
+        allow(visits_association).to receive(:create!).and_raise(ActiveRecord::RecordInvalid.new(Visit.new))
+        service = described_class.new(user, valid_params.merge(status: 'suggested'))
+
+        expect { service.call }.not_to have_enqueued_job(Places::NameFetchingJob)
+      end
     end
 
     context 'when timestamps are unusable' do
@@ -287,6 +296,90 @@ RSpec.describe Visits::Create do
         service.call
 
         expect(service).to be_duplicate
+      end
+    end
+
+    context 'when the place name fetch cannot be enqueued' do
+      before do
+        allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+        allow(Places::NameFetchingJob).to receive(:perform_later).and_raise(RedisClient::ConnectionError)
+      end
+
+      it 'still reports the committed visit as created' do
+        service = described_class.new(user, valid_params.merge(status: 'suggested'))
+
+        expect(service.call).to be_truthy
+        expect(service.visit).to be_persisted
+      end
+
+      it 'keeps the visit even though the job could not be queued' do
+        service = described_class.new(user, valid_params.merge(status: 'suggested'))
+
+        expect { service.call }.to change { user.visits.count }.by(1)
+      end
+    end
+
+    context 'when coordinates are unusable' do
+      it 'refuses a missing latitude instead of creating a place at Null Island' do
+        service = described_class.new(user, valid_params.merge(latitude: nil))
+
+        expect(service.call).to be(false)
+        expect(service.errors).to be_present
+      end
+
+      it 'refuses a non-numeric longitude' do
+        service = described_class.new(user, valid_params.merge(longitude: 'east'))
+
+        expect(service.call).to be(false)
+      end
+
+      it 'refuses an out-of-range latitude' do
+        service = described_class.new(user, valid_params.merge(latitude: 91.0))
+
+        expect(service.call).to be(false)
+      end
+
+      it 'creates no place when coordinates are unusable' do
+        expect do
+          described_class.new(user, valid_params.merge(latitude: nil)).call
+        end.not_to(change { Place.count })
+      end
+    end
+
+    context 'when a machine retry replays a visit the user removed' do
+      let(:suggested_params) { valid_params.merge(status: 'suggested') }
+
+      it 'does not resurrect a visit the user deleted' do
+        first = described_class.new(user, suggested_params)
+        first.call
+        first.visit.soft_delete!
+
+        service = described_class.new(user, suggested_params)
+        service.call
+
+        expect(first.visit.reload.deleted_at).to be_present
+      end
+
+      it 'does not un-decline a visit the user declined' do
+        first = described_class.new(user, suggested_params)
+        first.call
+        first.visit.update!(status: :declined)
+
+        service = described_class.new(user, suggested_params)
+        service.call
+
+        expect(first.visit.reload.status).to eq('declined')
+      end
+
+      it 'still resurrects when a person re-creates the visit explicitly' do
+        first = described_class.new(user, valid_params)
+        first.call
+        first.visit.soft_delete!
+
+        service = described_class.new(user, valid_params)
+        service.call
+
+        expect(first.visit.reload.deleted_at).to be_nil
       end
     end
 

--- a/spec/services/visits/create_spec.rb
+++ b/spec/services/visits/create_spec.rb
@@ -301,6 +301,15 @@ RSpec.describe Visits::Create do
         described_class.new(user, valid_params.merge(name: ''), report_exceptions: false).call
       end
 
+      it 'still reports a queue outage, which is infrastructure and not bad input' do
+        allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+        allow(Places::NameFetchingJob).to receive(:perform_later).and_raise(RedisClient::ConnectionError)
+
+        expect(ExceptionReporter).to receive(:call).at_least(:once)
+
+        described_class.new(user, valid_params.merge(status: 'suggested'), report_exceptions: false).call
+      end
+
       it 'still reports by default' do
         expect(ExceptionReporter).to receive(:call).at_least(:once)
 

--- a/spec/services/visits/create_spec.rb
+++ b/spec/services/visits/create_spec.rb
@@ -214,6 +214,82 @@ RSpec.describe Visits::Create do
       end
     end
 
+    context 'geocoding a machine-named place' do
+      before { allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true) }
+
+      it 'enqueues Places::NameFetchingJob for a place created from a suggested visit' do
+        service = described_class.new(user, valid_params.merge(status: 'suggested'))
+
+        expect { service.call }.to have_enqueued_job(Places::NameFetchingJob).with(an_instance_of(Integer))
+      end
+
+      it 'does not enqueue for a confirmed visit, whose name the user asserted' do
+        service = described_class.new(user, valid_params)
+
+        expect { service.call }.not_to have_enqueued_job(Places::NameFetchingJob)
+      end
+
+      it 'does not enqueue when an existing place is reused' do
+        existing = create(:place, user: user, latitude: 52.52, longitude: 13.405, lonlat: 'POINT(13.405 52.52)')
+        create(:visit, user: user, place: existing)
+        service = described_class.new(user, valid_params.merge(status: 'suggested'))
+
+        expect { service.call }.not_to have_enqueued_job(Places::NameFetchingJob)
+      end
+
+      it 'does not enqueue when reverse geocoding is disabled' do
+        allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(false)
+        service = described_class.new(user, valid_params.merge(status: 'suggested'))
+
+        expect { service.call }.not_to have_enqueued_job(Places::NameFetchingJob)
+      end
+    end
+
+    context 'when timestamps are unusable' do
+      it 'fails cleanly on an unparseable started_at instead of raising' do
+        service = described_class.new(user, valid_params.merge(started_at: 'not-a-timestamp'))
+
+        expect(service.call).to be(false)
+        expect(service.errors).to be_present
+      end
+
+      it 'fails cleanly on a missing ended_at' do
+        service = described_class.new(user, valid_params.merge(ended_at: nil))
+
+        expect(service.call).to be(false)
+      end
+
+      it 'does not report an exception for a malformed timestamp' do
+        expect(ExceptionReporter).not_to receive(:call)
+
+        described_class.new(user, valid_params.merge(started_at: 'garbage')).call
+      end
+
+      it 'does not create a visit when timestamps are unusable' do
+        expect do
+          described_class.new(user, valid_params.merge(started_at: 'garbage')).call
+        end.not_to(change { Visit.count })
+      end
+    end
+
+    context 'reporting whether the visit was newly created' do
+      it 'is not a duplicate on first creation' do
+        service = described_class.new(user, valid_params)
+        service.call
+
+        expect(service).not_to be_duplicate
+      end
+
+      it 'flags a replayed visit as a duplicate' do
+        described_class.new(user, valid_params).call
+
+        service = described_class.new(user, valid_params)
+        service.call
+
+        expect(service).to be_duplicate
+      end
+    end
+
     context 'when place creation fails' do
       subject(:service) { described_class.new(user, valid_params) }
 

--- a/spec/services/visits/create_spec.rb
+++ b/spec/services/visits/create_spec.rb
@@ -274,10 +274,37 @@ RSpec.describe Visits::Create do
         described_class.new(user, valid_params.merge(started_at: 'garbage')).call
       end
 
+      it 'refuses an ended_at that precedes started_at' do
+        service = described_class.new(user, valid_params.merge(ended_at: '2023-12-01T09:00:00Z'))
+
+        expect(service.call).to be(false)
+        expect(service.errors).to be_present
+      end
+
+      it 'creates no visit when ended_at precedes started_at' do
+        expect do
+          described_class.new(user, valid_params.merge(ended_at: '2023-12-01T09:00:00Z')).call
+        end.not_to(change { Visit.count })
+      end
+
       it 'does not create a visit when timestamps are unusable' do
         expect do
           described_class.new(user, valid_params.merge(started_at: 'garbage')).call
         end.not_to(change { Visit.count })
+      end
+    end
+
+    context 'when exception reporting is suppressed' do
+      it 'stays silent for a rejected record' do
+        expect(ExceptionReporter).not_to receive(:call)
+
+        described_class.new(user, valid_params.merge(name: ''), report_exceptions: false).call
+      end
+
+      it 'still reports by default' do
+        expect(ExceptionReporter).to receive(:call).at_least(:once)
+
+        described_class.new(user, valid_params.merge(name: '')).call
       end
     end
 

--- a/spec/swagger/api/v1/visits_controller_spec.rb
+++ b/spec/swagger/api/v1/visits_controller_spec.rb
@@ -443,13 +443,14 @@ describe 'Visits API', type: :request do
                      type: :object,
                      properties: {
                        index: { type: :integer },
-                       status: { type: :string, enum: %w[created failed] },
+                       status: { type: :string, enum: %w[created duplicate failed] },
                        visit: { type: :object },
                        error: { type: :string }
                      }
                    }
                  },
                  created_count: { type: :integer },
+                 duplicate_count: { type: :integer },
                  failed_count: { type: :integer }
                }
 

--- a/spec/swagger/api/v1/visits_controller_spec.rb
+++ b/spec/swagger/api/v1/visits_controller_spec.rb
@@ -390,4 +390,84 @@ describe 'Visits API', type: :request do
       end
     end
   end
+  path '/api/v1/visits/batch' do
+    post 'Create visits in batch' do
+      tags 'Visits'
+      consumes 'application/json'
+      produces 'application/json'
+      parameter name: :Authorization, in: :header, type: :string, required: true, description: 'Bearer token'
+      parameter name: :batch, in: :body, schema: {
+        type: :object,
+        properties: {
+          visits: {
+            type: :array,
+            maxItems: Api::V1::VisitsController::BATCH_MAX,
+            items: {
+              type: :object,
+              properties: {
+                name: { type: :string },
+                latitude: { type: :number },
+                longitude: { type: :number },
+                started_at: { type: :string, format: 'date-time' },
+                ended_at: { type: :string, format: 'date-time' },
+                status: { type: :string, enum: %w[suggested confirmed declined] }
+              },
+              required: %w[name latitude longitude started_at ended_at]
+            }
+          }
+        },
+        required: %w[visits]
+      }
+
+      response '200', 'batch processed' do
+        let(:batch) do
+          {
+            visits: [
+              {
+                name: 'Home',
+                latitude: 52.52,
+                longitude: 13.405,
+                started_at: '2023-12-01T10:00:00Z',
+                ended_at: '2023-12-01T12:00:00Z',
+                status: 'suggested'
+              }
+            ]
+          }
+        end
+
+        schema type: :object,
+               properties: {
+                 results: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       index: { type: :integer },
+                       status: { type: :string, enum: %w[created failed] },
+                       visit: { type: :object },
+                       error: { type: :string }
+                     }
+                   }
+                 },
+                 created_count: { type: :integer },
+                 failed_count: { type: :integer }
+               }
+
+        run_test!
+      end
+
+      response '422', 'invalid request' do
+        let(:batch) { { visits: [] } }
+
+        run_test!
+      end
+
+      response '401', 'unauthorized' do
+        let(:Authorization) { 'Bearer invalid-token' }
+        let(:batch) { { visits: [] } }
+
+        run_test!
+      end
+    end
+  end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -6176,6 +6176,88 @@ paths:
               required:
               - visit_ids
               - status
+  "/api/v1/visits/batch":
+    post:
+      summary: Create visits in batch
+      tags:
+      - Visits
+      parameters:
+      - name: Authorization
+        in: header
+        required: true
+        description: Bearer token
+        schema:
+          type: string
+      responses:
+        '200':
+          description: batch processed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        index:
+                          type: integer
+                        status:
+                          type: string
+                          enum:
+                          - created
+                          - failed
+                        visit:
+                          type: object
+                        error:
+                          type: string
+                  created_count:
+                    type: integer
+                  failed_count:
+                    type: integer
+        '422':
+          description: invalid request
+        '401':
+          description: unauthorized
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                visits:
+                  type: array
+                  maxItems: 100
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      latitude:
+                        type: number
+                      longitude:
+                        type: number
+                      started_at:
+                        type: string
+                        format: date-time
+                      ended_at:
+                        type: string
+                        format: date-time
+                      status:
+                        type: string
+                        enum:
+                        - suggested
+                        - confirmed
+                        - declined
+                    required:
+                    - name
+                    - latitude
+                    - longitude
+                    - started_at
+                    - ended_at
+              required:
+              - visits
 servers:
 - url: http://{defaultHost}
   variables:

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -6207,12 +6207,15 @@ paths:
                           type: string
                           enum:
                           - created
+                          - duplicate
                           - failed
                         visit:
                           type: object
                         error:
                           type: string
                   created_count:
+                    type: integer
+                  duplicate_count:
                     type: integer
                   failed_count:
                     type: integer


### PR DESCRIPTION
## Summary

Two backend changes that let the mobile apps sync detected visits without one HTTP request per visit.

**1. `POST /api/v1/visits/batch`** — up to 100 visits in one request.

**2. Suggested visits no longer lock the place name** — a device-detected visit is a guess, not a user assertion, so reverse geocoding must still be able to name the place.

## `POST /api/v1/visits/batch`

Request:

```json
{ "visits": [
  { "name": "Home", "latitude": 52.52, "longitude": 13.405,
    "started_at": "2023-12-01T10:00:00Z", "ended_at": "2023-12-01T12:00:00Z",
    "status": "suggested" }
] }
```

Response (always `200` when the envelope is valid, even on partial failure):

```json
{ "results": [ { "index": 0, "status": "created", "visit": { } } ],
  "created_count": 1, "failed_count": 0 }
```

- Each visit goes through `Visits::Create`, which opens its own transaction and rescues its own errors. There is deliberately **no outer transaction** — one bad visit must not roll back the rest of the batch.
- Every result carries its submitted `index`, so a client can map server ids back onto local rows when some entries fail.
- Replaying a batch is safe: `Visits::Create` already resolves `ActiveRecord::RecordNotUnique` against `idx_visits_user_started_at_place_unique` and returns the existing visit.
- Envelope errors return `422`: missing `visits`, empty `visits`, or more than `BATCH_MAX` (100), the last with `limit` and `requested` in the payload.
- Auth matches the existing visits endpoints — API key only, no `require_write_api!`. Visits stay writable on every plan, unchanged from today.

## Why the name-lock change

`Visits::Create#create_new_place` hardcoded `user_named: true`, which trips `Place#lock_name_on_user_edit` and sets `name_locked_at`. Both `ReverseGeocoding::Places::FetchData` and `Places::NameFetcher` skip renaming a locked place.

The mobile client names a detected visit from whatever Core Location gives it, falling back to a coarse locality or the literal string `"Visited place"`. Under the old behaviour every phone-created place would have been permanently stuck with that name, unfixable without a data migration.

Now the place is created `machine_named` when the incoming visit is `suggested`. Visits created without a status still default to `confirmed` and still lock, so existing API callers are unaffected.

## Verification

Run against an isolated test database from this branch:

- `spec/requests/api/v1/visits_spec.rb`, `spec/requests/api/v1/visits`, `spec/services/visits` — **341 examples, 0 failures**
- `spec/requests/api`, `spec/services/visits`, `spec/regressions` — **1798 examples, 0 failures**
- All five locale coverage specs (de, es, fr, ca, pl) plus enum coverage — **24 examples, 0 failures**
- `spec/swagger/api/v1/visits_controller_spec.rb` — **23 examples, 0 failures**; `swagger/v1/swagger.yaml` regenerated additively (+82 lines, 0 deletions)
- RuboCop on all changed Ruby files — no offenses

The name-lock specs were written first and observed failing for the right reason (`name_locked_at` present on a suggested visit) before the fix.

## Follow-up, not in this PR

`multiplatform-app` #67 (`feature/visits-sync`) currently posts one visit at a time and is `CONFLICTING`. Two things to fix there once this lands:

1. Switch the upload sweep to `/visits/batch`.
2. Classify `429` alongside `unauthorized`/`network_error` rather than as a per-visit rejection. Today a throttled request burns an upload attempt, and the query drops visits at `uploadAttempts >= 10` — so a rate-limited "Upload all visits" run can dead-letter valid visits permanently.
