### PR TITLE
feat: import GPX waypoints as places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- GPX waypoints are now imported as places. Favourites exported from OsmAnd+ and similar apps (`favourites.gpx`) previously imported as nothing at all, because Dawarich only read recorded tracks. Each waypoint becomes a place, its category becomes a tag, and re-importing an updated file will not duplicate anything — so the import watcher can keep a favourites file in sync. Waypoints never become timeline points, so they do not affect your distance or statistics. (#1261)
+- GPX waypoints are now imported as places, so a `favourites.gpx` exported from OsmAnd+ and similar apps no longer imports as nothing at all. Each waypoint's category becomes a tag, re-importing an updated file does not duplicate anything, and waypoints never become timeline points, so they do not affect your distance or statistics. (#1261)
 - The API now accepts visits in batches: `POST /api/v1/visits/batch` takes up to 100 visits in one request and reports each one's outcome separately, so a single rejected visit no longer costs the whole sync. The mobile apps previously had to send one request per detected visit.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- GPX waypoints are now imported as places. Favourites exported from OsmAnd+ and similar apps (`favourites.gpx`) previously imported as nothing at all, because Dawarich only read recorded tracks. Each waypoint becomes a place, its category becomes a tag, and re-importing an updated file will not duplicate anything — so the import watcher can keep a favourites file in sync. Waypoints never become timeline points, so they do not affect your distance or statistics. (#1261)
 - The API now accepts visits in batches: `POST /api/v1/visits/batch` takes up to 100 visits in one request and reports each one's outcome separately, so a single rejected visit no longer costs the whole sync. The mobile apps previously had to send one request per detected visit.
 
 ### Fixed

--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -25,7 +25,7 @@ module ImportsHelper
   }.freeze
 
   def extraction_status_badge(import)
-    badge = EXTRACTION_STATUS_BADGES[import.additional_data_extraction_status]
+    badge = EXTRACTION_STATUS_BADGES[import.resolved_additional_data_extraction_status]
     return if badge.nil?
 
     tag.span(class: "badge badge-sm #{badge[:css]}") do

--- a/app/jobs/enhanced_import/extract_job.rb
+++ b/app/jobs/enhanced_import/extract_job.rb
@@ -80,7 +80,7 @@ module EnhancedImport
     def process_stream(import)
       counts = Hash.new(0)
       user = import.user
-      place_writer = Writers::PlaceWriter.new(user, import)
+      place_writer = Writers::PlaceWriter.new(user, import, source: place_source_for(import))
       visit_writer = Writers::VisitWriter.new(user, import)
       track_writer = Writers::TrackWriter.new(user, import)
       segment_writer = Writers::SegmentWriter.new
@@ -113,6 +113,10 @@ module EnhancedImport
       end
 
       counts
+    end
+
+    def place_source_for(import)
+      import.gpx? ? :gpx_waypoint : :photon
     end
 
     def trust_source?(import)

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Import < ApplicationRecord
+  ELEMENT_COUNT_KEYS = %w[waypoints_seen trackpoints_seen route_points_seen].freeze
+
   belongs_to :user
   has_many :points, dependent: :destroy
   has_many :extracted_visits, class_name: 'Visit', dependent: :nullify
@@ -82,6 +84,25 @@ class Import < ApplicationRecord
 
   def additional_data_extraction_supported?
     EnhancedImport::Translator.supported?(source)
+  end
+
+  def additional_data_extraction_unavailable?
+    !additional_data_extraction_supported?
+  end
+
+  def gpx_without_waypoints?
+    return false unless gpx?
+
+    counts = raw_data || {}
+    return false unless ELEMENT_COUNT_KEYS.any? { |key| counts.key?(key) }
+
+    counts['waypoints_seen'].to_i.zero?
+  end
+
+  def resolved_additional_data_extraction_status
+    return 'not_attempted' if additional_data_extraction_unsupported? && additional_data_extraction_supported?
+
+    additional_data_extraction_status
   end
 
   def extraction_counts
@@ -182,6 +203,7 @@ class Import < ApplicationRecord
     return false unless saved_change_to_status? && completed?
     return false unless additional_data_extraction_supported?
     return false unless additional_data_extraction_not_attempted?
+    return false if gpx_without_waypoints?
 
     true
   end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -26,16 +26,17 @@ class Place < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :lonlat, presence: true
 
-  enum :source, { manual: 0, photon: 1 }
+  enum :source, { manual: 0, photon: 1, gpx_waypoint: 2 }
 
   scope :for_user, ->(user) { where(user: user) }
   scope :ordered, -> { order(:name) }
   scope :linked_to_confirmed_visits, lambda { |user|
     where(id: user.visits.active.confirmed.where.not(place_id: nil).select(:place_id))
   }
+  scope :imported, -> { where(source: sources[:gpx_waypoint]) }
   scope :tagged, -> { where(id: Tagging.where(taggable_type: 'Place').select(:taggable_id)) }
   scope :map_visible, lambda { |user|
-    manual.or(linked_to_confirmed_visits(user)).or(tagged)
+    manual.or(imported).or(linked_to_confirmed_visits(user)).or(tagged)
   }
 
   # Legacy places predate the lonlat column and carry coordinates only in the

--- a/app/policies/imports/extraction_policy.rb
+++ b/app/policies/imports/extraction_policy.rb
@@ -6,6 +6,7 @@ module Imports
       user.present? &&
         record.user == user &&
         record.additional_data_extraction_supported? &&
+        !record.gpx_without_waypoints? &&
         !in_flight?
     end
 

--- a/app/services/enhanced_import/adapters/gpx_adapter.rb
+++ b/app/services/enhanced_import/adapters/gpx_adapter.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'digest/sha1'
+require 'nokogiri'
+
+module EnhancedImport
+  module Adapters
+    class GpxAdapter < BaseAdapter
+      XML_BOMS = [
+        "\xEF\xBB\xBF".b,
+        "\xFE\xFF".b,
+        "\xFF\xFE".b,
+        "\x00\x00\xFE\xFF".b,
+        "\xFF\xFE\x00\x00".b
+      ].freeze
+
+      def translate(&block)
+        return enum_for(:translate) unless block_given?
+
+        stream_file do |io|
+          seek_to_document_start(io)
+          Nokogiri::XML::SAX::Parser.new(WptStreamHandler.new(&block)).parse(io)
+        end
+      end
+
+      private
+
+      def seek_to_document_start(io)
+        prefix = io.read(256) || ''
+        offset = XML_BOMS.any? { |bom| prefix.start_with?(bom) } ? 0 : prefix.index('<') || 0
+        io.seek(offset)
+      end
+
+      class WptStreamHandler < Nokogiri::XML::SAX::Document
+        CAPTURED_FIELDS = %w[name type color].freeze
+
+        def initialize(&block)
+          super()
+          @callback = block
+          @attrs = nil
+          @fields = {}
+          @field = nil
+          @text = +''
+        end
+
+        def start_element_namespace(name, attrs = [], _prefix = nil, _uri = nil, _namespaces = [])
+          if name == 'wpt'
+            @attrs = attrs.each_with_object({}) { |a, h| h[a.localname] = a.value }
+            @fields = {}
+            @field = nil
+            return
+          end
+
+          return if @attrs.nil?
+          return unless CAPTURED_FIELDS.include?(name)
+
+          @field = name
+          @text = +''
+        end
+
+        def characters(string)
+          @text << string if @field
+        end
+
+        def end_element_namespace(name, _prefix = nil, _uri = nil)
+          if name == 'wpt'
+            emit
+            @attrs = nil
+            @fields = {}
+            @field = nil
+            return
+          end
+
+          return unless @field == name
+
+          @fields[name] = @text.strip
+          @field = nil
+          @text = +''
+        end
+
+        private
+
+        def emit
+          return if @attrs.nil?
+
+          latitude = @attrs['lat']
+          longitude = @attrs['lon']
+          return if latitude.blank? || longitude.blank?
+
+          category = @fields['type'].presence
+
+          @callback.call(
+            Extracted::Place.new(
+              external_place_id: identity(@fields['name'], latitude, longitude),
+              name: @fields['name'].presence,
+              latitude: latitude.to_f,
+              longitude: longitude.to_f,
+              semantic_type: category,
+              geodata_extras: {},
+              tag_name: category,
+              tag_color: normalized_color(@fields['color'])
+            )
+          )
+        end
+
+        def identity(name, latitude, longitude)
+          seed = format(
+            '%<name>s|%<latitude>.5f|%<longitude>.5f',
+            name: name.to_s.strip.downcase,
+            latitude: latitude.to_f,
+            longitude: longitude.to_f
+          )
+
+          "gpx:#{Digest::SHA1.hexdigest(seed)[0, 32]}"
+        end
+
+        def normalized_color(value)
+          return if value.blank?
+
+          hex = value.to_s.strip.delete_prefix('#').downcase
+          return unless hex.match?(/\A[0-9a-f]+\z/)
+
+          case hex.length
+          when 6 then "##{hex}"
+          when 8 then "##{hex[2, 6]}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/enhanced_import/adapters/gpx_adapter.rb
+++ b/app/services/enhanced_import/adapters/gpx_adapter.rb
@@ -16,6 +16,7 @@ module EnhancedImport
 
       def translate(&block)
         return enum_for(:translate) unless block_given?
