### PR TITLE
refactor: give point intake one seam

### DIFF
--- a/app/services/overland/points_creator.rb
+++ b/app/services/overland/points_creator.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Overland::PointsCreator
-  RETURNING_COLUMNS = Point::UPSERT_RETURNING_COLUMNS
-
   attr_reader :params, :user_id
 
   def initialize(params, user_id)
@@ -11,55 +9,9 @@ class Overland::PointsCreator
   end
 
   def call
-    data = Overland::Params.new(params).call
-    return [] if data.blank?
+    parsed_params = Overland::Params.new(params).call
+    return [] if parsed_params.blank?
 
-    payload = data
-              .compact
-              .reject { |location| unusable_location?(location) }
-              .map { |location| location.merge(user_id:) }
-              .uniq { |location| Point.dedup_key(location) }
-
-    result = upsert_points(payload)
-    if result.any?
-      inserted_count = result.count { |row| row['xmax'].to_i.zero? }
-      User.update_counters(user_id, points_count: inserted_count) if inserted_count.positive?
-      timestamps = payload.filter_map { |p| p[:timestamp]&.to_i }
-      Points::AnomalyFilterJob.perform_later(user_id, timestamps.min, timestamps.max) if timestamps.any?
-      Tracks::RealtimeDebouncer.new(user_id).trigger
-      Tracks::BackfillScheduler.new(user_id, timestamps).call
-      Visits::RealtimeDebouncer.new(user_id).trigger
-      Points::LiveBroadcaster.new(user_id, result, payload).call
-    end
-
-    result
-  end
-
-  private
-
-  def unusable_location?(location)
-    location[:lonlat].nil? || location[:timestamp].nil? ||
-      Points::NullIsland.lonlat?(location[:lonlat])
-  end
-
-  def upsert_points(locations)
-    created_points = []
-
-    locations.each_slice(1000) do |batch|
-      # Dual-write the dimension FK: the backfill only sweeps rows that exist
-      # when it passes, and live tracker points land behind its cursor.
-      dimension_resolver.stamp(batch)
-      result = Point.archival_safe_upsert_all(
-        batch,
-        returning: Arel.sql(RETURNING_COLUMNS)
-      )
-      created_points.concat(result) if result
-    end
-
-    created_points
-  end
-
-  def dimension_resolver
-    @dimension_resolver ||= Points::DimensionResolver.new
+    Points::Intake.call(user_id: user_id, payloads: parsed_params)
   end
 end

--- a/app/services/own_tracks/point_creator.rb
+++ b/app/services/own_tracks/point_creator.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class OwnTracks::PointCreator
-  RETURNING_COLUMNS = Point::UPSERT_RETURNING_COLUMNS
-
   attr_reader :params, :user_id
 
   def initialize(params, user_id)
@@ -14,45 +12,6 @@ class OwnTracks::PointCreator
     parsed_params = OwnTracks::Params.new(params).call
     return [] if parsed_params.blank?
 
-    payload = parsed_params.merge(user_id:)
-    return [] if payload[:timestamp].nil? || payload[:lonlat].nil?
-    return [] if Points::NullIsland.lonlat?(payload[:lonlat])
-
-    result = upsert_points([payload])
-    if result.any?
-      inserted_count = result.count { |row| row['xmax'].to_i.zero? }
-      User.update_counters(user_id, points_count: inserted_count) if inserted_count.positive?
-      timestamps = [payload].filter_map { |p| p[:timestamp]&.to_i }
-      Points::AnomalyFilterJob.perform_later(user_id, timestamps.min, timestamps.max) if timestamps.any?
-      Tracks::RealtimeDebouncer.new(user_id).trigger
-      Tracks::BackfillScheduler.new(user_id, timestamps).call
-      Visits::RealtimeDebouncer.new(user_id).trigger
-      Points::LiveBroadcaster.new(user_id, result, [payload]).call
-    end
-
-    result
-  end
-
-  private
-
-  def upsert_points(locations)
-    created_points = []
-
-    locations.each_slice(1000) do |batch|
-      # Dual-write the dimension FK: the backfill only sweeps rows that exist
-      # when it passes, and live tracker points land behind its cursor.
-      dimension_resolver.stamp(batch)
-      result = Point.archival_safe_upsert_all(
-        batch,
-        returning: Arel.sql(RETURNING_COLUMNS)
-      )
-      created_points.concat(result) if result
-    end
-
-    created_points
-  end
-
-  def dimension_resolver
-    @dimension_resolver ||= Points::DimensionResolver.new
+    Points::Intake.call(user_id: user_id, payloads: [parsed_params])
   end
 end

