### PR TITLE
fix(poster): force the map's track load before drawing the poster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Invited family members are no longer sent to the subscription checkout when signing up on the web or in the mobile app.
 - A GeoJSON file whose points carry no timestamp is now rejected at import with an explanation, instead of storing points that no date range could ever return.
 - Restoring a user-data export no longer reports success while importing nothing. An archive carrying a point column this version no longer has aborted every batch; unknown columns are now ignored and the points are restored.
+- The poster studio now draws your route when tiled rendering is on. It never asked the map to load the route data, and under tiled rendering nothing else does, so the preview came up empty and Save was blocked with "No location data in this date range" even though the range had plenty.
 
 ## [1.14.1] - 2026-08-31, Berlin
 

--- a/app/javascript/controllers/poster_studio_editor_controller.js
+++ b/app/javascript/controllers/poster_studio_editor_controller.js
@@ -162,6 +162,7 @@ export default class extends Controller {
       if (!this.subtitleInputTarget.value)
         this.subtitleInputTarget.value = this.dateRangeLabel()
       this.seedDateInputs()
+      await this.provider.ensureTrackLoaded()
 
       this.resizeFrame()
       await this.loadFonts()
@@ -518,6 +519,7 @@ export default class extends Controller {
     this.setStatus(translate("poster.loading_tracks"))
     try {
       await this.provider.applyDates(start, end)
+      await this.provider.ensureTrackLoaded()
 
       if (subtitleWasAuto)
         this.subtitleInputTarget.value = this.dateRangeLabel()

--- a/app/javascript/poster_studio/data/providers.js
+++ b/app/javascript/poster_studio/data/providers.js
@@ -40,13 +40,21 @@ export class MapPageProvider {
     }
   }
 
+  // The map loads points lazily and the poster never needs the points
+  // themselves — but that same load is what builds the routes GeoJSON and
+  // fills the routes layer. Under tiled rendering the bulk points and tracks
+  // fetches are both skipped, so nothing else fills it and a studio that only
+  // draws the track still has to force the load.
+  async ensureTrackLoaded() {
+    await this.controller?.mapDataManager?.ensurePointsLoaded()
+  }
+
   // Timestamped points, for consumers that animate the track rather than
-  // draw it flat. The map loads points lazily, so this forces the fetch the
-  // poster path never needs.
+  // draw it flat.
   async points() {
     const controller = this.controller
     if (!controller) return []
-    await controller.mapDataManager?.ensurePointsLoaded()
+    await this.ensureTrackLoaded()
     return controller._getLoadedPoints?.() ?? []
   }
 
@@ -163,6 +171,9 @@ export class TripProvider {
   defaultTitle() {
     return this.title
   }
+
+  // Nothing to load: a trip hands the studio its geojson up front.
+  async ensureTrackLoaded() {}
 
   async points() {
     return this.trackPoints

--- a/spec/javascript/poster_studio_providers_test.mjs
+++ b/spec/javascript/poster_studio_providers_test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+// MapPageProvider reaches the live map through document.getElementById; the
+// module itself imports nothing, so a minimal DOM shim is all Node needs.
+globalThis.document = { getElementById: () => ({}) }
+
+const source = await readFile(
+  new URL(
+    "../../app/javascript/poster_studio/data/providers.js",
+    import.meta.url,
+  ),
+  "utf8",
+)
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+const { MapPageProvider, TripProvider } = await import(moduleUrl)
+
+// Mirrors the real controller: ensurePointsLoaded() is what builds the routes
+// GeoJSON and fills the routes layer, so the track is only readable after it.
+function fakeMapPage() {
+  const controller = {
+    loads: 0,
+    mapDataManager: {
+      async ensurePointsLoaded() {
+        controller.loads += 1
+      },
+    },
+    _getLoadedPoints: () => [{ latitude: "51.3402", longitude: "12.3712" }],
+  }
+  const application = {
+    getControllerForElementAndIdentifier: () => controller,
+  }
+  return { controller, provider: new MapPageProvider({ application }) }
+}
+
+test("forces the map's lazy point load so the track becomes readable", async () => {
+  const { controller, provider } = fakeMapPage()
+
+  await provider.ensureTrackLoaded()
+
+  assert.equal(controller.loads, 1)
+})
+
+test("points still resolve through the same lazy load", async () => {
+  const { controller, provider } = fakeMapPage()
+
+  const points = await provider.points()
+
+  assert.equal(controller.loads, 1)
+  assert.equal(points.length, 1)
+})
+
+test("a trip provider satisfies the same contract without a map", async () => {
+  // Trip pages hand the studio their geojson up front, so there is nothing to
+  // load — but the studio calls this on whatever provider it was given.
+  const provider = new TripProvider({
+    geojson: { type: "FeatureCollection", features: [] },
+    points: [],
+  })
+
+  await provider.ensureTrackLoaded()
+})


### PR DESCRIPTION
Sibling of #3491, which fixes the same tiled-rendering blind spot in the video studio. Different cause, different fix, no shared files.

With **tiled rendering** on, the poster studio showed an empty preview and refused to save:

> No location data in this date range — pick a range with tracks in the date bar above.

The range had plenty. The advice sent people off to change something that would not have helped.

## Cause

The poster path never called `provider.points()` — no call sites anywhere under `poster_studio/` or in the editor controller. That call is the only thing that triggers `ensurePointsLoaded()`, and *that* is what builds the routes GeoJSON and pushes it into the routes layer (`map_data_manager.js` `_loadPoints` -> `_updateLayerBySource("routes", ...)`).

Outside tiled mode the eager map load has already filled that layer, so never asking for it went unnoticed. Under tiled rendering both bulk fetches are skipped —

```js
needsPoints   = (!tiledPointsActive && pointsVisible !== false) || bulkPointsRequired  // false
tracksViaBulk = tracksEnabled && !tiledPointsActive(current)                           // false
```

— so the layer stays empty, `collectCoords(this.trackGeojson)` returns nothing, and `syncSaveAvailability` disables Save with the misleading notice.

## Fix

`ensureTrackLoaded()` on both providers: real on `MapPageProvider`, a no-op on `TripProvider`, whose geojson is handed in up front. `points()` now routes through it too, so forcing the load has one home.

Called from **two** places in the editor — `open()` and after a date change. One is not enough: a map reload replaces `lastLoadedData` wholesale (`map_data_manager.js:120`) and `data.points` is `[]` under tiled rendering, so the layer empties again on every range change.

`trackGeojson` on the poster is a getter, so once the layer is filled every read picks it up — no stale capture to worry about, unlike the video studio.

Costs nothing outside tiled mode: `ensurePointsLoaded()` returns early when points are already loaded.

## Verification

- Three specs, each RED before its fix, each mutation-checked — reverting `ensureTrackLoaded` to a no-op, unhooking `points()`, and deleting the `TripProvider` method each kill exactly one spec and no others.
- `node --test spec/javascript/*_test.mjs` — 231 passed, 0 failed. Biome clean. No Ruby touched.

## Not verified

Not rendered in a browser — the code path is verified, the poster image isn't. The specs cover the providers rather than the editor's calls into them, so removing those two `await`s would not fail the suite.

## Follow-up, not in scope

Both studios now force a full point load in tiled mode, which is what tiled mode exists to avoid. Sourcing studio geometry from `/api/v1/tracks` would remove the need entirely. Separate change.