+        return if import.gpx_without_waypoints?
 
         stream_file do |io|
           seek_to_document_start(io)
@@ -32,7 +33,8 @@ module EnhancedImport
       end
 
       class WptStreamHandler < Nokogiri::XML::SAX::Document
-        CAPTURED_FIELDS = %w[name type color].freeze
+        DIRECT_FIELDS = %w[name type].freeze
+        NESTED_FIELDS = %w[color].freeze
 
         def initialize(&block)
           super()
@@ -40,6 +42,7 @@ module EnhancedImport
           @attrs = nil
           @fields = {}
           @field = nil
+          @depth = 0
           @text = +''
         end
 
@@ -48,14 +51,22 @@ module EnhancedImport
             @attrs = attrs.each_with_object({}) { |a, h| h[a.localname] = a.value }
             @fields = {}
             @field = nil
+            @depth = 0
             return
           end
 
           return if @attrs.nil?
-          return unless CAPTURED_FIELDS.include?(name)
+
+          @depth += 1
+          return if @field
+          return unless capturable?(name)
 
           @field = name
           @text = +''
+        end
+
+        def capturable?(name)
+          (DIRECT_FIELDS.include?(name) && @depth == 1) || NESTED_FIELDS.include?(name)
         end
 
         def characters(string)
@@ -68,14 +79,19 @@ module EnhancedImport
             @attrs = nil
             @fields = {}
             @field = nil
+            @depth = 0
             return
           end
 
-          return unless @field == name
+          return if @attrs.nil?
 
-          @fields[name] = @text.strip
-          @field = nil
-          @text = +''
+          if @field == name
+            @fields[name] = @text.strip
+            @field = nil
+            @text = +''
+          end
+
+          @depth -= 1
         end
 
         private
@@ -121,6 +137,7 @@ module EnhancedImport
           return unless hex.match?(/\A[0-9a-f]+\z/)
 
           case hex.length
+          when 3 then "##{hex.chars.map { |c| c * 2 }.join}"
           when 6 then "##{hex}"
           when 8 then "##{hex[2, 6]}"
           end

--- a/app/services/enhanced_import/extracted/place.rb
+++ b/app/services/enhanced_import/extracted/place.rb
@@ -8,9 +8,12 @@ module EnhancedImport
       :latitude,
       :longitude,
       :semantic_type,
-      :geodata_extras
+      :geodata_extras,
+      :tag_name,
+      :tag_color
     ) do
-      def initialize(external_place_id:, name:, latitude:, longitude:, semantic_type: nil, geodata_extras: {})
+      def initialize(external_place_id:, name:, latitude:, longitude:, semantic_type: nil,
+                     geodata_extras: {}, tag_name: nil, tag_color: nil)
         super
       end
     end

--- a/app/services/enhanced_import/translator.rb
+++ b/app/services/enhanced_import/translator.rb
@@ -8,13 +8,15 @@ module EnhancedImport
       google_phone_takeout
       google_semantic_history
       polarsteps
+      gpx
     ].freeze
 
     ADAPTER_LOOKUP = {
       'google_records' => 'EnhancedImport::Adapters::GoogleRecordsAdapter',
       'google_phone_takeout' => 'EnhancedImport::Adapters::GooglePhoneTakeoutAdapter',
       'google_semantic_history' => 'EnhancedImport::Adapters::GoogleSemanticHistoryAdapter',
-      'polarsteps' => 'EnhancedImport::Adapters::PolarstepsAdapter'
+      'polarsteps' => 'EnhancedImport::Adapters::PolarstepsAdapter',
+      'gpx' => 'EnhancedImport::Adapters::GpxAdapter'
     }.freeze
 
     def self.supported?(source)

--- a/app/services/enhanced_import/writers/place_writer.rb
+++ b/app/services/enhanced_import/writers/place_writer.rb
@@ -3,16 +3,20 @@
 module EnhancedImport
   module Writers
     class PlaceWriter
-      def initialize(user, import)
+      def initialize(user, import, source: :photon)
         @user = user
         @import = import
+        @source = source
       end
 
       NEARBY_METERS = 75
 
       def upsert(extracted)
         existing = find_by_external_id(extracted) || find_nearby(extracted)
-        return [existing, false] if existing
+        if existing
+          attach_tag(existing, extracted)
+          return [existing, false]
+        end
 
         place = Place.create!(
           user_id: @user.id,
@@ -21,9 +25,10 @@ module EnhancedImport
           latitude: extracted.latitude,
           longitude: extracted.longitude,
           lonlat: "POINT(#{extracted.longitude} #{extracted.latitude})",
-          source: :photon,
+          source: @source,
           geodata: build_geodata(extracted)
         )
+        attach_tag(place, extracted)
         [place, true]
       rescue ActiveRecord::RecordNotUnique
         existing = Place.where(user_id: @user.id)
@@ -33,6 +38,28 @@ module EnhancedImport
       end
 
       private
+
+      def attach_tag(place, extracted)
+        return if extracted.tag_name.blank?
+
+        tag = existing_tag(extracted.tag_name)
+        return if tag&.privacy_zone?
+
+        tag ||= create_tag(extracted)
+        return if tag.nil?
+
+        place.add_tag(tag)
+      end
+
+      def existing_tag(name)
+        @user.tags.where('LOWER(tags.name) = ?', name.downcase).first
+      end
+
+      def create_tag(extracted)
+        @user.tags.create!(name: extracted.tag_name, color: extracted.tag_color)
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+        existing_tag(extracted.tag_name)
+      end
 
       def find_by_external_id(extracted)
         Place.where(user_id: @user.id)

--- a/app/services/enhanced_import/writers/place_writer.rb
+++ b/app/services/enhanced_import/writers/place_writer.rb
@@ -12,8 +12,14 @@ module EnhancedImport
       NEARBY_METERS = 75
 
       def upsert(extracted)
-        existing = find_by_external_id(extracted) || find_nearby(extracted)
+        renamed = nil
+        existing = find_by_external_id(extracted)
+        existing ||= (renamed = find_renamed_waypoint(extracted))
+        existing ||= find_nearby(extracted)
+
         if existing
+          claim(existing)
+          renamed ? adopt_rename(existing, extracted) : adopt_identity(existing, extracted)
           attach_tag(existing, extracted)
           return [existing, false]
         end
@@ -21,23 +27,83 @@ module EnhancedImport
         place = Place.create!(
           user_id: @user.id,
           import_id: @import.id,
-          name: extracted.name.presence || 'Unknown',
+          name: place_name(extracted),
           latitude: extracted.latitude,
           longitude: extracted.longitude,
           lonlat: "POINT(#{extracted.longitude} #{extracted.latitude})",
           source: @source,
           geodata: build_geodata(extracted)
         )