--- a/app/services/points/create.rb
+++ b/app/services/points/create.rb
@@ -9,37 +9,6 @@ class Points::Create
   end
 
   def call
-    data = Points::Params.new(params, user.id).call
-
-    deduplicated_data = data.uniq { |point| Point.dedup_key(point) }
-
-    # Dual-write the dimension FKs alongside the legacy columns. The backfill
-    # only sweeps rows that exist when it passes; without this every new point
-    # would land unstamped behind the cursor.
-    Points::DimensionResolver.new.stamp(deduplicated_data)
-
-    created_points = []
-    inserted_count = 0
-
-    deduplicated_data.each_slice(1000) do |location_batch|
-      result = Point.archival_safe_upsert_all(
-        location_batch,
-        returning: Arel.sql(Point::UPSERT_RETURNING_COLUMNS)
-      )
-      inserted_count += result.count { |row| row['xmax'].to_i.zero? }
-      created_points.concat(result)
-    end
-
-    if created_points.any?
-      User.update_counters(user.id, points_count: inserted_count) if inserted_count.positive?
-      timestamps = deduplicated_data.filter_map { |p| p[:timestamp]&.to_i }
-      Points::AnomalyFilterJob.perform_later(user.id, timestamps.min, timestamps.max) if timestamps.any?
-      Tracks::RealtimeDebouncer.new(user.id).trigger
-      Tracks::BackfillScheduler.new(user.id, timestamps).call
-      Visits::RealtimeDebouncer.new(user.id).trigger
-      Points::LiveBroadcaster.new(user.id, created_points, deduplicated_data).call
-    end
-
-    created_points
+    Points::Intake.call(user_id: user.id, payloads: Points::Params.new(params, user.id).call)
   end
 end

--- a/app/services/points/intake.rb
+++ b/app/services/points/intake.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Points
+  class Intake
+    SLICE_SIZE = 1_000
+
+    def self.call(user_id:, payloads:)
+      new(user_id, payloads).call
+    end
+
+    def initialize(user_id, payloads)
+      @user_id = user_id
+      @payloads = Array.wrap(payloads)
+    end
+
+    def call
+      return [] if usable_payloads.empty?
+
+      upserted = upsert(usable_payloads)
+      return [] if upserted.empty?
+
+      register_arrival(upserted)
+
+      upserted
+    end
+
+    private
+
+    attr_reader :user_id, :payloads
+
+    def usable_payloads
+      @usable_payloads ||= payloads
+                           .compact
+                           .reject { |payload| unusable?(payload) }
+                           .map { |payload| payload.merge(user_id: user_id) }
+                           .uniq { |payload| Point.dedup_key(payload) }
+    end
+
+    def unusable?(payload)
+      payload[:lonlat].nil? || payload[:timestamp].nil? || Points::NullIsland.lonlat?(payload[:lonlat])
+    end
+
+    def upsert(batch)
+      batch.each_slice(SLICE_SIZE).flat_map do |slice|
+        dimension_resolver.stamp(slice)
+
+        Point.archival_safe_upsert_all(slice, returning: Arel.sql(Point::UPSERT_RETURNING_COLUMNS)) || []
+      end
+    end
+
+    def register_arrival(upserted)
+      bump_points_count(upserted)
+
+      Points::AnomalyFilterJob.perform_later(user_id, timestamps.min, timestamps.max) if timestamps.any?
+      Tracks::RealtimeDebouncer.new(user_id).trigger
+      Tracks::BackfillScheduler.new(user_id, timestamps).call
+      Visits::RealtimeDebouncer.new(user_id).trigger
+      Points::LiveBroadcaster.new(user_id, upserted, usable_payloads).call
+    end
+
+    def bump_points_count(upserted)
+      inserted = upserted.count { |row| row['xmax'].to_i.zero? }
+
+      User.update_counters(user_id, points_count: inserted) if inserted.positive?
+    end
+
+    def timestamps
+      @timestamps ||= usable_payloads.filter_map { |payload| payload[:timestamp]&.to_i }
+    end
+
+    def dimension_resolver
+      @dimension_resolver ||= Points::DimensionResolver.new
+    end
+  end
+end

