### PR TITLE
Match admin password input to Devise constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- The Add User form now displays and enforces the configured password length before submission (#2688).
+
 ## [1.14.2] - 2026-09-02, Berlin
 
 ### Added

--- a/app/views/settings/users/index.html.erb
+++ b/app/views/settings/users/index.html.erb
@@ -116,7 +116,8 @@
         <%= f.label :password do %>
           <%= t('.password') %>
         <% end %>
-        <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "input input-bordered", minlength: 6 %>
+        <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "input input-bordered", minlength: Devise.password_length.min, maxlength: Devise.password_length.max, required: true, aria: { describedby: "create-user-password-hint" } %>
+        <p id="create-user-password-hint" class="text-sm text-base-content/70 mt-1"><%= t('devise.registrations.new.characters_minimum', count: Devise.password_length.min) %></p>
       </div>
       <div class="form-control mt-5">
         <%= f.submit t('.create'), class: "btn btn-primary" %>

--- a/spec/regressions/admin_password_constraints_spec.rb
+++ b/spec/regressions/admin_password_constraints_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin user creation password constraints', type: :request do
+  before do
+    allow(DawarichSettings).to receive(:self_hosted?).and_return(true)
+    sign_in create(:user, :admin)
+  end
+
+  it 'renders the server password constraints on the required password field' do
+    get settings_users_path
+
+    password = Nokogiri::HTML(response.body).at_css('#create_user input[name="user[password]"]')
+    expect(password['minlength']).to eq(Devise.password_length.min.to_s)
+    expect(password['maxlength']).to eq(Devise.password_length.max.to_s)
+    expect(password.key?('required')).to be true
+  end
+
+  it 'still rejects a short password when client validation is bypassed' do
+    expect do
+      post settings_users_path, params: { user: { email: 'new-user@example.com', password: 'short' } }
+    end.not_to change(User, :count)
+
+    expect(response).to have_http_status(:see_other)
+    expect(flash[:alert]).to include('Password is too short')
+  end
+end


### PR DESCRIPTION
The Add User form still advertised a six-character minimum although Devise requires twelve characters. It now uses Devise's configured minimum and maximum, requires a password, and displays the existing translated minimum-length hint with an accessible association.

Refs #2688.

Server-side validation and the existing 303 redirect with validation errors are unchanged. No database writes beyond the existing form flow, schema changes, migrations, or additional queries.

Validation: regression reproduced against the original form; 46 RSpec examples pass (new constraints/regression tests plus all settings/users request specs); RuboCop and diff checks pass. Local Playwright confirmed the rendered 12–128 limits, required-field behavior, short-password rejection, valid-password acceptance, and readable hint. Screenshot: local review artifact `password-form.png` (synthetic admin). A pre-existing rails-ujs duplicate-load console error remains unrelated to the native password validation.

Two independent engineering, QA, and product review rounds completed with no blockers. QA independently verified native validation and the accessible hint in Chromium. Full GitHub CI ran 9,347 RSpec examples; its only failure is the Photos API 502 also independently reproduced on clean dev. Other CI checks passed. There is no Makefile in current dev; focused suites were invoked directly.