+        claim(place)
         attach_tag(place, extracted)
         [place, true]
       rescue ActiveRecord::RecordNotUnique
-        existing = Place.where(user_id: @user.id)
-                        .where("geodata ->> 'external_place_id' = ?", extracted.external_place_id)
-                        .first
+        existing = find_by_external_id(extracted)
+        if existing
+          claim(existing)
+          attach_tag(existing, extracted)
+        end
         [existing, false]
       end
 
       private
+
+      NAME_LIMIT = 255
+      SAME_PIN_METERS = 1
+      SAME_PIN_CANDIDATE_LIMIT = 10
+
+      def claim(place)
+        claimed_ids << place.id
+      end
+
+      def claimed_ids
+        @claimed_ids ||= Set.new
+      end
+
+      def find_renamed_waypoint(extracted)
+        return unless @source.to_s == 'gpx_waypoint'
+
+        rows = Place.where(user_id: @user.id, source: Place.sources[:gpx_waypoint])
+                    .where(
+                      'ST_DWithin(places.lonlat::geography, ST_SetSRID(ST_MakePoint(?, ?), 4326)::geography, ?)',
+                      extracted.longitude.to_f, extracted.latitude.to_f, SAME_PIN_METERS
+                    )
+                    .limit(SAME_PIN_CANDIDATE_LIMIT).to_a
+        return if rows.size >= SAME_PIN_CANDIDATE_LIMIT
+
+        candidates = rows.reject { |place| claimed_ids.include?(place.id) }
+        candidates.first if candidates.size == 1
+      end
+
+      def adopt_rename(place, extracted)
+        attributes = {
+          geodata: (place.geodata || {}).merge('external_place_id' => extracted.external_place_id),
+          updated_at: Time.current
+        }
+        attributes[:name] = place_name(extracted) unless place.name_locked?
+
+        place.update_columns(attributes)
+      rescue ActiveRecord::RecordNotUnique
+        nil
+      end
+
+      def place_name(extracted)
+        extracted.name.presence&.truncate(NAME_LIMIT) || 'Unknown'
+      end
+
+      def adopt_identity(place, extracted)
+        return if extracted.external_place_id.blank?
+
+        geodata = place.geodata || {}
+        return if geodata['external_place_id'].present?
+
+        place.update_columns(
+          geodata: geodata.merge('external_place_id' => extracted.external_place_id),
+          updated_at: Time.current
+        )
+      rescue ActiveRecord::RecordNotUnique
+        nil
+      end
 
       def attach_tag(place, extracted)
         return if extracted.tag_name.blank?

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -125,6 +125,7 @@ class Imports::Create
   def notify_if_all_skipped(import)
     import.reload
     return unless import.points.count.zero?
+    return if awaiting_place_extraction?(import)
 
     if import.doubles.to_i.positive?
       I18n.with_locale(import.user.locale) do
@@ -146,6 +147,13 @@ class Imports::Create
         )
       end
     end
+  end
+
+  def awaiting_place_extraction?(import)
+    return false unless import.additional_data_extraction_supported?
+    return false unless import.raw_data&.dig('waypoints_seen').to_i.positive?
+
+    !import.additional_data_extraction_completed?
   end
 
   def zero_points_content(import)

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -125,7 +125,6 @@ class Imports::Create
   def notify_if_all_skipped(import)
     import.reload
     return unless import.points.count.zero?
-    return if awaiting_place_extraction?(import)
 
     if import.doubles.to_i.positive?
       I18n.with_locale(import.user.locale) do
@@ -147,16 +146,6 @@ class Imports::Create
         )
       end
     end
-  end
-
-  def awaiting_place_extraction?(import)
-    return false unless import.additional_data_extraction_supported?
-
-    data = import.raw_data || {}
-    return false if data['trackpoints_seen'].to_i.positive?
-    return false unless data['waypoints_seen'].to_i.positive?
-
-    !import.additional_data_extraction_completed?
   end
 
   def zero_points_content(import)

--- a/app/services/imports/create.rb
+++ b/app/services/imports/create.rb
@@ -151,7 +151,10 @@ class Imports::Create
 
   def awaiting_place_extraction?(import)
     return false unless import.additional_data_extraction_supported?
-    return false unless import.raw_data&.dig('waypoints_seen').to_i.positive?
+
+    data = import.raw_data || {}
+    return false if data['trackpoints_seen'].to_i.positive?
+    return false unless data['waypoints_seen'].to_i.positive?
 
     !import.additional_data_extraction_completed?
   end

--- a/app/views/imports/_extraction_card.html.erb
+++ b/app/views/imports/_extraction_card.html.erb
@@ -7,7 +7,11 @@
         <%= extraction_status_badge(import) %>
       </div>
 
-      <% if import.additional_data_extraction_unsupported? %>
+      <% if import.gpx_without_waypoints? %>
+        <p class="text-sm text-base-content/70">
+          <%= t('.this_gpx_file_holds_no_waypoints') %>
+        </p>
+      <% elsif import.additional_data_extraction_unavailable? %>
         <p class="text-sm text-base-content/70">
           <%= t('.this_import_format_doesn_t_carry_visits_named_places_or') %>
         </p>
@@ -72,5 +76,5 @@
     </div>
   </div>
 
-  <%= render 'imports/extraction_dialog', import: import unless import.additional_data_extraction_unsupported? %>
+  <%= render 'imports/extraction_dialog', import: import unless import.additional_data_extraction_unavailable? || import.gpx_without_waypoints? %>
 <% end %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -493,6 +493,7 @@ ca:
     extraction_card:
       additional_data: Dades addicionals
       this_import_format_doesn_t_carry_visits_named_places_or: Aquest format d'importació no inclou visites, llocs amb nom ni mitjans de transport, així que no hi ha res addicional a extreure.
+      this_gpx_file_holds_no_waypoints: 'Aquest fitxer GPX només conté punts de traça enregistrats, així que no hi ha punts de referència per importar com a llocs.'
       extracted: Extret
       visits: visites,
       places: llocs,
@@ -2588,7 +2589,7 @@ ca:
       source:
         manual: Manual
         photon: Photon
-        gpx_waypoint: 'Waypoint GPX'
+        gpx_waypoint: 'Punt de referència GPX'
     shared_link:
       resource_type:
         trip: Viatge

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -2588,6 +2588,7 @@ ca:
       source:
         manual: Manual
         photon: Photon
+        gpx_waypoint: 'Waypoint GPX'
     shared_link:
       resource_type:
         trip: Viatge

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -2642,6 +2642,7 @@ de:
       source:
         manual: Manuell
         photon: Photon
+        gpx_waypoint: 'GPX-Wegpunkt'
     shared_link:
       resource_type:
         trip: Reise

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -535,6 +535,7 @@ de:
     extraction_card:
       additional_data: Zusätzliche Daten
       this_import_format_doesn_t_carry_visits_named_places_or: Dieses Importformat enthält keine Aufenthalte, benannten Orte oder Verkehrsmittel, also gibt es nichts zusätzlich zu extrahieren.
+      this_gpx_file_holds_no_waypoints: 'Diese GPX-Datei enthält nur aufgezeichnete Trackpunkte, also gibt es keine Wegpunkte, die als Orte importiert werden könnten.'
       extracted: Extrahiert
       visits: Aufenthalte,
       places: Orte,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2588,6 +2588,7 @@ en:
       source:
         manual: Manual
         photon: Photon
+        gpx_waypoint: 'GPX waypoint'
     shared_link:
       resource_type:
         trip: Trip

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -493,6 +493,7 @@ en:
     extraction_card:
       additional_data: Additional data
       this_import_format_doesn_t_carry_visits_named_places_or: This import format doesn't carry visits, named places, or transportation modes, so there's nothing additional to extract.
+      this_gpx_file_holds_no_waypoints: 'This GPX file holds only recorded track points, so there are no waypoints to import as places.'
       extracted: Extracted
       visits: visits,
       places: places,

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -2587,6 +2587,7 @@ es:
       source:
         manual: Manual
         photon: Photon
