### PR TITLE
Store Traccar form uploads and reject unstored points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Traccar latitude/longitude form uploads now save points, including Unix timestamps in seconds or milliseconds. Payloads that cannot be stored return an error instead of a false success; repeated valid uploads remain safe. (#3299)
+
 ## [1.14.2] - 2026-09-02, Berlin
 
 ### Added

--- a/app/controllers/api/v1/traccar/points_controller.rb
+++ b/app/controllers/api/v1/traccar/points_controller.rb
@@ -5,7 +5,14 @@ class Api::V1::Traccar::PointsController < ApiController
   before_action :validate_points_limit, only: %i[create]
 
   def create
-    Traccar::PointCreator.new(point_params, current_api_user.id).call
+    result = Traccar::PointCreator.new(point_params, current_api_user.id).call
+
+    if result.blank?
+      Rails.logger.warn('Traccar point rejected: unsupported or invalid payload')
+
+      return render json: { error: I18n.t('controllers.api.v1.traccar.points.point_creation_failed') },
+                    status: :unprocessable_content
+    end
 
     render json: [], status: :ok
   rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid, ArgumentError => e
@@ -20,7 +27,7 @@ class Api::V1::Traccar::PointsController < ApiController
 
   def point_params
     params.permit(
-      :device_id,
+      :device_id, :id, :lat, :lon, :timestamp, :accuracy, :altitude, :speed, :bearing, :batt, :charge, :alarm,
       location: [
         :timestamp, :latitude, :longitude, :accuracy, :speed, :heading, :altitude,
         :is_moving, :odometer, :event, :manual,

--- a/app/services/traccar/params.rb
+++ b/app/services/traccar/params.rb
@@ -84,10 +84,10 @@ class Traccar::Params
   end
 
   def battery_level
-    level = battery[:level]
+    level = form_payload? ? raw_payload[:batt] : battery[:level]
     return nil if level.nil?
 
-    value = (level.to_f * 100).to_i
+    value = form_payload? ? level.to_i : (level.to_f * 100).to_i
     value.positive? ? value : nil
   end
 
@@ -108,7 +108,7 @@ class Traccar::Params
   end
 
   def normalize_protocol(input)
-    return input unless input[:location].blank? && input[:lat].present? && input[:lon].present?
+    return input unless form_payload?
 
     {
       device_id: input[:id],
@@ -123,9 +123,12 @@ class Traccar::Params
         event: input[:alarm]
       },
       battery: {
-        level: input[:batt].present? ? input[:batt].to_f / 100 : nil,
         is_charging: ActiveModel::Type::Boolean.new.cast(input[:charge])
       }.compact
     }
+  end
+
+  def form_payload?
+    raw_payload[:location].blank? && raw_payload[:lat].present? && raw_payload[:lon].present?
   end
 end

--- a/app/services/traccar/params.rb
+++ b/app/services/traccar/params.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
-# Normalizes the JSON payload sent by a Traccar-style tracker into a point hash.
+# Normalizes JSON and latitude/longitude form payloads from Traccar trackers.
 # Supports both the flat Dawarich mobile client shape (coords directly on
 # `location`, `battery`/`activity` at the top level) and the nested upstream
 # traccar-client shape (coords under `location.coords`, `battery`/`activity`
 # under `location`).
 class Traccar::Params
-  attr_reader :payload
+  attr_reader :payload, :raw_payload
 
   def initialize(payload)
-    @payload = normalize(payload)
+    @raw_payload = normalize(payload)
+    @payload = normalize_protocol(raw_payload)
   end
 
   def call
@@ -34,7 +35,7 @@ class Traccar::Params
       battery:        battery_level,
       battery_status: battery_status,
       motion_data:    Points::MotionDataExtractor.from_traccar(payload),
-      raw_data:       payload.deep_stringify_keys
+      raw_data:       raw_payload.deep_stringify_keys
     }
     attrs[:altitude_decimal] = altitude_value if Point.column_names.include?('altitude_decimal')
     attrs
@@ -60,6 +61,11 @@ class Traccar::Params
   end
 
   def parse_timestamp(value)
+    if value.to_s.match?(/\A\d+\z/)
+      numeric = Integer(value.to_s, 10)
+      return numeric > 10_000_000_000 ? numeric / 1000 : numeric
+    end
+
     DateTime.parse(value.to_s).to_i
   rescue ArgumentError, TypeError
     nil
@@ -99,5 +105,27 @@ class Traccar::Params
            end
 
     hash.deep_symbolize_keys
+  end
+
+  def normalize_protocol(input)
+    return input unless input[:location].blank? && input[:lat].present? && input[:lon].present?
+
+    {
+      device_id: input[:id],
+      location: {
+        timestamp: input[:timestamp],
+        latitude: input[:lat],
+        longitude: input[:lon],
+        accuracy: input[:accuracy],
+        altitude: input[:altitude],
+        speed: input[:speed].present? ? input[:speed].to_f / 1.94384 : nil,
+        heading: input[:bearing],
+        event: input[:alarm]
+      },
+      battery: {
+        level: input[:batt].present? ? input[:batt].to_f / 100 : nil,
+        is_charging: ActiveModel::Type::Boolean.new.cast(input[:charge])
+      }.compact
+    }
   end
 end

--- a/spec/regressions/traccar_rejected_point_response_spec.rb
+++ b/spec/regressions/traccar_rejected_point_response_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Traccar rejected point responses', type: :request do
+  let(:user) { create(:user) }
+  let(:form_payload) do
+    { id: 'synthetic-device', timestamp: '1785920400', lat: '48.2082', lon: '16.3738' }
+  end
+
+  it 'acknowledges a repeated upload without duplicating the point or counter' do
+    2.times do
+      post "/api/v1/traccar/points?api_key=#{user.api_key}", params: form_payload
+      expect(response).to have_http_status(:ok)
+    end
+
+    expect(user.points.count).to eq(1)
+    expect(user.reload.points_count).to eq(1)
+  end
+
+  it 'stores millisecond timestamps as seconds' do
+    post "/api/v1/traccar/points?api_key=#{user.api_key}",
+         params: form_payload.merge(timestamp: '1785920400000')
+
+    expect(response).to have_http_status(:ok)
+    expect(user.points.sole.timestamp).to eq(1_785_920_400)
+  end
+
+  it 'does not acknowledge a location deliberately filtered by intake' do
+    expect do
+      post "/api/v1/traccar/points?api_key=#{user.api_key}", params: form_payload.merge(lat: '0', lon: '0')
+    end.not_to change(Point, :count)
+
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+
+  it 'rejects an empty payload' do
+    post "/api/v1/traccar/points?api_key=#{user.api_key}", params: {}, as: :json
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(user.points).to be_empty
+  end
+
+  it 'stores a Traccar form-protocol point' do
+    payload = {
+      id: 'synthetic-device',
+      timestamp: '1785920400',
+      lat: '48.2082',
+      lon: '16.3738',
+      accuracy: '6.0',
+      speed: '9.72',
+      batt: '80',
+      charge: 'false'
+    }
+
+    expect do
+      post "/api/v1/traccar/points?api_key=#{user.api_key}", params: payload
+    end.to change(Point, :count).by(1)
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'returns a non-success response when the payload cannot create a point' do
+    payload = {
+      id: 'synthetic-device',
+      timestamp: '2026-08-05T09:00:00Z',
+      lat: 'invalid',
+      lon: '16.3738'
+    }
+
+    expect do
+      post "/api/v1/traccar/points?api_key=#{user.api_key}", params: payload
+    end.not_to change(Point, :count)
+
+    expect(response).to have_http_status(:unprocessable_content)
+    expect(JSON.parse(response.body)).to include('error')
+  end
+end

--- a/spec/requests/api/v1/traccar/points_spec.rb
+++ b/spec/requests/api/v1/traccar/points_spec.rb
@@ -68,12 +68,13 @@ RSpec.describe 'Api::V1::Traccar::Points', type: :request do
       context 'when payload is malformed' do
         before { payload[:location][:timestamp] = 'not-a-date' }
 
-        it 'returns ok and does not create a point' do
+        it 'rejects the request and does not create a point' do
           expect do
             post "/api/v1/traccar/points?api_key=#{user.api_key}", params: payload, as: :json
           end.not_to change(Point, :count)
 
-          expect(response).to have_http_status(:ok)
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(JSON.parse(response.body)).to include('error')
         end
       end
 

--- a/spec/services/traccar/params_spec.rb
+++ b/spec/services/traccar/params_spec.rb
@@ -199,6 +199,14 @@ RSpec.describe Traccar::Params do
 
         expect(params[:battery_status]).to eq('unknown')
       end
+
+      [29, 57, 58].each do |percentage|
+        it "preserves a reported battery percentage of #{percentage}" do
+          input[:batt] = percentage.to_s
+
+          expect(params[:battery]).to eq(percentage)
+        end
+      end
     end
   end
 end

--- a/spec/services/traccar/params_spec.rb
+++ b/spec/services/traccar/params_spec.rb
@@ -159,5 +159,46 @@ RSpec.describe Traccar::Params do
         expect(params[:tracker_id]).to eq('x')
       end
     end
+
+    context 'with the Traccar form protocol' do
+      let(:input) do
+        {
+          id: 'android-tracker',
+          lat: '48.2082',
+          lon: '16.3738',
+          timestamp: '1785920400',
+          accuracy: '8.5',
+          altitude: '180.0',
+          speed: '9.72',
+          bearing: '125.0',
+          batt: '84',
+          charge: 'true',
+          alarm: 'sos'
+        }
+      end
+
+      it 'normalizes coordinates, time, and device id' do
+        expect(params).to include(
+          lonlat: 'POINT(16.3738 48.2082)',
+          timestamp: 1_785_920_400,
+          tracker_id: 'android-tracker'
+        )
+      end
+
+      it 'converts knots to meters per second' do
+        expect(params[:velocity].to_f).to be_within(0.01).of(5.0)
+      end
+
+      it 'normalizes battery state and preserves the original payload' do
+        expect(params).to include(battery: 84, battery_status: 'charging')
+        expect(params[:raw_data]).to include('lat' => '48.2082', 'batt' => '84')
+      end
+
+      it 'keeps charging state unknown when it is not reported' do
+        input.delete(:charge)
+
+        expect(params[:battery_status]).to eq('unknown')
+      end
+    end
   end
 end

--- a/spec/swagger/api/v1/traccar/points_controller_spec.rb
+++ b/spec/swagger/api/v1/traccar/points_controller_spec.rb
@@ -91,6 +91,13 @@ description: 'Event type that produced the fix (e.g. motionchange, heartbeat)' }
 
         run_test!
       end
