### PR TITLE
Keep the stats sweep running when one user fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Shared link addresses are now always three words. One hyphenated entry in the word list could produce a four-word address.
 - Places created from a suggested visit now get their real address. Visits detected on a phone arrive with a generated name such as "Visited place"; that name is no longer locked, reverse geocoding is queued for the new place, and the resolved address now replaces the generated name on the visit as well as the place.
+- Stats recalculation no longer stops for every remaining user when one user's stats fail to calculate.
 
 ## [1.14.1] - 2026-08-31, Berlin
 

--- a/app/errors/stats/sweep_failed.rb
+++ b/app/errors/stats/sweep_failed.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Stats
+  class SweepFailed < StandardError; end
+end

--- a/app/jobs/bulk_stats_calculating_job.rb
+++ b/app/jobs/bulk_stats_calculating_job.rb
@@ -5,9 +5,27 @@ class BulkStatsCalculatingJob < ApplicationJob
 
   def perform
     user_ids = User.active.pluck(:id) + User.trial.pluck(:id)
+    return if user_ids.empty?
 
-    user_ids.each do |user_id|
-      Stats::BulkCalculator.new(user_id).call
-    end
+    failed = user_ids.count { |user_id| !calculate_for(user_id) }
+
+    return unless failed == user_ids.size
+
+    raise Stats::SweepFailed, "stats calculation failed for all #{failed} users"
+  end
+
+  private
+
+  def calculate_for(user_id)
+    Stats::BulkCalculator.new(user_id).call
+
+    true
+  rescue StandardError => e
+    message = "BulkStatsCalculatingJob failed for user #{user_id}"
+
+    Rails.logger.error("#{message}: #{e.class}: #{e.message}")
+    ExceptionReporter.call(e, message)
+
+    false
   end
 end

--- a/app/services/stats/bulk_calculator.rb
+++ b/app/services/stats/bulk_calculator.rb
@@ -30,7 +30,7 @@ module Stats
                                        'EXTRACT(YEAR FROM to_timestamp(timestamp) AT TIME ZONE ?)::int AS year, ' \
                                        'EXTRACT(MONTH FROM to_timestamp(timestamp) AT TIME ZONE ?)::int AS month ' \
                                        'FROM points WHERE user_id = ? AND timestamp BETWEEN ? AND ?',
-                                       user.timezone, user.timezone, user_id, start_ts, end_ts
+                                       user.timezone_iana, user.timezone_iana, user_id, start_ts, end_ts
                                      ])
 
       Point.connection.select_rows(sql).map { |y, m| [y.to_i, m.to_i] }

--- a/spec/regressions/stats_sweep_survives_one_user_failure_spec.rb
+++ b/spec/regressions/stats_sweep_survives_one_user_failure_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Stats sweep resilience' do
+  describe 'a user whose timezone is an ActiveSupport friendly name' do
+    let(:user) { create(:user, status: :active, settings: { 'timezone' => 'Eastern Time (US & Canada)' }) }
+
+    before { create(:point, user: user, timestamp: 1.hour.ago.to_i) }
+
+    it 'resolves the timezone to IANA instead of handing Postgres a name it rejects' do
+      expect { Stats::BulkCalculator.new(user.id).call }.not_to raise_error
+    end
+
+    it 'still selects the month the points fall in' do
+      expect { Stats::BulkCalculator.new(user.id).call }
+        .to have_enqueued_job(Stats::CalculatingJob)
+    end
+  end
+
+  describe 'one user failing mid-sweep' do
+    let!(:failing_user) { create(:user, status: :active) }
+    let!(:healthy_user) { create(:user, status: :active) }
+
+    before do
+      create(:point, user: healthy_user, timestamp: 1.hour.ago.to_i)
+
+      allow(Stats::BulkCalculator).to receive(:new).and_call_original
+      allow(Stats::BulkCalculator).to receive(:new).with(failing_user.id).and_raise(
+        ActiveRecord::StatementInvalid, 'boom'
+      )
+    end
+
+    it 'does not abort the sweep' do
+      expect { BulkStatsCalculatingJob.perform_now }.not_to raise_error
+    end
+
+    it 'still processes the users behind the failure' do
+      BulkStatsCalculatingJob.perform_now
+
+      expect(Stats::BulkCalculator).to have_received(:new).with(healthy_user.id)
+    end
+
+    it 'reports the failure rather than swallowing it' do
+      allow(ExceptionReporter).to receive(:call)
+
+      BulkStatsCalculatingJob.perform_now
+
+      expect(ExceptionReporter).to have_received(:call).with(
+        an_instance_of(ActiveRecord::StatementInvalid), /#{failing_user.id}/
+      )
+    end
+  end
+
+  describe 'every user failing' do
+    let!(:first_user) { create(:user, status: :active) }
+    let!(:second_user) { create(:user, status: :active) }
+
+    before do
+      allow(Stats::BulkCalculator).to receive(:new).and_raise(ActiveRecord::StatementInvalid, 'boom')
+    end
+
+    it 'raises so the sweep is retried rather than reported as a success' do
+      expect { BulkStatsCalculatingJob.perform_now }.to raise_error(Stats::SweepFailed)
+    end
+
+    it 'still attempts every user before raising' do
+      expect { BulkStatsCalculatingJob.perform_now }.to raise_error(Stats::SweepFailed)
+
+      expect(Stats::BulkCalculator).to have_received(:new).with(first_user.id)
+      expect(Stats::BulkCalculator).to have_received(:new).with(second_user.id)
+    end
+  end
+
+  describe 'no users to sweep' do
+    it 'does not raise' do
+      expect { BulkStatsCalculatingJob.perform_now }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
`BulkStatsCalculatingJob` iterates every active and trial user with no per-user rescue, so one user raising aborts the sweep for everyone behind them in the loop. GlitchTip `DAWARICH-ML` is a live instance of this: a `RedisClient::CommandError` inside `Stats::BulkCalculator#schedule_calculations` took out a whole run.

Each user is now wrapped. A failure is logged and reported, and the sweep continues. `Stats::SweepFailed` is raised only when *every* user failed, so a systemic outage (DB or Redis down) is still retried by Sidekiq instead of being recorded as a successful run that did nothing.

Separately, `Stats::BulkCalculator` interpolated the raw `user.timezone` into `AT TIME ZONE`. Postgres rejects ActiveSupport friendly names — `time zone "Eastern Time (US & Canada)" not recognized` — while the four sibling call sites (`CalculateMonth`, `HexagonCalculator`, `Stat#calculate_data_bounds`, `FlightDistanceQuery`) all use `timezone_iana`. No Cloud user currently stores a non-IANA value, so this is defensive alignment rather than a live incident; the settings dropdown submits IANA, but `ENV['TIME_ZONE']` and the API do not enforce it.

### Testing

`spec/regressions/stats_sweep_survives_one_user_failure_spec.rb` — 8 examples covering the friendly-name timezone, one user failing mid-sweep, every user failing, and no users at all.

48 examples pass across the sweep, calculator and stats services. Rubocop clean. `zeitwerk:check` clean for the new `app/errors/stats/` namespace.

### Note

Touches the same file as #3483. Whichever merges second will need a small conflict resolution in `Stats::BulkCalculator` — that PR moves the timezone line into a new `months_with_new_points` method.