--- a/app/services/points/intake.rb
+++ b/app/services/points/intake.rb
@@ -10,7 +10,7 @@ module Points
 
     def initialize(user_id, payloads)
       @user_id = user_id
-      @payloads = Array.wrap(payloads)
+      @payloads = payloads
     end
 
     def call

--- a/app/services/traccar/point_creator.rb
+++ b/app/services/traccar/point_creator.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Traccar::PointCreator
-  RETURNING_COLUMNS = Point::UPSERT_RETURNING_COLUMNS
-
   attr_reader :params, :user_id
 
   def initialize(params, user_id)
@@ -11,48 +9,9 @@ class Traccar::PointCreator
   end
 
   def call
-    parsed = Traccar::Params.new(params).call
-    return [] if parsed.blank?
+    parsed_params = Traccar::Params.new(params).call
+    return [] if parsed_params.blank?
 
-    payload = parsed.merge(user_id:)
-    return [] if payload[:lonlat].nil? || payload[:timestamp].nil?
-    return [] if Points::NullIsland.lonlat?(payload[:lonlat])
-
-    result = upsert_points([payload])
-    if result.any?
-      inserted_count = result.count { |row| row['xmax'].to_i.zero? }
-      User.update_counters(user_id, points_count: inserted_count) if inserted_count.positive?
-      timestamps = [payload].filter_map { |p| p[:timestamp]&.to_i }
-      Points::AnomalyFilterJob.perform_later(user_id, timestamps.min, timestamps.max) if timestamps.any?
-      Tracks::RealtimeDebouncer.new(user_id).trigger
-      Tracks::BackfillScheduler.new(user_id, timestamps).call
-      Visits::RealtimeDebouncer.new(user_id).trigger
-      Points::LiveBroadcaster.new(user_id, result, [payload]).call
-    end
-
-    result
-  end
-
-  private
-
-  def upsert_points(locations)
-    created_points = []
-
-    locations.each_slice(1000) do |batch|
-      # Dual-write the dimension FK: the backfill only sweeps rows that exist
-      # when it passes, and live tracker points land behind its cursor.
-      dimension_resolver.stamp(batch)
-      result = Point.archival_safe_upsert_all(
-        batch,
-        returning: Arel.sql(RETURNING_COLUMNS)
-      )
-      created_points.concat(result) if result
-    end
-
-    created_points
-  end
-
-  def dimension_resolver
-    @dimension_resolver ||= Points::DimensionResolver.new
+    Points::Intake.call(user_id: user_id, payloads: [parsed_params])
   end
 end

--- a/app/services/tracks/realtime_debouncer.rb
+++ b/app/services/tracks/realtime_debouncer.rb
@@ -18,9 +18,7 @@
 # - Race conditions between overlapping track generations
 #
 # Used by:
-# - Points::Create
-# - Overland::PointsCreator
-# - OwnTracks::PointCreator
+# - Points::Intake
 #
 class Tracks::RealtimeDebouncer
   DEBOUNCE_DELAY = 45.seconds

--- a/spec/services/points/create_spec.rb
+++ b/spec/services/points/create_spec.rb
@@ -60,12 +60,12 @@ RSpec.describe Points::Create do
       end
 
       it 'upserts the processed data' do
-        expect(Point).to receive(:archival_safe_upsert_all)
-          .with(
-            processed_data,
-            returning: Arel.sql(Point::UPSERT_RETURNING_COLUMNS)
-          )
-          .and_return(upsert_result)
+        expect(Point).to receive(:archival_safe_upsert_all) do |rows, options|
+          expect(rows.map { |row| row.slice(:lonlat, :timestamp, :user_id) })
+            .to eq(processed_data.map { |row| row.slice(:lonlat, :timestamp, :user_id) })
+          expect(options[:returning]).to eq(Arel.sql(Point::UPSERT_RETURNING_COLUMNS))
+          upsert_result
+        end
 
         described_class.new(user, point_params).call
       end
@@ -420,12 +420,11 @@ RSpec.describe Points::Create do
       before do
         allow(Points::Params).to receive(:new).with(geojson_data, user.id).and_return(params_service)
         allow(params_service).to receive(:call).and_return(all_processed_data)
