### PR TITLE
Reject GeoJSON points without timestamps at import

### DIFF
--- a/app/services/geojson/importer.rb
+++ b/app/services/geojson/importer.rb
@@ -23,6 +23,7 @@ class Geojson::Importer
       stream_features(path)
       flush_batch
     end
+    report_skipped_timeless
   ensure
     cleanup_temp_file
   end
@@ -40,6 +41,7 @@ class Geojson::Importer
   def initialize_stream
     @points_batch = []
     @processed_points = 0
+    @skipped_timeless = 0
   end
 
   def stream_features(path)
@@ -57,6 +59,13 @@ class Geojson::Importer
   def process_feature(feature)
     Geojson::Params.new(feature).each_point do |point|
       next if point[:lonlat].nil?
+
+      # GPX and KML already reject timeless points; a point without a
+      # timestamp can never surface in any range query.
+      if point[:timestamp].nil?
+        @skipped_timeless += 1
+        next
+      end
 
       @points_batch << point.merge(point_metadata)
       flush_batch if @points_batch.size >= BATCH_SIZE
@@ -80,6 +89,23 @@ class Geojson::Importer
     bulk_insert_points(batch)
     @processed_points += batch.size
     broadcast_import_progress(import, @processed_points)
+  end
+
+  def report_skipped_timeless
+    return if @skipped_timeless.zero?
+
+    import.update!(raw_data: (import.raw_data || {}).merge('skipped_timeless' => @skipped_timeless))
+
+    user = import.user
+    I18n.with_locale(user.locale) do
+      Notifications::Create.new(
+        user:,
+        kind: :warning,
+        title: I18n.t('services.imports.geojson_importer.points_skipped_title'),
+        content: I18n.t('services.imports.geojson_importer.points_skipped',
+                        name: import.name, skipped: @skipped_timeless)
+      ).call
+    end
   end
 
   def atomic_bulk_insert?

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -149,7 +149,7 @@ class Imports::Create
   end
 
   def zero_points_content(import)
-    if import.gpx? || import.kml?
+    if import.gpx? || import.kml? || import.geojson?
       I18n.t('services.imports.create.zero_points_with_timestamps', name: import.name)
     else
       I18n.t('services.imports.create.zero_points', name: import.name)

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3453,12 +3453,15 @@ ca:
     imports:
       bulk_insertable:
         importer_name_import_error: "Error d'importació de %{importer_name}"
+      geojson_importer:
+        points_skipped_title: La importació ha omès punts sense marca de temps
+        points_skipped: 'El teu fitxer %{name} contenia %{skipped} punts sense marca de temps; s''han omès. Els punts GeoJSON necessiten una propietat "timestamp" o un quart valor de coordenada [lon, lat, altitude, time] per ser importats.'
       create:
         import_post_processing_incomplete: El postprocessament de la importació no s'ha completat
         import_completed_with_no_new_points: La importació ha finalitzat sense punts nous
         import_completed_with_no_points: La importació ha finalitzat sense punts
         import_failed: La importació ha fallat
-        zero_points_with_timestamps: "El teu arxiu %{name} ha importat 0 punts. No s'ha trobat cap punt d'ubicació amb marca de temps. Les importacions de GPX i KML requereixen un valor &lt;time&gt;/&lt;when&gt; per a cada coordenada."
+        zero_points_with_timestamps: "El teu arxiu %{name} ha importat 0 punts. No s'ha trobat cap punt d'ubicació amb marca de temps. Les importacions de GPX, KML i GeoJSON requereixen un valor de temps per a cada coordenada (&lt;time&gt;, &lt;when&gt; o una propietat timestamp)."
         zero_points: "El teu arxiu %{name} ha importat 0 punts. No s'ha trobat cap punt d'ubicació nou en aquest arxiu."
         import_failed_self_hosted: 'La importació "%{name}" ha fallat: %{message}, traça: %{backtrace}'
         import_failed_cloud: 'La importació "%{name}" ha fallat, contacta amb nosaltres a hi@dawarich.com'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3515,6 +3515,9 @@ de:
     imports:
       bulk_insertable:
         importer_name_import_error: "%{importer_name} Importfehler"
