### PR TITLE
fix: confirm Immich location persistence before reporting success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Immich photo enrichment now checks saved coordinates in the background and explains unconfirmed updates, including read-only external library and XMP permission problems (#3065).
+
 - Traccar latitude/longitude form uploads now save points, including Unix timestamps in seconds or milliseconds. Payloads that cannot be stored return an error instead of a false success; repeated valid uploads remain safe. (#3299)
 ## Unreleased
 

--- a/app/javascript/controllers/maps/immich_enrich_controller.js
+++ b/app/javascript/controllers/maps/immich_enrich_controller.js
@@ -417,12 +417,17 @@ export default class extends Controller {
       }
 
       const message =
-        data.failed > 0
-          ? translate("immich.partially_enriched", {
-              enriched: data.enriched,
+        data.pending > 0
+          ? translate("immich.pending_enrichment", {
+              count: data.pending,
               failed: data.failed,
             })
-          : translate("immich.enriched", { count: data.enriched })
+          : data.failed > 0
+            ? translate("immich.partially_enriched", {
+                enriched: data.enriched,
+                failed: data.failed,
+              })
+            : translate("immich.enriched", { count: data.enriched })
 
       Flash.show(data.failed > 0 ? "warning" : "notice", message)
       this.removeMarkers()

--- a/app/jobs/immich/verify_enrichment_job.rb
+++ b/app/jobs/immich/verify_enrichment_job.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class Immich::VerifyEnrichmentJob < ApplicationJob
+  queue_as :default
+
+  BATCH_SIZE = 20
+  MAX_PASSES = 3
+
+  def perform(notification_id, assets, immich_url, pass: 1, confirmed: 0, unconfirmed: [])
+    notification = Notification.find_by(id: notification_id)
+    return unless notification
+
+    user = notification.user
+    return unless user
+
+    if user.safe_settings.immich_url != immich_url || user.safe_settings.immich_api_key.blank?
+      finish(notification, confirmed, assets.size + unconfirmed.size)
+      return
+    end
+
+    saved, pending = Immich::VerifyEnrichment.new(user, assets.first(BATCH_SIZE)).call
+    confirmed += saved.size
+    unconfirmed += pending
+    remaining = assets.drop(BATCH_SIZE)
+
+    if remaining.any?
+      self.class.perform_later(notification_id, remaining, immich_url, pass:, confirmed:, unconfirmed:)
+    elsif unconfirmed.any? && pass < MAX_PASSES
+      self.class.set(wait: 30.seconds).perform_later(
+        notification_id, unconfirmed, immich_url, pass: pass + 1, confirmed:
+      )
+    else
+      finish(notification, confirmed, unconfirmed.size)
+    end
+  end
+
+  private
+
+  def finish(notification, confirmed, unconfirmed)
+    I18n.with_locale(notification.user.locale) do
+      notification.update!(
+        title: I18n.t('services.immich.enrich_photos.result_title'),
+        content: result_message(confirmed, unconfirmed),
+        kind: unconfirmed.positive? ? :warning : :info,
+        read_at: nil
+      )
+    end
+    notification.broadcast_replace_to(
+      [notification.user, :notifications], target: "notification_#{notification.id}",
+      partial: 'notifications/navbar_item', locals: { notification: }
+    )
+    notification.broadcast_replace_to(
+      [notification.user, :notifications], target: 'notifications-badge',
+      partial: 'notifications/badge', locals: { count: notification.user.notifications.unread.count }
+    )
+  end
+
+  def result_message(confirmed, unconfirmed)
+    message = I18n.t('services.immich.enrich_photos.confirmed', count: confirmed)
+    return message if unconfirmed.zero?
+
+    "#{message} #{I18n.t('services.immich.enrich_photos.unconfirmed', count: unconfirmed)}"
+  end
+end

--- a/app/jobs/immich/verify_enrichment_job.rb
+++ b/app/jobs/immich/verify_enrichment_job.rb
@@ -38,21 +38,13 @@ class Immich::VerifyEnrichmentJob < ApplicationJob
 
   def finish(notification, confirmed, unconfirmed)
     I18n.with_locale(notification.user.locale) do
-      notification.update!(
+      notification.update_with_broadcast!(
         title: I18n.t('services.immich.enrich_photos.result_title'),
         content: result_message(confirmed, unconfirmed),
         kind: unconfirmed.positive? ? :warning : :info,
         read_at: nil
       )
     end
-    notification.broadcast_replace_to(
-      [notification.user, :notifications], target: "notification_#{notification.id}",
-      partial: 'notifications/navbar_item', locals: { notification: }
-    )
-    notification.broadcast_replace_to(
-      [notification.user, :notifications], target: 'notifications-badge',
-      partial: 'notifications/badge', locals: { count: notification.user.notifications.unread.count }
-    )
   end
 
   def result_message(confirmed, unconfirmed)

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -15,6 +15,19 @@ class Notification < ApplicationRecord
     read_at.present?
   end
 
+  def update_with_broadcast!(attributes)
+    update!(attributes)
+    broadcast_notification
+    broadcast_replace_to(
+      [user, :notifications], target: "notification_#{id}",
+      partial: 'notifications/notification', locals: { notification: self, show_content: false }
+    )
+    broadcast_replace_to(
+      [user, :notifications], target: "detail_notification_#{id}",
+      partial: 'notifications/notification', locals: { notification: self, show_content: true }
+    )
+  end
+
   private
 
   def broadcast_notification

--- a/app/services/immich/enrich_photos.rb
+++ b/app/services/immich/enrich_photos.rb
@@ -15,9 +15,9 @@ class Immich::EnrichPhotos
     if user.safe_settings.immich_api_key.blank?
       return error_result(I18n.t('services.immich.configuration.api_key_missing'))
     end
-    return { enriched: 0, failed: 0, errors: [] } if assets.empty?
+    return { enriched: 0, pending: 0, failed: 0, errors: [] } if assets.empty?
 
-    enriched = 0
+    submitted = []
     failed = 0
     errors = []
 
@@ -25,17 +25,28 @@ class Immich::EnrichPhotos
       result = update_asset(asset)
 
       if result[:success]
-        enriched += 1
+        submitted << asset
       else
         failed += 1
         errors << { immich_asset_id: asset['immich_asset_id'], error: result[:error] }
       end
     end
 
-    { enriched:, failed:, errors: }
+    schedule_verification(submitted) if submitted.any?
+
+    { enriched: 0, pending: submitted.size, failed:, errors: }
   end
 
   private
+
+  def schedule_verification(submitted)
+    notification = user.notifications.create!(
+      kind: :info,
+      title: I18n.t('services.immich.enrich_photos.checking_title'),
+      content: I18n.t('services.immich.enrich_photos.checking', count: submitted.size)
+    )
+    Immich::VerifyEnrichmentJob.set(wait: 10.seconds).perform_later(notification.id, submitted, immich_url)
+  end
 
   def update_asset(asset)
     options = {
@@ -72,6 +83,6 @@ error: I18n.t('services.immich.enrich_photos.http_code_message', code: response.
   end
 
   def error_result(message)
-    { error: message, enriched: 0, failed: 0, errors: [] }
+    { error: message, enriched: 0, pending: 0, failed: 0, errors: [] }
   end
 end

--- a/app/services/immich/verify_enrichment.rb
+++ b/app/services/immich/verify_enrichment.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Immich::VerifyEnrichment
+  include SslConfigurable
+
+  def initialize(user, assets)
+    @user = user
+    @assets = assets
+  end
+
+  def call
+    @assets.partition { |asset| confirmed?(asset) }
+  end
+
+  private
+
+  def confirmed?(asset)
+    headers = { 'x-api-key' => @user.safe_settings.immich_api_key, 'accept' => 'application/json' }
+    response = HTTParty.get(
+      "#{@user.safe_settings.immich_url}/api/assets/#{ERB::Util.url_encode(asset['immich_asset_id'])}",
+      http_options_with_ssl(@user, :immich, headers:, timeout: 5)
+    )
+    return false unless response.success?
+
+    data = JSON.parse(response.body)
+    exif = data.is_a?(Hash) && data['exifInfo']
+    return false unless exif.is_a?(Hash)
+
+    %w[latitude longitude].all? do |coordinate|
+      actual = Float(exif[coordinate], exception: false)
+      expected = Float(asset[coordinate], exception: false)
+      actual&.finite? && expected&.finite? && (actual - expected).abs <= 0.00001
+    end
+  rescue *Photos::ConnectionErrors::HANDLED, JSON::ParserError
+    false
+  end
+end

--- a/app/views/notifications/_navbar_item.html.erb
+++ b/app/views/notifications/_navbar_item.html.erb
@@ -1,4 +1,4 @@
-<li class="notification-item" id="<%= dom_id(notification) %>">
+<li class="notification-item" id="<%= dom_id(notification, :navbar) %>">
   <div class="divider p-0 m-0"></div>
   <%= link_to notification do %>
     <%= notification.title %>

--- a/app/views/notifications/_navbar_item.html.erb
+++ b/app/views/notifications/_navbar_item.html.erb
@@ -1,5 +1,5 @@
-<div class="divider p-0 m-0"></div>
-<li class="notification-item">
+<li class="notification-item" id="<%= dom_id(notification) %>">
+  <div class="divider p-0 m-0"></div>
   <%= link_to notification do %>
     <%= notification.title %>
     <div class="badge badge-xs justify-self-end badge-<%= notification.kind %>"></div>

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,11 +1,12 @@
-<div role="<%= notification.kind %>" class="<%= notification.kind %> shadow-lg p-5 flex justify-between items-center mb-4 rounded-lg bg-base-200" id="<%= dom_id notification %>">
+<% show_content = local_assigns.fetch(:show_content, params[:action] == 'show') %>
+<div role="<%= notification.kind %>" class="<%= notification.kind %> shadow-lg p-5 flex justify-between items-center mb-4 rounded-lg bg-base-200" id="<%= dom_id(notification, show_content ? :detail : nil) %>">
   <div class="flex-1 min-w-0 [overflow-wrap:anywhere]">
     <h3 class="font-bold text-xl">
       <%= link_to notification.title, notification, class: "link hover:no-underline #{notification_link_color(notification)}" %>
     </h3>
     <div class="text-sm text-gray-500"><%= t('common.time_ago', time: relative_distance_in_words(notification.created_at)) %></div>
 
-    <% if params[:action] == 'show' %>
+    <% if show_content %>
       <div class="mt-2">
         <%= sanitize notification.content %>
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3429,6 +3429,13 @@ ca:
         immich_api_key_missing_permission_asset_view: 'A la clau API d''Immich li falta el permís: asset.view'
         immich_thumbnail_check_failed_code: 'La comprovació de la miniatura d''Immich ha fallat: %{code}'
       enrich_photos:
+        checking_title: "Comprovant les actualitzacions d’ubicació d’Immich"
+        checking: "S’han enviat %{count} actualitzacions d’ubicació a Immich. S’està comprovant si s’han desat les coordenades."
+        result_title: "Resultats de les actualitzacions d’ubicació d’Immich"
+        confirmed:
+          one: "Ubicació desada confirmada per a %{count} foto."
+          other: "Ubicacions desades confirmades per a %{count} fotos."
+        unconfirmed: "Actualitzacions d’ubicació encara sense confirmar: %{count}. Pot ser que Immich encara estigui processant els canvis. Comprova les tasques de metadades i el permís asset.read de la clau API. A les biblioteques externes, Immich ha de poder escriure fitxers auxiliars XMP: els muntatges de només lectura o els permisos dels fitxers poden impedir que es desin. Un cop resolt, torna a cercar abans de reintentar-ho."
         http_code_message: 'HTTP %{code}: %{message}'
       enrich_scan:
         failed_to_fetch_photos_from_immich: No s'han pogut obtenir les fotos d'Immich
@@ -4130,6 +4137,7 @@ ca:
       no_matches: No s'ha trobat cap coincidència dins de la tolerància
       open_in_immich: Obre a Immich
       partially_enriched: "S'han enriquit %{enriched} fotos. %{failed} han fallat."
+      pending_enrichment: "S’han enviat %{count} actualitzacions d’ubicació a Immich; %{failed} no s’han pogut enviar. Rebràs una notificació després de comprovar les coordenades desades."
       photos_without_gps:
         one: "%{count} foto sense GPS"
         other: "%{count} fotos sense GPS"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3491,6 +3491,13 @@ de:
         immich_api_key_missing_permission_asset_view: 'Immich-API-Schlüssel fehlt Berechtigung: asset.view'
         immich_thumbnail_check_failed_code: 'Immich-Thumbnail-Prüfung fehlgeschlagen: %{code}'
       enrich_photos:
+        checking_title: "Immich-Standortaktualisierungen werden geprüft"
+        checking: "%{count} Standortaktualisierungen an Immich gesendet. Es wird geprüft, ob die Koordinaten gespeichert wurden."
+        result_title: "Ergebnisse der Immich-Standortaktualisierung"
+        confirmed:
+          one: "Der gespeicherte Standort für %{count} Foto wurde bestätigt."
+          other: "Gespeicherte Standorte für %{count} Fotos wurden bestätigt."
+        unconfirmed: "Noch nicht bestätigte Standortaktualisierungen: %{count}. Immich verarbeitet die Änderungen möglicherweise noch. Prüfe die Metadatenaufträge und die Berechtigung asset.read deines API-Schlüssels. Bei externen Bibliotheken muss Immich XMP-Begleitdateien schreiben können: Schreibgeschützte Einbindungen oder Dateiberechtigungen können das Speichern verhindern. Suche nach der Behebung erneut, bevor du es noch einmal versuchst."
         http_code_message: 'HTTP %{code}: %{message}'
       enrich_scan:
         failed_to_fetch_photos_from_immich: Fehler beim Abrufen der Fotos von Immich
@@ -4182,6 +4189,7 @@ de:
       no_matches: Keine Übereinstimmungen innerhalb der Toleranz gefunden
       open_in_immich: In Immich öffnen
       partially_enriched: "%{enriched} Fotos bereichert. %{failed} fehlgeschlagen."
+      pending_enrichment: "%{count} Standortaktualisierungen an Immich gesendet; %{failed} konnten nicht gesendet werden. Du erhältst nach der Prüfung der gespeicherten Koordinaten eine Benachrichtigung."
       photos_without_gps:
         one: "%{count} Foto ohne GPS"
         other: "%{count} Fotos ohne GPS"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3417,6 +3417,13 @@ en:
         immich_api_key_missing_permission_asset_view: 'Immich API key missing permission: asset.view'
         immich_thumbnail_check_failed_code: 'Immich thumbnail check failed: %{code}'
       enrich_photos:
+        checking_title: Checking Immich location updates
+        checking: "Submitted %{count} location updates to Immich. Checking whether the coordinates were saved."
+        result_title: Immich location update results
+        confirmed:
+          one: "Confirmed the saved location for %{count} photo."
+          other: "Confirmed saved locations for %{count} photos."
+        unconfirmed: "Could not confirm saved locations for %{count} photos. Immich may still be processing the updates. Check its metadata jobs and your API key's asset.read permission. For external libraries, check that Immich can write XMP sidecar files: read-only mounts or file permissions can prevent saving. Once resolved, scan again before retrying."
         http_code_message: 'HTTP %{code}: %{message}'
       enrich_scan:
         failed_to_fetch_photos_from_immich: Failed to fetch photos from Immich
@@ -4121,6 +4128,7 @@ en:
       no_matches: No matches found within tolerance
       open_in_immich: Open in Immich
       partially_enriched: Enriched %{enriched} photos. %{failed} failed.
+      pending_enrichment: "Submitted %{count} location updates to Immich; %{failed} failed to send. You will receive a notification after the saved coordinates are checked."
       photos_without_gps:
         one: "%{count} photo without GPS"
         other: "%{count} photos without GPS"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3423,7 +3423,7 @@ en:
         confirmed:
           one: "Confirmed the saved location for %{count} photo."
           other: "Confirmed saved locations for %{count} photos."
-        unconfirmed: "Could not confirm saved locations for %{count} photos. Immich may still be processing the updates. Check its metadata jobs and your API key's asset.read permission. For external libraries, check that Immich can write XMP sidecar files: read-only mounts or file permissions can prevent saving. Once resolved, scan again before retrying."
+        unconfirmed: "Location updates still unconfirmed: %{count}. Immich may still be processing the updates. Check its metadata jobs and your API key's asset.read permission. For external libraries, check that Immich can write XMP sidecar files: read-only mounts or file permissions can prevent saving. Once resolved, scan again before retrying."
         http_code_message: 'HTTP %{code}: %{message}'
       enrich_scan:
         failed_to_fetch_photos_from_immich: Failed to fetch photos from Immich

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3436,6 +3436,13 @@ es:
         immich_api_key_missing_permission_asset_view: A la clave API de Immich le falta el permiso asset.view
         immich_thumbnail_check_failed_code: 'Falló el chequeo de miniatura en Immich: %{code}'
       enrich_photos:
+        checking_title: "Comprobando las actualizaciones de ubicación de Immich"
+        checking: "Se enviaron %{count} actualizaciones de ubicación a Immich. Comprobando si se guardaron las coordenadas."
+        result_title: "Resultados de las actualizaciones de ubicación de Immich"
+        confirmed:
+          one: "Ubicación guardada confirmada para %{count} foto."
+          other: "Ubicaciones guardadas confirmadas para %{count} fotos."
+        unconfirmed: "Actualizaciones de ubicación aún sin confirmar: %{count}. Es posible que Immich siga procesando los cambios. Comprueba sus tareas de metadatos y el permiso asset.read de tu clave API. En las bibliotecas externas, Immich debe poder escribir archivos auxiliares XMP: los montajes de solo lectura o los permisos de archivos pueden impedir que se guarden. Una vez resuelto, vuelve a buscar antes de reintentarlo."
         http_code_message: 'HTTP %{code}: %{message}'
       enrich_scan:
         failed_to_fetch_photos_from_immich: Falló obtener fotos desde Immich
@@ -4126,6 +4133,7 @@ es:
       no_matches: No se encontraron coincidencias dentro del umbral de tolerancia
       open_in_immich: Abrir en Immich
       partially_enriched: Mejorada %{enriched} fotos. %{failed} falló.
+      pending_enrichment: "Se enviaron %{count} actualizaciones de ubicación a Immich; %{failed} no se pudieron enviar. Recibirás una notificación cuando se comprueben las coordenadas guardadas."
       photos_without_gps:
         one: "%{count} foto sin GPS"
         other: "%{count} fotos sin GPS"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4531,6 +4531,13 @@ fr:
         immich_thumbnail_check_failed_code: 'Vérification de miniature Immich échouée :
           %{code}'
       enrich_photos:
+        checking_title: "Vérification des mises à jour de localisation Immich"
+        checking: "%{count} mises à jour de localisation envoyées à Immich. Vérification de l’enregistrement des coordonnées."
+        result_title: "Résultats des mises à jour de localisation Immich"
+        confirmed:
+          one: "Localisation enregistrée confirmée pour %{count} photo."
+          other: "Localisations enregistrées confirmées pour %{count} photos."
+        unconfirmed: "Mises à jour de localisation non confirmées : %{count}. Immich traite peut-être encore les modifications. Vérifiez ses tâches de métadonnées et l’autorisation asset.read de votre clé API. Pour les bibliothèques externes, Immich doit pouvoir écrire les fichiers annexes XMP : un montage en lecture seule ou les permissions des fichiers peuvent empêcher l’enregistrement. Après correction, relancez la recherche avant de réessayer."
         http_code_message: 'HTTP %{code} : %{message}'
       enrich_scan:
         failed_to_fetch_photos_from_immich: Impossible de récupérer les photos d'Immich
@@ -5399,6 +5406,7 @@ fr:
       no_matches: Aucune correspondance trouvée dans la tolérance
       open_in_immich: Ouvrir dans Immich
       partially_enriched: 'Photos enrichies : %{enriched}. Échecs : %{failed}'
+      pending_enrichment: "%{count} mises à jour de localisation envoyées à Immich ; %{failed} envois ont échoué. Une notification vous informera après la vérification des coordonnées enregistrées."
       photos_without_gps:
         one: "%{count} photo sans GPS"
         other: "%{count} photos sans GPS"

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -3484,6 +3484,15 @@ pl:
         immich_api_key_missing_permission_asset_view: 'Klucz API Immich nie ma uprawnienia: asset.view'
         immich_thumbnail_check_failed_code: 'Sprawdzenie miniatury Immich nie powiodło się: %{code}'
       enrich_photos:
+        checking_title: "Sprawdzanie aktualizacji lokalizacji w Immich"
+        checking: "Wysłano %{count} aktualizacji lokalizacji do Immich. Trwa sprawdzanie, czy współrzędne zostały zapisane."
+        result_title: "Wyniki aktualizacji lokalizacji w Immich"
+        confirmed:
+          one: "Potwierdzono zapisaną lokalizację dla %{count} zdjęcia."
+          other: "Potwierdzono zapisane lokalizacje dla %{count} zdjęć."
+          few: "Potwierdzono zapisane lokalizacje dla %{count} zdjęć."
+          many: "Potwierdzono zapisane lokalizacje dla %{count} zdjęć."
+        unconfirmed: "Niepotwierdzone aktualizacje lokalizacji: %{count}. Immich może nadal przetwarzać zmiany. Sprawdź zadania metadanych i uprawnienie asset.read klucza API. W bibliotekach zewnętrznych Immich musi mieć możliwość zapisywania plików pomocniczych XMP: montowanie tylko do odczytu lub uprawnienia plików mogą uniemożliwić zapis. Po rozwiązaniu problemu wyszukaj zdjęcia ponownie przed kolejną próbą."
         http_code_message: 'HTTP %{code}: %{message}'
       enrich_scan:
         failed_to_fetch_photos_from_immich: Nie udało się pobrać zdjęć z Immich
@@ -4185,6 +4194,7 @@ pl:
       no_matches: Nie znaleziono dopasowań w zakresie tolerancji
       open_in_immich: Otwórz w Immich
       partially_enriched: Uzupełniono %{enriched} zdjęć. Dla %{failed} nie udało się.
+      pending_enrichment: "Wysłano %{count} aktualizacji lokalizacji do Immich; %{failed} nie udało się wysłać. Otrzymasz powiadomienie po sprawdzeniu zapisanych współrzędnych."
       photos_without_gps:
         one: "%{count} zdjęcie bez GPS"
         other: "%{count} zdjęć bez GPS"

--- a/spec/jobs/immich/verify_enrichment_job_spec.rb
+++ b/spec/jobs/immich/verify_enrichment_job_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Immich::VerifyEnrichmentJob, type: :job do
+  let(:user) { create(:user, settings: { 'immich_url' => 'http://immich.test', 'immich_api_key' => 'test-key' }) }
+  let(:notification) { create(:notification, user:, title: 'Checking', content: 'Pending', kind: :info) }
+  let(:assets) { [{ 'immich_asset_id' => 'asset-1', 'latitude' => 52.52, 'longitude' => 13.405 }] }
+  let(:url) { 'http://immich.test' }
+
+  def metadata(id, latitude: 52.52, longitude: 13.405)
+    stub_request(:get, "#{url}/api/assets/#{id}")
+      .to_return(status: 200, body: { exifInfo: { latitude:, longitude: } }.to_json,
+                 headers: { 'content-type' => 'application/json' })
+  end
+
+  it 'confirms coordinates returned by Immich without writing any location updates' do
+    metadata('asset-1', latitude: 52.520000001)
+    described_class.perform_now(notification.id, assets, url)
+
+    expect(notification.reload).to be_info
+    expect(notification.content).to include('Confirmed the saved location for 1 photo')
+    expect(WebMock).not_to have_requested(:put, /immich/)
+  end
+
+  it 'explains unconfirmed writes and external-library permissions after bounded retries' do
+    metadata('asset-1', latitude: nil, longitude: nil)
+    perform_enqueued_jobs do
+      described_class.perform_later(notification.id, assets, url)
+    end
+
+    expect(notification.reload).to be_warning
+    expect(notification.content).to include('Could not confirm saved locations for 1 photos', 'read-only', 'XMP')
+    expect(WebMock).to have_requested(:get, "#{url}/api/assets/asset-1").times(3)
+  end
+
+  it 'allows a delayed metadata job to complete without warning prematurely' do
+    stub_request(:get, "#{url}/api/assets/asset-1").to_return(
+      { status: 200, body: '{"exifInfo": {"latitude": null, "longitude": null}}' },
+      { status: 200, body: '{"exifInfo": {"latitude": 52.52, "longitude": 13.405}}' }
+    )
+    perform_enqueued_jobs do
+      described_class.perform_later(notification.id, assets, url)
+    end
+
+    expect(notification.reload).to be_info
+    expect(notification.content).to include('Confirmed the saved location for 1 photo')
+    expect(WebMock).to have_requested(:get, "#{url}/api/assets/asset-1").twice
+  end
+
+  it 'does not confuse missing coordinates with a requested zero coordinate' do
+    metadata('asset-1', latitude: nil, longitude: nil)
+    assets.first.merge!('latitude' => 0, 'longitude' => 0)
+    described_class.perform_now(notification.id, assets, url, pass: 3)
+
+    expect(notification.reload).to be_warning
+  end
+
+  it 'preserves partial success across batches and retries only unconfirmed assets' do
+    batch = 21.times.map do |i|
+      metadata("asset-#{i}", latitude: i.zero? ? nil : 52.52)
+      assets.first.merge('immich_asset_id' => "asset-#{i}")
+    end
+    perform_enqueued_jobs do
+      described_class.perform_later(notification.id, batch, url)
+    end
+
+    expect(notification.reload.content).to include('Confirmed saved locations for 20 photos', 'for 1 photos')
+    expect(WebMock).to have_requested(:get, "#{url}/api/assets/asset-0").times(3)
+    expect(WebMock).to have_requested(:get, "#{url}/api/assets/asset-20").once
+  end
+
+  it 'keeps a replayed completion in the same notification' do
+    metadata('asset-1')
+    id = notification.id
+    expect do
+      2.times { described_class.perform_now(id, assets, url) }
+    end.not_to change(Notification, :count)
+  end
+
+  it 'does not query a different Immich instance after settings change' do
+    user.update!(settings: user.settings.merge('immich_url' => 'http://other.test'))
+    described_class.perform_now(notification.id, assets, url)
+
+    expect(notification.reload).to be_warning
+    expect(WebMock).not_to have_requested(:get, /immich|other/)
+  end
+
+  it 'ignores a deleted notification and its user' do
+    described_class.perform_now(-1, assets, url)
+    expect(WebMock).not_to have_requested(:get, /immich/)
+  end
+
+  [403, 500].each do |status|
+    it "reports that verification could not be completed after HTTP #{status}" do
+      stub_request(:get, "#{url}/api/assets/asset-1").to_return(status:)
+      described_class.perform_now(notification.id, assets, url, pass: 3)
+      expect(notification.reload).to be_warning
+      expect(notification.content).to include('asset.read')
+    end
+  end
+
+  it 'reports unconfirmed coordinates when the connection times out' do
+    stub_request(:get, "#{url}/api/assets/asset-1").to_timeout
+    described_class.perform_now(notification.id, assets, url, pass: 3)
+    expect(notification.reload).to be_warning
+  end
+
+  ['not json', 'null', '{"exifInfo": []}'].each do |body|
+    it "handles a malformed metadata response: #{body}" do
+      stub_request(:get, "#{url}/api/assets/asset-1").to_return(status: 200, body:)
+      described_class.perform_now(notification.id, assets, url, pass: 3)
+      expect(notification.reload).to be_warning
+    end
+  end
+end

--- a/spec/jobs/immich/verify_enrichment_job_spec.rb
+++ b/spec/jobs/immich/verify_enrichment_job_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Immich::VerifyEnrichmentJob, type: :job do
     end
 
     expect(notification.reload).to be_warning
-    expect(notification.content).to include('Could not confirm saved locations for 1 photos', 'read-only', 'XMP')
+    expect(notification.content).to include('Location updates still unconfirmed: 1', 'read-only', 'XMP')
     expect(WebMock).to have_requested(:get, "#{url}/api/assets/asset-1").times(3)
   end
 
@@ -65,7 +65,8 @@ RSpec.describe Immich::VerifyEnrichmentJob, type: :job do
       described_class.perform_later(notification.id, batch, url)
     end
 
-    expect(notification.reload.content).to include('Confirmed saved locations for 20 photos', 'for 1 photos')
+    expect(notification.reload.content).to include('Confirmed saved locations for 20 photos',
+                                                   'Location updates still unconfirmed: 1')
     expect(WebMock).to have_requested(:get, "#{url}/api/assets/asset-0").times(3)
     expect(WebMock).to have_requested(:get, "#{url}/api/assets/asset-20").once
   end

--- a/spec/regressions/immich_enrichment_confirmation_spec.rb
+++ b/spec/regressions/immich_enrichment_confirmation_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Immich enrichment confirmation' do
+  let(:user) { create(:user, settings: { 'immich_url' => 'http://immich.test', 'immich_api_key' => 'test-key' }) }
+  let(:assets) { [{ 'immich_asset_id' => 'asset-1', 'latitude' => 52.52, 'longitude' => 13.405 }] }
+
+  it 'does not claim that an accepted asynchronous update has been saved' do
+    stub_request(:put, 'http://immich.test/api/assets/asset-1')
+      .to_return(status: 200, body: '{}', headers: { 'content-type' => 'application/json' })
+
+    result = Immich::EnrichPhotos.new(user, assets).call
+
+    expect(result).to include(enriched: 0, pending: 1, failed: 0)
+  end
+end

--- a/spec/regressions/immich_enrichment_confirmation_spec.rb
+++ b/spec/regressions/immich_enrichment_confirmation_spec.rb
@@ -15,3 +15,30 @@ RSpec.describe 'Immich enrichment confirmation' do
     expect(result).to include(enriched: 0, pending: 1, failed: 0)
   end
 end
+
+RSpec.describe 'Immich result notification rendering', type: :request do
+  let(:user) { create(:user) }
+  let!(:notification) { create(:notification, user:, title: 'Checking Immich updates', content: 'Pending') }
+
+  it 'keeps the detail card distinct from its navbar item' do
+    sign_in user
+    get notifications_path
+    expect(Nokogiri::HTML(response.body).css("#navbar_notification_#{notification.id}").size).to eq(1)
+    get notification_path(notification)
+    html = Nokogiri::HTML(response.body)
+
+    expect(html.css("#detail_notification_#{notification.id}").size).to eq(1)
+    expect(html.css("#navbar_notification_#{notification.id}").size).to be <= 1
+    expect(html.at_css("#detail_notification_#{notification.id}").text).to include('Pending')
+  end
+
+  it 'broadcasts the full result to the detail card after it has been read' do
+    notification.update!(read_at: Time.current)
+    expect do
+      notification.update_with_broadcast!(content: 'Check XMP write permissions', kind: :warning, read_at: nil)
+    end.to have_broadcasted_to("#{user.to_gid_param}:notifications").with(
+      a_string_including("target=\"detail_notification_#{notification.id}\"", 'Check XMP write permissions')
+    )
+    expect(notification.reload).not_to be_read
+  end
+end

--- a/spec/regressions/imports_surface_zero_points_without_timestamps_spec.rb
+++ b/spec/regressions/imports_surface_zero_points_without_timestamps_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Imports surface zero points with no timestamps', type: :request 
       sign_in user
       get notification_url(notification)
 
-      rendered_notification = Nokogiri::HTML(response.body).at_css("#notification_#{notification.id}")
+      rendered_notification = Nokogiri::HTML(response.body).at_css("#detail_notification_#{notification.id}")
       expect(rendered_notification.text).to include('<time>')
     end
   end

--- a/spec/requests/api/v1/immich/enrich_spec.rb
+++ b/spec/requests/api/v1/immich/enrich_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe 'Api::V1::Immich::Enrich', type: :request do
 
         expect(response).to have_http_status(:ok)
         body = response.parsed_body
-        expect(body['enriched']).to eq(1)
+        expect(body['enriched']).to eq(0)
+        expect(body['pending']).to eq(1)
         expect(body['failed']).to eq(0)
       end
     end

--- a/spec/services/immich/enrich_photos_spec.rb
+++ b/spec/services/immich/enrich_photos_spec.rb
@@ -25,10 +25,11 @@ RSpec.describe Immich::EnrichPhotos do
           .to_return(status: 200, body: '{}', headers: { 'content-type' => 'application/json' })
       end
 
-      it 'returns enriched count' do
+      it 'returns pending count' do
         result = service.call
 
-        expect(result[:enriched]).to eq(2)
+        expect(result[:enriched]).to eq(0)
+        expect(result[:pending]).to eq(2)
         expect(result[:failed]).to eq(0)
         expect(result[:errors]).to be_empty
       end
@@ -62,7 +63,8 @@ RSpec.describe Immich::EnrichPhotos do
       it 'returns partial results' do
         result = service.call
 
-        expect(result[:enriched]).to eq(1)
+        expect(result[:enriched]).to eq(0)
+        expect(result[:pending]).to eq(1)
         expect(result[:failed]).to eq(1)
       end
 
@@ -86,7 +88,8 @@ RSpec.describe Immich::EnrichPhotos do
       it 'continues processing remaining assets after failure' do
         result = service.call
 
-        expect(result[:enriched]).to eq(1)
+        expect(result[:enriched]).to eq(0)
+        expect(result[:pending]).to eq(1)
         expect(result[:failed]).to eq(1)
       end
     end

--- a/spec/swagger/api/v1/immich/enrich_controller_spec.rb
+++ b/spec/swagger/api/v1/immich/enrich_controller_spec.rb
@@ -60,7 +60,8 @@ describe 'Immich Enrich API', type: :request do
     post 'Writes location data back to Immich photos' do
       tags 'Immich'
       description 'Pushes latitude/longitude updates for the supplied Immich asset IDs back to the ' \
-                  "user's Immich instance."
+                  "user's Immich instance. Accepted updates are returned as pending; " \
+                  'background verification reports saved coordinates or actionable warnings through notifications.'
       consumes 'application/json'
       produces 'application/json'
       parameter name: :api_key, in: :query, type: :string, required: true, description: 'API Key'
@@ -84,7 +85,7 @@ describe 'Immich Enrich API', type: :request do
         required: %w[assets]
       }
 
-      response '200', 'enrich completed' do
+      response '200', 'updates submitted' do
         schema type: :object, additionalProperties: true
 
         let(:payload) do
@@ -93,7 +94,7 @@ describe 'Immich Enrich API', type: :request do
 
         before do
           allow_any_instance_of(Immich::EnrichPhotos).to receive(:call).and_return(
-            updated: 1, failed: 0
+            enriched: 0, pending: 1, failed: 0, errors: []
           )
         end
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1716,7 +1716,9 @@ paths:
       tags:
       - Immich
       description: Pushes latitude/longitude updates for the supplied Immich asset
-        IDs back to the user's Immich instance.
+        IDs back to the user's Immich instance. Accepted updates are returned as pending;
+        background verification reports saved coordinates or actionable warnings through
+        notifications.
       parameters:
       - name: api_key
         in: query
@@ -1726,7 +1728,7 @@ paths:
           type: string
       responses:
         '200':
-          description: enrich completed
+          description: updates submitted
           content:
             application/json:
               schema:


### PR DESCRIPTION
Immich can accept a location update before its metadata job saves it. With a read-only external library, the request succeeds but writing the XMP sidecar fails; Dawarich previously reported those photos as enriched.

Return a pending count after submission and verify the saved coordinates in background batches of 20, with up to three passes. Update one notification with confirmed and unconfirmed counts. The warning explains metadata processing, `asset.read`, and external-library/XMP write permissions without assuming every unconfirmed update is a read-only failure. Live notification updates preserve the full detail view and use distinct DOM IDs for the menu, list, and detail card. Messages are translated into every supported locale.

Validation:
- Reproduced the original false-success behavior before fixing it, including a failing regression test.
- Real Immich 2.7.5: two identical GPS-free photos in RO and RW external libraries; both PUTs accepted, only RW coordinates persisted. The new verifier confirms one and warns about the other after its bounded retries.
- 232 JavaScript tests passed; 28 focused RSpec examples passed; changed Ruby files pass RuboCop.
- Final full RSpec: **9,387 examples, 0 failures** (7m50s).
- Playwright: actual map controls submit selected coordinates and show pending confirmation instead of success; final actionable notification is visible in the browser. The UI test stubs the API boundary; the real-Immich experiment separately validates persistence.

Review: two post-publication engineering and product rounds approved, and two QA passes found no verified PR-introduced defects. Browser validation covers actual Rails-rendered Turbo payloads, repeat delivery, detail/list navigation, and a 390px viewport. **Live WebSocket delivery remains unverified**: the isolated test server connected but did not confirm its Turbo subscription; separate-process persistence and page reload succeeded.

Companion Playwright regression: https://github.com/Freika/e2e-dawarich-playwright/pull/7.

No schema migration or point-table writes are introduced. Verification uses the user's existing integration and stops if its URL changes or its key is removed.

Refs #3065. Leave the issue open for release verification.
