### PR TITLE
Highlight hovered transportation segments in the timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Hovering a transportation segment in the map timeline now animates only that segment and restores the existing track highlight on exit. (#3497)
+
 - Traccar latitude/longitude form uploads now save points, including Unix timestamps in seconds or milliseconds. Payloads that cannot be stored return an error instead of a false success; repeated valid uploads remain safe. (#3299)
 ## Unreleased
 

--- a/app/javascript/controllers/maps/maplibre_controller.js
+++ b/app/javascript/controllers/maps/maplibre_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { formatNumber, translate } from "i18n"
 import { Toast } from "maps_maplibre/components/toast"
 import { ReplayPanel } from "maps_maplibre/managers/replay_panel"
+import { TimelineSegmentHover } from "maps_maplibre/managers/timeline_segment_hover"
 import { ApiClient } from "maps_maplibre/services/api_client"
 import { CleanupHelper } from "maps_maplibre/utils/cleanup_helper"
 import { featureToPhoto } from "maps_maplibre/utils/feature_to_photo"
@@ -263,6 +264,10 @@ export default class extends Controller {
       this.boundHandleEntryDeselect,
     )
 
+    this.timelineSegmentHover = new TimelineSegmentHover(this, () =>
+      SettingsManager.getSetting("tracksEnabled"),
+    )
+
     // SPA date-range change from the Timeline calendar — refetch all enabled
     // layers for the new start/end without tearing down the map instance.
     this.boundHandleDateNavigated = this.handleTimelineDateNavigated.bind(this)
@@ -357,6 +362,7 @@ export default class extends Controller {
     this.settingsController?.stopRecalculationPolling()
     this.searchManager?.destroy()
     this.visitsManager?.destroy()
+    this.timelineSegmentHover?.destroy()
     this.eventHandlers?.destroy()
     cancelAllPreviews()
     if (this._persistView) this.map?.off("moveend", this._persistView)

--- a/app/javascript/maps_maplibre/layers/tracks_layer.js
+++ b/app/javascript/maps_maplibre/layers/tracks_layer.js
@@ -26,6 +26,8 @@ export class TracksLayer extends BaseLayer {
     this.animationActive = false
     this.segmentsActive = false
     this.selectedTrackLength = 0 // meters
+    this.selectedFeature = null
+    this.selectionRevision = 0
     this.flowTrackColor = "#ff0000"
 
     this.onSegmentHover = null // Callback for segment hover events
@@ -146,15 +148,18 @@ export class TracksLayer extends BaseLayer {
    * Set selected track for highlighting
    * @param {Object|null} feature - Track feature or null to clear
    */
-  setSelectedTrack(feature) {
+  setSelectedTrack(feature, { preserveSegments = false } = {}) {
     if (!this.map) return
 
     const selectionSource = this.map.getSource(this.selectionSourceId)
     if (!selectionSource) return
 
+    this.selectedFeature = feature || null
+    this.selectionRevision += 1
+
     if (feature) {
       this.flowTrackColor = feature.properties?.color || "#ff0000"
-      this.segmentsActive = false
+      if (!preserveSegments) this.segmentsActive = false
       this.selectedTrackLength = this._computeLineLength(
         feature.geometry?.coordinates || [],
       )
@@ -170,7 +175,7 @@ export class TracksLayer extends BaseLayer {
       }
     } else {
       this._stopFlowAnimation()
-      this.segmentsActive = false
+      if (!preserveSegments) this.segmentsActive = false
       this.selectedTrackLength = 0
       selectionSource.setData({ type: "FeatureCollection", features: [] })
 

--- a/app/javascript/maps_maplibre/managers/timeline_segment_hover.js
+++ b/app/javascript/maps_maplibre/managers/timeline_segment_hover.js
@@ -1,0 +1,183 @@
+import { CleanupHelper } from "../utils/cleanup_helper"
+
+// Temporary use of the existing track shimmer. A newer selection always wins;
+// hover must never restore an old track over a click or a date change.
+export class TimelineSegmentHover {
+  constructor(controller, isEnabled) {
+    this.controller = controller
+    this.isEnabled = isEnabled
+    this.cleanup = new CleanupHelper()
+    this.generation = 0
+    this.cleanup.addEventListener(
+      document,
+      "dawarich:segment-hover",
+      (event) => {
+        if (event.target === document) return // map-to-row notification
+        this.hover(event)
+      },
+    )
+    this.cleanup.addEventListener(
+      document,
+      "dawarich:segment-unhover",
+      (event) => {
+        if (event.target === this.row) this.leave()
+      },
+    )
+    for (const event of [
+      "timeline-feed:entry-hover",
+      "timeline-feed:entry-click",
+      "timeline-feed:entry-deselect",
+      "timeline-feed:date-navigated",
+      "timeline-feed:day-collapsed",
+      "dawarich:segment-mode-changed",
+    ]) {
+      this.cleanup.addEventListener(document, event, () => this.reset())
+    }
+    this.onMapClick = () => this.reset()
+    controller.map.on("click", this.onMapClick)
+    controller.map.on("style.load", this.onMapClick)
+  }
+
+  get layer() {
+    return this.controller.layerManager.getLayer("tracks")
+  }
+
+  async hover(event) {
+    this.leave()
+    const { trackId, segmentId } = event.detail
+    if (!trackId || !segmentId || !this.isEnabled() || !this.layer) return
+    const layer = this.layer
+    const source = this.controller.map.getSource(layer.selectionSourceId)
+    if (!source) return
+    const revision = layer.selectionRevision
+    const generation = this.generation
+    this.row = event.target
+    try {
+      const track = await this.loadTrack(trackId)
+      if (
+        generation !== this.generation ||
+        !this.row?.isConnected ||
+        !this.isEnabled() ||
+        layer !== this.layer ||
+        this.controller.map.getSource(layer.selectionSourceId) !== source ||
+        layer.selectionRevision !== revision
+      )
+        return
+      const segment = track?.properties?.segments?.find(
+        (item) => String(item.id) === String(segmentId),
+      )
+      const coordinates = segmentCoordinates(track, segment)
+      if (!coordinates) return
+
+      this.previous = {
+        layer,
+        source,
+        feature: layer.selectedFeature,
+        opacity: this.controller.map.getLayer(layer.id)
+          ? this.controller.map.getPaintProperty(layer.id, "line-opacity")
+          : null,
+      }
+      layer.setSelectedTrack(
+        {
+          type: "Feature",
+          geometry: { type: "LineString", coordinates },
+          properties: {
+            ...track.properties,
+            color: segment.color || track.properties.color,
+          },
+        },
+        { preserveSegments: true },
+      )
+      this.ownedRevision = layer.selectionRevision
+    } catch {
+      // Hover is optional: retain the ordinary track highlight on failure.
+      // Failed requests are evicted by loadTrack so another hover can retry.
+    }
+  }
+
+  loadTrack(trackId) {
+    if (this.cached?.id === String(trackId)) return this.cached.promise
+    this.cached?.abort.abort()
+    const abort = new AbortController()
+    const entry = { id: String(trackId), abort }
+    entry.promise = this.controller.api
+      .fetchTrackWithSegments(trackId, { signal: abort.signal })
+      .catch((error) => {
+        if (this.cached === entry) this.cached = null
+        throw error
+      })
+    this.cached = entry
+    return entry.promise
+  }
+
+  leave() {
+    this.generation += 1
+    this.row = null
+    const layer = this.layer
+    if (
+      this.previous &&
+      layer === this.previous.layer &&
+      this.controller.map.getSource(layer.selectionSourceId) ===
+        this.previous.source &&
+      layer.selectionRevision === this.ownedRevision
+    ) {
+      layer.setSelectedTrack(this.previous.feature, { preserveSegments: true })
+      if (
+        this.previous.opacity != null &&
+        this.controller.map.getLayer(layer.id)
+      ) {
+        this.controller.map.setPaintProperty(
+          layer.id,
+          "line-opacity",
+          this.previous.opacity,
+        )
+      }
+    }
+    this.previous = null
+    this.ownedRevision = null
+  }
+
+  reset() {
+    this.leave()
+    this.cached?.abort.abort()
+    this.cached = null
+  }
+
+  destroy() {
+    this.reset()
+    this.cleanup.cleanup()
+    this.controller.map.off("click", this.onMapClick)
+    this.controller.map.off("style.load", this.onMapClick)
+  }
+}
+
+export function segmentCoordinates(track, segment) {
+  if (!segment) return null
+  let coordinates = segment.coordinates
+  if (!coordinates) {
+    const { start_index: start, end_index: end } = segment
+    const full = track?.geometry?.coordinates
+    if (
+      track?.geometry?.type !== "LineString" ||
+      !Array.isArray(full) ||
+      !Number.isInteger(start) ||
+      !Number.isInteger(end) ||
+      start < 0 ||
+      end < start ||
+      end >= full.length
+    )
+      return null
+    coordinates = full.slice(start, end + 1)
+  }
+  return Array.isArray(coordinates) &&
+    coordinates.length >= 2 &&
+    coordinates.every(
+      (point) =>
+        Array.isArray(point) &&
+        point.length >= 2 &&
+        Number.isFinite(point[0]) &&
+        Number.isFinite(point[1]),
+    )
+    ? coordinates
+    : null
+}

--- a/app/javascript/maps_maplibre/services/api_client.js
+++ b/app/javascript/maps_maplibre/services/api_client.js
@@ -574,11 +574,12 @@ export class ApiClient {
    * @param {number|string} trackId - The track ID
    * @returns {Promise<Object>} GeoJSON Feature with segments
    */
-  async fetchTrackWithSegments(trackId) {
+  async fetchTrackWithSegments(trackId, { signal } = {}) {
     const url = `${this.baseURL}/tracks/${trackId}`
 
     const response = await fetch(url, {
       headers: this.getHeaders(),
+      signal,
     })
 
     if (!response.ok) {

--- a/app/serializers/tracks/geojson_serializer.rb
+++ b/app/serializers/tracks/geojson_serializer.rb
@@ -119,6 +119,7 @@ class Tracks::GeojsonSerializer
 
   def segment_identity(segment)
     {
+      id: segment.id,
       mode: segment.transportation_mode,
       emoji: emoji_for_mode(segment.transportation_mode),
       color: color_for_mode(segment.transportation_mode),

--- a/spec/javascript/timeline_segment_hover_test.mjs
+++ b/spec/javascript/timeline_segment_hover_test.mjs
@@ -1,0 +1,290 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const read = (path) =>
+  readFile(new URL(`../../app/javascript/${path}`, import.meta.url), "utf8")
+const url = (source) =>
+  `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+const strip = (source) => source.replace(/^import[\s\S]*?from "[^"]+"\n/gm, "")
+const cleanup = await read("maps_maplibre/utils/cleanup_helper.js")
+const { TimelineSegmentHover, segmentCoordinates } = await import(
+  url(
+    `${cleanup}\n${strip(await read("maps_maplibre/managers/timeline_segment_hover.js"))}`,
+  )
+)
+const { TracksLayer } = await import(
+  url(
+    `${await read("maps_maplibre/layers/base_layer.js")}\n${strip(await read("maps_maplibre/layers/tracks_layer.js"))}`,
+  )
+)
+globalThis.requestAnimationFrame = () => 1
+globalThis.cancelAnimationFrame = () => {}
+const full = {
+  type: "Feature",
+  properties: {
+    id: 1,
+    color: "blue",
+    segments: [
+      {
+        id: 10,
+        coordinates: [
+          [1, 1],
+          [2, 2],
+        ],
+        color: "green",
+      },
+      { id: 11, start_index: 1, end_index: 2, color: "red" },
+    ],
+  },
+  geometry: {
+    type: "LineString",
+    coordinates: [
+      [0, 0],
+      [1, 1],
+      [2, 2],
+      [3, 3],
+    ],
+  },
+}
+function deferred() {
+  let resolve, reject
+  const promise = new Promise((yes, no) => {
+    resolve = yes
+    reject = no
+  })
+  return { promise, resolve, reject }
+}
+function setup(fetcher = async () => full) {
+  const listeners = new Map()
+  globalThis.document = {
+    addEventListener(name, cb) {
+      listeners.set(name, cb)
+    },
+    removeEventListener(name) {
+      listeners.delete(name)
+    },
+  }
+  const source = {
+    setData(data) {
+      this.data = data
+    },
+  }
+  const map = {
+    opacity: 0.6,
+    source,
+    on() {},
+    off() {},
+    getSource() {
+      return this.source
+    },
+    getLayer: () => ({}),
+    getPaintProperty() {
+      return this.opacity
+    },
+    setPaintProperty(_id, _key, value) {
+      this.opacity = value
+    },
+  }
+  const layer = new TracksLayer(map)
+  layer.setSelectedTrack(full)
+  layer.segmentsActive = true
+  map.opacity = 0.6
+  const requests = []
+  const controller = {
+    map,
+    layerManager: { getLayer: () => layer },
+    api: {
+      fetchTrackWithSegments(id, options) {
+        requests.push({ id, ...options })
+        return fetcher(id, options)
+      },
+    },
+  }
+  let enabled = true
+  const manager = new TimelineSegmentHover(controller, () => enabled)
+  const event = (id = 10, trackId = 1) => ({
+    target: { isConnected: true },
+    detail: { trackId, segmentId: id },
+  })
+  return {
+    manager,
+    layer,
+    map,
+    requests,
+    event,
+    listeners,
+    disable: () => {
+      enabled = false
+    },
+  }
+}
+
+test("hover animates the exact segment and restores the full track, colors and opacity", async () => {
+  const h = setup()
+  await h.manager.hover(h.event())
+  assert.deepEqual(h.map.source.data.features[0].geometry.coordinates, [
+    [1, 1],
+    [2, 2],
+  ])
+  assert.equal(h.layer.flowTrackColor, "green")
+  assert.equal(h.layer.animationActive, true)
+  h.manager.leave()
+  assert.equal(h.map.source.data.features[0], full)
+  assert.equal(h.layer.segmentsActive, true)
+  assert.equal(h.map.opacity, 0.6)
+  h.manager.destroy()
+})
+test("rapid segment changes share one in-flight request and only the latest wins", async () => {
+  const d = deferred(),
+    h = setup(() => d.promise)
+  const first = h.manager.hover(h.event(10))
+  const second = h.manager.hover(h.event(11))
+  assert.equal(h.requests.length, 1)
+  d.resolve(full)
+  await Promise.all([first, second])
+  assert.equal(h.layer.flowTrackColor, "red")
+  assert.deepEqual(h.layer.selectedFeature.geometry.coordinates, [
+    [1, 1],
+    [2, 2],
+  ])
+  await h.manager.hover(h.event(10))
+  assert.equal(h.requests.length, 1)
+  h.manager.destroy()
+})
+test("leaving before a response keeps the original selection", async () => {
+  const d = deferred(),
+    h = setup(() => d.promise)
+  const pending = h.manager.hover(h.event())
+  h.manager.leave()
+  d.resolve(full)
+  await pending
+  assert.equal(h.layer.selectedFeature, full)
+  h.manager.destroy()
+})
+test("a newer map selection wins both before response and after segment hover", async () => {
+  const d = deferred(),
+    h = setup(() => d.promise)
+  const newer = { ...full, properties: { id: 2 } }
+  const pending = h.manager.hover(h.event())
+  h.layer.setSelectedTrack(newer)
+  d.resolve(full)
+  await pending
+  assert.equal(h.layer.selectedFeature, newer)
+  await h.manager.hover(h.event())
+  h.layer.setSelectedTrack(newer)
+  h.manager.leave()
+  assert.equal(h.layer.selectedFeature, newer)
+  h.manager.destroy()
+})
+test("reset aborts requests and invalidates cached data, while destroy removes listeners", async () => {
+  const d = deferred(),
+    h = setup(() => d.promise)
+  const pending = h.manager.hover(h.event())
+  h.listeners.get("timeline-feed:date-navigated")()
+  assert.equal(h.requests[0].signal.aborted, true)
+  d.resolve(full)
+  await pending
+  assert.equal(h.layer.selectedFeature, full)
+  await h.manager.hover(h.event())
+  assert.equal(h.requests.length, 2)
+  h.manager.destroy()
+  assert.equal(h.listeners.size, 0)
+})
+test("only one track is cached and failed requests can be retried", async () => {
+  let fail = true
+  const h = setup(async () => {
+    if (fail) throw new Error("offline")
+    return full
+  })
+  await h.manager.hover(h.event())
+  assert.equal(h.layer.selectedFeature, full)
+  fail = false
+  await h.manager.hover(h.event())
+  await h.manager.hover(h.event(10, 2))
+  await h.manager.hover(h.event(10, 1))
+  assert.equal(h.requests.length, 4)
+  assert.equal(h.requests[1].signal.aborted, true)
+  h.manager.destroy()
+})
+test("tiled main-layer visibility does not block shimmer, but disabling Tracks does", async () => {
+  const h = setup()
+  h.layer.visible = false
+  await h.manager.hover(h.event())
+  assert.notEqual(h.layer.selectedFeature, full)
+  h.manager.leave()
+  h.disable()
+  await h.manager.hover(h.event())
+  assert.equal(h.layer.selectedFeature, full)
+  assert.equal(h.requests.length, 1)
+  h.manager.destroy()
+})
+test("a replaced map source cannot receive a stale segment response or restoration", async () => {
+  const d = deferred(),
+    h = setup(() => d.promise)
+  const pending = h.manager.hover(h.event())
+  const replacement = {
+    setData(data) {
+      this.data = data
+    },
+  }
+  h.map.source = replacement
+  d.resolve(full)
+  await pending
+  assert.equal(replacement.data, undefined)
+  h.manager.destroy()
+  assert.equal(replacement.data, undefined)
+})
+test("map-origin segment broadcasts are ignored", () => {
+  const h = setup()
+  h.listeners.get("dawarich:segment-hover")({
+    target: document,
+    detail: { trackId: 1, segmentId: 10 },
+  })
+  assert.equal(h.requests.length, 0)
+  h.manager.destroy()
+})
+test("legacy slicing is inclusive and invalid or unavailable geometry is never invented", () => {
+  assert.deepEqual(segmentCoordinates(full, { start_index: 1, end_index: 2 }), [
+    [1, 1],
+    [2, 2],
+  ])
+  for (const segment of [
+    undefined,
+    {},
+    { start_index: -1, end_index: 2 },
+    { start_index: 0, end_index: 9 },
+    { start_index: 0, end_index: 0 },
+    { coordinates: [] },
+    {
+      coordinates: [
+        [1, 2],
+        [NaN, 2],
+      ],
+    },
+  ]) {
+    assert.equal(segmentCoordinates(full, segment), null)
+  }
+})
+
+test("a segment overlay arriving during hover keeps its current visibility on restoration", async () => {
+  const h = setup()
+  h.layer.segmentsActive = false
+  await h.manager.hover(h.event())
+  h.layer.segmentsActive = true
+  h.manager.leave()
+  assert.equal(h.layer.selectedFeature, full)
+  assert.equal(h.layer.segmentsActive, true)
+  h.manager.destroy()
+})
+
+test("no prior selection stays empty after hovering a segment", async () => {
+  const h = setup()
+  h.layer.setSelectedTrack(null)
+  await h.manager.hover(h.event())
+  assert.equal(h.layer.selectedFeature.geometry.coordinates.length, 2)
+  h.manager.leave()
+  assert.equal(h.layer.selectedFeature, null)
+  assert.deepEqual(h.map.source.data.features, [])
+  h.manager.destroy()
+})

--- a/spec/serializers/tracks/geojson_serializer_spec.rb
+++ b/spec/serializers/tracks/geojson_serializer_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe Tracks::GeojsonSerializer do
   end
 
   describe '#call' do
+    it 'identifies detailed segments by the same persisted IDs as their timeline rows' do
+      segment = create(:track_segment, track: track)
+      feature = described_class.new(track, include_segments: true).call[:features].first
+
+      expect(feature[:properties][:segments].map { |item| item[:id] }).to eq([segment.id])
+    end
+
     it 'returns a FeatureCollection structure' do
       result = described_class.new([track]).call
 


### PR DESCRIPTION
Hovering a transportation segment in the timeline kept the entire track shimmering. Segment rows already emitted their persisted ID, but the map did not consume those hover events and the detail API did not expose IDs for matching.

Connect row hover to the existing track shimmer using the segment’s own geometry (or validated inclusive legacy indices into the full fetched track). Restore the prior selection on exit. Preserve newer clicks, date changes and map-source replacements; late responses cannot overwrite them. The shared selection layer keeps existing segment-color state.

The existing owner-scoped detail API adds segment IDs without extra queries. Keep only one track’s detail request/data per map, deduplicate concurrent hovers, abort obsolete requests on reset and allow retries after failure. No database writes, migrations, new endpoint, zoom changes or touch interaction are added.

Validation:
- Real current-dev reproduction: cursor over Cycling segment #2, selection still contained all 41 track points. Corrected browser run selects only its 16 points and existing blue shimmer; screenshot inspected.
- Serializer regression: 3 examples / 1 expected failure before the fix, then 23 serializer/API examples pass. All 244 JavaScript tests pass, including 12 new scenarios for async ownership, restoration, bounded caching, failed requests, tiled visibility, source replacement and invalid/legacy geometry. Biome and RuboCop pass.
- Actual tiled-mode check: vector tracks source active, classic GeoJSON remains empty, hovered segment contains 16 points and restores the prior empty selection on leave. Camera was positioned over the synthetic route for visual inspection; existing tiled whole-track auto-fit behavior is unchanged.
- Independent browser QA checks delayed segment A→B, cached A/B/A with one actual detail request, restoration of the whole track and ignored map-origin broadcasts.

Only rows with a concrete segment ID gain this behavior. Grouped transfer summaries remain unchanged. One complete track response is cached; this does not change the existing endpoint’s geometry size for very large tracks.

Refs #3497

Test infrastructure notes: initial browser attempts had readiness/covered-element timeouts and were discarded; successful runs wait for the selection source. Existing rails-ujs startup error and Chromium GPU warnings reproduce on the baseline.