+      geojson_importer:
+        points_skipped_title: Import hat Punkte ohne Zeitstempel übersprungen
+        points_skipped: 'Deine Datei %{name} enthielt %{skipped} Punkte ohne Zeitstempel; sie wurden übersprungen. GeoJSON-Punkte benötigen eine "timestamp"-Eigenschaft oder einen vierten [lon, lat, altitude, time]-Koordinatenwert, um importiert zu werden.'
       create:
         import_post_processing_incomplete: Import-Post-Processing unvollständig
         import_completed_with_no_new_points: Import abgeschlossen, aber keine neuen Punkte
@@ -3525,7 +3528,7 @@ de:
         source_missing: Importquelle darf nicht null sein
         unsupported_source: 'Nicht unterstützte Quelle: %{source}'
         zip_unclassified: Zip-Inhalt konnte nicht klassifiziert werden – Datei könnte beschädigt sein
-        zero_points_with_timestamps: "Deine Datei %{name} hat 0 Punkte importiert. Es wurden keine Standortpunkte mit Zeitstempeln gefunden. GPX- und KML-Importe benötigen für jede Koordinate einen eigenen &lt;time&gt;/&lt;when&gt;-Wert."
+        zero_points_with_timestamps: "Deine Datei %{name} hat 0 Punkte importiert. Es wurden keine Standortpunkte mit Zeitstempeln gefunden. GPX-, KML- und GeoJSON-Importe benötigen für jede Koordinate einen eigenen Zeitwert (&lt;time&gt;, &lt;when&gt; oder eine timestamp-Eigenschaft)."
         zero_points: "Deine Datei %{name} hat 0 Punkte importiert. In dieser Datei wurden keine neuen Standortpunkte gefunden."
         import_failed_self_hosted: "Import \"%{name}\" fehlgeschlagen: %{message}, Stacktrace: %{backtrace}"
         import_failed_cloud: "Import \"%{name}\" fehlgeschlagen, bitte kontaktiere uns unter hi@dawarich.com"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3441,12 +3441,15 @@ en:
     imports:
       bulk_insertable:
         importer_name_import_error: "%{importer_name} Import Error"
+      geojson_importer:
+        points_skipped_title: Import skipped points without timestamps
+        points_skipped: 'Your file %{name} contained %{skipped} points without timestamps; they were skipped. GeoJSON points need a "timestamp" property or a fourth [lon, lat, altitude, time] coordinate value to be imported.'
       create:
         import_post_processing_incomplete: Import post-processing incomplete
         import_completed_with_no_new_points: Import completed with no new points
         import_completed_with_no_points: Import completed with no points
         import_failed: Import failed
-        zero_points_with_timestamps: Your file %{name} imported 0 points. No location points with timestamps were found. GPX and KML imports require a per-point &lt;time&gt;/&lt;when&gt; value for each coordinate.
+        zero_points_with_timestamps: Your file %{name} imported 0 points. No location points with timestamps were found. GPX, KML and GeoJSON imports require a per-point time value (&lt;time&gt;, &lt;when&gt;, or a timestamp property).
         zero_points: Your file %{name} imported 0 points. No new location points were found in this file.
         import_failed_self_hosted: 'Import "%{name}" failed: %{message}, stacktrace: %{backtrace}'
         import_failed_cloud: 'Import "%{name}" failed, please contact us at hi@dawarich.com'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3460,6 +3460,9 @@ es:
     imports:
       bulk_insertable:
         importer_name_import_error: "%{importer_name} Error de importación"
+      geojson_importer:
+        points_skipped_title: La importación omitió puntos sin marca de tiempo
+        points_skipped: 'Tu archivo %{name} contenía %{skipped} puntos sin marca de tiempo; se omitieron. Los puntos GeoJSON necesitan una propiedad "timestamp" o un cuarto valor de coordenada [lon, lat, altitude, time] para ser importados.'
       create:
         import_post_processing_incomplete: Importación post-procesada incompleta
         import_completed_with_no_new_points: Importación completada sin puntos nuevos
@@ -3470,7 +3473,7 @@ es:
         source_missing: La fuente de importación no puede estar vacía
         unsupported_source: 'Fuente no soportada: %{source}'
         zip_unclassified: No se pudo clasificar el contenido del archivo ZIP; puede que esté dañado
