### PR TITLE
Restore complete public trip photo galleries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Public trip galleries include photos beyond the first hundred, load each day's images when expanded, and no longer show a misleading separator before daily distances. (#3232)
+
 - Traccar latitude/longitude form uploads now save points, including Unix timestamps in seconds or milliseconds. Payloads that cannot be stored return an error instead of a false success; repeated valid uploads remain safe. (#3299)
 ## Unreleased
 

--- a/app/controllers/api/v1/shared/photos_controller.rb
+++ b/app/controllers/api/v1/shared/photos_controller.rb
@@ -32,30 +32,36 @@ module Api
         # Geotagged photos in the shared window, capped so a long trip doesn't
         # flood the map with markers (and the browser with thumbnail requests).
         def mappable_photos
-          photos = capped_geotagged(fetch_photos)
-          Rails.cache.write(allowed_ids_cache_key, allowed_ids_for(photos), expires_in: 10.minutes)
-          photos
+          photos = geotagged_photos(fetch_photos)
+          Rails.cache.write(allowed_ids_cache_key, allowed_ids_for(authorized_photos(photos)), expires_in: 10.minutes)
+          photos.first(Photos::Mappable::MAX_PHOTOS)
         end
 
         # Cache the id set so each thumbnail request validates against it instead
         # of re-running the (expensive) photo search on every single thumbnail.
         def allowed_photo?(photo_id, source)
           ids = Rails.cache.fetch(allowed_ids_cache_key, expires_in: 10.minutes) do
-            allowed_ids_for(capped_geotagged(fetch_photos))
+            allowed_ids_for(authorized_photos(geotagged_photos(fetch_photos)))
           end
-          ids.include?("#{source}:#{photo_id}")
+          ids.key?("#{source}:#{photo_id}")
         end
 
-        def capped_geotagged(photos)
-          ::Photos::Mappable.new(photos, privacy_zones: privacy_zones).call
+        def geotagged_photos(photos)
+          ::Photos::Mappable.new(photos, privacy_zones: privacy_zones, max: nil).call
         end
 
         def allowed_ids_for(photos)
-          photos.map { |p| "#{p[:source]}:#{p[:id]}" }
+          photos.to_h { |p| ["#{p[:source]}:#{p[:id]}", true] }
+        end
+
+        def authorized_photos(photos)
+          return photos if link.resource_type.to_sym == :trip
+
+          photos.first(Photos::Mappable::MAX_PHOTOS)
         end
 
         def allowed_ids_cache_key
-          "shared_link/#{link.id}/photo_ids/#{privacy_zones_fingerprint}"
+          "shared_link/#{link.id}/photo_ids/v2/#{privacy_zones_fingerprint}"
         end
 
         def privacy_zones_fingerprint

--- a/app/javascript/controllers/lazy_gallery_controller.js
+++ b/app/javascript/controllers/lazy_gallery_controller.js
@@ -1,0 +1,23 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["template", "content"]
+
+  connect() {
+    this.toggle()
+  }
+
+  toggle() {
+    if (!this.hasTemplateTarget || !this.hasContentTarget) return
+
+    if (this.element.open) {
+      if (!this.contentTarget.hasChildNodes()) {
+        this.contentTarget.replaceChildren(
+          this.templateTarget.content.cloneNode(true),
+        )
+      }
+    } else {
+      this.contentTarget.replaceChildren()
+    }
+  }
+}

--- a/app/services/photos/mappable.rb
+++ b/app/services/photos/mappable.rb
@@ -10,9 +10,10 @@ class Photos::Mappable
   end
 
   def call
-    @photos.select { |p| p[:latitude].present? && p[:longitude].present? }
-           .reject { |p| within_privacy_zone?(p[:latitude], p[:longitude]) }
-           .first(@max)
+    photos = @photos.select { |p| p[:latitude].present? && p[:longitude].present? }
+                    .reject { |p| within_privacy_zone?(p[:latitude], p[:longitude]) }
+
+    @max ? photos.first(@max) : photos
   end
 
   private

--- a/app/services/shared_links/trip_photos.rb
+++ b/app/services/shared_links/trip_photos.rb
@@ -26,7 +26,11 @@ module SharedLinks
     private
 
     def mappable_photos
-      Photos::Mappable.new(search_photos, privacy_zones: Users::PrivacyZones.new(@link.user).call).call
+      Photos::Mappable.new(
+        search_photos,
+        privacy_zones: Users::PrivacyZones.new(@link.user).call,
+        max: nil
+      ).call
     end
 
     def search_photos

--- a/app/services/shared_links/trip_presenter.rb
+++ b/app/services/shared_links/trip_presenter.rb
@@ -83,5 +83,10 @@ module SharedLinks
 
       { day_key: day_key, action: ROW_ACTIONS, 'shared-trip-map-day-key-param': day_key }
     end
+
+    def gallery_row_data(day_key)
+      data = row_data(day_key)
+      data.merge(controller: 'lazy-gallery', action: [data[:action], 'toggle->lazy-gallery#toggle'].compact.join(' '))
+    end
   end
 end