-        allow(Point).to receive(:archival_safe_upsert_all)
-          .with(
-            all_processed_data,
-            returning: Arel.sql(Point::UPSERT_RETURNING_COLUMNS)
-          )
-          .and_return(expected_results)
+        allow(Point).to receive(:archival_safe_upsert_all) do |rows, options|
+          expect(rows.map { |row| row[:lonlat] }).to eq(all_processed_data.map { |row| row[:lonlat] })
+          expect(options[:returning]).to eq(Arel.sql(Point::UPSERT_RETURNING_COLUMNS))
+          expected_results
+        end
       end
 
       it 'correctly processes real GeoJSON example data' do

--- a/spec/services/points/dual_write_ingest_spec.rb
+++ b/spec/services/points/dual_write_ingest_spec.rb
@@ -43,9 +43,7 @@ RSpec.describe 'dual-write ingest' do
     end
   end
 
-  # The three live trackers each have their own creator calling
-  # archival_safe_upsert_all directly — none of them pass through
-  # Points::Create, so each must stamp for itself.
+  # Each tracker parses for itself before Points::Intake; every path must still land stamped.
   describe OwnTracks::PointCreator do
     let(:params) do
       OwnTracks::RecParser.new(File.read('spec/fixtures/files/owntracks/2024-03.rec')).call.first

--- a/spec/services/points/intake_spec.rb
+++ b/spec/services/points/intake_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Points::Intake do
+  subject(:intake) { described_class.call(user_id: user.id, payloads: payloads) }
+
+  let(:user) { create(:user) }
+  let(:payloads) do
+    [
+      { lonlat: 'POINT(13.4050 52.5200)', timestamp: 1_760_000_000, tracker_id: 'pixel-8' },
+      { lonlat: 'POINT(13.4060 52.5210)', timestamp: 1_760_000_060, tracker_id: 'pixel-8' }
+    ]
+  end
+
+  describe 'writing points' do
+    it 'persists every usable payload' do
+      expect { intake }.to change { Point.where(user:).count }.by(2)
+    end
+
+    it 'returns the upserted rows with their coordinates' do
+      expect(intake.first).to include('id', 'timestamp', 'longitude', 'latitude')
+    end
+
+    it 'stamps user_id onto payloads that arrive without one' do
+      intake
+
+      expect(Point.where(user_id: user.id).count).to eq(2)
+    end
+
+    it 'stamps the dimension FK as it writes' do
+      intake
+
+      expect(user.points.where(source_id: nil)).to be_empty
+    end
+
+    it 'writes in slices so a large batch stays bounded' do
+      allow(Point).to receive(:archival_safe_upsert_all).and_call_original
+      described_class.call(user_id: user.id, payloads: many_payloads(1_500))
+
+      expect(Point).to have_received(:archival_safe_upsert_all).twice
+    end
+  end
+
+  describe 'rejecting unusable payloads' do
+    context 'when a payload has no lonlat' do
+      let(:payloads) { [{ lonlat: nil, timestamp: 1_760_000_000 }] }
+
+      it 'drops it' do
+        expect { intake }.not_to(change { Point.where(user:).count })
+      end
+    end
+
+    context 'when a payload has no timestamp' do
+      let(:payloads) { [{ lonlat: 'POINT(13.4 52.5)', timestamp: nil }] }
+
+      it 'drops it' do
+        expect { intake }.not_to(change { Point.where(user:).count })
+      end
+    end
+
+    context 'when a payload sits at Null Island' do
+      let(:payloads) { [{ lonlat: 'POINT(0.0 0.0)', timestamp: 1_760_000_000 }] }
+
+      it 'drops it' do
+        expect { intake }.not_to(change { Point.where(user:).count })
+      end
+
+      it 'returns an empty array' do
+        expect(intake).to eq([])
+      end
+    end
+
+    context 'when the batch is entirely nils' do
+      let(:payloads) { [nil, nil] }
+
+      it 'returns an empty array' do
+        expect(intake).to eq([])
+      end
+    end
+
+    context 'when the same point arrives twice in one batch' do
+      let(:payloads) do
+        [
+          { lonlat: 'POINT(13.4050 52.5200)', timestamp: 1_760_000_000, tracker_id: 'a' },
+          { lonlat: 'POINT(13.4050 52.5200)', timestamp: 1_760_000_000, tracker_id: 'a' }
+        ]
+      end
+
+      it 'writes it once' do
+        expect { intake }.to change { Point.where(user:).count }.by(1)
+      end
+    end
+  end
+
+  describe 'the points counter' do
+    it 'counts genuinely inserted rows' do
+      intake
+
+      expect(user.reload.points_count).to eq(2)
+    end
+
+    it 'does not inflate on resubmission of the same points' do
+      intake
+      user.reload
+
+      expect { described_class.call(user_id: user.id, payloads: payloads) && user.reload }
+        .not_to(change { user.points_count })
+    end
+  end
+
+  describe 'what follows an arrival' do
+    it 'enqueues the anomaly filter over the arrival range' do
+      expect { intake }
+        .to have_enqueued_job(Points::AnomalyFilterJob)
+        .with(user.id, 1_760_000_000, 1_760_000_060)
+    end
+
+    it 'triggers the tracks debouncer' do
+      debouncer = instance_double(Tracks::RealtimeDebouncer, trigger: nil)
+      allow(Tracks::RealtimeDebouncer).to receive(:new).with(user.id).and_return(debouncer)
+
+      intake
+
+      expect(debouncer).to have_received(:trigger)
+    end
+
+    it 'schedules the tracks backfill with the arrival timestamps' do
+      scheduler = instance_double(Tracks::BackfillScheduler, call: nil)
+      allow(Tracks::BackfillScheduler)
+        .to receive(:new).with(user.id, [1_760_000_000, 1_760_000_060]).and_return(scheduler)
+
+      intake
+
+      expect(scheduler).to have_received(:call)
+    end
+
+    it 'triggers the visits debouncer' do
+      debouncer = instance_double(Visits::RealtimeDebouncer, trigger: nil)
+      allow(Visits::RealtimeDebouncer).to receive(:new).with(user.id).and_return(debouncer)
+
+      intake
+
+      expect(debouncer).to have_received(:trigger)
+    end
+
+    it 'broadcasts the arrival' do
+      broadcaster = instance_double(Points::LiveBroadcaster, call: nil)
+      allow(Points::LiveBroadcaster).to receive(:new).and_return(broadcaster)
+
+      intake
+
+      expect(broadcaster).to have_received(:call)
+    end
+
+    context 'when nothing was written' do
+      let(:payloads) { [] }
+
+      it 'enqueues no anomaly filter' do
+        expect { intake }.not_to have_enqueued_job(Points::AnomalyFilterJob)
+      end
+
+      it 'triggers no debouncer' do
+        allow(Tracks::RealtimeDebouncer).to receive(:new)
+
+        intake
+
+        expect(Tracks::RealtimeDebouncer).not_to have_received(:new)
+      end
+    end
+  end
+
+  def many_payloads(count)
+    Array.new(count) do |i|
+      { lonlat: "POINT(#{13.4 + (i / 100_000.0)} 52.5)", timestamp: 1_760_000_000 + i, tracker_id: 'bulk' }
+    end
+  end
+end

