### PR TITLE
Reduce Redis writes from idle background workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Idle background workers no longer repeatedly write locks for empty queues to Redis; newly queued work is picked up within the normal two-second polling interval. (#3315)
+
 - Traccar latitude/longitude form uploads now save points, including Unix timestamps in seconds or milliseconds. Payloads that cannot be stored return an error instead of a false success; repeated valid uploads remain safe. (#3299)
 ## Unreleased
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -55,6 +55,9 @@ end
 # removed. The floor of 1 matters for the same reason - limit_fetch treats 0 as
 # "never acquire", which would strand the queue permanently.
 if Sidekiq.server?
+  require 'dawarich/idle_queue_check'
+  Sidekiq::LimitFetch::Global::Selector.singleton_class.prepend(Dawarich::IdleQueueCheck)
+
   pool_size = ENV['BACKGROUND_PROCESSING_CONCURRENCY'].presence&.to_i || 10
   configured = ENV['REVERSE_GEOCODING_CONCURRENCY'].presence&.to_i
 

--- a/lib/dawarich/idle_queue_check.rb
+++ b/lib/dawarich/idle_queue_check.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Dawarich
+  # Avoid limit_fetch's per-queue lock writes when there is no work to reserve.
+  # Returning no queues uses its normal idle sleep (at most two seconds before
+  # checking again). Once work exists, its normal atomic limits still apply.
+  module IdleQueueCheck
+    def acquire(queues, namespace)
+      return [] if queues.empty?
+
+      keys = queues.map { |queue| "#{namespace}queue:#{queue}" }
+      return [] if Sidekiq.redis { |connection| connection.exists(*keys) }.zero?
+
+      super
+    end
+  end
+end

--- a/spec/lib/dawarich/idle_queue_check_spec.rb
+++ b/spec/lib/dawarich/idle_queue_check_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Dawarich::IdleQueueCheck do
+  let(:selector) do
+    selector_class = Class.new do
+      def acquire(queues, namespace)
+        [queues, namespace]
+      end
+    end
+    selector_class.prepend(described_class)
+    selector_class.new
+  end
+  let(:connection) { double('Redis connection') }
+
+  before { allow(Sidekiq).to receive(:redis).and_yield(connection) }
+
+  it 'skips lock acquisition when all queue lists are absent' do
+    allow(connection).to receive(:exists).with('queue:default', 'queue:points').and_return(0)
+
+    expect(selector.acquire(%w[default points], '')).to eq([])
+  end
+
+  it 'retains the entire ordered queue list when any queue has work' do
+    allow(connection).to receive(:exists).with('queue:default', 'queue:points').and_return(1)
+
+    expect(selector.acquire(%w[default points], '')).to eq([%w[default points], ''])
+  end
+
+  it 'checks the supplied namespace without changing selector arguments' do
+    allow(connection).to receive(:exists).with('tenant:queue:points').and_return(1)
+
+    expect(selector.acquire(['points'], 'tenant:')).to eq([['points'], 'tenant:'])
+  end
+
+  it 'does not query Redis when no queues are configured' do
+    expect(connection).not_to receive(:exists)
+
+    expect(selector.acquire([], '')).to eq([])
+  end
+
+  it 'checks again on the next poll so newly enqueued work is not stranded' do
+    allow(connection).to receive(:exists).with('queue:default').and_return(0, 1)
+
+    expect(selector.acquire(['default'], '')).to eq([])
+    expect(selector.acquire(['default'], '')).to eq([['default'], ''])
+  end
+
+  it 'lets connection errors reach the existing fetch retry handler' do
+    allow(connection).to receive(:exists).and_raise(RedisClient::ConnectionError)
+
+    expect { selector.acquire(['default'], '') }.to raise_error(RedisClient::ConnectionError)
+  end
+end
+
+RSpec.describe 'Idle queue checks with Redis limit enforcement' do
+  let(:namespace) { "idle-fetch-spec:#{SecureRandom.hex(8)}:" }
+  let(:selector) do
+    selector_class = Class.new do
+      include Sidekiq::LimitFetch::Global::Selector
+      prepend Dawarich::IdleQueueCheck
+    end
+    selector_class.new
+  end
+
+  after do
+    Sidekiq.redis do |connection|
+      keys = connection.keys("#{namespace}*")
+      connection.del(*keys) if keys.any?
+    end
+  end
+
+  it 'does not create probe locks for empty queues' do
+    3.times { expect(selector.acquire(%w[default points], namespace)).to eq([]) }
+
+    expect(Sidekiq.redis { |connection| connection.keys("#{namespace}limit_fetch:probed:*") }).to eq([])
+  end
+
+  it 'acquires newly populated queues and still enforces the shared limit' do
+    expect(selector.acquire(['points'], namespace)).to eq([])
+    Sidekiq.redis do |connection|
+      connection.lpush("#{namespace}queue:points", 'pending job')
+      connection.set("#{namespace}limit_fetch:limit:points", 1)
+    end
+
+    expect(selector.acquire(['points'], namespace)).to eq(['points'])
+    expect(selector.acquire(['points'], namespace)).to eq([])
+
+    selector.release(['points'], namespace)
+    expect(selector.acquire(['points'], namespace)).to eq(['points'])
+  end
+
+  it 'keeps populated paused queues unavailable' do
+    Sidekiq.redis do |connection|
+      connection.lpush("#{namespace}queue:points", 'pending job')
+      connection.set("#{namespace}limit_fetch:pause:points", '1')
+    end
+
+    expect(selector.acquire(['points'], namespace)).to eq([])
+  end
+end


### PR DESCRIPTION
An idle Dawarich worker repeatedly reserves and releases locks for all 22 queues through `sidekiq-limit_fetch`, even when every queue is empty. With the default ten worker threads, an actual empty Sidekiq process produced approximately 12,853 Redis changes per minute without processing a job, matching the reported repeated persistence activity.

The fetch selector now checks whether any configured queue contains work before reserving locks. Empty queues follow the fetcher's existing two-second sleep; populated queues still use its existing atomic concurrency, pause and ordering logic. Work arriving immediately after an empty check can therefore wait up to two seconds for the next poll. This adds one read command per acquisition and removes the empty-queue lock writes. There are no PostgreSQL writes, migrations, queue renames, persistence-setting changes or new jobs.

Validation:
- Actual Rails/Sidekiq 8.1.6 with separate Redis and database, ten threads, all 22 application queues, cron disabled: approximately **12,853 → 75 Redis changes/minute** over 20-second observation windows; no jobs queued or processed. Remaining heartbeat activity is expected. This measures current application behavior on macOS, not a full NixOS deployment.
- Two actual Sidekiq processes completed **58 synthetic jobs exactly once across all 22 queues**. The reverse-geocoding limit remained two globally, both processes handled jobs, and pause/resume worked after allowing an already-started blocking read to expire. Idle wake-up measured 0.99 seconds.
- Ten focused examples pass, including real Redis/Lua checks for no empty-queue probe locks, arrival of new work, the shared limit, and paused queues. Three changed Ruby files pass RuboCop.
- Complete final-head Rails suite: **9,379 examples, 0 failures** in 7m50s on a clean database and dedicated Redis instance. Post-publication engineering, QA and product review round one found no actionable issues; final review is in progress.

Refs #3315.