+
+      response '422', 'Point rejected' do
+        let(:point) { { device_id: 'x' } }
+        let(:api_key) { create(:user).api_key }
+
+        run_test!
+      end
     end
   end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -5115,6 +5115,8 @@ paths:
           description: Point created
         '401':
           description: Unauthorized
+        '422':
+          description: Point rejected
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Traccar form uploads with `lat`, `lon`, and a Unix timestamp were ignored while the endpoint still returned 200. The endpoint now normalizes those uploads and acknowledges success only when point intake returns a stored row. Invalid, empty, and filtered payloads return 422; repeated valid uploads still return 200 without duplicating a point or incrementing its counter again.

Refs #3299.

Supports seconds/milliseconds and existing date strings, preserves original raw payloads, and converts the form protocol's default speed units (knots) to m/s. Existing flat/nested JSON clients retain their behavior. This is the latitude/longitude form used by the reported client, not a complete implementation of every optional OsmAnd extension. Protocol reference: https://www.traccar.org/osmand/.

No migrations or changes to the shared intake/upsert path, archival handling, jobs, or uniqueness rules. One existing write path per accepted request; no additional database queries.

Validation: two new request regressions fail on clean dev before the fix; 80 focused examples pass across form/JSON requests, params, point creation, shared intake, and the OpenAPI response spec. Includes retry/counter idempotency, rejected Null Island points, empty input, milliseconds, and missing charging state. Changed Ruby files pass RuboCop; generated OpenAPI advertises 422.

Two independent engineering, QA, and product review rounds completed. The first round found a one-percentage-point floating conversion error in form battery data; it was reproduced, fixed without changing JSON handling, and covered by three targeted regression cases. The second round has no remaining findings. The existing Photos API 502 failure is independently reproduced on clean dev and in the accompanying PR's full CI suite.
