### PR TITLE
Keep version checks out of page rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Pages no longer wait for GitHub when checking for a newer version; update checks now run only in the background (#3485).
+
 ## [1.14.2] - 2026-09-02, Berlin
 
 ### Added

--- a/app/jobs/app_version_checking_job.rb
+++ b/app/jobs/app_version_checking_job.rb
@@ -5,8 +5,6 @@ class AppVersionCheckingJob < ApplicationJob
   sidekiq_options retry: false
 
   def perform
-    Rails.cache.delete(CheckAppVersion::VERSION_CACHE_KEY)
-
-    CheckAppVersion.new.call
+    CheckAppVersion.new.refresh
   end
 end

--- a/app/services/check_app_version.rb
+++ b/app/services/check_app_version.rb
@@ -10,19 +10,26 @@ class CheckAppVersion
   def call
     return false if Rails.env.production?
 
-    latest_version != APP_VERSION
+    cached_version = Rails.cache.read(VERSION_CACHE_KEY)
+    cached_version.present? && cached_version != APP_VERSION
   rescue StandardError
     false
   end
 
-  private
+  def refresh
+    return false if Rails.env.production?
 
-  def latest_version
-    Rails.cache.fetch(VERSION_CACHE_KEY, expires_in: 6.hours) do
-      versions = JSON.parse(Net::HTTP.get(URI.parse(@repo_url)))
-      # Find first version that contains only numbers and dots
-      release_version = versions.find { |v| v['name'].match?(/^\d+\.\d+\.\d+$/) }
-      release_version ? release_version['name'] : APP_VERSION
+    uri = URI.parse(@repo_url)
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: 5, read_timeout: 5,
+                                                max_retries: 0) do |http|
+      http.get(uri.request_uri)
     end
+    return false unless response.is_a?(Net::HTTPSuccess)
+
+    versions = JSON.parse(response.body)
+    release_version = versions.find { |version| version['name'].match?(/^\d+\.\d+\.\d+$/) }
+    Rails.cache.write(VERSION_CACHE_KEY, release_version ? release_version['name'] : APP_VERSION, expires_in: 6.hours)
+  rescue StandardError
+    false
   end
 end

--- a/spec/jobs/app_version_checking_job_spec.rb
+++ b/spec/jobs/app_version_checking_job_spec.rb
@@ -3,13 +3,25 @@
 require 'rails_helper'
 
 RSpec.describe AppVersionCheckingJob, type: :job do
-  describe '#perform' do
-    let(:job) { described_class.new }
+  before do
+    allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+    stub_const('APP_VERSION', '0.9.0')
+  end
 
-    it 'calls CheckAppVersion service' do
-      expect(CheckAppVersion).to receive(:new).and_return(instance_double(CheckAppVersion, call: true))
+  it 'refreshes the release displayed by the version indicator' do
+    described_class.perform_now
 
-      job.perform
-    end
+    expect(CheckAppVersion.new.call).to be true
+    expect(Rails.cache.read(CheckAppVersion::VERSION_CACHE_KEY)).to eq('1.0.0')
+  end
+
+  it 'keeps the last successful release when the background refresh fails' do
+    Rails.cache.write(CheckAppVersion::VERSION_CACHE_KEY, '1.0.0')
+    stub_request(:get, 'https://api.github.com/repos/Freika/dawarich/tags').to_timeout
+
+    described_class.perform_now
+
+    expect(CheckAppVersion.new.call).to be true
+    expect(Rails.cache.read(CheckAppVersion::VERSION_CACHE_KEY)).to eq('1.0.0')
   end
 end

--- a/spec/regressions/version_indicator_offline_spec.rb
+++ b/spec/regressions/version_indicator_offline_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Version indicator without internet access', type: :helper do
+  include ApplicationHelper
+
+  let(:version_url) { 'https://api.github.com/repos/Freika/dawarich/tags' }
+
+  before do
+    allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+    allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('development'))
+    stub_const('APP_VERSION', '1.0.0')
+    stub_request(:get, version_url).to_timeout
+  end
+
+  it 'renders repeated cold-cache checks without contacting GitHub' do
+    2.times { expect(new_version_available?).to be false }
+
+    expect(a_request(:get, version_url)).not_to have_been_made
+  end
+
+  it 'uses the cached release without contacting GitHub' do
+    Rails.cache.write(CheckAppVersion::VERSION_CACHE_KEY, '1.1.0')
+
+    expect(new_version_available?).to be true
+    expect(a_request(:get, version_url)).not_to have_been_made
+  end
+end

--- a/spec/services/check_app_version_spec.rb
+++ b/spec/services/check_app_version_spec.rb
@@ -3,51 +3,108 @@
 require 'rails_helper'
 
 RSpec.describe CheckAppVersion do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:version_url) { 'https://api.github.com/repos/Freika/dawarich/tags' }
+
+  before do
+    stub_const('APP_VERSION', '1.0.0')
+    allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+  end
+
   describe '#call' do
     subject(:check_app_version) { described_class.new.call }
 
-    before do
-      stub_const('APP_VERSION', '1.0.0')
+    it 'returns false before the first background refresh' do
+      expect(check_app_version).to be false
     end
 
