### PR TITLE
fix(video): draw route videos in chronological order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - A photo layer that fails to load now tells you so instead of quietly showing nothing. An unreachable or erroring Immich or PhotoPrism was previously indistinguishable from simply having no photos in range; when one of several sources fails, the photos that were retrieved are still shown alongside a warning. (#1137)
 - Places created from a suggested visit now get their real address. Visits detected on a phone arrive with a generated name such as "Visited place"; that name is no longer locked, reverse geocoding is queued for the new place, and the resolved address now replaces the generated name on the visit as well as the place.
 - Stats recalculation no longer stops for every remaining user when one user's stats fail to calculate.
+- Route videos now play forwards. When the map was showing Tracks rather than Routes, the video studio drew the day in the order the tracks API returns them — newest first — so the route animated from evening back to morning while the clock counted forwards.
 
 ## [1.14.1] - 2026-08-31, Berlin
 

--- a/app/javascript/video_studio/route_timeline.js
+++ b/app/javascript/video_studio/route_timeline.js
@@ -5,15 +5,42 @@
 import { haversineDistance } from "video_studio/geo"
 import { smoothSegmentCoords } from "video_studio/path_smoothing"
 
+// Feature order is playback order here, but only the routes feed arrives
+// chronologically: /api/v1/tracks orders start_at DESC (Tracks::IndexQuery),
+// and the serializer maps that order straight through, so an unsorted tracks
+// collection animates the route backwards. Tracks carry an ISO start_at,
+// routes carry unix-second startTime; a feed with any untimed feature keeps
+// the order it came in with.
+function startTimeOf(feature) {
+  const raw = feature?.properties?.start_at ?? feature?.properties?.startTime
+  if (raw == null) return null
+  if (typeof raw === "number") return Number.isFinite(raw) ? raw : null
+  const parsed = Date.parse(raw)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function chronological(features) {
+  const timed = features.map((feature) => ({
+    feature,
+    startedAt: startTimeOf(feature),
+  }))
+  if (timed.some(({ startedAt }) => startedAt === null)) return features
+  return timed
+    .sort((a, b) => a.startedAt - b.startedAt)
+    .map(({ feature }) => feature)
+}
+
 export function buildRouteTimeline(trackGeojson, { smooth = false } = {}) {
   const entries = []
   let totalDistance = 0
-  const features = trackGeojson?.features ?? []
+  const features = chronological(
+    (trackGeojson?.features ?? []).filter(
+      (feature) => feature?.geometry?.type === "LineString",
+    ),
+  )
   let seg = 0
   for (const feature of features) {
-    const geometry = feature?.geometry
-    if (geometry?.type !== "LineString") continue
-    let coordinates = geometry.coordinates ?? []
+    let coordinates = feature.geometry.coordinates ?? []
     if (coordinates.length < 2) continue
     if (smooth) coordinates = smoothSegmentCoords(coordinates)
     for (let i = 0; i < coordinates.length; i += 1) {

--- a/spec/javascript/video_studio_route_timeline_test.mjs
+++ b/spec/javascript/video_studio_route_timeline_test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+// route_timeline reaches its dependencies through importmap bare specifiers,
+// which Node cannot resolve — concatenate the sources with the imports
+// stripped, the same approach video_studio_hud_overlay_test.mjs uses.
+const read = (name) =>
+  readFile(
+    new URL(`../../app/javascript/video_studio/${name}.js`, import.meta.url),
+    "utf8",
+  )
+
+const sources = await Promise.all(
+  ["geo", "path_smoothing", "route_timeline"].map(read),
+)
+const bundle = sources
+  .join("\n")
+  .replace(/^import[\s\S]*?from "[^"]+"\n/gm, "")
+  .replace(/^export /gm, "")
+  .concat("\nexport { buildRouteTimeline }\n")
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(bundle).toString("base64")}`
+const { buildRouteTimeline } = await import(moduleUrl)
+
+// Leipzig, heading east through the day.
+const MORNING = [
+  [12.3712, 51.3402],
+  [12.376, 51.3402],
+]
+const EVENING = [
+  [12.39, 51.3402],
+  [12.395, 51.3402],
+]
+
+const lineString = (coordinates, properties) => ({
+  type: "Feature",
+  properties,
+  geometry: { type: "LineString", coordinates },
+})
+
+const collection = (features) => ({ type: "FeatureCollection", features })
+
+test("draws chronologically when the tracks feed arrives newest-first", () => {
+  // Tracks::IndexQuery orders start_at DESC, and Tracks::GeojsonSerializer
+  // maps that order straight into the FeatureCollection.
+  const { entries } = buildRouteTimeline(
+    collection([
+      lineString(EVENING, { start_at: "2026-08-20T18:00:00Z" }),
+      lineString(MORNING, { start_at: "2026-08-20T08:00:00Z" }),
+    ]),
+  )
+
+  assert.deepEqual(entries[0].coord, MORNING[0])
+  assert.deepEqual(entries[entries.length - 1].coord, EVENING[1])
+})
+
+test("orders the routes feed by its unix-second startTime", () => {
+  const { entries } = buildRouteTimeline(
+    collection([
+      lineString(EVENING, { startTime: 1_787_248_800 }),
+      lineString(MORNING, { startTime: 1_787_212_800 }),
+    ]),
+  )
+
+  assert.deepEqual(entries[0].coord, MORNING[0])
+  assert.deepEqual(entries[entries.length - 1].coord, EVENING[1])
+})
+
+test("keeps the given order when a feature carries no start time", () => {
+  // The trip page's pathData fallback builds a bare LineString with no
+  // properties. A partially timed feed must not be reshuffled around the
+  // features it cannot place — treating a missing time as 0 would drag them
+  // to the front of the video.
+  const { entries } = buildRouteTimeline(
+    collection([
+      lineString(MORNING, { start_at: "2026-08-20T08:00:00Z" }),
+      lineString(EVENING, {}),
+    ]),
+  )
+
+  assert.deepEqual(entries[0].coord, MORNING[0])
+  assert.deepEqual(entries[entries.length - 1].coord, EVENING[1])
+})


### PR DESCRIPTION
Users reported route videos playing backwards.

## Cause

`buildRouteTimeline` treats the incoming feature order as the playback order — it accumulates distance across features in array order, and that ordering is what `sliceAtFraction` walks frame by frame.

But `/api/v1/tracks` returns tracks newest-first:

```ruby
# app/queries/tracks/index_query.rb:17
.order(start_at: :desc)
```

`Tracks::GeojsonSerializer` maps that order straight into the FeatureCollection. So whenever the studio's track source resolved to `tracks`, the pen drew the day from evening back to morning.

The giveaway is that `route_clock.js` already sorts ascending, so the HUD clock counted *forward* while the pen ran *backwards*.

## Who hit it

`trackSource()` in `poster_studio/data/providers.js` prefers `routes` and only falls back to `tracks` when the routes layer has no features. Routes GeoJSON is only built when `needsPoints` is true (`data_loader.js:147`), so **Routes layer off + Tracks on** produced a reversed video.

Unaffected: the normal map path (`route_segmenter.js:276` sorts each tracker bucket by timestamp) and the trip page (`day_routes_layer.js:61` sorts day keys).

## Fix

Sort features chronologically in `buildRouteTimeline` before walking them, keyed on `properties.start_at` (tracks, ISO) falling back to `properties.startTime` (routes, unix seconds). A feed carrying any untimed feature — the trip page's `pathData` fallback builds a bare LineString — keeps the order it arrived in rather than guessing.

## Verification

Three specs in `spec/javascript/video_studio_route_timeline_test.mjs`, each mutation-checked to confirm it can actually fail:

| Mutation | Specs killed |
| --- | --- |
| Drop the `chronological()` call | 1, 2 |
| Drop the `startTime` fallback | 2 |
| Treat a missing time as `0` instead of bailing out | 3 |

Run against the real payload shapes — `start_at DESC` tracks, string lat/lon from `Api::SlimPointSerializer`:

```
frac   pen lon    HUD clock
0.00   12.3712    2026-08-20T08:00:00Z
0.50   12.3901    2026-08-20T18:00:00Z
1.00   12.4000    2026-08-20T18:00:02Z
```

Pen advances in step with the clock. The same input before this change gave `12.3902 -> 12.3810`, backwards.

`node --test spec/javascript/*_test.mjs` — 228 passed, 0 failed. Biome clean.

## Known, not fixed here

In tiled-rendering mode both `needsPoints` and `tracksViaBulk` are false, so the routes and tracks layers are both empty when the studio opens — and `reloadTrack()` reads `trackGeojson()` before the `await provider.points()` call that force-loads points and populates the routes layer. The render guard checks `points.length`, not track geometry, so it renders a blank world map with a real HUD over it. Separate fix; it involves a decision about which geometry a video should prefer when both are available.