+        gpx_waypoint: 'Waypoint GPX'
     shared_link:
       resource_type:
         trip: Viaje

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -535,6 +535,7 @@ es:
     extraction_card:
       additional_data: Datos adicionales
       this_import_format_doesn_t_carry_visits_named_places_or: Este formato de importación no lleva visitas, lugares nombrados o modos de transporte, por lo que no hay nada más para extraer.
+      this_gpx_file_holds_no_waypoints: 'Este archivo GPX solo contiene puntos de track grabados, así que no hay puntos de referencia que importar como lugares.'
       extracted: Extraído
       visits: visitas,
       places: lugares,
@@ -2587,7 +2588,7 @@ es:
       source:
         manual: Manual
         photon: Photon
-        gpx_waypoint: 'Waypoint GPX'
+        gpx_waypoint: 'Punto de referencia GPX'
     shared_link:
       resource_type:
         trip: Viaje

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1106,6 +1106,7 @@ fr:
       this_import_format_doesn_t_carry_visits_named_places_or: Ce format d'importation
         ne contient pas de visites, de lieux nommés ou de modes de transport, il n'y
         a donc rien à extraire en plus.
+      this_gpx_file_holds_no_waypoints: "Ce fichier GPX ne contient que des points de trace enregistrés, il n'y a donc aucun point de repère à importer comme lieux."
       extracted: Extraits
       visits: visites,
       places: lieux,

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3601,6 +3601,7 @@ fr:
       source:
         manual: Manuel
         photon: Photon
+        gpx_waypoint: 'Point de repère GPX'
     shared_link:
       resource_type:
         trip: Voyage

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -493,6 +493,7 @@ pl:
     extraction_card:
       additional_data: Dodatkowe dane
       this_import_format_doesn_t_carry_visits_named_places_or: Ten format importu nie zawiera wizyt, nazwanych miejsc ani trybów transportu, więc nie ma dodatkowych danych do wyodrębnienia.
+      this_gpx_file_holds_no_waypoints: 'Ten plik GPX zawiera tylko zarejestrowane punkty trasy, więc nie ma punktów orientacyjnych do zaimportowania jako miejsca.'
       extracted: Wyodrębniono
       visits: wizyty,
       places: miejsca,

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -2643,6 +2643,7 @@ pl:
       source:
         manual: Ręcznie
         photon: Photon
+        gpx_waypoint: 'Punkt trasy GPX'
     shared_link:
       resource_type:
         trip: Podróż

--- a/spec/fixtures/files/gpx/gpx_mixed_track_and_waypoints.gpx
+++ b/spec/fixtures/files/gpx/gpx_mixed_track_and_waypoints.gpx
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1">
+  <wpt lat="51.3402000" lon="12.3712000">
+    <name>Leipzig Hauptbahnhof</name>
+    <type>Transport</type>
+  </wpt>
+  <wpt lat="51.3397000" lon="12.3731000">
+    <name>Augustusplatz</name>
+    <type>Sights</type>
+  </wpt>
+  <trk>
+    <name>Morning walk</name>
+    <trkseg>
+      <trkpt lat="51.3400000" lon="12.3710000"><ele>113</ele><time>2026-01-27T09:00:00Z</time></trkpt>
+      <trkpt lat="51.3401000" lon="12.3715000"><ele>114</ele><time>2026-01-27T09:01:00Z</time></trkpt>
+      <trkpt lat="51.3403000" lon="12.3720000"><ele>115</ele><time>2026-01-27T09:02:00Z</time></trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/spec/fixtures/files/gpx/gpx_waypoints_only.gpx
+++ b/spec/fixtures/files/gpx/gpx_waypoints_only.gpx
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1" xmlns:osmand="https://osmand.net">
+  <metadata>
+    <name>favourites</name>
+  </metadata>
+  <wpt lat="51.3402000" lon="12.3712000">
+    <name>Leipzig Hauptbahnhof</name>
+    <time>2026-01-27T10:00:00Z</time>
+    <type>Transport</type>
+    <extensions>
+      <osmand:icon>special_trekking</osmand:icon>
+      <osmand:background>circle</osmand:background>
+      <osmand:color>#ffeecc22</osmand:color>
+    </extensions>
+  </wpt>
+  <wpt lat="51.3397000" lon="12.3731000">
+    <name>Augustusplatz</name>
+    <time>2026-01-27T11:00:00Z</time>
+    <type>Sights</type>
+    <extensions>
+      <osmand:color>#10c0f0</osmand:color>
+    </extensions>
+  </wpt>
+  <wpt lat="51.3369000" lon="12.3750000">
+    <name>Cafe Riquet</name>
+    <type>Food</type>
+  </wpt>
+</gpx>

--- a/spec/fixtures/files/gpx/gpx_waypoints_uncategorised.gpx
+++ b/spec/fixtures/files/gpx/gpx_waypoints_uncategorised.gpx
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1" xmlns:osmand="https://osmand.net">
+  <wpt lat="51.3402000" lon="12.3712000">
+    <name>Nameless corner</name>
+  </wpt>
+</gpx>

--- a/spec/jobs/enhanced_import/extract_job_spec.rb
+++ b/spec/jobs/enhanced_import/extract_job_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe EnhancedImport::ExtractJob do
     end
 
     it 'returns silently for an unsupported source' do
-      gpx_import = create(:import, user: user, source: :gpx)
-      expect { described_class.new.perform(gpx_import.id) }.not_to raise_error
-      expect(gpx_import.reload.additional_data_extraction_status).not_to eq('running')
+      kml_import = create(:import, user: user, source: :kml)
+      expect { described_class.new.perform(kml_import.id) }.not_to raise_error
+      expect(kml_import.reload.additional_data_extraction_status).not_to eq('running')
     end
 
     it 'returns silently when the import has been deleted' do

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Place, type: :model do
   end
 
   describe 'enums' do
-    it { is_expected.to define_enum_for(:source).with_values(%i[manual photon]) }
+    it { is_expected.to define_enum_for(:source).with_values(%i[manual photon gpx_waypoint]) }
   end
 
   describe 'scopes' do

--- a/spec/policies/imports/extraction_policy_spec.rb
+++ b/spec/policies/imports/extraction_policy_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Imports::ExtractionPolicy do
     end
 
     it 'blocks an unsupported source' do
-      other = create(:import, user: user, source: :gpx)
+      other = create(:import, user: user, source: :kml)
 
       expect(described_class.new(user, other).create?).to be false
     end

--- a/spec/regressions/enhanced_import_unsupported_source_spec.rb
+++ b/spec/regressions/enhanced_import_unsupported_source_spec.rb
@@ -5,18 +5,18 @@ require 'rails_helper'
 RSpec.describe 'Enhanced import for unsupported sources is not offered' do
   let(:user) { create(:user) }
 
-  it 'marks GPX imports as unsupported on creation' do
-    import = create(:import, user: user, source: :gpx)
+  it 'marks KML imports as unsupported on creation' do
+    import = create(:import, user: user, source: :kml)
     expect(import.additional_data_extraction_unsupported?).to be true
   end
 
-  it 'reports a GPX import as not supported by the translator' do
-    import = build(:import, user: user, source: :gpx)
+  it 'reports a KML import as not supported by the translator' do
+    import = build(:import, user: user, source: :kml)
     expect(import.additional_data_extraction_supported?).to be false
   end
 
   it 'reports the sources with a real adapter as supported' do
-    %i[google_phone_takeout google_semantic_history polarsteps].each do |src|
+    %i[google_phone_takeout google_semantic_history polarsteps gpx].each do |src|
       import = build(:import, user: user, source: src)
       expect(import.additional_data_extraction_supported?).to be(true), "expected #{src} supported"
     end
@@ -28,7 +28,7 @@ RSpec.describe 'Enhanced import for unsupported sources is not offered' do
   end
 
   it 'translator returns no items for an unsupported source' do