-    context 'when in production' do
-      before { allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production')) }
+    context 'with a cached release' do
+      before { Rails.cache.write(described_class::VERSION_CACHE_KEY, '1.0.0') }
 
       it { is_expected.to be false }
-    end
 
-    context 'when latest version is newer' do
-      before { stub_const('APP_VERSION', '0.9.0') }
+      context 'when latest version is newer' do
+        before { stub_const('APP_VERSION', '0.9.0') }
 
-      it { is_expected.to be true }
-    end
-
-    context 'when latest version is the same' do
-      it { is_expected.to be false }
-    end
-
-    context 'when latest version is older' do
-      before { stub_const('APP_VERSION', '1.1.0') }
-
-      it { is_expected.to be true }
-    end
-
-    context 'when latest version is not a stable release' do
-      before do
-        stub_request(:any, 'https://api.github.com/repos/Freika/dawarich/tags')
-          .to_return(status: 200, body: '[{"name": "1.0.0-rc.1"}]', headers: {})
+        it { is_expected.to be true }
       end
 
-      it { is_expected.to be false }
-    end
+      context 'when latest version is older' do
+        before { stub_const('APP_VERSION', '1.1.0') }
 
-    context 'when request fails' do
-      before do
-        allow(Net::HTTP).to receive(:get).and_raise(StandardError)
-        allow(File).to receive(:read).with('.app_version').and_return(APP_VERSION)
+        it { is_expected.to be true }
       end
 
-      it { is_expected.to be false }
+      context 'when in production' do
+        before do
+          stub_const('APP_VERSION', '0.9.0')
+          allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+        end
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe '#refresh' do
+    subject(:refresh) { described_class.new.refresh }
+
+    it 'caches the first stable release, replacing the previous value' do
+      Rails.cache.write(described_class::VERSION_CACHE_KEY, '0.9.0')
+      stub_request(:get, version_url).to_return(body: '[{"name":"1.2.0-rc.1"},{"name":"1.1.0"}]')
+
+      refresh
+
+      expect(Rails.cache.read(described_class::VERSION_CACHE_KEY)).to eq('1.1.0')
+      expect(described_class.new.call).to be true
+    end
+
+    it 'uses the current version when there are no stable releases' do
+      stub_request(:get, version_url).to_return(body: '[{"name":"1.2.0-rc.1"}]')
+
+      refresh
+
+      expect(described_class.new.call).to be false
+      expect(Rails.cache.read(described_class::VERSION_CACHE_KEY)).to eq('1.0.0')
+    end
+
+    it 'expires the cached release after six hours' do
+      refresh
+
+      travel 6.hours + 1.second do
+        expect(Rails.cache.read(described_class::VERSION_CACHE_KEY)).to be_nil
+      end
+    end
+
+    it 'preserves the cached version when GitHub times out' do
+      Rails.cache.write(described_class::VERSION_CACHE_KEY, '1.1.0')
+      stub_request(:get, version_url).to_timeout
+
+      expect(refresh).to be false
+      expect(Rails.cache.read(described_class::VERSION_CACHE_KEY)).to eq('1.1.0')
+    end
+
+    it 'ignores HTTP failures even when the body resembles a release list' do
+      stub_request(:get, version_url).to_return(status: 503, body: '[{"name":"1.1.0"}]')
+
+      expect(refresh).to be false
+      expect(Rails.cache.read(described_class::VERSION_CACHE_KEY)).to be_nil
+    end
+
+    it 'preserves the cached version when GitHub returns malformed data' do
+      Rails.cache.write(described_class::VERSION_CACHE_KEY, '1.1.0')
+      stub_request(:get, version_url).to_return(body: 'not JSON')
+
+      expect(refresh).to be false
+      expect(Rails.cache.read(described_class::VERSION_CACHE_KEY)).to eq('1.1.0')
+    end
+
+    it 'does not contact GitHub in production' do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new('production'))
+
+      expect(refresh).to be false
+      expect(a_request(:get, version_url)).not_to have_been_made
     end
   end
 end


### PR DESCRIPTION
When GitHub is unreachable, self-hosted pages currently wait for a synchronous version check on every cache miss. The version indicator now reads only the cache; the existing scheduled job refreshes it with explicit connection/read timeouts and leaves an unexpired cached result untouched on failure.

Refs #3485. Refs #3301.

No database/schema migrations, user-data writes, or new configuration. The existing six-hour refresh schedule and production behavior are preserved. On a cold cache the update highlight remains absent until the scheduled refresh succeeds.

Validation:
- Regression reproduced before the fix: two page helper calls made two GitHub requests. After the fix, page helper calls make none.
- 16 focused RSpec examples pass, all 232 JavaScript tests pass, changed Ruby files pass RuboCop.
- Full RSpec ran 9,354 examples: one Photos API failure (502 instead of 200) is independently reproduced on clean `dev` at `5fbc2220`; an initial test-helper import failure was corrected and the final focused suite passes. The full suite was not rerun after that test-only correction.
- Clean `dev` comparison: 84 examples, only the same Photos API failure. `make test` is unavailable because current `dev` has no Makefile; suites were invoked directly.
- Two independent engineering, QA, and product review rounds completed with no blockers.
