### PR TITLE
fix: keep shared link phrases to three words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Shared link addresses are now always three words. One hyphenated entry in the word list could produce a four-word address.
 - Places created from a suggested visit now get their real address. Visits detected on a phone arrive with a generated name such as "Visited place"; that name is no longer locked, reverse geocoding is queued for the new place, and the resolved address now replaces the generated name on the visit as well as the place.
 
 ## [1.14.1] - 2026-08-31, Berlin

--- a/config/shared_link_wordlist.txt
+++ b/config/shared_link_wordlist.txt
@@ -1283,7 +1283,6 @@ year
 yeast
 yelp
 yield
-yo-yo
 yodel
 yoga
 yoyo

--- a/spec/models/shared_link/phrase_generator_spec.rb
+++ b/spec/models/shared_link/phrase_generator_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe SharedLink::PhraseGenerator do
       expect(phrases.size).to be > 15
     end
 
+    it 'draws from a wordlist whose every entry survives the hyphen join' do
+      words = File.readlines(Rails.root.join('config/shared_link_wordlist.txt'), chomp: true)
+
+      expect(words.reject { |word| word.match?(/\A[a-z]+\z/) }).to be_empty
+    end
+
     it 'uses only words from the wordlist' do
       wordlist = File.readlines(Rails.root.join('config/shared_link_wordlist.txt'), chomp: true).to_set
       10.times do


### PR DESCRIPTION
## Summary

`SharedLink::PhraseGenerator` joins three random words with `-`, so a hyphenated entry in the word list yields a four-word address. `config/shared_link_wordlist.txt` had exactly one: `yo-yo`, entry 1286 of 1296.

It also made `spec/models/shared_link/phrase_generator_spec.rb` fail at random, which is how it surfaced — it turned #3468's CI red on an otherwise green branch.

## Why it loses nothing

The list already carries `yoyo` two lines below `yo-yo`, so the hyphenated entry was a redundant spelling. Removing it drops the count from 1296 to 1295 and costs no vocabulary.

```
year
yeast
yelp
yield
yo-yo   <- removed
yodel
yoga
yoyo    <- already here
yummy
```

## Failure rate

Roughly **2.5% of CI runs**, from two examples in that spec:

- `returns a three-word hyphenated phrase` draws 3 words: `1 - (1295/1296)^3` ≈ 0.23%
- `uses only words from the wordlist` draws 30: `1 - (1295/1296)^30` ≈ 2.3%

The observed failure on #3468 was the first of those.

## The guard

Removing the entry fixes today's flake but not the next one, so this adds a deterministic spec asserting every entry survives the hyphen join. It fails immediately and loudly on any future hyphenated word rather than waiting for an unlucky draw.

## Verification

- The new spec fails on the pre-fix word list and passes after — watched both ways.
- All 9 shared-link spec files: **69 examples, 0 failures**.
- Stress check: **20,000 generated phrases, 0 malformed**. Against the old list ~46 would be expected.
- RuboCop clean.