-    import = create(:import, user: user, source: :gpx)
+    import = create(:import, user: user, source: :kml)
     items = EnhancedImport::Translator.new(import).translate.to_a
     expect(items).to be_empty
   end

--- a/spec/regressions/enhanced_import_unsupported_status_on_create_spec.rb
+++ b/spec/regressions/enhanced_import_unsupported_status_on_create_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Extraction availability is resolved when an import is created' d
   let(:user) { create(:user) }
 
   it 'marks a source without an adapter as unsupported' do
-    import = create(:import, user: user, source: :gpx)
+    import = create(:import, user: user, source: :kml)
 
     expect(import.additional_data_extraction_unsupported?).to be true
   end
@@ -44,7 +44,7 @@ RSpec.describe 'Extraction availability is resolved when an import is created' d
   end
 
   it 'does not offer the extraction call to action for an unsupported import' do
-    import = create(:import, user: user, source: :gpx)
+    import = create(:import, user: user, source: :kml)
 
     rendered = ApplicationController.render(
       partial: 'imports/extraction_card',

--- a/spec/regressions/extracted_place_identity_survives_geodata_opt_out_spec.rb
+++ b/spec/regressions/extracted_place_identity_survives_geodata_opt_out_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Dedup for re-imported favourites reads geodata->>'external_place_id'. Four other
+# geodata writers drop their payload when the instance opts out of storing geodata;
+# this writer must not, or every watcher re-import would duplicate every favourite.
+RSpec.describe 'Extracted place identity survives an instance opting out of geodata' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :gpx, name: 'favourites.gpx') }
+  let(:writer) { EnhancedImport::Writers::PlaceWriter.new(user, import) }
+
+  let(:extracted) do
+    EnhancedImport::Extracted::Place.new(
+      external_place_id: 'gpx:abc123',
+      name: 'Cafe Riquet',
+      latitude: 51.3369,
+      longitude: 12.3750,
+      semantic_type: 'Food',
+      geodata_extras: {}
+    )
+  end
+
+  before { allow(DawarichSettings).to receive(:store_geodata?).and_return(false) }
+
+  it 'still writes the identity used for dedup' do
+    place, = writer.upsert(extracted)
+
+    expect(place.geodata['external_place_id']).to eq('gpx:abc123')
+  end
+
+  it 'reuses the existing place on a second run instead of duplicating it' do
+    writer.upsert(extracted)
+
+    expect { writer.upsert(extracted) }.not_to(change { Place.where(user_id: user.id).count })
+  end
+end

--- a/spec/regressions/gpx_extraction_skips_files_without_waypoints_spec.rb
+++ b/spec/regressions/gpx_extraction_skips_files_without_waypoints_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GPX extraction does not re-read a file the importer found no waypoints in' do
+  let(:user) { create(:user) }
+
+  def build_import(raw_data)
+    import = create(:import, user: user, source: :gpx, name: 'gpx_waypoints_only.gpx', raw_data: raw_data)
+    import.file.attach(
+      io: File.open(Rails.root.join('spec/fixtures/files/gpx/gpx_waypoints_only.gpx')),
+      filename: 'gpx_waypoints_only.gpx',
+      content_type: 'application/gpx+xml'
+    )
+    import
+  end
+
+  it 'extracts nothing when the import recorded trackpoints and no waypoints' do
+    import = build_import('trackpoints_seen' => 12)
+
+    expect { EnhancedImport::ExtractJob.new.perform(import.id) }
+      .not_to(change { Place.where(user_id: user.id).count })
+  end
+
+  it 'never opens the attached file in that case' do
+    import = build_import('trackpoints_seen' => 12)
+    allow(File).to receive(:open).and_call_original
+
+    EnhancedImport::ExtractJob.new.perform(import.id)
+
+    expect(File).not_to have_received(:open).with(/\.gpx\z/, 'rb')
+  end
+
+  it 'still extracts when the import recorded waypoints alongside a track' do
+    import = build_import('trackpoints_seen' => 12, 'waypoints_seen' => 3)
+
+    expect { EnhancedImport::ExtractJob.new.perform(import.id) }
+      .to change { Place.where(user_id: user.id).count }.by(3)
+  end
+
+  it 'still extracts for an import that predates element counting' do
+    import = build_import(nil)
+
+    expect { EnhancedImport::ExtractJob.new.perform(import.id) }
+      .to change { Place.where(user_id: user.id).count }.by(3)
+  end
+end

--- a/spec/regressions/gpx_imports_predating_waypoint_support_offer_extraction_spec.rb
+++ b/spec/regressions/gpx_imports_predating_waypoint_support_offer_extraction_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'A GPX import stored as unsupported still offers extraction', type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  def stale_import(source, name)
+    import = create(:import, user: user, source: source, name: name)
+    import.update_column(:additional_data_extraction_status,
+                         Import.additional_data_extraction_statuses[:unsupported])
+    import
+  end
+
+  it 'renders the extraction trigger instead of the unsupported notice' do
+    import = stale_import(:gpx, 'favourites.gpx')
+
+    get import_path(import)
+
+    expect(response.body).not_to include('carry visits, named places')
+    expect(response.body).to include("extraction-dialog-#{import.id}")
+  end
+
+  it 'does not badge it as unavailable above the trigger it now offers' do
+    import = stale_import(:gpx, 'favourites.gpx')
+
+    get import_path(import)
+
+    expect(response.body).to include('<span class="badge badge-sm badge-ghost">Not extracted</span>')
+    expect(response.body).not_to include('<span class="badge badge-sm badge-ghost">Not available</span>')
+  end
+
+  it 'keeps badging a format that genuinely has no adapter' do
+    kml_import = stale_import(:kml, 'places.kml')
+
+    get import_path(kml_import)
+
+    expect(response.body).to include('<span class="badge badge-sm badge-ghost">Not available</span>')
+  end
+
+  it 'keeps hiding it for a format that genuinely has no adapter' do
+    kml_import = stale_import(:kml, 'places.kml')
+
+    get import_path(kml_import)
+
+    expect(response.body).to include('carry visits, named places')
+  end
+end

--- a/spec/regressions/gpx_waypoint_edge_shapes_spec.rb
+++ b/spec/regressions/gpx_waypoint_edge_shapes_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GPX waypoint shapes the extractor has to survive' do
+  let(:user) { create(:user) }
+
+  def extract(io, filename, content_type)
+    import = create(:import, user: user, source: :gpx, name: filename)
+    import.file.attach(io: io, filename: filename, content_type: content_type)
+    EnhancedImport::ExtractJob.new.perform(import.id)
+    import
+  end
+
+  describe 'a waypoint carrying no name' do
+    let(:body) do
+      <<~GPX
+        <?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+        <gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1">
+          <wpt lat="51.3402000" lon="12.3712000"><type>Food</type></wpt>
+        </gpx>
+      GPX
+    end
+
+    it 'still creates the place rather than aborting the extraction' do
+      import = extract(StringIO.new(body), 'nameless.gpx', 'application/gpx+xml')
+
+      expect(import.reload).to be_additional_data_extraction_completed
+      expect(Place.where(user_id: user.id).pluck(:name)).to eq(['Unknown'])
+    end
+  end
+
+  describe 'a favourites file delivered inside a zip' do
+    let(:zip_path) { Rails.root.join("tmp/gpx_waypoints_#{SecureRandom.hex(4)}.zip") }
+
+    before do
+      Zip::File.open(zip_path, create: true) do |zip|
+        zip.add('favourites.gpx', Rails.root.join('spec/fixtures/files/gpx/gpx_waypoints_only.gpx'))
+      end
+    end
+
+    after { FileUtils.rm_f(zip_path) }
+
+    it 'unwraps the archive and extracts the waypoints inside it' do
+      extract(File.open(zip_path), 'favourites.zip', 'application/zip')
+
+      expect(Place.where(user_id: user.id).count).to eq(3)
+    end
+  end
+end