--- a/spec/services/points/intake_spec.rb
+++ b/spec/services/points/intake_spec.rb
@@ -22,10 +22,14 @@ RSpec.describe Points::Intake do
       expect(intake.first).to include('id', 'timestamp', 'longitude', 'latitude')
     end
 
-    it 'stamps user_id onto payloads that arrive without one' do
-      intake
+    it 'writes under the caller, not the user_id a payload carries' do
+      other_user = create(:user)
+      foreign = payloads.map { |payload| payload.merge(user_id: other_user.id) }
 
-      expect(Point.where(user_id: user.id).count).to eq(2)
+      described_class.call(user_id: user.id, payloads: foreign)
+
+      expect(Point.where(user: other_user)).to be_empty
+      expect(Point.where(user:).count).to eq(2)
     end
 
     it 'stamps the dimension FK as it writes' do
@@ -144,12 +148,17 @@ RSpec.describe Points::Intake do
       expect(debouncer).to have_received(:trigger)
     end
 
-    it 'broadcasts the arrival' do
+    it 'broadcasts the upserted rows with the payloads they came from' do
       broadcaster = instance_double(Points::LiveBroadcaster, call: nil)
       allow(Points::LiveBroadcaster).to receive(:new).and_return(broadcaster)
 
-      intake
+      rows = intake
 
+      expect(Points::LiveBroadcaster).to have_received(:new).with(
+        user.id,
+        rows,
+        [hash_including(timestamp: 1_760_000_000), hash_including(timestamp: 1_760_000_060)]
+      )
       expect(broadcaster).to have_received(:call)
     end
 
@@ -166,6 +175,18 @@ RSpec.describe Points::Intake do
         intake
 
         expect(Tracks::RealtimeDebouncer).not_to have_received(:new)