--- a/app/views/shared/links/_trip.html.erb
+++ b/app/views/shared/links/_trip.html.erb
@@ -55,7 +55,7 @@
             <% has_note = trip.show_day_notes? && note&.body.present? %>
             <% day_photos = trip.photos_for(day) %>
             <% if has_note || day_photos.any? %>
-              <%= tag.details class: "collapse collapse-arrow bg-base-200 rounded-lg#{trip.interactive_class}", data: trip.row_data(day_key) do %>
+              <%= tag.details class: "collapse collapse-arrow bg-base-200 rounded-lg#{trip.interactive_class}", data: trip.gallery_row_data(day_key) do %>
                 <summary class="collapse-title flex items-center gap-2 text-sm font-medium min-h-0 cursor-pointer">
                   <%= render "shared/links/trip_day_header", day: day, day_key: day_key %>
                 </summary>
@@ -64,16 +64,19 @@
                     <p class="whitespace-pre-wrap text-sm text-base-content/80"><%= note.body %></p>
                   <% end %>
                   <% if day_photos.any? %>
-                    <div class="grid grid-cols-3 gap-2 mt-3">
-                      <% day_photos.each do |photo| %>
-                        <div class="aspect-square overflow-hidden rounded-lg">
-                          <img src="<%= url_for(controller: 'api/v1/shared/photos', action: 'thumbnail', id: link.id, photo_id: photo[:id], source: photo[:source], only_path: true) %>"
-                               loading="lazy"
-                               alt=""
-                               class="h-full w-full object-cover">
-                        </div>
-                      <% end %>
-                    </div>
+                    <template data-lazy-gallery-target="template">
+                      <div class="grid grid-cols-3 gap-2 mt-3">
+                        <% day_photos.each do |photo| %>
+                          <div class="aspect-square overflow-hidden rounded-lg">
+                            <img src="<%= url_for(controller: 'api/v1/shared/photos', action: 'thumbnail', id: link.id, photo_id: photo[:id], source: photo[:source], only_path: true) %>"
+                                 loading="lazy"
+                                 alt=""
+                                 class="h-full w-full object-cover">
+                          </div>
+                        <% end %>
+                      </div>
+                    </template>
+                    <div data-lazy-gallery-target="content"></div>
                   <% end %>
                 </div>
               <% end %>

--- a/app/views/shared/links/_trip_day_header.html.erb
+++ b/app/views/shared/links/_trip_day_header.html.erb
@@ -2,7 +2,7 @@
 <span><%= l(day[:date], format: :short_month_day_weekday) %></span>
 <% if day[:has_data] %>
   <span class="text-base-content/50 text-xs"><%= l(day[:first_time], format: :hour_minute) %> – <%= l(day[:last_time], format: :hour_minute) %></span>
-  <span class="text-base-content/50 ml-auto mr-6 text-xs"><%= t('.middot') %> <%= day[:distance_label] %></span>
+  <span class="text-base-content/50 ml-auto mr-6 text-xs"><%= day[:distance_label] %></span>
 <% else %>
   <span class="text-base-content/50 ml-auto mr-6 text-xs"><%= t('.no_data') %></span>
 <% end %>