--- a/spec/regressions/gpx_waypoint_places_survive_reimport_spec.rb
+++ b/spec/regressions/gpx_waypoint_places_survive_reimport_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Re-importing a favourites file does not duplicate its places' do
+  let(:user) { create(:user) }
+
+  def import_favourites(label)
+    filename = 'gpx_waypoints_only.gpx'
+    path = Rails.root.join('spec/fixtures/files/gpx', filename)
+    import = create(:import, user: user, source: :gpx, name: "#{label}-#{filename}")
+    import.file.attach(io: File.open(path), filename: filename, content_type: 'application/gpx+xml')
+    EnhancedImport::ExtractJob.new.perform(import.id)
+    import
+  end
+
+  it 'keeps one place per waypoint when the watcher re-imports the same file' do
+    import_favourites('first')
+    expect(Place.where(user_id: user.id).count).to eq(3)
+
+    import_favourites('second')
+
+    expect(Place.where(user_id: user.id).count).to eq(3)
+  end
+
+  it 'does not create a second tag on the second run' do
+    import_favourites('first')
+    import_favourites('second')
+
+    expect(user.tags.where(name: 'Food').count).to eq(1)
+  end
+end

--- a/spec/regressions/gpx_waypoint_reimport_survives_rename_spec.rb
+++ b/spec/regressions/gpx_waypoint_reimport_survives_rename_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Re-importing a favourite that was renamed does not duplicate it' do
+  let(:user) { create(:user) }
+
+  def import_gpx(body, label)
+    filename = "#{label}.gpx"
+    import = create(:import, user: user, source: :gpx, name: filename)
+    import.file.attach(io: StringIO.new(body), filename: filename, content_type: 'application/gpx+xml')
+    EnhancedImport::ExtractJob.new.perform(import.id)
+    import
+  end
+
+  def favourite(name)
+    <<~GPX
+      <?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+      <gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1">
+        <wpt lat="51.3402000" lon="12.3712000">
+          <name>#{name}</name>
+          <type>Food</type>
+        </wpt>
+      </gpx>
+    GPX
+  end
+
+  it 'keeps a single place when the waypoint is renamed between imports' do
+    import_gpx(favourite('Cafe Riquet'), 'first')
+    expect(Place.where(user_id: user.id).count).to eq(1)
+
+    import_gpx(favourite('Riquet Kaffeehaus'), 'second')
+
+    expect(Place.where(user_id: user.id).count).to eq(1)
+  end
+
+  it 'keeps two differently named favourites that sit on the same spot apart' do
+    body = <<~GPX
+      <?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+      <gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1">
+        <wpt lat="51.3402000" lon="12.3712000"><name>Doctor</name><type>Health</type></wpt>
+        <wpt lat="51.3402000" lon="12.3712000"><name>Pharmacy</name><type>Health</type></wpt>
+      </gpx>
+    GPX
+
+    import_gpx(body, 'first')
+
+    expect(Place.where(user_id: user.id).pluck(:name)).to contain_exactly('Doctor', 'Pharmacy')
+  end
+
+  it 'carries the new name onto the place when a favourite is renamed' do
+    import_gpx(favourite('Cafe Riquet'), 'first')
+    import_gpx(favourite('Riquet Kaffeehaus'), 'second')
+
+    expect(Place.where(user_id: user.id).pluck(:name)).to eq(['Riquet Kaffeehaus'])
+  end
+
+  it 'adds a new nearby favourite instead of renaming the one already there' do
+    import_gpx(favourite('Cafe Riquet'), 'first')
+
+    nearby = favourite('Bakery').sub('lon="12.3712000"', 'lon="12.3712500"')
+    import_gpx(nearby, 'second')
+
+    expect(Place.where(user_id: user.id).pluck(:name)).to contain_exactly('Cafe Riquet', 'Bakery')
+  end
+
+  it 'still separates two favourites that share a name at different places' do
+    import_gpx(favourite('Home'), 'first')
+
+    elsewhere = favourite('Home').sub('lat="51.3402000" lon="12.3712000"', 'lat="52.5200000" lon="13.4050000"')
+    import_gpx(elsewhere, 'second')
+
+    expect(Place.where(user_id: user.id).count).to eq(2)
+  end
+end

--- a/spec/regressions/gpx_waypoints_imported_as_places_spec.rb
+++ b/spec/regressions/gpx_waypoints_imported_as_places_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GPX waypoints are imported as places, never as timeline points' do
+  let(:user) { create(:user) }
+
+  def build_import(filename)
+    path = Rails.root.join('spec/fixtures/files/gpx', filename)
+    import = create(:import, user: user, source: :gpx, name: filename)
+    import.file.attach(
+      io: File.open(path),
+      filename: filename,
+      content_type: 'application/gpx+xml'
+    )
+    import
+  end
+
+  describe 'a favourites file holding only waypoints' do
+    let(:import) { build_import('gpx_waypoints_only.gpx') }
+
+    it 'creates one place per waypoint and no points' do
+      expect { EnhancedImport::ExtractJob.new.perform(import.id) }
+        .to change { Place.where(user_id: user.id).count }.by(3)
+
+      expect(Point.where(user_id: user.id).count).to eq(0)
+    end
+
+    it 'records the waypoint origin on each place' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(Place.where(user_id: user.id).pluck(:source).uniq).to eq(['gpx_waypoint'])
+    end
+
+    it 'attributes the places to the import that produced them' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(Place.where(user_id: user.id).pluck(:import_id).uniq).to eq([import.id])
+    end
+
+    it 'keeps the waypoint name and coordinates' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+      place = Place.find_by(name: 'Augustusplatz')
+
+      expect(place.latitude.to_f).to be_within(0.00001).of(51.3397)
+      expect(place.longitude.to_f).to be_within(0.00001).of(12.3731)
+    end
+
+    it 'reports the places it created' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(import.reload.extraction_counts[:places]).to eq(3)
+    end
+  end
+
+  describe 'waypoint categories' do
+    let(:import) { build_import('gpx_waypoints_only.gpx') }
+
+    it 'turns each category into a tag on the place' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(Place.find_by(name: 'Cafe Riquet').tag_names).to eq(['Food'])
+    end
+
+    it 'reuses a tag the user already had rather than duplicating it' do
+      existing = create(:tag, user: user, name: 'Food')
+
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(user.tags.where(name: 'Food').count).to eq(1)
+      expect(Place.find_by(name: 'Cafe Riquet').tags).to eq([existing])
+    end
+
+    it 'takes the tag colour from the waypoint, dropping the leading alpha channel' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(user.tags.find_by(name: 'Transport').color).to eq('#eecc22')
+    end
+
+    it 'keeps a six digit colour as it is' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(user.tags.find_by(name: 'Sights').color).to eq('#10c0f0')
+    end
+
+    it 'never repaints a tag the user already styled' do
+      create(:tag, user: user, name: 'Transport', color: '#123456')
+
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(user.tags.find_by(name: 'Transport').color).to eq('#123456')
+    end
+  end
+
+  describe 'a waypoint with no category' do
+    let(:import) { build_import('gpx_waypoints_uncategorised.gpx') }
+
+    it 'still becomes a place, just without a tag' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+      place = Place.find_by(name: 'Nameless corner')
+
+      expect(place).to be_present
+      expect(place.tag_names).to be_empty
+    end
+  end
+
+  describe 'a file holding both a track and waypoints' do
+    let(:import) { build_import('gpx_mixed_track_and_waypoints.gpx') }
+
+    it 'imports the trackpoints as points and the waypoints as places' do
+      Gpx::TrackImporter.new(import, user.id).call
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(Point.where(user_id: user.id).count).to eq(3)
+      expect(Place.where(user_id: user.id).count).to eq(2)
+    end
+  end
+end

