### PR TITLE
Fix trip photo time window and surface photo source failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Shared link addresses are now always three words. One hyphenated entry in the word list could produce a four-word address.
 - Photos are now matched to a trip or map range on the photo's UTC timestamp rather than its local wall-clock time. Previously a trip could hide photos taken in its final hours, drop one taken exactly on its start or end boundary, or — when it began or ended near midnight — lose photos before they were even fetched. A photo with a missing or unreadable timestamp is now skipped instead of failing the whole fetch. (#1137)
+- A photo layer that fails to load now tells you so instead of quietly showing nothing. An unreachable or erroring Immich or PhotoPrism was previously indistinguishable from simply having no photos in range; when one of several sources fails, the photos that were retrieved are still shown alongside a warning. (#1137)
 - Places created from a suggested visit now get their real address. Visits detected on a phone arrive with a generated name such as "Visited place"; that name is no longer locked, reverse geocoding is queued for the new place, and the resolved address now replaces the generated name on the visit as well as the place.
 
 ## [1.14.1] - 2026-08-31, Berlin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Shared link addresses are now always three words. One hyphenated entry in the word list could produce a four-word address.
+- Photos are now matched to a trip or map range on the photo's UTC timestamp rather than its local wall-clock time. Previously a trip could hide photos taken in its final hours, drop one taken exactly on its start or end boundary, or — when it began or ended near midnight — lose photos before they were even fetched. A photo with a missing or unreadable timestamp is now skipped instead of failing the whole fetch. (#1137)
 - Places created from a suggested visit now get their real address. Visits detected on a phone arrive with a generated name such as "Visited place"; that name is no longer locked, reverse geocoding is queued for the new place, and the resolved address now replaces the generated name on the visit as well as the place.
 
 ## [1.14.1] - 2026-08-31, Berlin

--- a/app/controllers/api/v1/photos_controller.rb
+++ b/app/controllers/api/v1/photos_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::V1::PhotosController < ApiController
   THUMBNAIL_BROWSER_CACHE_MAX_AGE = 30.minutes
+  PHOTO_SOURCE_ERRORS_HEADER = 'X-Photo-Source-Errors'
 
   before_action :check_integration_configured, only: %i[index thumbnail]
   before_action :check_source, only: %i[thumbnail]
@@ -13,12 +14,15 @@ class Api::V1::PhotosController < ApiController
 
     search = Photos::Search.new(current_api_user, start_date: params[:start_date], end_date: params[:end_date])
     @photos = search.call
+    return render_source_failure if search.all_sources_failed?
+
     Rails.cache.write(cache_key, @photos, expires_in: 30.minutes) if search.errors.blank? && @photos.present?
+    response.set_header(PHOTO_SOURCE_ERRORS_HEADER, search.errors.join(',')) if search.errors.any?
 
     render json: @photos, status: :ok
   rescue StandardError => e
     Rails.logger.error("Photo search failed: #{e.message}")
-    render json: { error: I18n.t('controllers.api.v1.photos.failed_to_fetch_photos') }, status: :bad_gateway
+    render_source_failure
   end
 
   def thumbnail
@@ -30,6 +34,10 @@ class Api::V1::PhotosController < ApiController
   end
 
   private
+
+  def render_source_failure
+    render json: { error: I18n.t('controllers.api.v1.photos.failed_to_fetch_photos') }, status: :bad_gateway
+  end
 
   def handle_thumbnail_response(upstream)
     if upstream.success?

--- a/app/javascript/maps_maplibre/services/api_client.js
+++ b/app/javascript/maps_maplibre/services/api_client.js
@@ -1,3 +1,6 @@
+import { translate } from "i18n"
+import { Toast } from "maps_maplibre/components/toast"
+
 /**
  * API client for Maps V2
  * Wraps all API endpoints with consistent error handling
@@ -390,7 +393,17 @@ export class ApiClient {
     })
 
     if (!response.ok) {
+      Toast.error(translate("messages.failed_to_load_photos"))
       throw new Error(`Failed to fetch photos: ${response.statusText}`)
+    }
+
+    const failedSources = response.headers.get("X-Photo-Source-Errors")
+    if (failedSources) {
+      Toast.warning(
+        translate("messages.some_photo_sources_unavailable", {
+          sources: failedSources.split(",").join(", "),
+        }),
+      )
     }
 
     return response.json()

--- a/app/services/photoprism/request_photos.rb
+++ b/app/services/photoprism/request_photos.rb
@@ -100,7 +100,7 @@ class Photoprism::RequestPhotos
 
   def request_params(offset = 0)
     params = offset.zero? ? default_params : default_params.merge(offset: offset)
-    params[:before] = (end_date.to_date + 1.day).iso8601 if end_date.present?
+    params[:before] = (utc_date(end_date) + 1.day).iso8601 if end_date.present?
     params
   end
 
@@ -109,9 +109,15 @@ class Photoprism::RequestPhotos
       q: '',
       public: true,
       quality: 3,
-      after: start_date.to_date.iso8601,
+      after: utc_date(start_date).iso8601,
       count: 1000
     }
+  end
+
+  # Photoprism filters after/before on the UTC TakenAt date, while the bounds it
+  # is given arrive rendered in the application time zone.
+  def utc_date(value)
+    value.to_datetime.utc.to_date
   end
 
   # A bare date names a whole day, so an end bound written that way has to
@@ -122,8 +128,22 @@ class Photoprism::RequestPhotos
     range_end = range_end.end_of_day if date_only?(end_date)
 
     data.flatten.select do |photo|
-      DateTime.parse(photo['TakenAtLocal']).between?(range_start, range_end)
+      taken_at = parse_taken_at(photo)
+      next false if taken_at.nil?
+
+      taken_at.between?(range_start, range_end)
     end
+  end
+
+  # TakenAtLocal is wall-clock time in the photo's own zone, serialised with a
+  # trailing Z, so only TakenAt is comparable to an absolute bound.
+  def parse_taken_at(photo)
+    value = photo['TakenAt'].presence || photo['TakenAtLocal'].presence
+    return if value.blank?
+
+    DateTime.parse(value)
+  rescue ArgumentError, TypeError
+    nil
   end
 
   def cache_preview_token(headers)

--- a/app/services/photos/search.rb
+++ b/app/services/photos/search.rb
@@ -20,6 +20,17 @@ class Photos::Search
     @errors = []
   end
 
+  def configured_sources
+    sources = []
+    sources << :immich if user.immich_integration_configured?
+    sources << :photoprism if user.photoprism_integration_configured?
+    sources
+  end
+
+  def all_sources_failed?
+    configured_sources.any? && (configured_sources - errors).empty?
+  end
+
   def call
     photos = []
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3756,6 +3756,7 @@ ca:
       failed_to_reload_routes: No s'han pogut tornar a carregar les rutes
       failed_to_load_scratch_layer: No s'ha pogut carregar la capa de mapa de rascar
       failed_to_load_photos: No s'han pogut carregar les fotos
+      some_photo_sources_unavailable: "Algunes fonts de fotos no estan disponibles: %{sources}"
       failed_to_load_areas: No s'han pogut carregar les àrees
       failed_to_load_tracks: No s'han pogut carregar els trajectes
       failed_to_load_flights: No s'han pogut carregar els vols

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3808,6 +3808,7 @@ de:
       failed_to_reload_routes: Route konnte nicht neu geladen werden
       failed_to_load_scratch_layer: Rubbelkartenebene konnte nicht geladen werden
       failed_to_load_photos: Fotos konnten nicht geladen werden
+      some_photo_sources_unavailable: "Einige Fotoquellen sind nicht verfügbar: %{sources}"
       failed_to_load_areas: Gebiete konnten nicht geladen werden
       failed_to_load_tracks: Tracks konnten nicht geladen werden
       failed_to_load_track_details: Track-Details konnten nicht geladen werden

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3747,6 +3747,7 @@ en:
       failed_to_reload_routes: Failed to reload routes
       failed_to_load_scratch_layer: Failed to load scratch layer
       failed_to_load_photos: Failed to load photos
+      some_photo_sources_unavailable: "Some photo sources are unavailable: %{sources}"
       failed_to_load_areas: Failed to load areas
       failed_to_load_tracks: Failed to load tracks
       failed_to_load_track_details: Failed to load track details

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3753,6 +3753,7 @@ es:
       failed_to_reload_routes: No se pudo recargar las rutas
       failed_to_load_scratch_layer: No se pudo cargar la capa de borrador
       failed_to_load_photos: No se pudo cargar las fotos
+      some_photo_sources_unavailable: "Algunas fuentes de fotos no están disponibles: %{sources}"
       failed_to_load_areas: No se pudo cargar los ámbitos
       failed_to_load_tracks: No se pudieron cargar los trayectos
       failed_to_load_track_details: No se pudieron cargar los detalles del trayecto

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4984,6 +4984,7 @@ fr:
       failed_to_reload_routes: Échec du rechargement des itinéraires
       failed_to_load_scratch_layer: Échec du chargement de la carte à gratter
       failed_to_load_photos: Échec du chargement des photos
+      some_photo_sources_unavailable: "Certaines sources de photos sont indisponibles : %{sources}"
       failed_to_load_areas: Échec du chargement des zones
       failed_to_load_tracks: Échec du chargement des trajets
       failed_to_load_track_details: Échec du chargement des détails du trajet

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -3811,6 +3811,7 @@ pl:
       failed_to_reload_routes: Nie udało się odświeżyć tras
       failed_to_load_scratch_layer: Nie udało się załadować warstwy scratch
       failed_to_load_photos: Nie udało się załadować zdjęć
+      some_photo_sources_unavailable: "Niektóre źródła zdjęć są niedostępne: %{sources}"
       failed_to_load_areas: Nie udało się załadować obszarów
       failed_to_load_tracks: Nie udało się załadować odcinków
       failed_to_load_track_details: Nie udało się wczytać szczegółów odcinka

--- a/spec/regressions/photo_source_failure_surfacing_spec.rb
+++ b/spec/regressions/photo_source_failure_surfacing_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Photo source failures are surfaced to the caller', type: :request do
+  let(:user) do
+    create(
+      :user,
+      settings: {
+        'immich_url' => 'http://immich.local',
+        'immich_api_key' => 'test_api_key'
+      }
+    )
+  end
+
+  before { allow(Rails.cache).to receive(:read).and_return(nil) }
+
+  def get_photos
+    get '/api/v1/photos',
+        params: { api_key: user.api_key, start_date: '2026-06-20T00:00:00Z', end_date: '2026-06-26T00:00:00Z' }
+  end
+
+  context 'when the Immich instance is unreachable' do
+    before { stub_request(:post, /immich\.local/).to_timeout }
+
+    it 'reports the failure to the caller' do
+      get_photos
+
+      expect(response).not_to have_http_status(:ok)
+    end
+  end
+
+  context 'when the Immich instance rejects the request' do
+    before do
+      stub_request(:post, /immich\.local/)
+        .to_return(status: 500, body: { error: 'boom' }.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'reports the failure to the caller' do
+      get_photos
+
+      expect(response).not_to have_http_status(:ok)
+    end
+
+    it 'does not present the failure as an empty photo list' do
+      get_photos
+
+      expect(JSON.parse(response.body)).not_to eq([])
+    end
+  end
+
+  context 'when one source fails and another still returns photos' do
+    let(:user) do
+      create(
+        :user,
+        settings: {
+          'immich_url' => 'http://immich.local',
+          'immich_api_key' => 'test_api_key',
+          'photoprism_url' => 'http://photoprism.local',
+          'photoprism_api_key' => 'test_api_key'
+        }
+      )
+    end
+
+    before do
+      stub_request(:post, /immich\.local/).to_return(status: 500, body: '{}',
+                                                     headers: { 'Content-Type' => 'application/json' })
+      stub_request(:get, /photoprism\.local/).to_return(
+        { status: 200,
+          body: [{ 'Hash' => 'abc', 'Type' => 'image', 'TakenAt' => '2026-06-22T10:00:00Z',
+                   'Lat' => 52.5, 'Lng' => 13.4 }].to_json,
+          headers: { 'Content-Type' => 'application/json' } },
+        { status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' } }
+      )
+    end
+
+    it 'still returns the photos that were retrieved' do
+      get_photos
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body).size).to eq(1)
+    end
+
+    it 'names the failed source in a response header' do
+      get_photos
+
+      expect(response.headers['X-Photo-Source-Errors']).to eq('immich')
+    end
+  end
+end

--- a/spec/regressions/photoprism_after_param_date_format_spec.rb
+++ b/spec/regressions/photoprism_after_param_date_format_spec.rb
@@ -30,14 +30,26 @@ RSpec.describe 'Photoprism date filters are sent as plain dates' do
 
   it 'reduces a minute-precision start_date to the plain after date Photoprism accepts' do
     stub_empty
-    Photoprism::RequestPhotos.new(user, start_date: '2026-06-21T00:00+02:00').call
+    Photoprism::RequestPhotos.new(user, start_date: '2026-06-21T09:00+02:00').call
     expect(captured('after')).to eq('2026-06-21')
   end
 
   it 'sends before as a plain date one day past end_date' do
     stub_empty
-    Photoprism::RequestPhotos.new(user, start_date: '2026-06-21', end_date: '2026-06-23T00:00+02:00').call
+    Photoprism::RequestPhotos.new(user, start_date: '2026-06-21', end_date: '2026-06-23T09:00+02:00').call
     expect(captured('before')).to eq('2026-06-24')
+  end
+
+  it 'derives after from the UTC instant when the offset crosses midnight' do
+    stub_empty
+    Photoprism::RequestPhotos.new(user, start_date: '2026-06-21T00:00+02:00').call
+    expect(captured('after')).to eq('2026-06-20')
+  end
+
+  it 'derives before from the UTC instant when the offset crosses midnight' do
+    stub_empty
+    Photoprism::RequestPhotos.new(user, start_date: '2026-06-21', end_date: '2026-06-23T00:00+02:00').call
+    expect(captured('before')).to eq('2026-06-23')
   end
 
   it 'defaults the after date and does not raise when start_date is nil' do
@@ -54,7 +66,8 @@ RSpec.describe 'Photoprism date filters are sent as plain dates' do
 
   it 'excludes photos taken after a precise end_date' do
     stub_request(:get, /photoprism\.local/).to_return(
-      { status: 200, body: [{ 'TakenAtLocal' => '2026-06-23T18:00:00Z' }].to_json,
+      { status: 200,
+        body: [{ 'TakenAt' => '2026-06-23T16:00:00Z', 'TakenAtLocal' => '2026-06-23T18:00:00Z' }].to_json,
         headers: { 'Content-Type' => 'application/json' } },
       { status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' } }
     )

--- a/spec/regressions/photoprism_sub_day_trip_photo_bounds_spec.rb
+++ b/spec/regressions/photoprism_sub_day_trip_photo_bounds_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Photoprism sub-day trip photo bounds' do
+  let(:user) do
+    create(
+      :user,
+      settings: {
+        'photoprism_url' => 'http://photoprism.local',
+        'photoprism_api_key' => 'test_api_key'
+      }
+    )
+  end
+
+  # Photoprism reports TakenAt in UTC and TakenAtLocal as wall-clock time in the
+  # photo's own zone, both serialized with a trailing Z. Munich in June is UTC+2,
+  # so a photo taken at 14:45 UTC carries TakenAtLocal 16:45.
+  let(:photo) do
+    {
+      'ID' => '5',
+      'UID' => 'pthgne34x970u6d5',
+      'Type' => 'image',
+      'TakenAt' => '2026-06-22T14:45:00Z',
+      'TakenAtLocal' => '2026-06-22T16:45:00Z',
+      'TimeZone' => 'Europe/Berlin',
+      'Lat' => 48.135125,
+      'Lng' => 11.5819805555556
+    }
+  end
+
+  around { |example| Time.use_zone('UTC') { example.run } }
+
+  before do
+    stub_request(:get, %r{http://photoprism\.local/api/v1/photos})
+      .to_return(
+        { status: 200, body: [photo].to_json, headers: { 'Content-Type' => 'application/json' } },
+        { status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' } }
+      )
+  end
+
+  def photos_between(start_at, end_at)
+    Photoprism::RequestPhotos.new(user, start_date: start_at.iso8601, end_date: end_at.iso8601).call.size
+  end
+
+  it 'excludes a photo taken before the trip started' do
+    expect(photos_between(Time.utc(2026, 6, 22, 15, 0, 0), Time.utc(2026, 6, 22, 23, 59, 59))).to eq(0)
+  end
+
+  it 'includes a photo taken exactly at the trip end boundary' do
+    expect(photos_between(Time.utc(2026, 6, 22, 0, 0, 0), Time.utc(2026, 6, 22, 14, 45, 0))).to eq(1)
+  end
+
+  it 'excludes a photo taken after the trip ended' do
+    expect(photos_between(Time.utc(2026, 6, 22, 0, 0, 0), Time.utc(2026, 6, 22, 12, 0, 0))).to eq(0)
+  end
+
+  it 'includes a photo taken within a full-day trip' do
+    expect(photos_between(Time.utc(2026, 6, 22, 0, 0, 0), Time.utc(2026, 6, 22, 23, 59, 59))).to eq(1)
+  end
+
+  it 'requests the window using the trip dates without extra start padding' do
+    photos_between(Time.utc(2026, 6, 22, 0, 0, 0), Time.utc(2026, 6, 22, 23, 59, 59))
+
+    expect(
+      a_request(:get, %r{http://photoprism\.local/api/v1/photos})
+        .with(query: hash_including('after' => '2026-06-22', 'before' => '2026-06-23'))
+    ).to have_been_made.at_least_once
+  end
+
+  context 'when the trip bounds render in a non-UTC application zone' do
+    # Photoprism's after/before filter on the UTC TakenAt date, so the requested
+    # window has to be derived from the UTC instant rather than the local date.
+    let(:photo) do
+      {
+        'ID' => '12',
+        'Type' => 'image',
+        'TakenAt' => '2026-06-25T23:30:00Z',
+        'TakenAtLocal' => '2026-06-26T01:30:00Z',
+        'TimeZone' => 'Europe/Berlin'
+      }
+    end
+
+    around { |example| Time.use_zone('Europe/Berlin') { example.run } }
+
+    def photos_between_local(start_at, end_at)
+      Photoprism::RequestPhotos.new(
+        user, start_date: start_at.in_time_zone.iso8601, end_date: end_at.in_time_zone.iso8601
+      ).call.size
+    end
+
+    it 'requests the window using UTC dates, not the local ones' do
+      photos_between_local(Time.utc(2026, 6, 25, 23, 0, 0), Time.utc(2026, 6, 25, 23, 59, 59))
+
+      expect(
+        a_request(:get, %r{http://photoprism\.local/api/v1/photos})
+          .with(query: hash_including('after' => '2026-06-25', 'before' => '2026-06-26'))
+      ).to have_been_made.at_least_once
+    end
+
+    it 'still returns a photo that falls inside the trip' do
+      expect(photos_between_local(Time.utc(2026, 6, 25, 23, 0, 0), Time.utc(2026, 6, 25, 23, 59, 59))).to eq(1)
+    end
+  end
+
+  context 'with a photo from a negative UTC offset zone' do
+    # Los Angeles in June is UTC-7, so local wall-clock runs behind UTC and the
+    # old comparison skewed the window in the opposite direction.
+    let(:photo) do
+      {
+        'ID' => '9',
+        'Type' => 'image',
+        'TakenAt' => '2026-06-22T02:00:00Z',
+        'TakenAtLocal' => '2026-06-21T19:00:00Z',
+        'TimeZone' => 'America/Los_Angeles',
+        'Lat' => 34.0522,
+        'Lng' => -118.2437
+      }
+    end
+
+    it 'includes a photo whose UTC instant falls inside the trip' do
+      expect(photos_between(Time.utc(2026, 6, 22, 0, 0, 0), Time.utc(2026, 6, 22, 23, 59, 59))).to eq(1)
+    end
+
+    it 'excludes a photo whose UTC instant falls before the trip' do
+      expect(photos_between(Time.utc(2026, 6, 22, 6, 0, 0), Time.utc(2026, 6, 22, 23, 59, 59))).to eq(0)
+    end
+  end
+
+  context 'when Photoprism omits TakenAt' do
+    let(:photo) { { 'ID' => '7', 'Type' => 'image', 'TakenAtLocal' => '2026-06-22T16:45:00Z' } }
+
+    it 'falls back to TakenAtLocal' do
+      expect(photos_between(Time.utc(2026, 6, 22, 0, 0, 0), Time.utc(2026, 6, 22, 23, 59, 59))).to eq(1)
+    end
+  end
+
+  context 'when Photoprism sends a blank TakenAt' do
+    let(:photo) do
+      { 'ID' => '8', 'Type' => 'image', 'TakenAt' => '', 'TakenAtLocal' => '2026-06-22T16:45:00Z' }
+    end
+
+    it 'falls back to TakenAtLocal' do
+      expect(photos_between(Time.utc(2026, 6, 22, 0, 0, 0), Time.utc(2026, 6, 22, 23, 59, 59))).to eq(1)
+    end
+  end
+
+  context 'when a photo carries no usable timestamp' do
+    let(:photo) { { 'ID' => '10', 'Type' => 'image' } }
+
+    it 'skips the photo instead of aborting the whole fetch' do
+      expect(photos_between(Time.utc(2026, 6, 22, 0, 0, 0), Time.utc(2026, 6, 22, 23, 59, 59))).to eq(0)
+    end
+  end
+
+  context 'when a photo carries a malformed timestamp' do
+    let(:photo) { { 'ID' => '11', 'Type' => 'image', 'TakenAt' => 'not-a-date' } }
+
+    it 'skips the photo instead of aborting the whole fetch' do
+      expect(photos_between(Time.utc(2026, 6, 22, 0, 0, 0), Time.utc(2026, 6, 22, 23, 59, 59))).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Two related fixes behind the long-running #1137 thread. Both target 1.14.2.

## Photos were matched on local wall-clock time

`Photoprism::RequestPhotos` filtered on `TakenAtLocal` — the wall-clock time in the photo's own zone, which Photoprism serialises with a misleading trailing `Z` — and compared it against trip and map bounds, which are absolute instants. The window was therefore skewed by each photo's UTC offset, dropping photos taken in a trip's final hours. Extending the trip end into the next day pulled them back, which is the symptom originally reported.

Separately, `after`/`before` were derived with `.to_date`, yielding the *local* date. A range starting or ending near midnight asked Photoprism for the wrong day and got nothing back before any filtering ran.

Verified live against a Photoprism image pulled 2026-09-01: `after`/`before` accept only bare `YYYY-MM-DD` (any timestamp returns 400) and filter on the **UTC** `TakenAt` date. A fixture whose UTC date is 06-25 and local date 06-26 is omitted by `after=2026-06-26` and returned by `after=2026-06-25`.

A photo with a missing or unparseable timestamp is now skipped instead of raising and failing the whole fetch.

## A failed photo fetch looked exactly like an empty one

`Photos::Search` collected per-source errors, but the controller read them only to decide whether to cache and then rendered `200 []` regardless. An unreachable Immich and a date range with no photos were indistinguishable — a brief spinner, then nothing. That ambiguity is why the thread ran sixteen months across three reporters without converging.

The controller now renders the `bad_gateway` response it already had when every configured source failed. On partial failure the retrieved photos are still returned, with the failed sources named in `X-Photo-Source-Errors` — so the documented response body is unchanged and no swagger update is needed.

The toast lives in `fetchPhotos` rather than in each caller, so `data_loader.js`, `routes_manager.js` and `trip_maplibre_controller.js` are untouched and keep their existing error handling. `javascript.messages.failed_to_load_photos` already existed; one new key was added across all six locales.

`Api::V1::Shared::PhotosController` deliberately still returns an empty list on failure — its viewers are not the owner and should not learn the state of the owner's infrastructure. That asymmetry is intentional and recorded as an ADR.

## Testing

- New: `spec/regressions/photoprism_sub_day_trip_photo_bounds_spec.rb`, `spec/regressions/photo_source_failure_surfacing_spec.rb`; four added examples in `photoprism_after_param_date_format_spec.rb`.
- Failure verified before the fix by restoring the pre-fix files, then green after.
- 1040 examples, 0 failures across `spec/regressions`, the photos/photoprism/immich/trips services, photos and trips requests, and serializers. 40 examples, 0 failures on `spec/requests/api/v1/shared`.
- Rubocop and Biome clean.

Refs #1137