-        zero_points_with_timestamps: "Tu archivo %{name} importó 0 puntos. No se encontraron puntos de ubicación con marcas de tiempo. Las importaciones GPX y KML necesitan un valor &lt;time&gt;/&lt;when&gt; por cada coordenada."
+        zero_points_with_timestamps: "Tu archivo %{name} importó 0 puntos. No se encontraron puntos de ubicación con marcas de tiempo. Las importaciones GPX, KML y GeoJSON necesitan un valor de tiempo por cada coordenada (&lt;time&gt;, &lt;when&gt; o una propiedad timestamp)."
         zero_points: "Tu archivo %{name} importó 0 puntos. No se encontraron puntos de ubicación nuevos en este archivo."
         import_failed_self_hosted: "La importación \"%{name}\" falló: %{message}, traza: %{backtrace}"
         import_failed_cloud: "La importación \"%{name}\" falló, contáctanos en hi@dawarich.com"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4558,14 +4558,18 @@ fr:
     imports:
       bulk_insertable:
         importer_name_import_error: Erreur d'importation %{importer_name}
+      geojson_importer:
+        points_skipped_title: L'import a ignoré des points sans horodatage
+        points_skipped: 'Votre fichier %{name} contenait %{skipped} points sans horodatage ; ils ont été ignorés. Les points GeoJSON nécessitent une propriété "timestamp" ou une quatrième valeur de coordonnée [lon, lat, altitude, time] pour être importés.'
       create:
         import_post_processing_incomplete: Traitement post-importation incomplet
         import_completed_with_no_new_points: Importation terminée sans nouveau point
         import_completed_with_no_points: Importation terminée sans point
         import_failed: L'importation a échoué
         zero_points_with_timestamps: Votre fichier « %{name} » n'a importé aucun point.
-          Aucun point de localisation horodaté n'a été trouvé. Les importations GPX
-          et KML exigent une valeur &lt;time&gt;/&lt;when&gt; pour chaque coordonnée.
+          Aucun point de localisation horodaté n'a été trouvé. Les importations GPX,
+          KML et GeoJSON exigent une valeur de temps pour chaque coordonnée (&lt;time&gt;,
+          &lt;when&gt; ou une propriété timestamp).
         zero_points: Votre fichier « %{name} » n'a importé aucun point. Aucun nouveau
           point de localisation n'a été trouvé dans ce fichier.
         import_failed_self_hosted: 'L''importation « %{name} » a échoué : %{message},

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -3508,12 +3508,15 @@ pl:
     imports:
       bulk_insertable:
         importer_name_import_error: Błąd importu %{importer_name}
+      geojson_importer:
+        points_skipped_title: Import pominął punkty bez znacznika czasu
+        points_skipped: 'Twój plik %{name} zawierał %{skipped} punktów bez znacznika czasu; zostały pominięte. Punkty GeoJSON wymagają właściwości "timestamp" lub czwartej wartości współrzędnej [lon, lat, altitude, time], aby zostały zaimportowane.'
       create:
         import_post_processing_incomplete: Końcowe przetwarzanie importu nie zostało ukończone
         import_completed_with_no_new_points: Import zakończony bez nowych punktów
         import_completed_with_no_points: Import zakończony bez punktów
         import_failed: Import nie powiódł się
-        zero_points_with_timestamps: Plik %{name} zaimportował 0 punktów. Nie znaleziono punktów lokalizacji ze znacznikami czasu. Import GPX i KML wymaga wartości &lt;time&gt;/&lt;when&gt; dla każdego punktu.
+        zero_points_with_timestamps: Plik %{name} zaimportował 0 punktów. Nie znaleziono punktów lokalizacji ze znacznikami czasu. Import GPX, KML i GeoJSON wymaga wartości czasu dla każdego punktu (&lt;time&gt;, &lt;when&gt; lub właściwości timestamp).
         zero_points: Plik %{name} zaimportował 0 punktów. Nie znaleziono w nim nowych punktów lokalizacji.
         import_failed_self_hosted: 'Import "%{name}" nie powiódł się: %{message}, stacktrace: %{backtrace}'
         import_failed_cloud: 'Import "%{name}" nie powiódł się, skontaktuj się z nami: hi@dawarich.com'

--- a/spec/regressions/imports_surface_zero_points_without_timestamps_spec.rb
+++ b/spec/regressions/imports_surface_zero_points_without_timestamps_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Imports surface zero points with no timestamps', type: :request 
       expect(notification.kind).to eq('warning')
       expect(notification.content).to include('no_timestamps.gpx')
       expect(notification.content).to include('0 points')
-      expect(notification.content).to include('&lt;time&gt;/&lt;when&gt;')
+      expect(notification.content).to include('&lt;time&gt;')
     end
 
     it 'uses the user language when the import runs in the background' do
