### PR TITLE
Refresh partial track metadata after chunk generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Track generation now refreshes surviving partial tracks from their assigned points, correcting stale time ranges, distance and elevation after buffered chunks overlap. Public links and manual transportation corrections are preserved. (#3209)
 - Traccar latitude/longitude form uploads now save points, including Unix timestamps in seconds or milliseconds. Payloads that cannot be stored return an error instead of a false success; repeated valid uploads remain safe. (#3299)
 ## Unreleased
 

--- a/app/jobs/tracks/boundary_resolver_job.rb
+++ b/app/jobs/tracks/boundary_resolver_job.rb
@@ -54,7 +54,13 @@ class Tracks::BoundaryResolverJob < ApplicationJob
 
   def resolve_boundary_tracks
     Tracks::PerUserLock.with_user_lock(user.id) do
-      Tracks::BoundaryDetector.new(user).resolve_cross_chunk_tracks
+      resolved = Tracks::BoundaryDetector.new(user).resolve_cross_chunk_tracks
+      result = Tracks::MetadataRefresher.new(user).call
+      data = session_manager.get_session_data
+      if data
+        session_manager.update_session(metadata: (data['metadata'] || {}).merge('track_metadata_refresh' => result))
+      end
+      resolved
     end
   end
 

--- a/app/services/tracks/metadata_refresher.rb
+++ b/app/services/tracks/metadata_refresher.rb
@@ -53,7 +53,7 @@ module Tracks
         # Lock current members as well: parallel chunk processors do not take
         # the finalizer's per-user lock and can otherwise remove these points
         # while the dependent statistics are being rebuilt.
-        points = track.points.order(:id).lock.to_a.sort_by(&:timestamp)
+        points = track.points.select(:id, :timestamp, :altitude).order(:id).lock.to_a.sort_by(&:timestamp)
         next :insufficient_points if points.size < 2
 
         start_at = Time.zone.at(points.first.timestamp)

--- a/app/services/tracks/metadata_refresher.rb
+++ b/app/services/tracks/metadata_refresher.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Tracks
+  # Buffered chunks can take points from an earlier partial track without that
+  # track qualifying for a spatial merge. Refresh its existing row once the
+  # chunks finish, so shares and manual transportation corrections keep identity.
+  class MetadataRefresher
+    include Tracks::TrackBuilder
+
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      result = { refreshed: 0, skipped: 0, reasons: Hash.new(0), sample_ids: [] }
+      mismatched_tracks.find_each do |track|
+        outcome = refresh(track)
+        next if outcome == :unchanged
+
+        if outcome == :refreshed
+          result[:refreshed] += 1
+        else
+          result[:skipped] += 1
+          result[:reasons][outcome] += 1
+          result[:sample_ids] << track.id if result[:sample_ids].size < 10
+        end
+      end
+      if result[:skipped].positive?
+        Rails.logger.warn("event=tracks.metadata_refresh_incomplete user_id=#{user.id} result=#{result.to_json}")
+      end
+      result
+    end
+
+    private
+
+    attr_reader :user
+
+    def mismatched_tracks
+      # Two endpoint probes use (track_id, timestamp), without aggregating every
+      # point or loading unchanged tracks into Ruby. No creation-time cutoff:
+      # earlier chunks of a long-running generation still need finalization.
+      user.tracks.where(<<~SQL.squish)
+        EXTRACT(EPOCH FROM tracks.start_at) <> (
+          SELECT timestamp FROM points WHERE track_id = tracks.id ORDER BY timestamp ASC LIMIT 1
+        ) OR EXTRACT(EPOCH FROM tracks.end_at) <> (
+          SELECT timestamp FROM points WHERE track_id = tracks.id ORDER BY timestamp DESC LIMIT 1
+        )
+      SQL
+    end
+
+    def refresh(track)
+      track.with_lock do
+        # Lock current members as well: parallel chunk processors do not take
+        # the finalizer's per-user lock and can otherwise remove these points
+        # while the dependent statistics are being rebuilt.
+        points = track.points.order(:id).lock.to_a.sort_by(&:timestamp)
+        next :insufficient_points if points.size < 2
+
+        start_at = Time.zone.at(points.first.timestamp)
+        end_at = Time.zone.at(points.last.timestamp)
+        next :unchanged if track.start_at == start_at && track.end_at == end_at
+
+        elevation = calculate_elevation_stats(points)
+        track.update!(start_at: start_at, end_at: end_at,
+                      elevation_gain: elevation[:gain], elevation_loss: elevation[:loss],
+                      elevation_min: elevation[:min], elevation_max: elevation[:max])
+        # Changing bounds invokes Track's path/distance/duration/speed callback.
+        # Strict reprocessing rolls back that update too if detection fails.
+        Tracks::Reprocessor.reprocess(track)
+        :refreshed
+      end
+    rescue ActiveRecord::RecordNotUnique => e
+      constraint = e.cause&.result&.error_field(PG::Result::PG_DIAG_CONSTRAINT_NAME)
+      raise unless constraint == 'index_tracks_on_user_tracker_start_end_unique'
+
+      # Preserve both identities; a permanent historical conflict must not
+      # prevent the remaining valid tracks from finishing on every new run.
+      :bounds_collision
+    end
+  end
+end

--- a/spec/regressions/completed_chunk_track_metadata_spec.rb
+++ b/spec/regressions/completed_chunk_track_metadata_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Completed chunk track metadata' do
+  let(:user) { create(:user, settings: { 'minutes_between_routes' => 60, 'meters_between_routes' => 100 }) }
+  let(:base_time) { Time.utc(2026, 7, 17) }
+
+  def generate_chunks(order, tracker_id: 'synthetic-device', step: 0.1)
+    rows = 217.times.map do |index|
+      { user_id: user.id, timestamp: base_time.to_i + index * 1200,
+        lonlat: "POINT(#{13 + index * step} 52)", tracker_id: tracker_id,
+        altitude: index, anomaly: false, created_at: Time.current, updated_at: Time.current }
+    end
+    Point.insert_all!(rows)
+    chunks = Tracks::TimeChunker.new(user, start_at: base_time, end_at: base_time + 3.days).call
+    session = Tracks::SessionManager.create_for_user(user.id)
+    session.mark_started(chunks.size)
+    order.each do |index|
+      Tracks::TimeChunkProcessorJob.perform_now(user.id, session.session_id, chunks.fetch(index))
+    end
+    Tracks::BoundaryResolverJob.perform_now(user.id, session.session_id)
+    expect(session.get_session_data.fetch('status')).to eq('completed')
+    session.get_session_data
+  ensure
+    session&.cleanup_session
+  end
+
+  def expect_consistent_metadata
+    expect(user.points.where.not(track_id: nil).count).to eq(217)
+    user.tracks.each do |track|
+      points = track.points.order(:timestamp).to_a
+      expect(track.start_at.to_i).to eq(points.first.timestamp)
+      expect(track.end_at.to_i).to eq(points.last.timestamp)
+      expect(track.duration).to eq(points.last.timestamp - points.first.timestamp)
+      # Initial generation uses a sphere; model recalculation uses the PostGIS
+      # spheroid. Both must describe these members, within that earth-model gap.
+      distance = Point.calculate_distance_for_array_geocoder(points, :m)
+      expect(track.distance).to be_within(distance * 0.005).of(distance)
+      expect(track.avg_speed.to_f).to eq(Track.avg_speed_kmh(track.distance, track.duration))
+      expect(track.elevation_gain).to eq(points.last.altitude - points.first.altitude)
+      expect(track.elevation_min).to eq(points.first.altitude)
+      expect(track.elevation_max).to eq(points.last.altitude)
+      expect(track.track_segments.auto_classified.minimum(:start_at)).to be >= track.start_at
+      expect(track.track_segments.auto_classified.maximum(:end_at)).to be <= track.end_at
+    end
+  end
+
+  [[0, 1, 2], [2, 1, 0], [0, 2, 1]].each do |order|
+    it "refreshes surviving partial tracks after chunks finish in order #{order}" do
+      generate_chunks(order)
+      expect(user.tracks.count).to eq(3)
+      expect_consistent_metadata
+    end
+  end
+
+  it 'refreshes imported points without a device identifier' do
+    generate_chunks([0, 1, 2], tracker_id: nil, step: 0.01)
+    expect(user.tracks.count).to eq(3)
+    expect_consistent_metadata
+  end
+
+  it 'retains the existing merge for a densely sampled route' do
+    generate_chunks([0, 2, 1], step: 0.01)
+    expect(user.tracks.count).to eq(1)
+    expect_consistent_metadata
+  end
+
+  it 'reports an unsupported historical track and still completes the new tracks' do
+    historical = create(:track, user: user, start_at: base_time - 3.days,
+                               end_at: base_time - 2.days, created_at: 3.days.ago)
+    create(:point, user: user, track: historical, timestamp: (base_time - 3.days).to_i)
+    original = historical.attributes
+
+    data = generate_chunks([0, 1, 2])
+
+    expect(data.dig('metadata', 'track_metadata_refresh')).to include(
+      'refreshed' => 2, 'skipped' => 1, 'reasons' => { 'insufficient_points' => 1 }, 'sample_ids' => [historical.id]
+    )
+    expect(historical.reload.attributes).to eq(original)
+    expect(user.tracks.where.not(id: historical.id).count).to eq(3)
+    user.tracks.where.not(id: historical.id).find_each do |track|
+      bounds = track.points.pick(Arel.sql('MIN(timestamp), MAX(timestamp)'))
+      expect([track.start_at.to_i, track.end_at.to_i]).to eq(bounds)
+    end
+  end
+end

--- a/spec/services/tracks/metadata_refresher_spec.rb
+++ b/spec/services/tracks/metadata_refresher_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tracks::MetadataRefresher do
+  let(:user) { create(:user) }
+  let(:base_time) { Time.utc(2026, 7, 17) }
+  let!(:track) do
+    create(:track, user: user, start_at: base_time, end_at: base_time + 2.hours,
+                   created_at: 2.days.ago)
+  end
+  let!(:points) do
+    [0, 30, 60].map do |minutes|
+      create(:point, user: user, track: track, timestamp: (base_time + minutes.minutes).to_i,
+                     lonlat: "POINT(#{13 + minutes * 0.001} 52)", altitude: minutes)
+    end
+  end
+
+  it 'preserves the track, its share and a manual correction crossing the trimmed boundary' do
+    link = create(:shared_link, user: user, resource_type: :track, resource_id: track.id)
+    correction = create(:track_segment, :anchored, track: track, source: 'manual',
+                                                   corrected_at: Time.current,
+                                                   start_at: base_time + 30.minutes,
+                                                   end_at: base_time + 90.minutes)
+    original = correction.attributes
+
+    described_class.new(user).call
+
+    expect(track.reload.end_at).to eq(base_time + 1.hour)
+    expect(link.reload.resource_id).to eq(track.id)
+    expect(correction.reload.attributes).to eq(original)
+    expect(track.elevation_gain).to eq(60)
+  end
+
+  it 'does no writes when the finalizer runs again' do
+    described_class.new(user).call
+    original = track.reload.attributes
+    segments = track.track_segments.order(:id).map(&:attributes)
+    expect(Tracks::Reprocessor).not_to receive(:reprocess)
+
+    described_class.new(user).call
+
+    expect(track.reload.attributes).to eq(original)
+    expect(track.track_segments.order(:id).map(&:attributes)).to eq(segments)
+  end
+
+  it 'rolls back all metrics and automatic segments when detection fails' do
+    segment = create(:track_segment, :anchored, track: track, start_at: base_time, end_at: track.end_at)
+    original = track.reload.attributes
+    detector = instance_double(TransportationModes::Detector)
+    allow(TransportationModes::Detector).to receive(:new).and_return(detector)
+    allow(detector).to receive(:call).and_raise('synthetic detection failure')
+
+    expect { described_class.new(user).call }.to raise_error('synthetic detection failure')
+
+    expect(track.reload.attributes).to eq(original)
+    expect(TrackSegment.exists?(segment.id)).to be(true)
+  end
+
+  it 'rolls back rather than overwrite another track when corrected bounds collide' do
+    other = create(:track, user: user, start_at: base_time, end_at: base_time + 1.hour)
+    original = track.reload.attributes
+
+    result = described_class.new(user).call
+
+    expect(result).to include(skipped: 1, reasons: { bounds_collision: 1 }, sample_ids: [track.id])
+    expect(track.reload.attributes).to eq(original)
+    expect(Track.exists?(other.id)).to be(true)
+    expect(points.map { |point| point.reload.track_id }.uniq).to eq([track.id])
+  end
+
+  it 'preserves a one-point track when a valid replacement path cannot be built' do
+    track.points.where.not(id: points.first.id).delete_all
+    original = track.reload.attributes
+
+    result = described_class.new(user).call
+
+    expect(result).to include(skipped: 1, reasons: { insufficient_points: 1 }, sample_ids: [track.id])
+    expect(track.reload.attributes).to eq(original)
+    expect(points.first.reload.track_id).to eq(track.id)
+  end
+
+  it 'does not touch empty tracks or another user’s tracks' do
+    track.points.delete_all
+    other = create(:track)
+    original = [track.reload.attributes, other.attributes]
+
+    described_class.new(user).call
+
+    expect([track.reload.attributes, other.reload.attributes]).to eq(original)
+  end
+end


### PR DESCRIPTION
Buffered track-generation chunks can reassign points from an earlier partial track. If the surviving tracks are too far apart for the existing spatial merge policy, their saved time bounds, distance, elevation and transportation segments continue describing points they no longer own. Finalization now refreshes those surviving rows from current membership, retaining track IDs, public links and manual transportation corrections.

The finalizer finds mismatched endpoints using the existing `(track_id, timestamp)` index, then locks each affected track and its current points while recalculating metrics and automatic segments in one transaction. It keeps the current split/merge thresholds. Historical rows with fewer than two points or a conflicting unique time span remain untouched; bounded skip counts, reasons and up to ten IDs are saved in the generation session metadata and logged. Unexpected recalculation failures still roll back and fail the session. This does not claim to repair every historical inconsistency: unchanged endpoints alone do not identify changes to interior membership, and future chunk writes may require their own finalization.

Validation:
- Actual current-dev chunk processors and finalizer: sparse 20-minute points with a device ID leave two of three tracks inconsistent in each of three processing orders; unidentified-device imports also fail. Dense-route control merges correctly. Maintained regression before the fix: 5 examples, 4 failures.
- Initial related suite: 402 examples pass. Final targeted suite after review changes: 20 examples pass, covering real chunk integration, older unsupported rows plus successful new generation, repeat execution without writes, preserved shares/manual corrections and rollback on detector failure or bounds conflicts. Changed Ruby files pass RuboCop.
- Read-only selection benchmark: 3,400 tracks / 850,000 synthetic points, 41.19 ms; PostgreSQL uses forward/backward index-only endpoint scans. This measures selection, not the cost of rebuilding every affected track.
- Complete Rails suite on `ccab162a`: **9,382 examples, 0 failures** in 7m39s. Final `bfc7d50c` only narrows locked point columns to ID, timestamp and altitude; the 20 targeted examples and RuboCop pass again.
- Independent actual two-connection PostgreSQL QA passed on the final source: a concurrent point reassignment waits for the refresher transaction. A temporary control with only the point lock removed reproduces inconsistent duration versus bounds/elevation. Owned fixture rows and processes were cleaned.
- Separate-process rebuild benchmark on the final source: one 50,000-point track refreshes in **4.22 seconds**, with **1.11 GiB maximum process RSS** (Rails included; fixture seeding occurred in another process). This is material memory usage for large tracks; finalization remains background work and processes affected tracks one at a time. No claim is made for bounded memory on arbitrary track sizes.
- Two post-publication engineering, QA and product review rounds completed with no remaining actionable findings. The large-track memory limit above remains material for deployment planning.

No migration, point deletion or changes to track membership. Existing unsupported rows are preserved; this PR does not introduce a new warning interface.

Refs #3209.
