### PR TITLE
Allowlist point attributes on profile import restore

### DIFF
--- a/app/services/users/import_data/points.rb
+++ b/app/services/users/import_data/points.rb
@@ -15,6 +15,7 @@ class Users::ImportData::Points
     @total_created = 0
     @processed_count = 0
     @skipped_count = 0
+    @failed_count = 0
     @preloaded = false
 
     @imports_lookup = {}
@@ -63,6 +64,12 @@ class Users::ImportData::Points
       "Points import completed. Created: #{@total_created}. " \
       "Processed #{@processed_count} valid points, skipped #{@skipped_count}."
     )
+
+    if @failed_count.positive?
+      logger.error(
+        "Points import had failures. Failed to insert #{@failed_count} of #{@processed_count} prepared points."
+      )
+    end
     @total_created
   end
 
@@ -114,10 +121,12 @@ class Users::ImportData::Points
         "Processed batch of #{@buffer.size} points, created #{batch_created}, total created: #{@total_created}"
       )
     rescue StandardError => e
+      @failed_count += @buffer.size
       logger.error "Failed to process point batch: #{e.message}"
       logger.error "Batch size: #{@buffer.size}"
       logger.error "First point in failed batch: #{@buffer.first.inspect}"
       logger.error "Backtrace: #{e.backtrace.first(5).join('\n')}"
+      ExceptionReporter.call(e, 'Failed to process point batch')
     ensure
       @buffer.clear
     end
@@ -214,7 +223,7 @@ class Users::ImportData::Points
     resolve_country_reference(attributes, point_data['country_info'])
     resolve_visit_reference(attributes, point_data['visit_reference'])
 
-    result = attributes.symbolize_keys
+    result = attributes.slice(*Point.column_names).symbolize_keys
 
     logger.debug "Prepared point attributes: #{result.slice(:lonlat, :timestamp, :import_id, :country_id, :visit_id)}"
     result

--- a/spec/services/users/import_data/points_dropped_column_spec.rb
+++ b/spec/services/users/import_data/points_dropped_column_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::ImportData::Points do
+  subject(:restore) { described_class.new(user, points_data).call }
+
+  let(:user) { create(:user) }
+
+  let(:point_payload) do
+    {
+      'lonlat' => 'POINT(12.3712 51.3402)',
+      'timestamp' => 1_709_287_200,
+      'battery' => 80,
+      'accuracy' => 5
+    }
+  end
+
+  context 'when the archive carries a column that no longer exists' do
+    let(:points_data) { [point_payload.merge('legacy_removed_column' => 'whatever')] }
+
+    it 'still restores the point' do
+      expect { restore }.to change { user.points.count }.by(1)
+    end
+
+    it 'ignores the unknown attribute' do
+      restore
+
+      expect(user.points.last.timestamp).to eq(1_709_287_200)
+    end
+  end
+
+  context 'when the archive matches the current schema' do
+    let(:points_data) { [point_payload] }
+
+    it 'restores the point' do
+      expect { restore }.to change { user.points.count }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`Users::ImportData::Points#prepare_point_attributes` filters with a denylist, so every other archive key passes through to `upsert_all`. An archive carrying a column the current schema no longer has raises `PG::UndefinedColumn` — which `flush_batch` logs and swallows, clears the buffer, and continues. The restore reports success with **zero points imported**, silently.

This already bit once during the `country` deprecation (that column was patched into the denylist by hand) and becomes a guaranteed data-loss path for every column drop in the points v2 rewrite: any pre-drop profile export would restore as an empty timeline.

## Fix

- `attributes.slice(*Point.column_names)` — unknown keys are dropped instead of crashing the batch
- failed batches are counted, surfaced in the completion log, and reported via `ExceptionReporter` instead of being swallowed

## Verification

New spec restores a payload carrying a removed column: on unpatched code it imports 0 points (red), with the fix the point restores and the unknown key is ignored (green). Full `spec/services/users/import_data` suite: 252 examples, 0 failures. RuboCop clean.