### PR TITLE
Fix segment speed coloring in tiled routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Speed coloring in tiled maps now reflects individual route segments when zoomed in, instead of the average speed of the whole track. Segment speeds are rounded to the nearest km/h to keep long date ranges compact. (Refs #3425)
+
 - Traccar latitude/longitude form uploads now save points, including Unix timestamps in seconds or milliseconds. Payloads that cannot be stored return an error instead of a false success; repeated valid uploads remain safe. (#3299)
 ## Unreleased
 

--- a/app/controllers/api/v1/tiles/tracks_controller.rb
+++ b/app/controllers/api/v1/tiles/tracks_controller.rb
@@ -5,25 +5,44 @@ class Api::V1::Tiles::TracksController < ApiController
 
   # ETag material — bump when Tracks::VectorTileQuery's SQL or its emitted
   # properties change.
-  TILE_SCHEMA_VERSION = 1
+  TILE_SCHEMA_VERSION = 2
+
+  rescue_from Tracks::SpeedVectorTileQuery::FeatureLimitError do
+    force_uncacheable_response
+    render json: { error: 'Too many route segments in this tile. Zoom in or shorten the date range.' },
+           status: :service_unavailable
+  end
 
   private
 
   def tile_schema_version
-    TILE_SCHEMA_VERSION
+    [TILE_SCHEMA_VERSION, speed_coloring?]
   end
 
   def tile_epoch_component
-    Tracks::TileEpoch.etag_component(current_api_user.id, cacheable_start_at, cacheable_end_at)
+    tracks_epoch = Tracks::TileEpoch.etag_component(current_api_user.id, cacheable_start_at, cacheable_end_at)
+    return tracks_epoch unless speed_coloring?
+
+    # Overlap semantics render whole tracks, including their portions outside
+    # the requested dates. Point edits in those portions must invalidate too.
+    first_at, last_at = filtered_tracks.pick(Arel.sql('MIN(start_at), MAX(end_at)'))
+    [tracks_epoch, Points::TileEpoch.etag_component(current_api_user.id, first_at, last_at)]
   end
 
   def tile_query
-    Tracks::VectorTileQuery.new(
+    options = {
       scope: filtered_tracks,
       z: params[:z],
       x: params[:x],
       y: params[:y]
-    )
+    }
+    return Tracks::VectorTileQuery.new(**options) unless speed_coloring?
+
+    Tracks::SpeedVectorTileQuery.new(points_scope: current_api_user.scoped_points, **options)
+  end
+
+  def speed_coloring?
+    params[:speed_coloring] == 'true'
   end
 
   def filtered_tracks

--- a/app/javascript/controllers/maps/maplibre/routes_manager.js
+++ b/app/javascript/controllers/maps/maplibre/routes_manager.js
@@ -77,7 +77,7 @@ export class RoutesManager {
     }
 
     if (tiledPointsActive(SettingsManager.getSettings())) {
-      // Per-track approximation on the tile layer; no bulk routes to rebuild.
+      // Reload speed segments through the tile source; keep the date range.
       const tracksMvtLayer = this.layerManager.getLayer("tracks-mvt")
       tracksMvtLayer?.setSpeedColoring(
         enabled,

--- a/app/javascript/maps_maplibre/layers/tracks_mvt_layer.js
+++ b/app/javascript/maps_maplibre/layers/tracks_mvt_layer.js
@@ -45,8 +45,8 @@ const MAX_SPEED_KMH = 150
 
 /**
  * Vector-tile line layer serving BOTH the Tracks and Routes toggles under
- * tiled mode. Coloring is per-track (avg_speed / flat), an approximation of
- * classic per-vertex speed gradients — disclosed in the settings copy.
+ * tiled mode. Speed tiles carry consecutive point segments when zoomed in;
+ * the overview keeps the same flat-color behavior as classic routes.
  */
 export class TracksMvtLayer extends BaseLayer {
   constructor(map, options = {}) {
@@ -175,19 +175,26 @@ export class TracksMvtLayer extends BaseLayer {
     ]
   }
 
-  // Color precedence: speed scale (approximate, per-track) > the user's route
+  // Color precedence: segment speed scale > the user's route
   // color when only Routes drives the layer > the track color.
   _lineColor() {
+    const flatColor = this._routesOnly() ? this.routeColor : this.trackColor
     if (this.speedColoredRoutes) {
       const stops = parseSpeedColorScale(this.speedColorScale)
       if (stops) {
         const expression = [
           "interpolate",
           ["linear"],
-          ["min", MAX_SPEED_KMH, ["coalesce", ["get", "avg_speed"], 0]],
+          ["min", MAX_SPEED_KMH, ["coalesce", ["get", "segment_speed"], 0]],
         ]
         for (const [speed, color] of stops) expression.push(speed, color)
-        return expression
+        return [
+          "step",
+          ["zoom"],
+          flatColor,
+          8,
+          ["case", ["has", "segment_speed"], expression, flatColor],
+        ]
       }
     }
     if (this._routesOnly()) return this.routeColor
@@ -224,6 +231,9 @@ export class TracksMvtLayer extends BaseLayer {
   setSpeedColoring(enabled, scale = this.speedColorScale) {
     this.speedColoredRoutes = enabled === true
     this.speedColorScale = scale
+    if (this.map.getSource(this.sourceId)) {
+      this.update({ startAt: this.startAt, endAt: this.endAt })
+    }
     this._repaint()
   }
 
@@ -269,6 +279,9 @@ export class TracksMvtLayer extends BaseLayer {
 
     if (startAt) params.set("start_at", startAt)
     if (endAt) params.set("end_at", endAt)
+    if (this.speedColoredRoutes && parseSpeedColorScale(this.speedColorScale)) {
+      params.set("speed_coloring", "true")
+    }
     // Never the raw api key: the Bearer header authenticates (transformRequest)
     if (this.apiKey) params.set("u", trackCachePartitioner(this.apiKey))
 

--- a/app/queries/tracks/speed_vector_tile_query.rb
+++ b/app/queries/tracks/speed_vector_tile_query.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# Speed colors need the timestamps of consecutive points, which original_path
+# does not contain. Read them only for intersecting tracks when coloring is on.
+class Tracks::SpeedVectorTileQuery < Tracks::VectorTileQuery
+  class FeatureLimitError < StandardError; end
+
+  MIN_SPEED_ZOOM = 8
+  # Combining equal whole-km/h speeds into one multi-line feature per track
+  # preserves each segment's speed to 0.5 km/h and avoids repeating popup
+  # metadata hundreds of thousands of times over a long date range.
+  MAX_SPEED_FEATURES_PER_TILE = 50_000
+
+  def initialize(points_scope:, **options)
+    @points_scope = points_scope
+    super(**options)
+  end
+
+  def call
+    super.tap do |result|
+      raise FeatureLimitError if z >= MIN_SPEED_ZOOM && result.truncated?
+    end
+  end
+
+  private
+
+  def tile_feature_limit
+    z < MIN_SPEED_ZOOM ? super : MAX_SPEED_FEATURES_PER_TILE + 1
+  end
+
+  # Materialize only the small per-segment geometry before the grouping sort;
+  # otherwise PostgreSQL carries full original_path copies into that sort.
+  def with_clauses
+    return super if z < MIN_SPEED_ZOOM
+
+    <<~SQL
+      WITH candidates AS MATERIALIZED (
+        SELECT * FROM (#{tile_scope.to_sql}) AS tracks
+        WHERE ST_Intersects(tracks.original_path, ST_Transform(#{margined_envelope}, 4326))
+      ), geometries AS MATERIALIZED (
+        SELECT tracks.id,
+          ROUND(segments.segment_speed::numeric)::double precision AS segment_speed,
+          ST_AsMVTGeom(
+            ST_Transform(COALESCE(segments.path, tracks.original_path), 3857),
+            ST_TileEnvelope(#{z}, #{x}, #{y}), #{EXTENT}, #{BUFFER}, true
+          ) AS geom
+        FROM candidates AS tracks
+        LEFT JOIN LATERAL (#{segments_sql}) AS segments ON true
+      ), grouped_segments AS (
+        SELECT id, segment_speed, ST_Collect(geom) AS geom
+        FROM geometries WHERE geom IS NOT NULL
+        GROUP BY id, segment_speed
+        LIMIT #{tile_feature_limit}
+      ), features AS (
+        SELECT #{property_columns}, grouped_segments.segment_speed, grouped_segments.geom
+        FROM grouped_segments JOIN candidates AS tracks USING (id)
+      )
+    SQL
+  end
+
+  # Compute neighbors before clipping: even two off-screen endpoints can have
+  # a visible connecting segment. The existing (track_id, timestamp) index
+  # supports this scan; no Point objects or raw metadata enter Ruby or JS.
+  def segments_sql
+    <<~SQL
+      SELECT ST_MakeLine(previous_position, position) AS path,
+        CASE WHEN timestamp > previous_timestamp THEN
+          LEAST(150.0, ST_DistanceSphere(previous_position, position) * 3.6 /
+                       (timestamp - previous_timestamp))
+        ELSE 0.0 END AS segment_speed
+      FROM (
+        SELECT points.timestamp, points.lonlat::geometry AS position,
+          LAG(points.lonlat::geometry) OVER sequence AS previous_position,
+          LAG(points.timestamp) OVER sequence AS previous_timestamp
+        FROM (#{point_scope_sql}) AS points
+        WHERE points.track_id = tracks.id
+          AND points.timestamp BETWEEN EXTRACT(EPOCH FROM tracks.start_at)::bigint AND EXTRACT(EPOCH FROM tracks.end_at)::bigint
+        WINDOW sequence AS (ORDER BY points.timestamp, points.id)
+      ) AS ordered_points
+      WHERE previous_position IS NOT NULL
+    SQL
+  end
+
+  def point_scope_sql
+    @points_scope.except(:select, :order, :includes, :preload, :eager_load)
+                 .where.not(lonlat: nil)
+                 .select(:id, :track_id, :timestamp, :lonlat).to_sql
+  end
+end

--- a/app/queries/tracks/speed_vector_tile_query.rb
+++ b/app/queries/tracks/speed_vector_tile_query.rb
@@ -28,6 +28,8 @@ class Tracks::SpeedVectorTileQuery < Tracks::VectorTileQuery
     z < MIN_SPEED_ZOOM ? super : MAX_SPEED_FEATURES_PER_TILE + 1
   end
 
+  # Collect before MVT quantization: its bbox fast-path can otherwise discard
+  # every meter-spaced segment of a long visible walking route at low zoom.
   # Materialize only the small per-segment geometry before the grouping sort;
   # otherwise PostgreSQL carries full original_path copies into that sort.
   def with_clauses
@@ -40,20 +42,24 @@ class Tracks::SpeedVectorTileQuery < Tracks::VectorTileQuery
       ), geometries AS MATERIALIZED (
         SELECT tracks.id,
           ROUND(segments.segment_speed::numeric)::double precision AS segment_speed,
-          ST_AsMVTGeom(
-            ST_Transform(COALESCE(segments.path, tracks.original_path), 3857),
-            ST_TileEnvelope(#{z}, #{x}, #{y}), #{EXTENT}, #{BUFFER}, true
-          ) AS geom
+          COALESCE(segments.path, tracks.original_path) AS geom
         FROM candidates AS tracks
         LEFT JOIN LATERAL (#{segments_sql}) AS segments ON true
       ), grouped_segments AS (
         SELECT id, segment_speed, ST_Collect(geom) AS geom
-        FROM geometries WHERE geom IS NOT NULL
+        FROM geometries
+        WHERE ST_Intersects(geom, ST_Transform(#{margined_envelope}, 4326))
         GROUP BY id, segment_speed
-        LIMIT #{tile_feature_limit}
+      ), projected AS MATERIALIZED (
+        SELECT id, segment_speed,
+          ST_AsMVTGeom(ST_Transform(geom, 3857), ST_TileEnvelope(#{z}, #{x}, #{y}),
+                       #{EXTENT}, #{BUFFER}, true) AS geom
+        FROM grouped_segments
       ), features AS (
-        SELECT #{property_columns}, grouped_segments.segment_speed, grouped_segments.geom
-        FROM grouped_segments JOIN candidates AS tracks USING (id)
+        SELECT #{property_columns}, projected.segment_speed, projected.geom
+        FROM projected JOIN candidates AS tracks USING (id)
+        WHERE projected.geom IS NOT NULL
+        LIMIT #{tile_feature_limit}
       )
     SQL
   end

--- a/app/queries/tracks/vector_tile_query.rb
+++ b/app/queries/tracks/vector_tile_query.rb
@@ -47,7 +47,7 @@ class Tracks::VectorTileQuery
     Result.new(
       tile: row['tile'],
       feature_count: row['feature_count'].to_i,
-      limit: TRACKS_PER_TILE_LIMIT
+      limit: tile_feature_limit
     )
   end
 
@@ -59,6 +59,10 @@ class Tracks::VectorTileQuery
   end
 
   private
+
+  def tile_feature_limit
+    TRACKS_PER_TILE_LIMIT
+  end
 
   attr_reader :scope, :z, :x, :y
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1138,8 +1138,8 @@ ca:
         water_labels: Etiquetes d'aigua
         tiled_rendering: "Renderitzat per tessel·les"
         beta: "Beta"
-        tiled_rendering_description: "Dibuixa els punts, les rutes, els trajectes i la boira a partir de tessel·les vectorials mentre et desplaces, de manera que un interval de dates llarg només carrega el que es veu. Les rutes mostren els trajectes que has generat, acolorits per trajecte."
-        tiled_rendering_caveats: "Actiu mentre el Mapa de rascar està desactivat. Les zones denses s'agrupen en marcadors amb un recompte de punts: amplia per obrir els punts individualment. L'edició de punts no està disponible, les rutes s'acoloreixen per trajecte (velocitat mitjana, no un degradat), en passar el cursor per una ruta ja no se'n mostra la finestra emergent (fes clic en un trajecte) i el rastre en directe pot trigar uns minuts."
+        tiled_rendering_description: "Dibuixa els punts, les rutes, els trajectes i la boira a partir de tessel·les vectorials mentre et desplaces, de manera que un interval de dates llarg només carrega el que es veu. Les rutes mostren els trajectes que has generat. Amplia per veure la velocitat de cada segment."
+        tiled_rendering_caveats: "Actiu mentre el Mapa de rascar està desactivat. Les zones denses s'agrupen en marcadors amb un recompte de punts: amplia per obrir els punts individualment. L'edició de punts no està disponible, en passar el cursor per una ruta ja no se'n mostra la finestra emergent (fes clic en un trajecte) i el rastre en directe pot trigar uns minuts."
         fill_gaps_with_the_default_basemap: "Omple els buits amb el mapa base predeterminat"
         uncovered_areas_are_drawn_from_dawarich_s_default_tile_server: "Per a un conjunt de tessel·les que només cobreix una part del món. Les zones que no cobreix es dibuixen des del servidor de tessel·les predeterminat de Dawarich, de manera que, si ho actives, s'hi enviaran peticions de tessel·les."
       visit_creation_modal:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -950,8 +950,8 @@ de:
         allow_dragging_points_to_correct_their_position_remembered_across_sessio: Erlaube das Ziehen von Punkten, um ihre Position zu korrigieren. Wird über Sitzungen hinweg gespeichert.
         tiled_rendering: "Gekachelte Darstellung"
         beta: "Beta"
-        tiled_rendering_description: "Zeichnet Punkte, Routen, Tracks und Kartennebel beim Bewegen der Karte aus Vektorkacheln, statt den gesamten Zeitraum vorab zu laden. Routen zeigen deine erzeugten Tracks, je Track eingefärbt."
-        tiled_rendering_caveats: "Aktiv, solange die Rubbelkarte aus ist. Dichte Bereiche werden zu Markern mit Punktanzahl zusammengefasst — zoome hinein, um einzelne Punkte zu öffnen. Punktbearbeitung ist nicht verfügbar, Routen werden je Track eingefärbt (Durchschnittsgeschwindigkeit statt Verlauf), das Routen-Popup beim Überfahren entfällt — klicke stattdessen auf einen Track — und die Live-Spur kann einige Minuten nachhängen."
+        tiled_rendering_description: "Zeichnet Punkte, Routen, Tracks und Kartennebel beim Bewegen der Karte aus Vektorkacheln, statt den gesamten Zeitraum vorab zu laden. Routen zeigen deine erzeugten Tracks. Zoome hinein, um die Geschwindigkeit einzelner Abschnitte zu sehen."
+        tiled_rendering_caveats: "Aktiv, solange die Rubbelkarte aus ist. Dichte Bereiche werden zu Markern mit Punktanzahl zusammengefasst — zoome hinein, um einzelne Punkte zu öffnen. Punktbearbeitung ist nicht verfügbar, das Routen-Popup beim Überfahren entfällt — klicke stattdessen auf einen Track — und die Live-Spur kann einige Minuten nachhängen."
         routes: Routen
         show_connected_route_lines: Zeige verbundene Routenlinien
         color_by_speed: Farbe nach Geschwindigkeit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -908,8 +908,8 @@ en:
         allow_dragging_points_to_correct_their_position_remembered_across_sessio: Allow dragging points to correct their position. Remembered across sessions.
         tiled_rendering: "Tiled rendering"
         beta: "Beta"
-        tiled_rendering_description: "Draws points, routes, tracks and fog from vector tiles as you pan, so a long date range loads only what is in view. Routes show your generated tracks, colored per track."
-        tiled_rendering_caveats: "Active while Scratch map is off. Dense areas merge into markers with a point count — zoom in to open individual points. Point editing is unavailable, routes are colored per track (average speed, not a gradient), hovering a route no longer shows its popup — click a track instead — and the live trail can lag a few minutes."
+        tiled_rendering_description: "Draws points, routes, tracks and fog from vector tiles as you pan, so a long date range loads only what is in view. Routes show your generated tracks. Zoom in to see the speed of each segment."
+        tiled_rendering_caveats: "Active while Scratch map is off. Dense areas merge into markers with a point count — zoom in to open individual points. Point editing is unavailable, hovering a route no longer shows its popup — click a track instead — and the live trail can lag a few minutes."
         routes: Routes
         show_connected_route_lines: Show connected route lines
         color_by_speed: Color by speed

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -950,8 +950,8 @@ es:
         allow_dragging_points_to_correct_their_position_remembered_across_sessio: Permite arrastrar puntos para corregir su posición. Recordado a lo largo de sesiones.
         tiled_rendering: "Renderizado en teselas"
         beta: "Beta"
-        tiled_rendering_description: "Dibuja puntos, rutas, tracks y niebla desde teselas vectoriales mientras te desplazas, en lugar de cargar todo el rango de fechas de antemano. Las rutas muestran tus tracks generados, coloreados por track."
-        tiled_rendering_caveats: "Activo mientras el mapa de pruebas está desactivado. Las zonas densas se agrupan en marcadores con un recuento — acércate para abrir puntos individuales. La edición de puntos no está disponible, las rutas se colorean por track (velocidad media, no un degradado), el globo de ruta al pasar el cursor desaparece — haz clic en un track — y el rastro en vivo puede retrasarse unos minutos."
+        tiled_rendering_description: "Dibuja puntos, rutas, tracks y niebla desde teselas vectoriales mientras te desplazas, en lugar de cargar todo el rango de fechas de antemano. Las rutas muestran tus tracks generados. Acércate para ver la velocidad de cada segmento."
+        tiled_rendering_caveats: "Activo mientras el mapa de pruebas está desactivado. Las zonas densas se agrupan en marcadores con un recuento — acércate para abrir puntos individuales. La edición de puntos no está disponible, el globo de ruta al pasar el cursor desaparece — haz clic en un track — y el rastro en vivo puede retrasarse unos minutos."
         routes: Rutas
         show_connected_route_lines: Muestra líneas de rutas conectadas
         color_by_speed: Color por velocidad

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1601,8 +1601,8 @@ fr:
           la traînée des points pour corriger leur position. Mémorisé entre sessions.
         tiled_rendering: "Rendu par tuiles"
         beta: "Bêta"
-        tiled_rendering_description: "Dessine les points, itinéraires, tracks et brouillard à partir de tuiles vectorielles pendant le déplacement, au lieu de charger toute la plage de dates à l'avance. Les itinéraires affichent vos tracks générés, colorés par track."
-        tiled_rendering_caveats: "Actif tant que la carte à gratter est désactivée. Les zones denses sont fusionnées en marqueurs avec un compteur — zoomez pour ouvrir les points individuels. La modification des points est indisponible, les itinéraires sont colorés par track (vitesse moyenne, pas un dégradé), l'info-bulle d'itinéraire au survol disparaît — cliquez sur un track — et la trace en direct peut avoir quelques minutes de retard."
+        tiled_rendering_description: "Dessine les points, itinéraires, tracks et brouillard à partir de tuiles vectorielles pendant le déplacement, au lieu de charger toute la plage de dates à l'avance. Les itinéraires affichent vos tracks générés. Zoomez pour voir la vitesse de chaque segment."
+        tiled_rendering_caveats: "Actif tant que la carte à gratter est désactivée. Les zones denses sont fusionnées en marqueurs avec un compteur — zoomez pour ouvrir les points individuels. La modification des points est indisponible, l'info-bulle d'itinéraire au survol disparaît — cliquez sur un track — et la trace en direct peut avoir quelques minutes de retard."
         routes: Itinéraires
         show_connected_route_lines: Afficher les lignes d'itinéraire connectées
         color_by_speed: Colorer par vitesse

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -908,8 +908,8 @@ pl:
         allow_dragging_points_to_correct_their_position_remembered_across_sessio: Pozwala przeciągać punkty, aby poprawić ich pozycję. Zapamiętywane między sesjami.
         tiled_rendering: Renderowanie kafelkowe
         beta: Beta
-        tiled_rendering_description: Rysuje punkty, trasy, odcinki i nieodkryty obszar z kafelków wektorowych podczas przesuwania mapy, dzięki czemu długi zakres dat wczytuje tylko to, co widać. Trasy pokazują wygenerowane odcinki, kolorowane osobno dla każdego z nich.
-        tiled_rendering_caveats: Aktywne, gdy warstwa Odkryte kraje jest wyłączona. W gęstych obszarach punkty łączą się w znaczniki z licznikiem punktów — przybliż, aby otworzyć pojedyncze punkty. Edycja punktów jest niedostępna, trasy są kolorowane osobno dla każdego odcinka (średnia prędkość, nie gradient), najechanie na trasę nie pokazuje już dymka — zamiast tego kliknij odcinek — a ślad na żywo może opóźniać się o kilka minut.
+        tiled_rendering_description: Rysuje punkty, trasy, odcinki i nieodkryty obszar z kafelków wektorowych podczas przesuwania mapy, dzięki czemu długi zakres dat wczytuje tylko to, co widać. Trasy pokazują wygenerowane odcinki. Przybliż mapę, aby zobaczyć prędkość każdego segmentu.
+        tiled_rendering_caveats: Aktywne, gdy warstwa Odkryte kraje jest wyłączona. W gęstych obszarach punkty łączą się w znaczniki z licznikiem punktów — przybliż, aby otworzyć pojedyncze punkty. Edycja punktów jest niedostępna, najechanie na trasę nie pokazuje już dymka — zamiast tego kliknij odcinek — a ślad na żywo może opóźniać się o kilka minut.
         routes: Trasy
         show_connected_route_lines: Pokaż połączone linie tras
         color_by_speed: Koloruj według prędkości

--- a/spec/javascript/tracks_mvt_layer_test.mjs
+++ b/spec/javascript/tracks_mvt_layer_test.mjs
@@ -147,9 +147,9 @@ test("speed coloring produces an interpolate expression clamped to the classic s
 
   const expression = layer._lineColor()
   assert.ok(Array.isArray(expression))
-  assert.equal(expression[0], "interpolate")
+  assert.equal(expression[0], "step")
   const flattened = JSON.stringify(expression)
-  assert.ok(flattened.includes("avg_speed"))
+  assert.ok(flattened.includes("segment_speed"))
   assert.ok(flattened.includes('"min",150'))
   assert.ok(flattened.includes("#00ff00"))
 })
@@ -162,6 +162,30 @@ test("an invalid speed scale falls back to flat color", () => {
   })
 
   assert.equal(layer._lineColor(), "#6366F1")
+})
+
+test("speed toggles replace tile data while preserving the selected dates and layer order", () => {
+  const { map, layer } = buildLayer({
+    tracksEnabled: false,
+    routesVisible: true,
+  })
+  map.addLayer({ id: "points-above-routes" })
+  const originalUrl = layer._tileUrl
+
+  layer.setSpeedColoring(true, "0:#00ff00|150:#ff0000")
+
+  assert.ok(layer._tileUrl.includes("speed_coloring=true"))
+  assert.ok(layer._tileUrl.includes("2024-01-01"))
+  assert.deepEqual(map.layers, ["tracks-mvt", "points-above-routes"])
+  assert.equal(layer.visible, true)
+  const speedUrl = layer._tileUrl
+
+  layer.setSpeedColoring(true, "0:#0000ff|150:#ffffff")
+  assert.equal(layer._tileUrl, speedUrl)
+
+  layer.setSpeedColoring(false)
+  assert.equal(layer._tileUrl, originalUrl)
+  assert.equal(layer._lineColor(), "#0000ff")
 })
 
 test("parseSpeedColorScale decodes and sorts the encoded stops", () => {

--- a/spec/queries/tracks/speed_vector_tile_query_spec.rb
+++ b/spec/queries/tracks/speed_vector_tile_query_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tracks::SpeedVectorTileQuery do
+  let(:user) { create(:user) }
+  let(:start_at) { Time.utc(2024, 6, 1, 10) }
+
+  def track_with_points(longitudes: [0.001, 0.002, 0.0021], offsets: [0, 10, 20])
+    path = "LINESTRING(#{longitudes.map { |longitude| "#{longitude} 0.001" }.join(', ')})"
+    create(:track, user:, original_path: path, start_at:, end_at: start_at + 1.hour).tap do |track|
+      longitudes.zip(offsets).each do |longitude, offset|
+        create(:point, user:, track:, longitude:, latitude: 0.001, timestamp: start_at.to_i + offset)
+      end
+    end
+  end
+
+  def query(points_scope: user.points, **coordinates)
+    described_class.new(scope: user.tracks, points_scope:, z: 15, x: 16_384, y: 16_383, **coordinates)
+  end
+
+  it 'colors the slow part independently while preserving track popup properties' do
+    track = track_with_points
+
+    rows = query.feature_rows
+
+    expect(rows.size).to eq(2)
+    expect(rows.map { |row| row['segment_speed'] }.sort)
+      .to match([be_within(0.05).of(4.0), be_within(0.05).of(40.0)])
+    expect(rows.map { |row| row['id'] }.uniq).to eq([track.id])
+    expect(rows.map { |row| row['avg_speed'] }.uniq).to eq([track.avg_speed])
+    expect(query.call.feature_count).to eq(2)
+  end
+
+  it 'keeps the connecting segment when both endpoints are beyond the tile buffer' do
+    track_with_points(longitudes: [-0.01, 0.03], offsets: [0, 300])
+
+    rows = query.feature_rows
+
+    expect(rows.size).to eq(1)
+    expect(rows.first['segment_speed']).to be_within(0.5).of(53.4)
+  end
+
+  it 'caps implausible speed and handles identical timestamps without dividing by zero' do
+    track_with_points(offsets: [0, 0, 0])
+    expect(query.feature_rows.map { |row| row['segment_speed'] }).to eq([0])
+
+    user.points.order(:id).last.update!(timestamp: start_at.to_i + 1)
+    user.points.order(:id).last.update!(lonlat: 'POINT(0.003 0.001)')
+    expect(query.feature_rows.map { |row| row['segment_speed'] }).to include(150)
+  end
+
+  it 'honors point visibility and does not reconnect through excluded points' do
+    track_with_points
+    restricted = user.points.where(timestamp: (start_at.to_i + 10)..)
+
+    rows = query(points_scope: restricted).feature_rows
+
+    expect(rows.size).to eq(1)
+    expect(rows.first['segment_speed']).to be_within(0.05).of(4.0)
+  end
+
+  it 'does not use another user\'s point even if it references the selected track' do
+    track = track_with_points
+    create(:point, user: create(:user), track:, longitude: 0.004, latitude: 0.001,
+                   timestamp: start_at.to_i + 5)
+
+    expect(query.feature_rows.map { |row| row['segment_speed'] }.sort)
+      .to match([be_within(0.05).of(4.0), be_within(0.05).of(40.0)])
+  end
+
+  it 'retains a flat track when its recording points are unavailable' do
+    create(:track, user:, original_path: 'LINESTRING(0.001 0.001, 0.002 0.001)')
+
+    rows = query.feature_rows
+
+    expect(rows.size).to eq(1)
+    expect(rows.first['segment_speed']).to be_nil
+  end
+
+  it 'uses the flat overview below the classic speed-color zoom threshold' do
+    track_with_points(longitudes: [0.001, 0.02, 0.03])
+
+    rows = query(z: 7, x: 64, y: 63).feature_rows
+
+    expect(rows.size).to eq(1)
+    expect(rows.first).not_to have_key('segment_speed')
+  end
+
+  it 'rejects a tile over capacity instead of presenting a partial route as complete' do
+    track_with_points
+    stub_const('Tracks::SpeedVectorTileQuery::MAX_SPEED_FEATURES_PER_TILE', 1)
+
+    expect { query.call }.to raise_error(described_class::FeatureLimitError)
+  end
+
+  it 'applies the statement timeout to the point scan too' do
+    track_with_points
+    allow(VectorTileTimeout).to receive(:query_timeout_ms).and_return(50)
+    slow_points = user.points.where('(SELECT pg_sleep(0.3)) IS NOT NULL')
+
+    expect { query(points_scope: slow_points).call }.to raise_error(ActiveRecord::QueryCanceled)
+  end
+end

--- a/spec/queries/tracks/speed_vector_tile_query_spec.rb
+++ b/spec/queries/tracks/speed_vector_tile_query_spec.rb
@@ -78,6 +78,22 @@ RSpec.describe Tracks::SpeedVectorTileQuery do
     expect(rows.first['segment_speed']).to be_nil
   end
 
+  it 'preserves a visible walking route whose individual segments are smaller than a tile pixel' do
+    longitudes = (0..600).map { |index| 0.001 + (index * 0.00001) }
+    path = "LINESTRING(#{longitudes.map { |longitude| "#{longitude} 0.001" }.join(', ')})"
+    track = create(:track, user:, original_path: path, start_at:, end_at: start_at + 600)
+    Point.insert_all!(longitudes.each_with_index.map do |longitude, index|
+      { user_id: user.id, track_id: track.id, timestamp: start_at.to_i + index,
+        lonlat: "POINT(#{longitude} 0.001)", created_at: start_at, updated_at: start_at }
+    end)
+
+    rows = query(z: 8, x: 128, y: 127).feature_rows
+
+    expect(rows.size).to eq(1)
+    expect(rows.first['segment_speed']).to eq(4)
+    expect(query(z: 8, x: 128, y: 127).call.tile).to be_present
+  end
+
   it 'uses the flat overview below the classic speed-color zoom threshold' do
     track_with_points(longitudes: [0.001, 0.02, 0.03])
 

--- a/spec/requests/api/v1/tiles/tracks_spec.rb
+++ b/spec/requests/api/v1/tiles/tracks_spec.rb
@@ -91,6 +91,28 @@ RSpec.describe 'Api::V1::Tiles::Tracks', type: :request do
         expect(response.body.b).not_to eq(original_tile)
       end
 
+      it 'invalidates an overlapping track when a point outside the requested year is edited' do
+        track = create_track_near_origin(user, start_at: Time.utc(2024, 12, 31, 23, 59, 50),
+                                              end_at: Time.utc(2025, 1, 1, 0, 0, 10),
+                                              original_path: 'LINESTRING(0.001 0.001, 0.002 0.001)')
+        endpoint = create(:point, user:, track:, longitude: 0.001, latitude: 0.001,
+                                  timestamp: track.start_at.to_i)
+        create(:point, user:, track:, longitude: 0.002, latitude: 0.001, timestamp: track.end_at.to_i)
+        params = { api_key: user.api_key, speed_coloring: 'true',
+                   start_at: '2025-01-01T00:00:00Z', end_at: '2025-01-02T00:00:00Z' }
+        tile_path = '/api/v1/tiles/tracks/15/16384/16383.mvt'
+        get(tile_path, params:)
+        expect(response).to have_http_status(:ok)
+        etag = response.headers['ETag']
+
+        patch "/api/v1/points/#{endpoint.id}",
+              params: { api_key: user.api_key, point: { longitude: 0.0015, latitude: 0.001 } }
+        expect(response).to have_http_status(:ok)
+        get tile_path, params:, headers: { 'If-None-Match' => etag }
+
+        expect(response).to have_http_status(:ok)
+      end
+
       it 'serves cacheable responses, honors ETags, and invalidates on track writes' do
         create_track_near_origin
 
@@ -140,6 +162,26 @@ RSpec.describe 'Api::V1::Tiles::Tracks', type: :request do
       expect(response).to have_http_status(:service_unavailable)
       expect(response.headers['Cache-Control']).to include('no-store')
       expect(response.headers['ETag']).to be_nil
+    end
+
+    it 'returns a non-cacheable error rather than a partial tile over the speed feature limit' do
+      track = create_track_near_origin(user,
+                                       original_path: 'LINESTRING(0.001 0.001, 0.002 0.001, 0.0021 0.001)')
+      [0.001, 0.002, 0.0021].each_with_index do |longitude, index|
+        create(:point, user:, track:, longitude:, latitude: 0.001,
+                       timestamp: track.start_at.to_i + (index * 10))
+      end
+      stub_const('Tracks::SpeedVectorTileQuery::MAX_SPEED_FEATURES_PER_TILE', 1)
+
+      get '/api/v1/tiles/tracks/15/16384/16383.mvt', params: {
+        api_key: user.api_key, speed_coloring: 'true',
+        start_at: '2024-06-01T00:00:00Z', end_at: '2024-06-02T00:00:00Z'
+      }
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.headers['Cache-Control']).to include('no-store')
+      expect(response.headers['ETag']).to be_nil
+      expect(response.parsed_body['error']).to include('Zoom in or shorten the date range')
     end
 
     it 'returns 400 for invalid tile coordinates' do

--- a/spec/requests/api/v1/tiles/tracks_spec.rb
+++ b/spec/requests/api/v1/tiles/tracks_spec.rb
@@ -14,6 +14,21 @@ RSpec.describe 'Api::V1::Tiles::Tracks', type: :request do
   end
 
   describe 'GET /show' do
+    it 'provides segment speeds when speed coloring is requested' do
+      track = create_track_near_origin(user,
+                                       original_path: 'LINESTRING(0.001 0.001, 0.002 0.001, 0.0021 0.001)')
+      [0.001, 0.002, 0.0021].each_with_index do |longitude, index|
+        create(:point, user:, track:, longitude:, latitude: 0.001,
+                       timestamp: track.start_at.to_i + (index * 10))
+      end
+
+      get '/api/v1/tiles/tracks/15/16384/16383.mvt',
+          params: { api_key: user.api_key, speed_coloring: 'true' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body.b).to include('segment_speed')
+    end
+
     it 'returns a vector tile with the serializer-matching property set' do
       create_track_near_origin(user, dominant_mode: :driving)
 
@@ -47,6 +62,34 @@ RSpec.describe 'Api::V1::Tiles::Tracks', type: :request do
 
     describe 'caching lifecycle' do
       let(:range) { { start_at: '2024-01-01T00:00:00Z', end_at: '2024-12-31T23:59:59Z' } }
+
+      it 'separates speed tiles and invalidates them when their points change' do
+        track = create_track_near_origin(user,
+                                         original_path: 'LINESTRING(0.001 0.001, 0.002 0.001)')
+        create(:point, user:, track:, longitude: 0.001, latitude: 0.001, timestamp: track.start_at.to_i)
+        endpoint = create(:point, user:, track:, longitude: 0.002, latitude: 0.001,
+                                  timestamp: track.start_at.to_i + 10)
+        tile_path = '/api/v1/tiles/tracks/15/16384/16383.mvt'
+        get tile_path, params: range.merge(api_key: user.api_key)
+        flat_etag = response.headers['ETag']
+
+        params = range.merge(api_key: user.api_key, speed_coloring: 'true')
+        get tile_path, params:, headers: { 'If-None-Match' => flat_etag }
+        expect(response).to have_http_status(:ok)
+        speed_etag = response.headers['ETag']
+        original_tile = response.body.b
+
+        get tile_path, params:, headers: { 'If-None-Match' => speed_etag }
+        expect(response).to have_http_status(:not_modified)
+
+        patch "/api/v1/points/#{endpoint.id}",
+              params: { api_key: user.api_key, point: { longitude: 0.0011, latitude: 0.001 } }
+        expect(response).to have_http_status(:ok)
+        get tile_path, params:, headers: { 'If-None-Match' => speed_etag }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body.b).not_to eq(original_tile)
+      end
 
       it 'serves cacheable responses, honors ETags, and invalidates on track writes' do
         create_track_near_origin


### PR DESCRIPTION
Color by speed in tiled maps currently paints a whole track using its average speed, so slowing down at an intersection leaves the route unchanged. This change calculates speed between consecutive recording points and sends those segments through the existing authenticated vector-tile endpoint. The track's original metadata remains available for track detail navigation.

Equal whole-km/h speeds are grouped per track to avoid repeating metadata for every point pair. This rounds each segment by at most 0.5 km/h, keeps the existing 150 km/h clamp, and retains the classic flat overview below zoom 8. The tile source switches when coloring is toggled, preserving dates, visibility and layer order; all six existing settings translations describe the updated behavior.

The query remains read-only and uses the existing `(track_id, timestamp)` index and five-second statement timeout. Speed tiles include point-edit epochs in their ETags, including portions of overlapping tracks outside the requested range. An over-capacity tile returns a non-cacheable error rather than a partial route. There are no migrations, backfills or extra background jobs.

Validation:
- Before the fix, an actual PostGIS tile for consecutive approximately 40 and 4 km/h segments contained only the track's 25 km/h average.
- Focused Rails checks: 32 examples, 0 failures. JavaScript: 233 tests, 0 failures. Changed Ruby and JS files pass RuboCop/Biome.
- Independent review found that converting each short segment to MVT before grouping could erase a visible walking route. A real 601-point regression failed on the first implementation and passes after collecting geometry before quantization.
- A synthetic account with 850,000 points and 3,400 tracks: speed tiles took about 1.5–1.7 seconds and 5.9–6.0 MB at zoom 8/11; about 47 ms and 157 KB at zoom 14; 10 ms and 17 KB at zoom 16. These are uncompressed tile sizes. Speed coloring over a multi-year dense range costs more than flat track rendering; the query retains a 50,000-feature guard.
- Real browser validation passed on the Rails `/map` page: distinct 40/4 km/h colors, speed and route toggles, preserved dates and opacity, track detail navigation, a 390 px mobile viewport, and a dense 601-point walking route at zoom 8/16. This was Chromium viewport coverage, not a physical device run.
- Complete final-head Rails suite: **9,384 examples, 0 failures** with a clean database and dedicated Redis instance (7m27s). An earlier run sharing Redis with other test databases had four backfill debounce failures and one process-group permission failure; all 18 examples in those files also passed separately in the isolated setup.

Refs #3425.
