### PR TITLE
chore: make the family migrations safe to re-run

### DIFF
--- a/db/migrate/20260828090000_add_access_until_to_families.rb
+++ b/db/migrate/20260828090000_add_access_until_to_families.rb
@@ -1,7 +1,15 @@
 # frozen_string_literal: true
 
 class AddAccessUntilToFamilies < ActiveRecord::Migration[8.0]
-  def change
+  def up
+    return if column_exists?(:families, :access_until)
+
     add_column :families, :access_until, :datetime
+  end
+
+  def down
+    return unless column_exists?(:families, :access_until)
+
+    remove_column :families, :access_until
   end
 end

--- a/db/migrate/20260828100000_backfill_families_for_family_plan_users.rb
+++ b/db/migrate/20260828100000_backfill_families_for_family_plan_users.rb
@@ -4,10 +4,8 @@ class BackfillFamiliesForFamilyPlanUsers < ActiveRecord::Migration[8.0]
   def up
     DataMigrations::BackfillFamiliesForFamilyPlanJob.perform_later
   rescue StandardError => e
-    Rails.logger.warn "[Migration] Could not enqueue BackfillFamiliesForFamilyPlanJob: #{e.message}"
+    Rails.logger.warn "[Migration] job=BackfillFamiliesForFamilyPlanJob enqueued=false error=#{e.message}"
   end
 
-  def down
-    # no-op: backfill is non-destructive
-  end
+  def down; end
 end

--- a/db/migrate/20260831120000_backfill_family_member_entitlements.rb
+++ b/db/migrate/20260831120000_backfill_family_member_entitlements.rb
@@ -4,10 +4,8 @@ class BackfillFamilyMemberEntitlements < ActiveRecord::Migration[8.0]
   def up
     DataMigrations::BackfillFamilyMemberEntitlementsJob.perform_later
   rescue StandardError => e
-    Rails.logger.warn "[Migration] Could not enqueue BackfillFamilyMemberEntitlementsJob: #{e.message}"
+    Rails.logger.warn "[Migration] job=BackfillFamilyMemberEntitlementsJob enqueued=false error=#{e.message}"
   end
 
-  def down
-    # no-op: backfill is non-destructive
-  end
+  def down; end
 end


### PR DESCRIPTION
Follow-up to #3467, which merged before this landed.

`AddAccessUntilToFamilies` used a bare `change` with `add_column`, so running it against a database that already has the column raises `DuplicateColumn`. It now guards on `column_exists?` in both directions, matching how the index migrations guard on `index_name_exists?` rather than using `if_not_exists:`.

The two backfill migrations only enqueue jobs, and those jobs are already idempotent — `Families::AutoCreate` re-checks eligibility, `Families::SyncMembers` converges on the same state, and the notified flag stops a repeat run re-sending the lapse email. They pick up the house `[Migration] key=value` logging so a failed enqueue is greppable.

**Modifying a merged migration is safe here:** the resulting schema is identical, and any database that has already run these will not run them again, so the change only affects a re-run.

## Verification

Run against a database already carrying the column, with the version rows deleted to force `up` a second time:

| Case | Result |
|---|---|
| `up` on a fresh database | applies cleanly |
| `up` again, column already present | no `DuplicateColumn`, column not duplicated |
| `down` then `up` (`db:migrate:redo`) | clean for all three |
| `down` twice | second is a no-op |
