### PR TITLE
Fix Chibigeo "get your free API key" link 

### DIFF
--- a/app/views/settings/integrations/_geocoding.html.erb
+++ b/app/views/settings/integrations/_geocoding.html.erb
@@ -39,7 +39,7 @@
 <% field_measure = 'w-full' %>
 <% chibigeo_utm = 'utm_source=dawarich&utm_medium=app&utm_campaign=geocoding_settings' %>
 <% chibigeo_site_url = "https://chibigeo.com/?#{chibigeo_utm}" %>
-<% chibigeo_docs_url = "https://chibigeo.com/docs/guides/dawarich-self-hosted-geocoding/?#{chibigeo_utm}" %>
+<% chibigeo_docs_url = "https://chibigeo.com/docs/guides/dawarich-self-hosted-geocoding?#{chibigeo_utm}" %>
 
 <div class="rounded-box border border-base-content/10 bg-base-200 max-w-3xl"
      data-controller="geocoding-settings"

--- a/app/views/settings/integrations/_geocoding.html.erb
+++ b/app/views/settings/integrations/_geocoding.html.erb
@@ -39,7 +39,7 @@
 <% field_measure = 'w-full' %>
 <% chibigeo_utm = 'utm_source=dawarich&utm_medium=app&utm_campaign=geocoding_settings' %>
 <% chibigeo_site_url = "https://chibigeo.com/?#{chibigeo_utm}" %>
-<% chibigeo_docs_url = "https://chibigeo.com/docs/guides/dawarich?#{chibigeo_utm}" %>
+<% chibigeo_docs_url = "https://chibigeo.com/docs/guides/dawarich-self-hosted-geocoding/?#{chibigeo_utm}" %>
 
 <div class="rounded-box border border-base-content/10 bg-base-200 max-w-3xl"
      data-controller="geocoding-settings"


### PR DESCRIPTION
Fixes a dead link that is 404 currently

<img width="752" height="668" alt="image" src="https://github.com/user-attachments/assets/f538ce61-3ee1-4406-b1e1-643a44f24336" />
