### PR TITLE
fix: refresh historical statistics after reverse geocoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Historical country and city statistics refresh after reverse geocoding, with bounded monthly repairs and protection against concurrent recalculation (#3499).
+
 - Traccar latitude/longitude form uploads now save points, including Unix timestamps in seconds or milliseconds. Payloads that cannot be stored return an error instead of a false success; repeated valid uploads remain safe. (#3299)
 ## Unreleased
 

--- a/app/services/reverse_geocoding/points/fetch_data.rb
+++ b/app/services/reverse_geocoding/points/fetch_data.rb
@@ -42,13 +42,18 @@ class ReverseGeocoding::Points::FetchData
     country_record = find_country(response) if response.country
 
     with_write_retry do
-      point.update!(
-        city: response.city,
-        country_name: response.country,
-        country_id: country_record&.id,
-        geodata: DawarichSettings.store_geodata? ? response.data : {},
-        reverse_geocoded_at: Time.current
-      )
+      Point.transaction do
+        point.update!(
+          city: response.city,
+          country_name: response.country,
+          country_id: country_record&.id,
+          geodata: DawarichSettings.store_geodata? ? response.data : {},
+          reverse_geocoded_at: Time.current
+        )
+        if point.saved_change_to_city? || point.saved_change_to_country_name? || point.saved_change_to_country_id?
+          Stats::InvalidateGeocodedMonth.call(point)
+        end
+      end
     end
   rescue *ReverseGeocoding::ProviderErrors::TRANSIENT => e
     Rails.logger.warn("Reverse geocoding provider error for point #{point.id}: #{e.message}")

--- a/app/services/stats/calculate_month.rb
+++ b/app/services/stats/calculate_month.rb
@@ -117,8 +117,8 @@ class Stats::CalculateMonth
       return unless stat
 
       # Points may arrive after the initial empty check while another calculation
-      # finishes. Recheck under the same lock before clearing its result.
-      if points.exists?
+      # finishes. Recheck under the same lock without the earlier query cache.
+      if Point.uncached { points.exists? }
         update_month_stats(year, month)
         return
       end

--- a/app/services/stats/calculate_month.rb
+++ b/app/services/stats/calculate_month.rb
@@ -112,19 +112,28 @@ class Stats::CalculateMonth
   end
 
   def reset_month_stats(year, month)
-    stat = Stat.find_by(year:, month:, user:)
-    return unless stat
+    Stat.transaction do
+      stat = Stat.lock.find_by(year:, month:, user:)
+      return unless stat
 
-    stat.update!(
-      daily_distance: {},
-      distance: 0,
-      flight_distance: flight_distance,
-      toponyms: [],
-      h3_hex_ids: {},
-      calculation_version: CALCULATION_VERSION
-    )
+      # Points may arrive after the initial empty check while another calculation
+      # finishes. Recheck under the same lock before clearing its result.
+      if points.exists?
+        update_month_stats(year, month)
+        return
+      end
 
-    Cache::InvalidateUserCaches.new(user.id, year: year).call
+      stat.update!(
+        daily_distance: {},
+        distance: 0,
+        flight_distance: flight_distance,
+        toponyms: [],
+        h3_hex_ids: {},
+        calculation_version: CALCULATION_VERSION
+      )
+
+      Cache::InvalidateUserCaches.new(user.id, year: year).call
+    end
   end
 
   def calculate_h3_hex_ids

--- a/app/services/stats/calculate_month.rb
+++ b/app/services/stats/calculate_month.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Stats::CalculateMonth
-  CALCULATION_VERSION = 1
+  CALCULATION_VERSION = 2
 
   def initialize(user_id, year, month, notify_on_failure: true)
     @user = User.find(user_id)
@@ -34,7 +34,10 @@ class Stats::CalculateMonth
 
   def update_month_stats(year, month)
     Stat.transaction do
-      stat = Stat.find_or_initialize_by(year:, month:, user:)
+      stat = Stat.find_or_create_by!(year:, month:, user:) { |record| record.distance = 0 }
+      # Serialize recalculation with geocoding invalidation for this month.
+      # A geocoder finishing during this calculation must leave the month stale.
+      stat.lock!
       distance_by_day = stat.distance_by_day
 
       stat.assign_attributes(

--- a/app/services/stats/invalidate_geocoded_month.rb
+++ b/app/services/stats/invalidate_geocoded_month.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Stats::InvalidateGeocodedMonth
+  def self.call(point)
+    date = Time.at(point.timestamp).in_time_zone(point.user.timezone_iana)
+    Stat.transaction do
+      stat = Stat.find_or_create_by!(user_id: point.user_id, year: date.year, month: date.month) do |record|
+        record.distance = 0
+      end
+      stat.lock!
+      stat.update_columns(calculation_version: 0) unless stat.calculation_version.zero?
+    end
+  end
+end

--- a/spec/regressions/empty_month_calculation_preserves_new_points_spec.rb
+++ b/spec/regressions/empty_month_calculation_preserves_new_points_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Empty monthly calculation after historical points arrive', type:
     repairs = enqueued_jobs.count { |job| job[:job] == Stats::CalculatingJob }
     stat.reload
     expect(stat.toponyms.present? || repairs.positive?).to be(true),
-                                                           'Previously recovered historical country/city data was erased and no repair remains eligible'
+                                                           'Recovered data was erased without a pending repair'
   ensure
     release_old&.count_down
     old&.join(20)

--- a/spec/regressions/empty_month_calculation_preserves_new_points_spec.rb
+++ b/spec/regressions/empty_month_calculation_preserves_new_points_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Deliberately avoids :non_transactional, whose shared helper truncates tables.
+# This standalone group cleans only the user/rows it creates.
+RSpec.describe 'Empty monthly calculation after historical points arrive', type: :request do
+  before(:context) { self.class.use_transactional_tests = false }
+  after(:context) { self.class.use_transactional_tests = true }
+
+  it 'does not let an older empty calculation erase completed historical recovery' do
+    owner = create(:user, stats_swept_at: Time.current,
+                          settings: { 'timezone' => 'Asia/Tokyo', 'min_minutes_spent_in_city' => 10 })
+    existing_country = Country.find_by(iso_a2: 'DE')
+    country = existing_country || create(:country, name: 'Germany', iso_a2: 'DE', iso_a3: 'DEU')
+    stat = create(:stat, user: owner, year: 2015, month: 1, toponyms: [], calculation_version: 0)
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+    allow(Geocoder).to receive(:search).and_return([double(city: 'Berlin', country: country.name, country_code: 'DE',
+                                                           data: {})])
+    empty_read = Concurrent::CountDownLatch.new(1)
+    release_old = Concurrent::CountDownLatch.new(1)
+    calculator = Stats::CalculateMonth.new(owner.id, 2015, 1)
+    allow(calculator).to receive(:reset_month_stats).and_wrap_original do |original, *args|
+      empty_read.count_down
+      raise 'Timed out releasing old calculation' unless release_old.wait(15)
+
+      original.call(*args)
+    end
+    old_pid = nil
+    old = Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection do |connection|
+        old_pid = connection.select_value('SELECT pg_backend_pid()')
+        calculator.call
+      end
+    end
+    expect(empty_read.wait(10)).to be(true)
+    new_pid = ActiveRecord::Base.connection.select_value('SELECT pg_backend_pid()')
+    expect(old_pid).not_to eq(new_pid)
+    points = 3.times.map do |i|
+      create(:point, user: owner, timestamp: Time.utc(2014, 12, 31, 23, i * 10).to_i,
+                     latitude: 52.52, longitude: 13.405)
+    end
+    points.each { |point| ReverseGeocoding::Points::FetchData.new(point.id).call }
+    expect(stat.reload.calculation_version).to eq(0)
+    Stats::CalculatingJob.perform_now(owner.id, 2015, 1)
+    expect(stat.reload.toponyms).not_to be_empty
+    expect(stat.calculation_version).to eq(Stats::CalculateMonth::CALCULATION_VERSION)
+    release_old.count_down
+    expect(old.join(10)).not_to be_nil
+    old.value
+    clear_enqueued_jobs
+    Stats::BulkCalculator.new(owner.id).call
+    repairs = enqueued_jobs.count { |job| job[:job] == Stats::CalculatingJob }
+    expect(stat.toponyms.present? || repairs.positive?).to be(true),
+                                                           'Previously recovered historical country/city data was erased and no repair remains eligible'
+  ensure
+    release_old&.count_down
+    old&.join(20)
+    if owner
+      Cache::InvalidateUserCaches.new(owner.id).call
+      Point.where(user_id: owner.id).delete_all
+      Stat.where(user_id: owner.id).delete_all
+      owner.destroy!
+    end
+    country&.destroy! if defined?(existing_country) && existing_country.nil?
+  end
+end

--- a/spec/regressions/empty_month_calculation_preserves_new_points_spec.rb
+++ b/spec/regressions/empty_month_calculation_preserves_new_points_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Empty monthly calculation after historical points arrive', type:
     old = Thread.new do
       ActiveRecord::Base.connection_pool.with_connection do |connection|
         old_pid = connection.select_value('SELECT pg_backend_pid()')
-        calculator.call
+        ActiveRecord::Base.cache { calculator.call }
       end
     end
     expect(empty_read.wait(10)).to be(true)
@@ -51,6 +51,7 @@ RSpec.describe 'Empty monthly calculation after historical points arrive', type:
     clear_enqueued_jobs
     Stats::BulkCalculator.new(owner.id).call
     repairs = enqueued_jobs.count { |job| job[:job] == Stats::CalculatingJob }
+    stat.reload
     expect(stat.toponyms.present? || repairs.positive?).to be(true),
                                                            'Previously recovered historical country/city data was erased and no repair remains eligible'
   ensure

--- a/spec/regressions/geocoded_historical_stats_refresh_spec.rb
+++ b/spec/regressions/geocoded_historical_stats_refresh_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Geocoded historical statistics' do
+  it 'schedules a historical month again after country data arrives' do
+    user = create(:user, stats_swept_at: Time.current, settings: { 'timezone' => 'Etc/UTC' })
+    point = create(:point, user:, timestamp: Time.utc(2014, 6, 15, 12).to_i)
+    stat = create(:stat, user:, year: 2014, month: 6, toponyms: [],
+                         calculation_version: Stats::CalculateMonth::CALCULATION_VERSION)
+    country = create(:country, name: 'Germany', iso_a2: 'DE', iso_a3: 'DEU')
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+    allow(Geocoder).to receive(:search).and_return([
+                                                     double(city: 'Berlin', country: country.name, country_code: 'DE',
+                                                            data: {})
+                                                   ])
+    clear_enqueued_jobs
+
+    ReverseGeocoding::Points::FetchData.new(point.id).call
+
+    expect(point.reload.country_id).to eq(country.id)
+    expect(point.city).to eq('Berlin')
+    expect(stat.reload.toponyms).to eq([])
+    Stats::BulkCalculator.new(user.id).call
+
+    expect(Stats::CalculatingJob).to have_been_enqueued.with(user.id, 2014, 6, notify_on_failure: false)
+  end
+end

--- a/spec/regressions/geocoding_during_stats_calculation_spec.rb
+++ b/spec/regressions/geocoding_during_stats_calculation_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Geocoding during monthly calculation', :non_transactional, threads: 3 do
+  it 'preserves invalidation when geocoding finishes after statistics read the points' do
+    user = create(:user, settings: { 'timezone' => 'Etc/UTC' })
+    point = create(:point, user:, timestamp: Time.utc(2014, 6, 15, 12).to_i)
+    stat = create(:stat, user:, year: 2014, month: 6, toponyms: [], calculation_version: 0)
+    allow(DawarichSettings).to receive(:reverse_geocoding_enabled?).and_return(true)
+    allow(Geocoder).to receive(:search).and_return([
+                                                     double(city: 'Berlin', country: 'Germany', country_code: 'DE',
+                                                            data: {})
+                                                   ])
+    read_points = Concurrent::CountDownLatch.new(1)
+    release_calculation = Concurrent::CountDownLatch.new(1)
+    geocoded = Concurrent::CountDownLatch.new(1)
+    calculator = Stats::CalculateMonth.new(user.id, 2014, 6)
+    allow(calculator).to receive(:toponyms).and_wrap_original do |method|
+      result = method.call
+      read_points.count_down
+      raise 'calculation release timed out' unless release_calculation.wait(10)
+
+      result
+    end
+    allow(Stats::InvalidateGeocodedMonth).to receive(:call).and_wrap_original do |method, record|
+      geocoded.count_down
+      method.call(record)
+    end
+
+    calculation = Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection { calculator.call }
+    end
+    expect(read_points.wait(10)).to be(true)
+    geocoding = Thread.new do
+      ActiveRecord::Base.connection_pool.with_connection do
+        ReverseGeocoding::Points::FetchData.new(point.id).call
+      end
+    end
+    expect(geocoded.wait(10)).to be(true)
+    release_calculation.count_down
+    expect(calculation.join(10)).not_to be_nil
+    expect(geocoding.join(10)).not_to be_nil
+    calculation.value
+    geocoding.value
+
+    expect(point.reload.city).to eq('Berlin')
+    expect(stat.reload.calculation_version).to eq(0)
+    Stats::CalculateMonth.new(user.id, 2014, 6).call
+    expect(stat.reload.calculation_version).to eq(Stats::CalculateMonth::CALCULATION_VERSION)
+  ensure
+    release_calculation&.count_down
+    [calculation, geocoding].compact.each { |thread| thread.join(10) }
+    Stat.where(user_id: user&.id).delete_all
+  end
+end

--- a/spec/services/stats/calculate_month_spec.rb
+++ b/spec/services/stats/calculate_month_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Stats::CalculateMonth do
 
         context 'when there is an error' do
           before do
-            allow(Stat).to receive(:find_or_initialize_by).and_raise(StandardError)
+            allow(Stats::DailyDistanceQuery).to receive(:new).and_raise(StandardError)
           end
 
           it 'does not create stats' do

--- a/spec/services/stats/invalidate_geocoded_month_spec.rb
+++ b/spec/services/stats/invalidate_geocoded_month_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Stats::InvalidateGeocodedMonth do
+  let(:user) { create(:user, settings: { 'timezone' => 'Asia/Tokyo' }) }
+  let(:point) { create(:point, user:, timestamp: Time.utc(2014, 12, 31, 23, 30).to_i) }
+
+  it 'invalidates the account-local month across the year boundary' do
+    december = create(:stat, user:, year: 2014, month: 12, calculation_version: 1)
+    january = create(:stat, user:, year: 2015, month: 1, calculation_version: 1)
+
+    described_class.call(point)
+
+    expect(january.reload.calculation_version).to eq(0)
+    expect(december.reload.calculation_version).to eq(1)
+  end
+
+  it 'coalesces repeated invalidations into one stats update' do
+    stat = create(:stat, user:, year: 2015, month: 1, calculation_version: 1)
+    point.id
+    updates = []
+    subscriber = lambda do |*args|
+      sql = args.last[:sql]
+      updates << sql if sql.match?(/UPDATE "stats"/)
+    end
+
+    ActiveSupport::Notifications.subscribed(subscriber, 'sql.active_record') do
+      10.times { described_class.call(point) }
+    end
+
+    expect(stat.reload.calculation_version).to eq(0)
+    expect(updates.size).to eq(1)
+  end
+
+  it 'leaves a new month eligible for repair if initial statistics are not ready' do
+    expect { described_class.call(point) }.to change { user.stats.count }.by(1)
+    stat = user.stats.find_by!(year: 2015, month: 1)
+    expect(stat.calculation_version).to eq(0)
+    expect(stat.distance).to eq(0)
+  end
+
+  it 'does not invalidate another user statistics' do
+    other = create(:stat, year: 2015, month: 1, calculation_version: 1)
+
+    described_class.call(point)
+
+    expect(other.reload.calculation_version).to eq(1)
+  end
+end


### PR DESCRIPTION
Historical imports can calculate monthly statistics before reverse geocoding completes. The points later acquire countries and cities, while Insights continues reading empty cached monthly toponyms.

Mark the point's account-local month stale when reverse geocoding changes its country or city, atomically with the point update. Repeated changes coalesce into one stale month and reuse the existing hourly repair sweep: **at most five stale months per user per run**, with the existing scheduling jitter. Recovery is gradual, including previously calculated statistics through calculation version 2.

Monthly calculation and geocoding invalidation lock the same monthly statistics row. A geocoder finishing while calculation reads points leaves that month eligible for another pass. The existing unique index handles concurrent first creation. No schema migration or table-wide data update is added. Geocoding may wait for an active calculation of the same month; this protects against losing invalidation.

Validation:
- Reproduced on current `dev` before changing production code: a 2014 point receives Berlin/Germany, but no recalculation job is queued for its existing monthly row.
- Final GitHub CI on `638bc2d8`: **9,377 RSpec examples, 0 failures**; all checks green ([run](https://github.com/Freika/dawarich/actions/runs/33931093679)). Local focused tests: **75 examples, 0 failures** on functional head `f1233fd6`; all eight changed Ruby files pass RuboCop.
- Independent QA verifies actual Insights API/HTML counters going from 0 countries/0 cities to 1/1, including Tokyo's year boundary and a previously absent month.
- Repeated post-publication reviews found and fixed an old empty calculation overwriting newer results, reuse of a stale Rails query-cache result, and a stale in-memory assertion in the regression. Real two-connection PostgreSQL tests fail on the broken code and pass after the fixes, including with query cache enabled.
- Final engineering, QA, and product reviews approve the functional head. GitHub checks are rerunning after the final assertion-message formatting fix.
- An earlier full run exposed an unchanged flaky GPX assertion: import ID259 happened to occur inside a hexadecimal tracker hash. The hash was correctly stable across imports; this coincidence was reproduced separately. No GPX code/test is changed here.

The empty-month reset also holds the monthly lock and rechecks points without query cache before clearing data, preserving a newer completed calculation.

Refs #3499. Leave the issue open for release verification.