--- a/spec/regressions/public_trip_photo_gallery_limit_spec.rb
+++ b/spec/regressions/public_trip_photo_gallery_limit_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Public trip photo galleries beyond the map marker limit', type: :request do
+  let(:owner) { create(:user) }
+  let(:trip) do
+    create(:trip, user: owner, started_at: Time.utc(2026, 7, 1), ended_at: Time.utc(2026, 7, 3))
+  end
+  let(:link) do
+    create(:shared_link, user: owner, resource_type: :trip, resource_id: trip.id,
+                         settings: { 'show_photos' => true })
+  end
+  let(:photos) do
+    100.times.map do |index|
+      {
+        id: "early-#{index}", source: 'immich', latitude: 52.0, longitude: 13.0,
+        capturedAt: '2026-07-01T12:00:00Z'
+      }
+    end + [
+      {
+        id: 'later-photo', source: 'immich', latitude: 53.0, longitude: 14.0,
+        capturedAt: '2026-07-02T12:00:00Z'
+      }
+    ]
+  end
+
+  before do
+    Rails.cache.clear
+    allow(Photos::Search).to receive(:cached).and_return(photos)
+  end
+
+  it 'groups photos from later days after the first hundred map markers' do
+    grouped = SharedLinks::TripPhotos.new(link, timezone: 'Etc/UTC').call
+
+    expect(grouped.fetch(Date.new(2026, 7, 2)).map { _1[:id] }).to include('later-photo')
+  end
+
+  it 'authorizes thumbnails after the first hundred map markers' do
+    upstream = instance_double(HTTParty::Response, success?: true, body: 'jpeg-bytes')
+    allow(Photos::Thumbnail).to receive(:new).with(owner, 'immich', 'later-photo').and_return(
+      instance_double(Photos::Thumbnail, call: upstream)
+    )
+
+    get "/api/v1/shared/#{link.id}/photos/later-photo/thumbnail", params: { source: 'immich' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq('jpeg-bytes')
+  end
+
+  it 'keeps the public map response capped at one hundred markers' do
+    get "/api/v1/shared/#{link.id}/photos"
+
+    expect(JSON.parse(response.body).size).to eq(100)
+  end
+
+  it 'does not reuse the old capped thumbnail authorization cache after an upgrade' do
+    cache = ActiveSupport::Cache::MemoryStore.new
+    allow(Rails).to receive(:cache).and_return(cache)
+    old_key = "shared_link/#{link.id}/photo_ids/#{Digest::MD5.hexdigest([].to_s)}"
+    cache.write(old_key, ['immich:early-0'], expires_in: 10.minutes)
+    upstream = instance_double(HTTParty::Response, success?: true, body: 'jpeg-bytes')
+    allow(Photos::Thumbnail).to receive(:new).with(owner, 'immich', 'later-photo').and_return(
+      instance_double(Photos::Thumbnail, call: upstream)
+    )
+
+    get "/api/v1/shared/#{link.id}/photos/later-photo/thumbnail", params: { source: 'immich' }
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'renders deferred galleries for later days even when the map is hidden' do
+    link.update!(settings: link.settings.merge('show_route' => false, 'show_days' => true))
+
+    get "/s/#{link.id}"
+
+    expect(response).to have_http_status(:ok)
+    document = Nokogiri::HTML(response.body)
+    expect(document.css('[data-controller="shared-trip-map"]')).to be_empty
+    expect(document.css('template img').size).to eq(101)
+    expect(document.css('[data-lazy-gallery-target="content"] img')).to be_empty
+    expect(document.css('details[data-controller="lazy-gallery"]').size).to eq(2)
+  end
+
+  it 'still excludes private photos beyond the marker limit from galleries and thumbnails' do
+    allow(Users::PrivacyZones).to receive(:new).with(owner).and_return(
+      instance_double(Users::PrivacyZones, call: [{ lat: 53.0, lon: 14.0, radius: 100 }])
+    )
+
+    grouped = SharedLinks::TripPhotos.new(link, timezone: 'Etc/UTC').call
+    expect(grouped.values.flatten.map { _1[:id] }).not_to include('later-photo')
+    expect(Photos::Thumbnail).not_to receive(:new)
+
+    get "/api/v1/shared/#{link.id}/photos/later-photo/thumbnail", params: { source: 'immich' }
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'does not authorize photos beyond the marker cap for shares without a gallery' do
+    track = create(:track, user: owner, start_at: trip.started_at, end_at: trip.ended_at)
+    track_link = create(
+      :shared_link,
+      user: owner,
+      resource_type: :track,
+      resource_id: track.id,
+      settings: { 'show_photos' => true }
+    )
+
+    expect(Photos::Thumbnail).not_to receive(:new)
+
+    get "/api/v1/shared/#{track_link.id}/photos/later-photo/thumbnail", params: { source: 'immich' }
+
+    expect(response).to have_http_status(:not_found)
+  end
+end


### PR DESCRIPTION
Public trip shares currently stop their galleries after the first 100 geotagged photos. A later day's photo is omitted from its gallery and its thumbnail returns 404, even though the owner can view it normally. Trip galleries now include all photos that pass the existing location/privacy filters, while the public map retains its 100-marker cap. Thumbnail authorization uses the complete trip-gallery set and a versioned cache key so an upgrade cannot reuse the old capped array.

Each day's images are kept in an inert template until its native disclosure opens, then removed when it closes. This also works when the share's map is hidden. The separator that resembled a minus sign before daily distance is removed. The initial response still contains every gallery template and metadata; this change defers active image nodes and requests, not the complete HTML payload. Non-trip shares keep their existing authorization cap.

Validation:
- Current `dev` reproduction: four examples, two failures — the later day is missing and its thumbnail returns 404.
- Additional upgrade reproduction: the earlier uncapped-gallery implementation still returned 404 with an existing capped authorization cache. The versioned key fixes that case.
- 159 focused Rails examples pass across photo services, shared links and APIs, including a gallery without a map and a private photo beyond the first 100. Existing JavaScript suite: 232 tests pass. Changed Ruby files and the new controller pass RuboCop/Biome.
- Complete Rails suite: **9,377 examples, 0 failures** in 7m40s on the final head with a clean database and dedicated Redis. Maintained real-browser tests: four scenarios fail on exact baseline `0e1e4719` and pass on the final fix (repeat: 4 passed in 5.6s). Desktop and 390px mobile gallery expansion/clear/reopen, privacy-zone exclusion and thumbnail 404, late thumbnail decoding, 100 map markers and day selection are covered. Only the external provider is synthetic; Rails, privacy checks and browser interactions are real. Companion tests: https://github.com/Freika/e2e-dawarich-playwright/pull/8. External provider pagination/availability and physical devices were not tested. Two post-publication engineering, QA and product review rounds completed with no remaining findings.

No database migrations, photo/point writes or new background jobs.

Refs #3232.
