### PR TITLE
fix: report waypoint-only GPX imports accurately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- A GPX file holding only waypoints (such as an OsmAnd+ `favourites.gpx`) now says so when it imports 0 points, instead of reporting that the file lacks per-point timestamps. That advice was wrong: OsmAnd waypoints do carry a time, and adding more timestamps never helped. (#1261)
 - Shared link addresses are now always three words. One hyphenated entry in the word list could produce a four-word address.
 - Places created from a suggested visit now get their real address. Visits detected on a phone arrive with a generated name such as "Visited place"; that name is no longer locked, reverse geocoding is queued for the new place, and the resolved address now replaces the generated name on the visit as well as the place.
 

--- a/app/services/gpx/track_importer.rb
+++ b/app/services/gpx/track_importer.rb
@@ -27,7 +27,7 @@ class Gpx::TrackImporter
 
   def call
     batch = []
-    each_trkpt do |point_hash, tracker_id|
+    waypoints_seen = each_trkpt do |point_hash, tracker_id|
       data = prepare_point(point_hash, tracker_id)
       next unless data
 
@@ -38,6 +38,7 @@ class Gpx::TrackImporter
       batch = []
     end
     flush(batch) unless batch.empty?
+    record_waypoints_seen(waypoints_seen)
   ensure
     cleanup_temp_file
   end
@@ -50,7 +51,14 @@ class Gpx::TrackImporter
       seek_to_document_start(io)
       handler = TrkptStreamHandler.new(import.id, import.name, &block)
       Nokogiri::XML::SAX::Parser.new(handler).parse(io)
+      handler.waypoint_count
     end
+  end
+
+  def record_waypoints_seen(count)
+    return if count.to_i.zero?
+
+    import.update!(raw_data: (import.raw_data || {}).merge('waypoints_seen' => count))
   end
 
   def seek_to_document_start(io)
@@ -98,11 +106,14 @@ class Gpx::TrackImporter
   end
 
   class TrkptStreamHandler < Nokogiri::XML::SAX::Document
+    attr_reader :waypoint_count
+
     def initialize(import_id, import_name, &block)
       super()
       @import_id = import_id
       @import_name = import_name
       @callback = block
+      @waypoint_count = 0
       @stack = nil
       @text = +''
       @trk_index = -1
@@ -125,6 +136,9 @@ class Gpx::TrackImporter
         return
       when 'trkseg'
         @seg_index += 1
+        return
+      when 'wpt'
+        @waypoint_count += 1
         return
       end
 

--- a/app/services/gpx/track_importer.rb
+++ b/app/services/gpx/track_importer.rb
@@ -27,7 +27,7 @@ class Gpx::TrackImporter
 
   def call
     batch = []
-    waypoints_seen = each_trkpt do |point_hash, tracker_id|
+    handler = each_trkpt do |point_hash, tracker_id|
       data = prepare_point(point_hash, tracker_id)
       next unless data
 
@@ -38,7 +38,7 @@ class Gpx::TrackImporter
       batch = []
     end
     flush(batch) unless batch.empty?
-    record_waypoints_seen(waypoints_seen)
+    record_element_counts(handler)
   ensure
     cleanup_temp_file
   end
@@ -51,14 +51,19 @@ class Gpx::TrackImporter
       seek_to_document_start(io)
       handler = TrkptStreamHandler.new(import.id, import.name, &block)
       Nokogiri::XML::SAX::Parser.new(handler).parse(io)
-      handler.waypoint_count
+      handler
     end
   end
 
-  def record_waypoints_seen(count)
-    return if count.to_i.zero?
+  def record_element_counts(handler)
+    counts = {
+      'waypoints_seen' => handler.waypoint_count,
+      'trackpoints_seen' => handler.trackpoint_count,
+      'route_points_seen' => handler.route_point_count
+    }.select { |_, value| value.positive? }
+    return if counts.empty?
 
-    import.update!(raw_data: (import.raw_data || {}).merge('waypoints_seen' => count))
+    import.update!(raw_data: (import.raw_data || {}).merge(counts))
   end
 
   def seek_to_document_start(io)
@@ -106,7 +111,7 @@ class Gpx::TrackImporter
   end
 
   class TrkptStreamHandler < Nokogiri::XML::SAX::Document
-    attr_reader :waypoint_count
+    attr_reader :waypoint_count, :trackpoint_count, :route_point_count
 
     def initialize(import_id, import_name, &block)
       super()
@@ -114,6 +119,8 @@ class Gpx::TrackImporter
       @import_name = import_name
       @callback = block
       @waypoint_count = 0
+      @trackpoint_count = 0
+      @route_point_count = 0
       @stack = nil
       @text = +''
       @trk_index = -1
@@ -140,6 +147,9 @@ class Gpx::TrackImporter
       when 'wpt'
         @waypoint_count += 1
         return
+      when 'rtept'
+        @route_point_count += 1
+        return
       end
 
       if @capturing_trk_field
@@ -156,6 +166,7 @@ class Gpx::TrackImporter
 
       attrs_h = attrs.each_with_object({}) { |a, h| h[a.localname] = a.value }
       if name == 'trkpt' && @stack.nil?
+        @trackpoint_count += 1
         @stack = [attrs_h]
         @text = +''
       elsif @stack

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -149,11 +149,24 @@ class Imports::Create
   end
 
   def zero_points_content(import)
-    waypoints = import.raw_data&.dig('waypoints_seen').to_i
+    trackless_gpx_content(import) || generic_zero_points_content(import)
+  end
 
-    if waypoints.positive?
-      I18n.t('services.imports.create.zero_points_waypoints_only', name: import.name, waypoints: waypoints)
-    elsif import.gpx? || import.kml? || import.geojson?
+  def trackless_gpx_content(import)
+    data = import.raw_data || {}
+    return if data['trackpoints_seen'].to_i.positive?
+
+    if data['waypoints_seen'].to_i.positive?
+      I18n.t('services.imports.create.zero_points_waypoints_only',
+             name: import.name, count: data['waypoints_seen'].to_i)
+    elsif data['route_points_seen'].to_i.positive?
+      I18n.t('services.imports.create.zero_points_route_only',
+             name: import.name, count: data['route_points_seen'].to_i)
+    end
+  end
+
+  def generic_zero_points_content(import)
+    if import.gpx? || import.kml? || import.geojson?
       I18n.t('services.imports.create.zero_points_with_timestamps', name: import.name)
     else
       I18n.t('services.imports.create.zero_points', name: import.name)

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -149,7 +149,11 @@ class Imports::Create
   end
 
   def zero_points_content(import)
-    if import.gpx? || import.kml? || import.geojson?
+    waypoints = import.raw_data&.dig('waypoints_seen').to_i
+
+    if waypoints.positive?
+      I18n.t('services.imports.create.zero_points_waypoints_only', name: import.name, waypoints: waypoints)
+    elsif import.gpx? || import.kml? || import.geojson?
       I18n.t('services.imports.create.zero_points_with_timestamps', name: import.name)
     else
       I18n.t('services.imports.create.zero_points', name: import.name)

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3462,6 +3462,7 @@ ca:
         import_completed_with_no_points: La importació ha finalitzat sense punts
         import_failed: La importació ha fallat
         zero_points_with_timestamps: "El teu arxiu %{name} ha importat 0 punts. No s'ha trobat cap punt d'ubicació amb marca de temps. Les importacions de GPX, KML i GeoJSON requereixen un valor de temps per a cada coordenada (&lt;time&gt;, &lt;when&gt; o una propietat timestamp)."
+        zero_points_waypoints_only: 'El teu fitxer %{name} ha importat 0 punts. Conté %{waypoints} waypoints (preferits o llocs desats) però cap ruta enregistrada. Dawarich actualment només importa rutes.'
         zero_points: "El teu arxiu %{name} ha importat 0 punts. No s'ha trobat cap punt d'ubicació nou en aquest arxiu."
         import_failed_self_hosted: 'La importació "%{name}" ha fallat: %{message}, traça: %{backtrace}'
         import_failed_cloud: 'La importació "%{name}" ha fallat, contacta amb nosaltres a hi@dawarich.com'

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3462,7 +3462,12 @@ ca:
         import_completed_with_no_points: La importació ha finalitzat sense punts
         import_failed: La importació ha fallat
         zero_points_with_timestamps: "El teu arxiu %{name} ha importat 0 punts. No s'ha trobat cap punt d'ubicació amb marca de temps. Les importacions de GPX, KML i GeoJSON requereixen un valor de temps per a cada coordenada (&lt;time&gt;, &lt;when&gt; o una propietat timestamp)."
-        zero_points_waypoints_only: 'El teu fitxer %{name} ha importat 0 punts. Conté %{waypoints} waypoints (preferits o llocs desats) però cap ruta enregistrada. Dawarich actualment només importa rutes.'
+        zero_points_waypoints_only:
+          one: 'El teu fitxer %{name} ha importat 0 punts. Conté %{count} waypoint (un preferit o lloc desat) però cap ruta enregistrada. Dawarich actualment només importa rutes enregistrades.'
+          other: 'El teu fitxer %{name} ha importat 0 punts. Conté %{count} waypoints (preferits o llocs desats) però cap ruta enregistrada. Dawarich actualment només importa rutes enregistrades.'
+        zero_points_route_only:
+          one: 'El teu fitxer %{name} ha importat 0 punts. Conté una ruta planificada de %{count} punt, però cap ruta enregistrada. Dawarich importa rutes enregistrades, no rutes planificades.'
+          other: 'El teu fitxer %{name} ha importat 0 punts. Conté una ruta planificada de %{count} punts, però cap ruta enregistrada. Dawarich importa rutes enregistrades, no rutes planificades.'
         zero_points: "El teu arxiu %{name} ha importat 0 punts. No s'ha trobat cap punt d'ubicació nou en aquest arxiu."
         import_failed_self_hosted: 'La importació "%{name}" ha fallat: %{message}, traça: %{backtrace}'
         import_failed_cloud: 'La importació "%{name}" ha fallat, contacta amb nosaltres a hi@dawarich.com'

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3529,7 +3529,12 @@ de:
         unsupported_source: 'Nicht unterstützte Quelle: %{source}'
         zip_unclassified: Zip-Inhalt konnte nicht klassifiziert werden – Datei könnte beschädigt sein
         zero_points_with_timestamps: "Deine Datei %{name} hat 0 Punkte importiert. Es wurden keine Standortpunkte mit Zeitstempeln gefunden. GPX-, KML- und GeoJSON-Importe benötigen für jede Koordinate einen eigenen Zeitwert (&lt;time&gt;, &lt;when&gt; oder eine timestamp-Eigenschaft)."
-        zero_points_waypoints_only: 'Deine Datei %{name} hat 0 Punkte importiert. Sie enthält %{waypoints} Wegpunkte (Favoriten oder gespeicherte Orte), aber keine aufgezeichnete Strecke. Dawarich importiert derzeit nur Strecken.'
+        zero_points_waypoints_only:
+          one: 'Deine Datei %{name} hat 0 Punkte importiert. Sie enthält %{count} Wegpunkt (einen Favoriten oder gespeicherten Ort), aber keine aufgezeichnete Strecke. Dawarich importiert derzeit nur Strecken.'
+          other: 'Deine Datei %{name} hat 0 Punkte importiert. Sie enthält %{count} Wegpunkte (Favoriten oder gespeicherte Orte), aber keine aufgezeichnete Strecke. Dawarich importiert derzeit nur Strecken.'
+        zero_points_route_only:
+          one: 'Deine Datei %{name} hat 0 Punkte importiert. Sie enthält eine geplante Route mit %{count} Punkt, aber keine aufgezeichnete Strecke. Dawarich importiert aufgezeichnete Strecken, keine geplanten Routen.'
+          other: 'Deine Datei %{name} hat 0 Punkte importiert. Sie enthält eine geplante Route mit %{count} Punkten, aber keine aufgezeichnete Strecke. Dawarich importiert aufgezeichnete Strecken, keine geplanten Routen.'
         zero_points: "Deine Datei %{name} hat 0 Punkte importiert. In dieser Datei wurden keine neuen Standortpunkte gefunden."
         import_failed_self_hosted: "Import \"%{name}\" fehlgeschlagen: %{message}, Stacktrace: %{backtrace}"
         import_failed_cloud: "Import \"%{name}\" fehlgeschlagen, bitte kontaktiere uns unter hi@dawarich.com"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3529,6 +3529,7 @@ de:
         unsupported_source: 'Nicht unterstützte Quelle: %{source}'
         zip_unclassified: Zip-Inhalt konnte nicht klassifiziert werden – Datei könnte beschädigt sein
         zero_points_with_timestamps: "Deine Datei %{name} hat 0 Punkte importiert. Es wurden keine Standortpunkte mit Zeitstempeln gefunden. GPX-, KML- und GeoJSON-Importe benötigen für jede Koordinate einen eigenen Zeitwert (&lt;time&gt;, &lt;when&gt; oder eine timestamp-Eigenschaft)."
+        zero_points_waypoints_only: 'Deine Datei %{name} hat 0 Punkte importiert. Sie enthält %{waypoints} Wegpunkte (Favoriten oder gespeicherte Orte), aber keine aufgezeichnete Strecke. Dawarich importiert derzeit nur Strecken.'
         zero_points: "Deine Datei %{name} hat 0 Punkte importiert. In dieser Datei wurden keine neuen Standortpunkte gefunden."
         import_failed_self_hosted: "Import \"%{name}\" fehlgeschlagen: %{message}, Stacktrace: %{backtrace}"
         import_failed_cloud: "Import \"%{name}\" fehlgeschlagen, bitte kontaktiere uns unter hi@dawarich.com"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3450,7 +3450,12 @@ en:
         import_completed_with_no_points: Import completed with no points
         import_failed: Import failed
         zero_points_with_timestamps: Your file %{name} imported 0 points. No location points with timestamps were found. GPX, KML and GeoJSON imports require a per-point time value (&lt;time&gt;, &lt;when&gt;, or a timestamp property).
-        zero_points_waypoints_only: 'Your file %{name} imported 0 points. It contains %{waypoints} waypoints (favourites or saved places) but no recorded track. Dawarich currently imports tracks only.'
+        zero_points_waypoints_only:
+          one: 'Your file %{name} imported 0 points. It contains %{count} waypoint (a favorite or saved place) but no recorded track. Dawarich currently imports tracks only.'
+          other: 'Your file %{name} imported 0 points. It contains %{count} waypoints (favorites or saved places) but no recorded track. Dawarich currently imports tracks only.'
+        zero_points_route_only:
+          one: 'Your file %{name} imported 0 points. It contains a planned route with %{count} point, but no recorded track. Dawarich imports recorded tracks, not planned routes.'
+          other: 'Your file %{name} imported 0 points. It contains a planned route with %{count} points, but no recorded track. Dawarich imports recorded tracks, not planned routes.'
         zero_points: Your file %{name} imported 0 points. No new location points were found in this file.
         import_failed_self_hosted: 'Import "%{name}" failed: %{message}, stacktrace: %{backtrace}'
         import_failed_cloud: 'Import "%{name}" failed, please contact us at hi@dawarich.com'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3450,6 +3450,7 @@ en:
         import_completed_with_no_points: Import completed with no points
         import_failed: Import failed
         zero_points_with_timestamps: Your file %{name} imported 0 points. No location points with timestamps were found. GPX, KML and GeoJSON imports require a per-point time value (&lt;time&gt;, &lt;when&gt;, or a timestamp property).
+        zero_points_waypoints_only: 'Your file %{name} imported 0 points. It contains %{waypoints} waypoints (favourites or saved places) but no recorded track. Dawarich currently imports tracks only.'
         zero_points: Your file %{name} imported 0 points. No new location points were found in this file.
         import_failed_self_hosted: 'Import "%{name}" failed: %{message}, stacktrace: %{backtrace}'
         import_failed_cloud: 'Import "%{name}" failed, please contact us at hi@dawarich.com'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3474,6 +3474,7 @@ es:
         unsupported_source: 'Fuente no soportada: %{source}'
         zip_unclassified: No se pudo clasificar el contenido del archivo ZIP; puede que esté dañado
         zero_points_with_timestamps: "Tu archivo %{name} importó 0 puntos. No se encontraron puntos de ubicación con marcas de tiempo. Las importaciones GPX, KML y GeoJSON necesitan un valor de tiempo por cada coordenada (&lt;time&gt;, &lt;when&gt; o una propiedad timestamp)."
+        zero_points_waypoints_only: 'Tu archivo %{name} importó 0 puntos. Contiene %{waypoints} waypoints (favoritos o lugares guardados) pero ninguna ruta grabada. Dawarich actualmente solo importa rutas.'
         zero_points: "Tu archivo %{name} importó 0 puntos. No se encontraron puntos de ubicación nuevos en este archivo."
         import_failed_self_hosted: "La importación \"%{name}\" falló: %{message}, traza: %{backtrace}"
         import_failed_cloud: "La importación \"%{name}\" falló, contáctanos en hi@dawarich.com"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3474,7 +3474,12 @@ es:
         unsupported_source: 'Fuente no soportada: %{source}'
         zip_unclassified: No se pudo clasificar el contenido del archivo ZIP; puede que esté dañado
         zero_points_with_timestamps: "Tu archivo %{name} importó 0 puntos. No se encontraron puntos de ubicación con marcas de tiempo. Las importaciones GPX, KML y GeoJSON necesitan un valor de tiempo por cada coordenada (&lt;time&gt;, &lt;when&gt; o una propiedad timestamp)."
-        zero_points_waypoints_only: 'Tu archivo %{name} importó 0 puntos. Contiene %{waypoints} waypoints (favoritos o lugares guardados) pero ninguna ruta grabada. Dawarich actualmente solo importa rutas.'
+        zero_points_waypoints_only:
+          one: 'Tu archivo %{name} importó 0 puntos. Contiene %{count} waypoint (un favorito o lugar guardado) pero ninguna ruta grabada. Dawarich actualmente solo importa rutas grabadas.'
+          other: 'Tu archivo %{name} importó 0 puntos. Contiene %{count} waypoints (favoritos o lugares guardados) pero ninguna ruta grabada. Dawarich actualmente solo importa rutas grabadas.'
+        zero_points_route_only:
+          one: 'Tu archivo %{name} importó 0 puntos. Contiene una ruta planificada de %{count} punto, pero ninguna ruta grabada. Dawarich importa rutas grabadas, no rutas planificadas.'
+          other: 'Tu archivo %{name} importó 0 puntos. Contiene una ruta planificada de %{count} puntos, pero ninguna ruta grabada. Dawarich importa rutas grabadas, no rutas planificadas.'
         zero_points: "Tu archivo %{name} importó 0 puntos. No se encontraron puntos de ubicación nuevos en este archivo."
         import_failed_self_hosted: "La importación \"%{name}\" falló: %{message}, traza: %{backtrace}"
         import_failed_cloud: "La importación \"%{name}\" falló, contáctanos en hi@dawarich.com"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4570,7 +4570,12 @@ fr:
           Aucun point de localisation horodaté n'a été trouvé. Les importations GPX,
           KML et GeoJSON exigent une valeur de temps pour chaque coordonnée (&lt;time&gt;,
           &lt;when&gt; ou une propriété timestamp).
-        zero_points_waypoints_only: 'Votre fichier %{name} a importé 0 point. Il contient %{waypoints} points de repère (favoris ou lieux enregistrés) mais aucune trace enregistrée. Dawarich n''importe actuellement que les traces.'
+        zero_points_waypoints_only:
+          one: 'Votre fichier %{name} a importé 0 point. Il contient %{count} point de repère (un favori ou lieu enregistré) mais aucune trace enregistrée. Dawarich n''importe actuellement que les traces.'
+          other: 'Votre fichier %{name} a importé 0 point. Il contient %{count} points de repère (favoris ou lieux enregistrés) mais aucune trace enregistrée. Dawarich n''importe actuellement que les traces.'
+        zero_points_route_only:
+          one: 'Votre fichier %{name} a importé 0 point. Il contient un itinéraire planifié de %{count} point, mais aucune trace enregistrée. Dawarich importe les traces enregistrées, pas les itinéraires planifiés.'
+          other: 'Votre fichier %{name} a importé 0 point. Il contient un itinéraire planifié de %{count} points, mais aucune trace enregistrée. Dawarich importe les traces enregistrées, pas les itinéraires planifiés.'
         zero_points: Votre fichier « %{name} » n'a importé aucun point. Aucun nouveau
           point de localisation n'a été trouvé dans ce fichier.
         import_failed_self_hosted: 'L''importation « %{name} » a échoué : %{message},

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4570,6 +4570,7 @@ fr:
           Aucun point de localisation horodaté n'a été trouvé. Les importations GPX,
           KML et GeoJSON exigent une valeur de temps pour chaque coordonnée (&lt;time&gt;,
           &lt;when&gt; ou une propriété timestamp).
+        zero_points_waypoints_only: 'Votre fichier %{name} a importé 0 point. Il contient %{waypoints} points de repère (favoris ou lieux enregistrés) mais aucune trace enregistrée. Dawarich n''importe actuellement que les traces.'
         zero_points: Votre fichier « %{name} » n'a importé aucun point. Aucun nouveau
           point de localisation n'a été trouvé dans ce fichier.
         import_failed_self_hosted: 'L''importation « %{name} » a échoué : %{message},

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -3517,6 +3517,7 @@ pl:
         import_completed_with_no_points: Import zakończony bez punktów
         import_failed: Import nie powiódł się
         zero_points_with_timestamps: Plik %{name} zaimportował 0 punktów. Nie znaleziono punktów lokalizacji ze znacznikami czasu. Import GPX, KML i GeoJSON wymaga wartości czasu dla każdego punktu (&lt;time&gt;, &lt;when&gt; lub właściwości timestamp).
+        zero_points_waypoints_only: 'Twój plik %{name} zaimportował 0 punktów. Zawiera %{waypoints} punktów trasy (ulubione lub zapisane miejsca), ale nie zawiera zarejestrowanej trasy. Dawarich obecnie importuje tylko trasy.'
         zero_points: Plik %{name} zaimportował 0 punktów. Nie znaleziono w nim nowych punktów lokalizacji.
         import_failed_self_hosted: 'Import "%{name}" nie powiódł się: %{message}, stacktrace: %{backtrace}'
         import_failed_cloud: 'Import "%{name}" nie powiódł się, skontaktuj się z nami: hi@dawarich.com'

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -3517,7 +3517,12 @@ pl:
         import_completed_with_no_points: Import zakończony bez punktów
         import_failed: Import nie powiódł się
         zero_points_with_timestamps: Plik %{name} zaimportował 0 punktów. Nie znaleziono punktów lokalizacji ze znacznikami czasu. Import GPX, KML i GeoJSON wymaga wartości czasu dla każdego punktu (&lt;time&gt;, &lt;when&gt; lub właściwości timestamp).
-        zero_points_waypoints_only: 'Twój plik %{name} zaimportował 0 punktów. Zawiera %{waypoints} punktów trasy (ulubione lub zapisane miejsca), ale nie zawiera zarejestrowanej trasy. Dawarich obecnie importuje tylko trasy.'
+        zero_points_waypoints_only:
+          one: 'Twój plik %{name} zaimportował 0 punktów. Zawiera %{count} punkt nawigacyjny (ulubione lub zapisane miejsce), ale nie zawiera zarejestrowanej trasy. Dawarich obecnie importuje tylko zarejestrowane trasy.'
+          other: 'Twój plik %{name} zaimportował 0 punktów. Zawiera %{count} punktów nawigacyjnych (ulubione lub zapisane miejsca), ale nie zawiera zarejestrowanej trasy. Dawarich obecnie importuje tylko zarejestrowane trasy.'
+        zero_points_route_only:
+          one: 'Twój plik %{name} zaimportował 0 punktów. Zawiera zaplanowaną trasę z %{count} punktem, ale nie zawiera zarejestrowanej trasy. Dawarich importuje zarejestrowane trasy, a nie zaplanowane.'
+          other: 'Twój plik %{name} zaimportował 0 punktów. Zawiera zaplanowaną trasę z %{count} punktami, ale nie zawiera zarejestrowanej trasy. Dawarich importuje zarejestrowane trasy, a nie zaplanowane.'
         zero_points: Plik %{name} zaimportował 0 punktów. Nie znaleziono w nim nowych punktów lokalizacji.
         import_failed_self_hosted: 'Import "%{name}" nie powiódł się: %{message}, stacktrace: %{backtrace}'
         import_failed_cloud: 'Import "%{name}" nie powiódł się, skontaktuj się z nami: hi@dawarich.com'

--- a/spec/fixtures/files/gpx/gpx_route_only.gpx
+++ b/spec/fixtures/files/gpx/gpx_route_only.gpx
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1" creator="Komoot" xmlns="http://www.topografix.com/GPX/1/1">
+  <rte>
+    <name>Planned tour</name>
+    <rtept lat="51.3400000" lon="12.3710000"><ele>113</ele></rtept>
+    <rtept lat="51.3401000" lon="12.3715000"><ele>114</ele></rtept>
+    <rtept lat="51.3403000" lon="12.3720000"><ele>115</ele></rtept>
+  </rte>
+</gpx>

--- a/spec/fixtures/files/gpx/gpx_single_waypoint.gpx
+++ b/spec/fixtures/files/gpx/gpx_single_waypoint.gpx
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1">
+  <wpt lat="51.3369000" lon="12.3750000">
+    <name>Cafe Riquet</name>
+    <type>Food</type>
+  </wpt>
+</gpx>

--- a/spec/fixtures/files/gpx/gpx_waypoints_and_timeless_track.gpx
+++ b/spec/fixtures/files/gpx/gpx_waypoints_and_timeless_track.gpx
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1" creator="overpass-turbo" xmlns="http://www.topografix.com/GPX/1/1">
+  <wpt lat="51.3402000" lon="12.3712000">
+    <name>Leipzig Hauptbahnhof</name>
+  </wpt>
+  <wpt lat="51.3397000" lon="12.3731000">
+    <name>Augustusplatz</name>
+  </wpt>
+  <trk>
+    <name>Planned walk</name>
+    <trkseg>
+      <trkpt lat="51.3400000" lon="12.3710000"><ele>113</ele></trkpt>
+      <trkpt lat="51.3401000" lon="12.3715000"><ele>114</ele></trkpt>
+      <trkpt lat="51.3403000" lon="12.3720000"><ele>115</ele></trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/spec/fixtures/files/gpx/gpx_waypoints_only.gpx
+++ b/spec/fixtures/files/gpx/gpx_waypoints_only.gpx
@@ -5,16 +5,21 @@
   </metadata>
   <wpt lat="51.3402000" lon="12.3712000">
     <name>Leipzig Hauptbahnhof</name>
+    <time>2026-01-27T10:00:00Z</time>
     <type>Transport</type>
     <extensions>
       <osmand:icon>special_trekking</osmand:icon>
       <osmand:background>circle</osmand:background>
-      <osmand:color>#eecc22ff</osmand:color>
+      <osmand:color>#ffeecc22</osmand:color>
     </extensions>
   </wpt>
   <wpt lat="51.3397000" lon="12.3731000">
     <name>Augustusplatz</name>
+    <time>2026-01-27T11:00:00Z</time>
     <type>Sights</type>
+    <extensions>
+      <osmand:color>#10c0f0</osmand:color>
+    </extensions>
   </wpt>
   <wpt lat="51.3369000" lon="12.3750000">
     <name>Cafe Riquet</name>

--- a/spec/fixtures/files/gpx/gpx_waypoints_only.gpx
+++ b/spec/fixtures/files/gpx/gpx_waypoints_only.gpx
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1" xmlns:osmand="https://osmand.net">
+  <metadata>
+    <name>favourites</name>
+  </metadata>
+  <wpt lat="51.3402000" lon="12.3712000">
+    <name>Leipzig Hauptbahnhof</name>
+    <type>Transport</type>
+    <extensions>
+      <osmand:icon>special_trekking</osmand:icon>
+      <osmand:background>circle</osmand:background>
+      <osmand:color>#eecc22ff</osmand:color>
+    </extensions>
+  </wpt>
+  <wpt lat="51.3397000" lon="12.3731000">
+    <name>Augustusplatz</name>
+    <type>Sights</type>
+  </wpt>
+  <wpt lat="51.3369000" lon="12.3750000">
+    <name>Cafe Riquet</name>
+    <type>Food</type>
+  </wpt>
+</gpx>

--- a/spec/fixtures/files/gpx/gpx_waypoints_with_time.gpx
+++ b/spec/fixtures/files/gpx/gpx_waypoints_with_time.gpx
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1" xmlns:osmand="https://osmand.net">
+  <wpt lat="51.3402000" lon="12.3712000">
+    <name>Leipzig Hauptbahnhof</name>
+    <time>2026-01-27T10:00:00Z</time>
+    <type>Transport</type>
+  </wpt>
+  <wpt lat="51.3397000" lon="12.3731000">
+    <name>Augustusplatz</name>
+    <time>2026-01-27T11:00:00Z</time>
+    <type>Sights</type>
+  </wpt>
+</gpx>

--- a/spec/regressions/gpx_waypoint_only_import_reporting_spec.rb
+++ b/spec/regressions/gpx_waypoint_only_import_reporting_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Reporting for GPX files that contain waypoints but no track' do
+  let(:user) { create(:user) }
+
+  def import_file(filename)
+    import = create(:import, user:, name: filename, source: 'gpx')
+    import.file.attach(
+      io: Rails.root.join('spec/fixtures/files/gpx', filename).open,
+      filename: filename,
+      content_type: 'application/gpx+xml'
+    )
+    Imports::Create.new(user, import).call
+    import.reload
+  end
+
+  def last_notification_content
+    user.notifications.order(:created_at).last.content
+  end
+
+  context 'when the file holds only waypoints' do
+    it 'names waypoints as the reason instead of blaming absent timestamps' do
+      import = import_file('gpx_waypoints_only.gpx')
+
+      expect(import.points.count).to eq(0)
+      expect(last_notification_content).to match(/waypoint/i)
+      expect(last_notification_content).to include('3')
+      expect(last_notification_content).not_to match(/timestamp/i)
+    end
+
+    it 'records the number of waypoints it saw' do
+      import = import_file('gpx_waypoints_only.gpx')
+
+      expect(import.raw_data['waypoints_seen']).to eq(3)
+    end
+  end
+
+  context 'when every waypoint carries a time' do
+    it 'still does not attribute the empty import to missing timestamps' do
+      import_file('gpx_waypoints_with_time.gpx')
+
+      expect(last_notification_content).to match(/waypoint/i)
+      expect(last_notification_content).not_to match(/timestamp/i)
+    end
+  end
+
+  context 'when the file holds trackpoints without times' do
+    it 'keeps the existing timestamp guidance' do
+      import_file('gpx_track_no_timestamps.gpx')
+
+      expect(last_notification_content).to match(/timestamp/i)
+      expect(last_notification_content).not_to match(/waypoint/i)
+    end
+  end
+end

--- a/spec/regressions/gpx_waypoint_only_import_reporting_spec.rb
+++ b/spec/regressions/gpx_waypoint_only_import_reporting_spec.rb
@@ -54,4 +54,45 @@ RSpec.describe 'Reporting for GPX files that contain waypoints but no track' do
       expect(last_notification_content).not_to match(/waypoint/i)
     end
   end
+
+  context 'when the file holds waypoints alongside a track whose points carry no time' do
+    it 'blames the missing timestamps rather than claiming there is no track' do
+      import_file('gpx_waypoints_and_timeless_track.gpx')
+
+      expect(last_notification_content).to match(/timestamp/i)
+      expect(last_notification_content).not_to match(/no recorded track/i)
+    end
+
+    it 'still records both counts' do
+      import = import_file('gpx_waypoints_and_timeless_track.gpx')
+
+      expect(import.raw_data['waypoints_seen']).to eq(2)
+      expect(import.raw_data['trackpoints_seen']).to eq(3)
+    end
+  end
+
+  context 'when the file holds a single waypoint' do
+    it 'does not say "1 waypoints"' do
+      import_file('gpx_single_waypoint.gpx')
+
+      expect(last_notification_content).to include('1 waypoint')
+      expect(last_notification_content).not_to include('1 waypoints')
+    end
+  end
+
+  context 'when the file holds only a planned route' do
+    it 'names the planned route rather than blaming missing timestamps' do
+      import = import_file('gpx_route_only.gpx')
+
+      expect(import.points.count).to eq(0)
+      expect(last_notification_content).to match(/planned route/i)
+      expect(last_notification_content).not_to match(/timestamp/i)
+    end
+
+    it 'records the route point count' do
+      import = import_file('gpx_route_only.gpx')
+
+      expect(import.raw_data['route_points_seen']).to eq(3)
+    end
+  end
 end


### PR DESCRIPTION
Refs #1261. Ships independently of the feature work, and is back-portable.

## The problem

A GPX file holding only waypoints — an OsmAnd+ `favourites.gpx`, for instance — imports 0 points, and since #3473 the user is told:

> Your file X imported 0 points. No location points with timestamps were found. GPX, KML and GeoJSON imports require a per-point time value (`<time>`, `<when>`, or a timestamp property).

That is wrong for this file shape, not merely unhelpful. OsmAnd waypoints **do** carry a `<time>` ([format docs](https://osmand.net/docs/technical/osmand-file-formats/osmand-gpx/)), so the user is told to add something their file already has. The real reason is that `TrkptStreamHandler` only opens a capture stack for `<trkpt>` (`app/services/gpx/track_importer.rb`) — `<wpt>` is never read, whatever it contains.

Reproduced on `dev`: a waypoint file with a `<time>` on every waypoint still imports 0 points and still receives the message above.

## The change

- `Gpx::TrackImporter` counts `<wpt>`, `<trkpt>` and `<rtept>` during the SAX pass it already makes, recording them in `raw_data`, following the pattern #3473 used for `skipped_timeless`.
- `Imports::Create#zero_points_content` picks a message from the file's shape, and **only after confirming there were no trackpoints**:
  - waypoints, no track → names the waypoints
  - a planned route (`<rte>`), no track → says planned routes are not imported
  - otherwise → the existing gpx/kml/geojson timestamp guidance, unchanged
- Both new strings pluralized (`one`/`other`) in all 6 locales, matching the `member_count` convention.

The trackpoint gate matters: a file with waypoints *and* a timeless `<trkpt>` track — what overpass-turbo and Komoot planning exports produce — must keep the timestamp advice, because that is the correct advice for it. Covered by a test.

The `<rte>` case is pre-existing rather than a regression: route points were ignored exactly as waypoints were, so those files inherited the same wrong timestamp advice this PR exists to remove. Fixed here rather than deferred, since the counting was already being added.

## Verification

- `spec/regressions/gpx_waypoint_only_import_reporting_spec.rb` — 4 examples, incl. a waypoint file where every waypoint has a `<time>`.
- 24 locale-parity examples, 280 examples across `spec/services/{gpx,imports,geojson}` — 0 failures.
- RuboCop clean.

## Note for review

Merges cleanly into `dev` and into #3479 (verified with `git merge-tree`). Merge order is not forced, but this one is the smaller, back-portable half and reads best first.