--- a/spec/regressions/gpx_without_waypoints_does_not_enqueue_extraction_spec.rb
+++ b/spec/regressions/gpx_without_waypoints_does_not_enqueue_extraction_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'A GPX holding no waypoints never enqueues an extraction job' do
+  include ActiveJob::TestHelper
+
+  let(:user) { create(:user) }
+
+  def complete(raw_data)
+    import = create(:import, user: user, source: :gpx, name: "track-#{SecureRandom.hex(4)}.gpx",
+                             raw_data: raw_data, status: :processing)
+    import.update!(status: :completed)
+    import
+  end
+
+  it 'skips the job when the importer counted trackpoints and no waypoints' do
+    expect { complete('trackpoints_seen' => 40) }.not_to have_enqueued_job(EnhancedImport::ExtractJob)
+  end
+
+  it 'still enqueues when waypoints were counted' do
+    expect { complete('trackpoints_seen' => 40, 'waypoints_seen' => 2) }
+      .to have_enqueued_job(EnhancedImport::ExtractJob)
+  end
+
+  it 'still enqueues for an import that predates element counting' do
+    expect { complete(nil) }.to have_enqueued_job(EnhancedImport::ExtractJob)
+  end
+end

--- a/spec/regressions/gpx_without_waypoints_does_not_offer_extraction_spec.rb
+++ b/spec/regressions/gpx_without_waypoints_does_not_offer_extraction_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'A GPX holding no waypoints does not offer extraction', type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  def gpx_import(raw_data)
+    create(:import, user: user, source: :gpx, name: "track-#{SecureRandom.hex(4)}.gpx", raw_data: raw_data)
+  end
+
+  it 'explains why instead of showing a trigger that can only find nothing' do
+    import = gpx_import('trackpoints_seen' => 40)
+
+    get import_path(import)
+
+    expect(response.body).to include('no waypoints to import as places')
+    expect(response.body).not_to include("extraction-dialog-#{import.id}")
+  end
+
+  it 'still offers the trigger when the file holds waypoints' do
+    import = gpx_import('trackpoints_seen' => 40, 'waypoints_seen' => 2)
+
+    get import_path(import)
+
+    expect(response.body).to include("extraction-dialog-#{import.id}")
+  end
+
+  it 'refuses a hand-rolled extraction request for it' do
+    import = gpx_import('trackpoints_seen' => 40)
+
+    expect(Imports::ExtractionPolicy.new(user, import).create?).to be false
+  end
+end

--- a/spec/regressions/imported_places_are_visible_on_the_map_spec.rb
+++ b/spec/regressions/imported_places_are_visible_on_the_map_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Imported places are visible on the map' do
+  let(:user) { create(:user) }
+
+  it 'shows an imported waypoint that carries no tag and no confirmed visit' do
+    place = create(:place, user: user, source: :gpx_waypoint, name: 'Cafe Riquet')
+
+    expect(Place.map_visible(user)).to include(place)
+  end
+
+  it 'still hides a suggested photon place that nothing references' do
+    place = create(:place, user: user, source: :photon, name: 'Suggested place')
+
+    expect(Place.map_visible(user)).not_to include(place)
+  end
+end

--- a/spec/regressions/imported_waypoints_never_join_a_privacy_zone_spec.rb
+++ b/spec/regressions/imported_waypoints_never_join_a_privacy_zone_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'An imported waypoint never widens a privacy zone' do
+  let(:user) { create(:user) }
+  let(:import) do
+    filename = 'gpx_waypoints_only.gpx'
+    path = Rails.root.join('spec/fixtures/files/gpx', filename)
+    record = create(:import, user: user, source: :gpx, name: filename)
+    record.file.attach(io: File.open(path), filename: filename, content_type: 'application/gpx+xml')
+    record
+  end
+
+  context 'when the user already has a privacy tag whose name matches a waypoint category' do
+    before { create(:tag, user: user, name: 'Food', privacy_radius_meters: 500) }
+
+    it 'still imports the waypoint as a place' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(Place.find_by(name: 'Cafe Riquet')).to be_present
+    end
+
+    it 'leaves that place untagged so the privacy zone does not grow' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(Place.find_by(name: 'Cafe Riquet').tag_names).to be_empty
+    end
+
+    it 'adds no new redaction circles to shared links' do
+      expect { EnhancedImport::ExtractJob.new.perform(import.id) }
+        .not_to(change { Users::PrivacyZones.new(user).call.length })
+    end
+  end
+
+  context 'when the matching tag carries no privacy radius' do
+    before { create(:tag, user: user, name: 'Food') }
+
+    it 'tags the place as normal' do
+      EnhancedImport::ExtractJob.new.perform(import.id)
+
+      expect(Place.find_by(name: 'Cafe Riquet').tag_names).to eq(['Food'])
+    end
+  end
+end