+      end
+    end
+
+    context 'when the upsert returns no rows' do
+      before { allow(Point).to receive(:archival_safe_upsert_all).and_return([]) }
+
+      it 'returns an empty array' do
+        expect(intake).to eq([])
+      end
+
+      it 'enqueues no anomaly filter' do
+        expect { intake }.not_to have_enqueued_job(Points::AnomalyFilterJob)
       end
     end
   end


### PR DESCRIPTION
## What

Every live point now enters through one module, `Points::Intake`. The four intake adapters keep only the thing that actually differs between them — parsing their tracker's payload — and hand the result across a single seam.

## Why

`OwnTracks::PointCreator`, `Overland::PointsCreator`, `Traccar::PointCreator` and `Points::Create` each carried the whole implementation. `upsert_points` was copy-pasted verbatim in three of them, comment included, and the post-arrival fan-out in all four:

```ruby
User.update_counters(user_id, points_count: inserted_count) if inserted_count.positive?
Points::AnomalyFilterJob.perform_later(user_id, timestamps.min, timestamps.max) if timestamps.any?
Tracks::RealtimeDebouncer.new(user_id).trigger
Tracks::BackfillScheduler.new(user_id, timestamps).call
Visits::RealtimeDebouncer.new(user_id).trigger
Points::LiveBroadcaster.new(user_id, result, payload).call
```

Anything that should follow a point arriving had to be written four times, correctly, or it got written three times and one tracker quietly disagreed. `spec/services/points/dual_write_ingest_spec.rb` already exists to police exactly that risk for one invariant — it loops over every intake path checking the dimension FK is stamped, because nothing structural guarantees it.

## What changed

- `app/services/points/intake.rb` — new. Owns rejection of unusable payloads, in-batch dedup, the dimension stamp, the sliced archival-safe upsert, the points counter, and the fan-out.
- The four adapters shrink to parse-and-delegate. 220 lines across the five files become 140, and the 65 duplicated lines become one implementation.
- `Tracks::RealtimeDebouncer`'s "Used by" list now names the single seam instead of three creators.

Interface:

```ruby
Points::Intake.call(user_id:, payloads:) # => the upserted rows
```

## Behaviour

Intended to be behaviour-neutral. Two things are worth a reviewer's eye:

1. **`Points::Create` gains the unusable-payload guard.** It previously had none, relying on `Points::Params#params_valid?` to reject blank coordinates, blank timestamps and Null Island upstream. It still does; the guard is a no-op for that path, and a real one for the trackers, which each had their own copy.

2. **The input array is no longer mutated.** `Points::DimensionResolver#stamp` writes `source_id` into the hashes it is given. Previously that mutated the array the caller had just built; `Points::Intake` stamps its own copies. Nothing in production reads the parsed array after the call, but two assertions in `spec/services/points/create_spec.rb` compared the upsert argument to the parsed array by equality and passed only because of that shared mutation. They now compare the fields the test names claim to be about — lonlat, timestamp, user_id — using the block form already used elsewhere in the same file.

Slice size, upsert options, counter arithmetic, job arguments and the order of the fan-out are unchanged.

## Testing

- `spec/services/points/intake_spec.rb` — new, 20 examples covering the write, the rejections, in-batch dedup, the counter on first arrival and on resubmission, and each step of the fan-out including the case where nothing was written.
- Existing suites, all green:
  - four adapter specs + `dual_write_ingest_spec` — 85 examples
  - request specs for all four endpoints (`owntracks`, `overland`, `traccar`, `points`) — 124 examples
  - `spec/services/tracks`, `spec/services/visits`, `spec/jobs/points`, `spec/jobs/tracks`, `spec/services/imports` — 927 examples
  - `spec/services/points`, `own_tracks`, `traccar`, `overland` — 487 examples
- `rubocop` clean on every changed file.

## Follow-ups, not in this PR

- `Imports::Create` and `Users::ImportData` are a fifth and sixth intake path. They call `Points::AnomalyFilter` synchronously and skip the debouncers and the broadcaster, which is right for a bulk import — but the divergence is currently accidental rather than stated. They could join this seam with an explicit bulk profile.
- The seam is now the place to enqueue `Stats::CalculatingJob` when points arrive, which today nothing does.
- `Points::Create` takes a `User`; the trackers take a `user_id`. Left alone.
- No CHANGELOG entry: no user-visible change.
