### PR TITLE
feat: state family entitlement and lapse explicitly in the API

### DIFF
--- a/app/controllers/api/v1/families/mine_controller.rb
+++ b/app/controllers/api/v1/families/mine_controller.rb
@@ -1,7 +1,35 @@
 # frozen_string_literal: true
 
 class Api::V1::Families::MineController < Api::V1::Families::BaseController
+  # A Lapsed user — Membership intact, Entitlement gone — has to learn that from
+  # a successful response rather than a refusal, which is indistinguishable from
+  # never having been entitled. This endpoint therefore replaces the inherited
+  # gates with one that lets a Lapsed user through while leaving every other
+  # status code exactly as it was.
+  skip_before_action :ensure_family_feature_available!
+  skip_before_action :ensure_user_in_family!
+  before_action :ensure_family_state_visible!
+
   def show
-    render json: Api::FamilySerializer.new(current_api_user).call
+    render json: serializer.call
+  end
+
+  private
+
+  def ensure_family_state_visible!
+    return if current_api_user&.in_family?
+    return ensure_family_feature_available! unless entitled?
+
+    ensure_user_in_family!
+  end
+
+  def entitled?
+    DawarichSettings.family_feature_available_for?(current_api_user)
+  end
+
+  def serializer
+    return Api::LapsedFamilySerializer.new(current_api_user) unless entitled?
+
+    Api::FamilySerializer.new(current_api_user)
   end
 end

--- a/app/serializers/api/family_serializer.rb
+++ b/app/serializers/api/family_serializer.rb
@@ -7,6 +7,7 @@ class Api::FamilySerializer
 
   def call
     {
+      lapsed: false,
       family: { name: family.name },
       me: me_payload,
       members: members_payload,

--- a/app/serializers/api/lapsed_family_serializer.rb
+++ b/app/serializers/api/lapsed_family_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# A user whose Membership survives but whose Entitlement has gone. The payload
+# carries only what is needed to explain the state — the family's name and
+# whether this user is the Family owner, so the client can offer renewal to the
+# one person who can act on it. Member identities and locations are deliberately
+# absent: a lapsed user has no entitlement to them.
+class Api::LapsedFamilySerializer
+  def initialize(user)
+    @user = user
+  end
+
+  def call
+    {
+      lapsed: true,
+      family: { name: user.family&.name },
+      me: {
+        user_id: user.id,
+        owner: user.family_owner?
+      }
+    }
+  end
+
+  private
+
+  attr_reader :user
+end

--- a/app/serializers/api/user_serializer.rb
+++ b/app/serializers/api/user_serializer.rb
@@ -13,7 +13,8 @@ class Api::UserSerializer
         created_at: user.created_at,
         updated_at: user.updated_at,
         settings: settings
-      }
+      },
+      features: DawarichSettings.features_for(user)
     }
 
     data.merge!(subscription: subscription) unless DawarichSettings.self_hosted?

--- a/spec/requests/api/v1/families/locations_spec.rb
+++ b/spec/requests/api/v1/families/locations_spec.rb
@@ -79,6 +79,36 @@ RSpec.describe 'Api::V1::Families::Locations', type: :request do
     end
   end
 
+  describe 'sibling endpoints when the Entitlement has lapsed' do
+    # The state endpoint answers a Lapsed user successfully so the client can
+    # explain itself; the data endpoints must keep refusing, or lapsing would
+    # not actually revoke access.
+    before do
+      allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+      user.update!(plan: :lite, status: :inactive, active_until: 1.day.ago)
+      family.update!(access_until: 1.day.ago)
+    end
+
+    it 'refuses locations' do
+      get '/api/v1/families/locations', params: { api_key: user.api_key }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'refuses history' do
+      get '/api/v1/families/locations/history',
+          params: { api_key: user.api_key, start_at: 1.day.ago.iso8601, end_at: Time.current.iso8601 }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'refuses sharing updates' do
+      patch '/api/v1/families/sharing', params: { api_key: user.api_key, enabled: true }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
   describe 'GET /api/v1/families/locations/history' do
     let(:now) { Time.zone.local(2026, 3, 13, 12, 0, 0) }
 

--- a/spec/requests/api/v1/families/mine_spec.rb
+++ b/spec/requests/api/v1/families/mine_spec.rb
@@ -50,6 +50,59 @@ RSpec.describe 'Api::V1::Families::Mine', type: :request do
       expect(response).to have_http_status(:not_found)
     end
 
+    context 'when the Entitlement has lapsed but the Membership survives' do
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+        member.update!(plan: :lite, status: :inactive, active_until: 1.day.ago)
+        family.update!(access_until: 1.day.ago)
+      end
+
+      it 'answers successfully and says so, rather than refusing' do
+        get '/api/v1/families/mine', headers: { 'Authorization' => "Bearer #{member.api_key}" }
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json['lapsed']).to be true
+        expect(json['family']['name']).to eq(family.name)
+        expect(json['me']['owner']).to be false
+      end
+
+      it 'discloses nothing about the other members' do
+        get '/api/v1/families/mine', headers: { 'Authorization' => "Bearer #{member.api_key}" }
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json).not_to have_key('members')
+        expect(json).not_to have_key('location_requests')
+        expect(response.body).not_to include(user.email)
+      end
+
+      it 'marks a lapsed Family owner as the owner, so the client can offer renewal' do
+        user.update!(plan: :lite, status: :inactive, active_until: 1.day.ago)
+
+        get '/api/v1/families/mine', headers: { 'Authorization' => "Bearer #{user.api_key}" }
+
+        json = JSON.parse(response.body)
+        expect(json['lapsed']).to be true
+        expect(json['me']['owner']).to be true
+      end
+    end
+
+    it 'reports an active Family member as not lapsed' do
+      get '/api/v1/families/mine', headers: { 'Authorization' => "Bearer #{member.api_key}" }
+
+      expect(JSON.parse(response.body)['lapsed']).to be false
+    end
+
+    it 'still refuses a user who is neither entitled nor in a family' do
+      allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+      solo = create(:user, plan: :pro)
+
+      get '/api/v1/families/mine', headers: { 'Authorization' => "Bearer #{solo.api_key}" }
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
     it 'returns 401 without an API key' do
       get '/api/v1/families/mine'
 

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Api::V1::Users', type: :request do
 
       json = JSON.parse(response.body, symbolize_names: true)
 