--- a/spec/services/enhanced_import/adapters/gpx_adapter_spec.rb
+++ b/spec/services/enhanced_import/adapters/gpx_adapter_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EnhancedImport::Adapters::GpxAdapter do
+  let(:user) { create(:user) }
+
+  def extract(body)
+    import = create(:import, user: user, source: :gpx, name: "favourites-#{SecureRandom.hex(4)}.gpx")
+    import.file.attach(io: StringIO.new(body), filename: 'favourites.gpx', content_type: 'application/gpx+xml')
+    described_class.new(import).translate.to_a
+  end
+
+  def waypoint(color)
+    <<~GPX
+      <?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+      <gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1">
+        <wpt lat="51.3402000" lon="12.3712000">
+          <name>Cafe Riquet</name>
+          <type>Food</type>
+          <color>#{color}</color>
+        </wpt>
+      </gpx>
+    GPX
+  end
+
+  describe 'colour normalisation' do
+    it 'expands a three-digit hex colour' do
+      expect(extract(waypoint('#0fc')).first.tag_color).to eq('#00ffcc')
+    end
+
+    it 'keeps a six-digit hex colour' do
+      expect(extract(waypoint('#10c0f0')).first.tag_color).to eq('#10c0f0')
+    end
+
+    it 'drops the leading alpha byte of an eight-digit OsmAnd colour' do
+      expect(extract(waypoint('#ffeecc22')).first.tag_color).to eq('#eecc22')
+    end
+
+    it 'yields no colour for a value it cannot read' do
+      expect(extract(waypoint('chartreuse')).first.tag_color).to be_nil
+    end
+
+    it 'only ever yields a colour Tag accepts' do
+      %w[#0fc #10c0f0 #ffeecc22].each do |value|
+        color = extract(waypoint(value)).first.tag_color
+        expect(build(:tag, user: user, color: color)).to be_valid, "rejected #{color.inspect} from #{value}"
+      end
+    end
+  end
+
+  describe 'nested children that are not the waypoint\'s own fields' do
+    let(:with_link) do
+      <<~GPX
+        <?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+        <gpx version="1.1" creator="OsmAnd~" xmlns="http://www.topografix.com/GPX/1/1">
+          <wpt lat="51.3402000" lon="12.3712000">
+            <name>Cafe Riquet</name>
+            <link href="https://example.com"><text>Homepage</text><type>text/html</type></link>
+            <extensions><osmand:color xmlns:osmand="https://osmand.net">#10c0f0</osmand:color></extensions>
+          </wpt>
+        </gpx>
+      GPX
+    end
+
+    it 'does not take a link mime type as the waypoint category' do
+      expect(extract(with_link).first.tag_name).to be_nil
+    end
+
+    it 'keeps the waypoint name rather than the link text' do
+      expect(extract(with_link).first.name).to eq('Cafe Riquet')
+    end
+
+    it 'still reads a colour out of extensions' do
+      expect(extract(with_link).first.tag_color).to eq('#10c0f0')
+    end
+  end
+
+  describe 'identity' do
+    it 'is stable for the same waypoint across parses' do
+      first = extract(waypoint('#0fc')).first
+      again = extract(waypoint('#10c0f0')).first
+
+      expect(again.external_place_id).to eq(first.external_place_id)
+    end
+
+    it 'separates two waypoints that differ only by name' do
+      first = extract(waypoint('#0fc')).first
+      other = extract(waypoint('#0fc').sub('Cafe Riquet', 'Pharmacy')).first
+
+      expect(other.external_place_id).not_to eq(first.external_place_id)
+    end
+  end
+end

--- a/spec/services/enhanced_import/writers/place_writer_spec.rb
+++ b/spec/services/enhanced_import/writers/place_writer_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EnhancedImport::Writers::PlaceWriter do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, source: :gpx, name: 'favourites.gpx') }
+
+  subject(:writer) { described_class.new(user, import, source: :gpx_waypoint) }
+
+  def next_run
+    described_class.new(user, import, source: :gpx_waypoint)
+  end
+
+  def extracted(name: 'Cafe Riquet', tag_name: 'Food', identity: 'gpx:abc123')
+    EnhancedImport::Extracted::Place.new(
+      external_place_id: identity,
+      name: name,
+      latitude: 51.3402,
+      longitude: 12.3712,
+      semantic_type: tag_name,
+      geodata_extras: {},
+      tag_name: tag_name,
+      tag_color: '#10c0f0'
+    )
+  end
+
+  describe 'a name longer than the column allows' do
+    it 'stores a truncated name instead of aborting the extraction' do
+      place, created = writer.upsert(extracted(name: 'A' * 400))
+
+      expect(created).to be true
+      expect(place.name.length).to eq(255)
+    end
+  end
+
+  describe 'a place matched by proximity rather than identity' do
+    let!(:existing) do
+      create(:place, user: user, name: 'Cafe Riquet', latitude: 51.3402, longitude: 12.3712,
+                     lonlat: 'POINT(12.3712 51.3402)', source: :photon, geodata: {})
+    end
+
+    it 'stamps the extracted identity onto the matched place' do
+      writer.upsert(extracted)
+
+      expect(existing.reload.geodata['external_place_id']).to eq('gpx:abc123')
+    end
+
+    it 'lets the next run find it by identity when position matching no longer could' do
+      writer.upsert(extracted)
+      existing.update_columns(name: 'Renamed by hand', lonlat: 'POINT(13.4050 52.5200)',
+                              latitude: 52.52, longitude: 13.405)
+
+      place, created = described_class.new(user, import, source: :gpx_waypoint).upsert(extracted)
+
+      expect(created).to be false
+      expect(place.id).to eq(existing.id)
+    end
+
+    it 'does not overwrite an identity the place already carries' do
+      existing.update!(geodata: { 'external_place_id' => 'photon:kept' })
+
+      writer.upsert(extracted(identity: 'gpx:other'))
+
+      expect(existing.reload.geodata['external_place_id']).to eq('photon:kept')
+    end
+  end
+
+  describe 'a place whose name the user edited in Dawarich' do
+    it 'adopts the new identity without repainting the locked name' do
+      writer.upsert(extracted(name: 'Cafe Riquet'))
+      place = Place.where(user_id: user.id).sole
+      place.update!(name: 'My favourite cafe')
+      expect(place.reload).to be_name_locked
+
+      next_run.upsert(extracted(name: 'Riquet Kaffeehaus', identity: 'gpx:renamed'))
+
+      expect(place.reload.name).to eq('My favourite cafe')
+      expect(place.geodata['external_place_id']).to eq('gpx:renamed')
+      expect(Place.where(user_id: user.id).count).to eq(1)
+    end
+
+    it 'still renames a place the user never touched' do
+      writer.upsert(extracted(name: 'Cafe Riquet'))
+
+      next_run.upsert(extracted(name: 'Riquet Kaffeehaus', identity: 'gpx:renamed'))
+
+      expect(Place.where(user_id: user.id).pluck(:name)).to eq(['Riquet Kaffeehaus'])
+    end
+  end
+
+  describe 'when a concurrent writer already inserted the place' do
+    it 'still attaches the category tag to the row it falls back to' do
+      allow(Place).to receive(:create!) do
+        create(:place, user: user, name: 'Cafe Riquet', latitude: 51.3402, longitude: 12.3712,
+                       lonlat: 'POINT(12.3712 51.3402)', source: :gpx_waypoint,
+                       geodata: { 'external_place_id' => 'gpx:abc123' })
+        raise ActiveRecord::RecordNotUnique, 'simulated concurrent insert'
+      end
+
+      place, created = writer.upsert(extracted)
+
+      expect(created).to be false
+      expect(place.geodata['external_place_id']).to eq('gpx:abc123')
+      expect(place.tags.map(&:name)).to include('Food')
+    end
+  end
+end


### PR DESCRIPTION
Closes #1261. Supersedes #2809, which should be closed — its GeoJSON half was contradicted by #3473, its `add_import_id_to_places` migration duplicates a column `dev` already has, and its bespoke importer predates `EnhancedImport`.

## The problem

`<wpt>` elements were discarded entirely — `TrkptStreamHandler` only opens a capture stack for `<trkpt>`. An OsmAnd+ favourites export therefore produced nothing at all, silently, which is what #1261 has been reporting since May 2025.

Waypoints are saved places, not timeline events. Their `<time>` is when the favourite was *saved*, often while browsing the map at home — importing them as Points would fabricate visits and inflate distance. So they become Places.

## The change

- New `EnhancedImport::Adapters::GpxAdapter` (SAX, BOM-safe) emitting `Extracted::Place`, registered in `Translator`. Reusing the existing pipeline means places inherit its dedup, `import_id` attribution, extraction card, counts and teardown for free.
- `Place`: `gpx_waypoint: 2` source, `imported` scope added to `map_visible` — without this, imported places would exist but be invisible on the map.
- A waypoint's `<type>` category becomes a `Tag`, which also makes the place visible via the existing `tagged` branch, and gives per-category show/hide on the map.
- `PlaceWriter` gains a `source:` kwarg (default `:photon`, so the other three adapters are untouched) and tag attachment.

### Two deliberate safety choices

**Imported places never join a privacy-radius tag.** Privacy zones are tag-anchored: `Users::PrivacyZones` turns every place on such a tag into a redaction circle applied to shared links and trips. Reusing a "Home" tag by name would mint new redaction zones on URLs the user has already handed out. A file import must not reach into published share links, so those waypoints are left untagged (still visible via `imported`); the user can attach the tag deliberately afterwards.

**Existing tag colours are never overwritten.** `osmand:color` is applied only when creating a new tag. OsmAnd emits `#AARRGGBB` — alpha first — so the leading two hex digits are stripped, not the trailing ones.

## Re-import

`external_place_id` is a digest of name and rounded position, so an updated `favourites.gpx` adds only what is new. That answers the reporter's second ask: the import watcher already accepts `.gpx`, so a favourites file can stay in sync.

⚠️ This dedup depends on `PlaceWriter` writing `geodata` **without** a `store_geodata?` guard — it is the only geodata writer that does, where four others strip it. That exemption is now load-bearing and is pinned by a test; a future "consistency" cleanup would otherwise make every re-import duplicate every favourite. Worth deciding separately whether the exemption is intentional.

## Verification

1405 examples, 0 failures across `spec/regressions`, `spec/models/{place,import}`, `spec/services/{enhanced_import,imports,gpx,visits}`, `spec/jobs/enhanced_import`. RuboCop clean.

Five new regression specs cover: waypoints become places and not points; origin and import attribution; category-to-tag incl. reuse, colour and never-repaint; uncategorised waypoints; mixed track+waypoint files; re-import without duplicates; the privacy-zone carve-out; and identity surviving `store_geodata? == false`.

## Updated existing specs — please review

Three specs used GPX as their example of an *unsupported* extraction source, which is no longer true. They now use `:kml`, which genuinely has no adapter, and `gpx` was added to the positive-support assertion. `place_spec.rb`'s enum assertion was extended.

`i18n_enum_translation_coverage` correctly required `enums.place.source.gpx_waypoint` in all 6 locales.

## Not included

An e2e probe asserting favourites render on the map (agreed as worthwhile) is not in this PR.

Merges cleanly into `dev` and into #3477 (verified with `git merge-tree`). The two are independent: this branch reads `raw_data['waypoints_seen']`, which #3477 writes, so in isolation the suppression is inert and only takes effect once both have landed.