@@ -50,13 +50,13 @@ RSpec.describe 'Imports surface zero points with no timestamps', type: :request 
       expect(notification.title).to eq('Importation terminée sans point')
       expect(notification.content).to include('sans_horodatage.gpx')
       expect(notification.content).to include("n'a importé aucun point")
-      expect(notification.content).to include('&lt;time&gt;/&lt;when&gt;')
+      expect(notification.content).to include('&lt;time&gt;')
 
       sign_in user
       get notification_url(notification)
 
       rendered_notification = Nokogiri::HTML(response.body).at_css("#notification_#{notification.id}")
-      expect(rendered_notification.text).to include('<time>/<when>')
+      expect(rendered_notification.text).to include('<time>')
     end
   end
 

--- a/spec/services/geojson/importer_spec.rb
+++ b/spec/services/geojson/importer_spec.rb
@@ -115,5 +115,69 @@ RSpec.describe Geojson::Importer do
         expect { invalid_utf8_service.call }.to change { Point.count }.by(1)
       end
     end
+
+    context 'when the file contains features without timestamps' do
+      let(:mixed_geojson) do
+        {
+          type: 'FeatureCollection',
+          features: [
+            { type: 'Feature', geometry: { type: 'Point', coordinates: [12.3712, 51.3402] },
+              properties: { timestamp: 1_709_287_200 } },
+            { type: 'Feature', geometry: { type: 'Point', coordinates: [12.3812, 51.3502] },
+              properties: { name: 'no time here' } },
+            { type: 'Feature', geometry: { type: 'LineString',
+                                           coordinates: [[12.39, 51.36], [12.40, 51.37], [12.41, 51.38]] },
+              properties: {} }
+          ]
+        }.to_json
+      end
+
+      def with_tempfile(content)
+        Tempfile.create(['timeless', '.geojson']) do |file|
+          file.write(content)
+          file.flush
+          yield file.path
+        end
+      end
+
+      it 'imports only the points that carry a timestamp' do
+        with_tempfile(mixed_geojson) do |path|
+          expect { described_class.new(import, user.id, path).call }.to change { Point.count }.by(1)
+        end
+      end
+
+      it 'never persists a point without a timestamp' do
+        with_tempfile(mixed_geojson) do |path|
+          described_class.new(import, user.id, path).call
+        end
+
+        expect(Point.where(timestamp: nil).count).to eq(0)
+      end
+
+      it 'records the skipped count on the import' do
+        with_tempfile(mixed_geojson) do |path|
+          described_class.new(import, user.id, path).call
+        end
+
+        expect(import.reload.raw_data['skipped_timeless']).to eq(4)
+      end
+
+      it 'notifies the user how many points were skipped and why' do
+        with_tempfile(mixed_geojson) do |path|
+          expect { described_class.new(import, user.id, path).call }
+            .to change { user.notifications.count }.by(1)
+        end
+
+        notification = user.notifications.last
+        expect(notification.kind).to eq('warning')
+        expect(notification.content).to include('4')
+      end
+    end
+
+    context 'when every feature carries a timestamp' do
+      it 'creates no skip notification' do
+        expect { call_service }.not_to(change { user.notifications.count })
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

GeoJSON is the only importer that accepts timeless features. Timeless LineString/MultiLineString coordinates (no 4th element) and Point features whose properties match none of the recognized time aliases import as `timestamp: NULL` points — invisible to every range query, so the user sees nothing and gets no explanation. Cloud has accumulated ~172k such rows from 30 users since January, and they'd crash imports outright once the points v2 rewrite makes `timestamp` NOT NULL.

## Fix

Aligns GeoJSON with what GPX and KML already do:

- `Geojson::Importer` skips points without a timestamp and counts them
- the skipped count is recorded on the import (`raw_data['skipped_timeless']`, same pattern as the CSV importer)
- the user gets a warning notification in their locale — "your file contained N points without timestamps" — explaining that GeoJSON needs a `timestamp` property or a fourth `[lon, lat, altitude, time]` coordinate value
- the all-timeless case reuses the existing zero-points notification; its copy now names GeoJSON alongside GPX and KML (updated in all six locales)

## Verification

Four new specs (skip behavior, no NULL persists, count recorded, notification content/locale), red on unpatched code. 108 examples green across `spec/services/geojson`, `imports/create_spec`, and all i18n coverage regressions. RuboCop clean.