-      expect(json.keys).to eq([:user])
+      expect(json.keys).to match_array(%i[user features])
       expect(json[:user].keys).to match_array(
         %i[email theme created_at updated_at settings]
       )
@@ -52,6 +52,66 @@ RSpec.describe 'Api::V1::Users', type: :request do
         body = JSON.parse(response.body)
         expect(body['error']).to eq('payment_required')
         expect(body['resume_url']).to be_present
+      end
+    end
+    describe 'features' do
+      it 'exposes the feature flags at the top level, not inside subscription' do
+        get '/api/v1/users/me', headers: headers
+
+        json = JSON.parse(response.body, symbolize_names: true)
+
+        expect(json[:features].keys).to match_array(%i[family reverse_geocoding])
+        expect(json.dig(:subscription, :features)).to be_nil
+      end
+
+      context 'when self-hosted' do
+        before { allow(DawarichSettings).to receive(:self_hosted?).and_return(true) }
+
+        it 'grants the family feature regardless of plan' do
+          user.update!(plan: :lite)
+
+          get '/api/v1/users/me', headers: headers
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(json[:features][:family]).to be true
+          expect(json[:subscription]).to be_nil
+        end
+      end
+
+      context 'when on cloud' do
+        before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
+
+        it 'withholds the family feature from a user without the plan' do
+          user.update!(plan: :pro)
+
+          get '/api/v1/users/me', headers: headers
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(json[:features][:family]).to be false
+        end
+
+        it 'grants the family feature to a user holding the family plan' do
+          user.update!(plan: :family)
+
+          get '/api/v1/users/me', headers: headers
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(json[:features][:family]).to be true
+        end
+
+        it 'grants the family feature to a member inheriting it from the family owner' do
+          owner = create(:user, plan: :family, active_until: 1.year.from_now)
+          family = create(:family, creator: owner)
+          create(:family_membership, user: owner, family: family, role: :owner)
+          create(:family_membership, user: user, family: family, role: :member)
+          family.update!(access_until: 1.year.from_now)
+          user.update!(plan: :pro)
+
+          get '/api/v1/users/me', headers: headers
+
+          json = JSON.parse(response.body, symbolize_names: true)
+          expect(json[:features][:family]).to be true
+        end
       end
     end
   end


### PR DESCRIPTION
## Problem

Mobile clients have to infer two separate facts about family sharing from HTTP status codes, and cannot tell them apart.

Whether a user's plan grants family sharing (**Entitlement**) and whether they belong to a family (**Membership**) are revoked by different events and call for different remedies, but `/api/v1/families/mine` answers `403`, `404` or `200` and leaves the client guessing. Worst is the lapsed case: a member whose family owner stopped paying gets a `403` that is indistinguishable from never having been entitled — even though the `Family::Membership` row still exists and the server knows exactly what happened.

## What this changes

**`GET /api/v1/users/me` gains a top-level `features` object**, from the existing `DawarichSettings.features_for`. It sits outside `subscription` deliberately: that key is omitted entirely on self-hosted instances, which is precisely where the family feature is always granted.

**`GET /api/v1/families/mine` stops discarding what it knows.** When a Membership exists but Entitlement does not, it now returns `200` with `lapsed: true` rather than refusing.

The lapsed payload is deliberately minimal — family name and the user's role, nothing else:

```json
{ "lapsed": true, "family": { "name": "..." }, "me": { "user_id": 1, "owner": false } }
```

No member list, no locations, no pending requests. A lapsed user has no entitlement to that data, so serving it would be a privacy regression. The role is there so a client can offer renewal to the one person who can act on it.

**Sibling endpoints are unchanged.** `locations`, `history`, `sharing` and `location_requests` keep refusing a lapsed user — they are data endpoints where refusal is the correct answer, and only the state endpoint needs to be expressive.

## Notes for review

- `MineController` replaces its two inherited gates with one. Every existing status code is preserved: a user who is neither entitled nor in a family still gets `403`, an entitled user with no family still gets `404`, and an active member's payload is unchanged apart from a `lapsed: false` flag added for a consistent shape.
- The new gate reuses the inherited renderers rather than duplicating their bodies, so the error envelopes and `upgrade_url` stay identical.
- `Api::LapsedFamilySerializer` is a separate class rather than a flag on `Api::FamilySerializer`. The guarantee that member data cannot leak is stronger when the code path has no access to it.
- Existing coverage asserted `json.keys == [:user]` on the account endpoint, which the new key breaks; that assertion is widened rather than removed.

## Verification

```
969 examples, 0 failures   family requests, regressions, policies, models, services
 58 examples, 0 failures   serializer, swagger, users endpoints
RuboCop: 9 files inspected, no offenses
```

Client work consuming this is on `feat/family-entitlement-client` in the multiplatform-app repo; it detects the contract by field presence, so older servers keep working and the two halves can ship independently.
