### PR TITLE
Restore map locations for visits without a place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Restore Timeline map centering and place search for visits that have GPS points but no attached place, area, or suggestions.
+
 - Traccar latitude/longitude form uploads now save points, including Unix timestamps in seconds or milliseconds. Payloads that cannot be stored return an error instead of a false success; repeated valid uploads remain safe. (#3299)
 ## Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Restore Timeline map centering and place search for visits that have GPS points but no attached place, area, or suggestions.
+- Restore map markers, area selection, Timeline centering and place search for visits that have GPS points but no attached place or area.
 
 - Traccar latitude/longitude form uploads now save points, including Unix timestamps in seconds or milliseconds. Payloads that cannot be stored return an error instead of a false success; repeated valid uploads remain safe. (#3299)
 ## Unreleased

--- a/app/controllers/api/v1/visits_controller.rb
+++ b/app/controllers/api/v1/visits_controller.rb
@@ -17,8 +17,9 @@ class Api::V1::VisitsController < ApiController
       response.set_header('X-Total-Count', visits.total_count.to_s)
     end
 
+    point_centers = visit_point_centers(visits)
     serialized_visits = visits.map do |visit|
-      Api::VisitSerializer.new(visit).call
+      Api::VisitSerializer.new(visit, point_center: point_centers[visit.id]).call
     end
 
     render json: serialized_visits
@@ -26,7 +27,7 @@ class Api::V1::VisitsController < ApiController
 
   def show
     visit = current_api_user.scoped_visits.find(params[:id])
-    render json: Api::VisitSerializer.new(visit).call
+    render json: serialize_visit(visit)
   end
 
   def create
@@ -35,7 +36,7 @@ class Api::V1::VisitsController < ApiController
     result = service.call
 
     if result
-      render json: Api::VisitSerializer.new(service.visit).call
+      render json: serialize_visit(service.visit)
     else
       error_message = service.errors || I18n.t('controllers.api.v1.visits.failed_to_create_visit')
       render json: { error: error_message }, status: :unprocessable_content
@@ -65,7 +66,7 @@ class Api::V1::VisitsController < ApiController
 
     visit = update_visit(visit, area: area)
 
-    render json: Api::VisitSerializer.new(visit).call
+    render json: serialize_visit(visit)
   end
 
   def merge
@@ -90,7 +91,7 @@ class Api::V1::VisitsController < ApiController
     merged_visit = service.call
 
     if merged_visit&.persisted?
-      render json: Api::VisitSerializer.new(merged_visit).call, status: :ok
+      render json: serialize_visit(merged_visit), status: :ok
     else
       render json: { error: service.errors.join(', ') }, status: :unprocessable_content
     end
@@ -162,6 +163,17 @@ class Api::V1::VisitsController < ApiController
 
   private
 
+  def visit_point_centers(visits)
+    ids = visits.select { |visit| visit.place.nil? && visit.area.nil? }.map(&:id)
+    return {} if ids.empty?
+
+    Visits::PointCenters.new(current_api_user, visit_ids: ids).call
+  end
+
+  def serialize_visit(visit)
+    Api::VisitSerializer.new(visit, point_center: visit_point_centers([visit])[visit.id]).call
+  end
+
   def visit_params
     params.require(:visit).permit(:name, :place_id, :area_id, :status, :latitude, :longitude, :started_at, :ended_at)
   end
@@ -184,7 +196,7 @@ class Api::V1::VisitsController < ApiController
 
     if service.call
       result = { index: index, status: service.duplicate? ? 'duplicate' : 'created' }
-      result[:visit] = Api::VisitSerializer.new(service.visit).call unless service.visit.soft_deleted?
+      result[:visit] = serialize_visit(service.visit) unless service.visit.soft_deleted?
       result
     else
       { index: index, status: 'failed',

--- a/app/serializers/api/visit_serializer.rb
+++ b/app/serializers/api/visit_serializer.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class Api::VisitSerializer
-  def initialize(visit)
+  def initialize(visit, point_center: nil)
     @visit = visit
+    @point_center = point_center
   end
 
   def call
@@ -18,8 +19,8 @@ class Api::VisitSerializer
       confidence: visit.confidence,
       confidence_band: visit.confidence_band,
       place: {
-        latitude: visit.place&.lat || visit.area&.latitude,
-        longitude: visit.place&.lon || visit.area&.longitude,
+        latitude: visit.place&.lat || visit.area&.latitude || point_center&.fetch(:lat),
+        longitude: visit.place&.lon || visit.area&.longitude || point_center&.fetch(:lng),
         id: visit.place&.id
       }
     }
@@ -27,5 +28,5 @@ class Api::VisitSerializer
 
   private
 
-  attr_reader :visit
+  attr_reader :visit, :point_center
 end

--- a/app/services/timeline/day_assembler.rb
+++ b/app/services/timeline/day_assembler.rb
@@ -37,6 +37,7 @@ module Timeline
       @segment_stats = load_segment_stats(tracks)
 
       @visit_point_counts = Point.where(visit_id: visits.map(&:id)).group(:visit_id).count
+      @visit_point_centers = load_point_centers(visits.select { |visit| needs_point_center?(visit) })
 
       days = group_by_day(visits, tracks)
       build_days(days)
@@ -55,6 +56,7 @@ module Timeline
         status: visit.status,
         confidence_band: visit.confidence_band,
         place_id: visit.place_id,
+        center: point_center_for(visit),
         point_count: point_count_for(visit),
         tags: build_tags(visit.place),
         started_at: visit.started_at.iso8601,
@@ -90,6 +92,30 @@ module Timeline
       return @visit_point_counts.fetch(visit.id, 0) if @visit_point_counts
 
       visit.points.count
+    end
+
+    # Preserve the existing place/area/suggestion precedence. Only visits that
+    # have none need a GPS fallback; aggregate those points in SQL rather than
+    # instantiating every Point (or issuing one query per timeline row).
+    def needs_point_center?(visit)
+      visit.place.nil? && visit.area.nil? && (!visit.suggested? || visit.suggested_places.empty?)
+    end
+
+    def load_point_centers(visits)
+      return {} if visits.empty?
+
+      user.scoped_points.where(visit_id: visits.map(&:id)).group(:visit_id)
+          .pluck(:visit_id, Arel.sql('AVG(ST_Y(lonlat::geometry))'), Arel.sql('AVG(ST_X(lonlat::geometry))'))
+          .each_with_object({}) do |(id, lat, lng), centers|
+        centers[id] = { lat: lat, lng: lng } if lat && lng
+      end
+    end
+
+    def point_center_for(visit)
+      return nil unless needs_point_center?(visit)
+      return @visit_point_centers[visit.id] if @visit_point_centers
+
+      load_point_centers([visit])[visit.id]
     end
 
     def fetch_tracks
@@ -314,10 +340,13 @@ module Timeline
       lngs = []
 
       visits.each do |visit|
-        next unless visit.place
-
-        lats << visit.place.lat
-        lngs << visit.place.lon
+        if visit.place
+          lats << visit.place.lat
+          lngs << visit.place.lon
+        elsif (center = point_center_for(visit))
+          lats << center[:lat]
+          lngs << center[:lng]
+        end
       end
 
       track_extent = tracks_extent(tracks)

--- a/app/services/timeline/day_assembler.rb
+++ b/app/services/timeline/day_assembler.rb
@@ -104,11 +104,7 @@ module Timeline
     def load_point_centers(visits)
       return {} if visits.empty?
 
-      user.scoped_points.where(visit_id: visits.map(&:id)).group(:visit_id)
-          .pluck(:visit_id, Arel.sql('AVG(ST_Y(lonlat::geometry))'), Arel.sql('AVG(ST_X(lonlat::geometry))'))
-          .each_with_object({}) do |(id, lat, lng), centers|
-        centers[id] = { lat: lat, lng: lng } if lat && lng
-      end
+      Visits::PointCenters.new(user, visit_ids: visits.map(&:id)).call
     end
 
     def point_center_for(visit)

--- a/app/services/visits/find_within_bounding_box.rb
+++ b/app/services/visits/find_within_bounding_box.rb
@@ -22,21 +22,24 @@ module Visits
     end
 
     def call
-      relation = user.scoped_visits
-                     .left_outer_joins(:place, :area)
-                     .includes(:place, :area)
-                     .references(:place, :area)
-                     .where(
-                       "(#{PLACE_INSIDE}) OR (#{AREA_INSIDE})",
-                       sw_lng, sw_lat, ne_lng, ne_lat,
-                       sw_lng, sw_lat, ne_lng, ne_lat
-                     )
+      # Apply the same dates and visibility scope to the GPS aggregate as to
+      # the result. In particular, do not scan unrelated historical visits.
+      visits = user.scoped_visits
+      visits = visits.where(started_at: start_at..end_at) if start_at && end_at
+      unlocated = visits.where(place_id: nil, area_id: nil)
+      point_centers_inside = Visits::PointCenters.new(user, visit_ids: unlocated.select(:id))
+                                                 .within_bounds(sw_lng: sw_lng, sw_lat: sw_lat,
+                                                                ne_lng: ne_lng, ne_lat: ne_lat)
+      relation = visits.left_outer_joins(:place, :area)
+                       .includes(:place, :area)
+                       .references(:place, :area)
+      located = relation.where(
+        "(#{PLACE_INSIDE}) OR (#{AREA_INSIDE})",
+        sw_lng, sw_lat, ne_lng, ne_lat,
+        sw_lng, sw_lat, ne_lng, ne_lat
+      )
 
-      # Filter by started_at only — mirrors Visits::FindInTime; adding an
-      # ended_at predicate silently drops boundary-crossing visits.
-      relation = relation.where(started_at: start_at..end_at) if start_at && end_at
-
-      relation.order(started_at: :desc)
+      located.or(relation.where(id: point_centers_inside)).order(started_at: :desc)
     end
 
     private

--- a/app/services/visits/point_centers.rb
+++ b/app/services/visits/point_centers.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Visits
+  # The same arithmetic center as Visit#center, without instantiating Point
+  # objects. Both marker coordinates and rectangle selection use this center.
+  # Callers restrict visit_ids to the displayed/queried unlocated visits;
+  # points also retain their owner's plan visibility scope.
+  class PointCenters
+    LATITUDE = 'AVG(ST_Y(points.lonlat::geometry))'
+    LONGITUDE = 'AVG(ST_X(points.lonlat::geometry))'
+
+    def initialize(user, visit_ids:)
+      @user = user
+      @visit_ids = visit_ids
+    end
+
+    def call
+      scope.pluck(:visit_id, Arel.sql(LATITUDE), Arel.sql(LONGITUDE))
+           .each_with_object({}) do |(id, lat, lng), centers|
+        centers[id] = { lat: lat, lng: lng } if lat && lng
+      end
+    end
+
+    def within_bounds(sw_lng:, sw_lat:, ne_lng:, ne_lat:)
+      scope.select(:visit_id).having(
+        "ST_Contains(ST_MakeEnvelope(?, ?, ?, ?, 4326), ST_SetSRID(ST_MakePoint(#{LONGITUDE}, #{LATITUDE}), 4326))",
+        sw_lng, sw_lat, ne_lng, ne_lat
+      )
+    end
+
+    private
+
+    def scope
+      @user.scoped_points.where(visit_id: @visit_ids).group(:visit_id)
+    end
+  end
+end

--- a/app/views/map/timeline_feeds/_visit_entry.html.erb
+++ b/app/views/map/timeline_feeds/_visit_entry.html.erb
@@ -1,5 +1,5 @@
 <% times = visit_entry_times(entry); all_day = visit_entry_all_day?(entry) %>
-<% coords = entry[:place] || entry[:area] || entry[:suggested_places]&.first %>
+<% coords = entry[:place] || entry[:area] || entry[:suggested_places]&.first || entry[:center] %>
 <% name_parts = visit_entry_name_parts(entry) %>
 <%# A visit renders the same regardless of detection status — showing it is
     asserting it. The only affordance is Edit: rename, re-attach a place,

--- a/spec/regressions/timeline_visit_point_center_spec.rb
+++ b/spec/regressions/timeline_visit_point_center_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Timeline coordinates for visits without a place', type: :request do
+  let(:user) { create(:user) }
+  let(:day) { Time.zone.parse('2026-09-04 00:00:00') }
+  let!(:visit) do
+    create(:visit, user: user, area: nil, place: nil, name: 'Unknown Location',
+                   started_at: day + 12.hours, ended_at: day + 13.hours, duration: 60)
+  end
+
+  before do
+    create(:point, user: user, visit: visit, latitude: 52.50, longitude: 13.40, timestamp: (day + 12.hours).to_i)
+    create(:point, user: user, visit: visit, latitude: 52.52, longitude: 13.42, timestamp: (day + 13.hours).to_i)
+    sign_in user
+  end
+
+  def assembler
+    Timeline::DayAssembler.new(user, start_at: day.iso8601, end_at: (day + 1.day).iso8601)
+  end
+
+  it 'carries the existing point-derived center without assigning a place' do
+    entry = assembler.call.first[:entries].first
+    expect(visit.reload.center).to match([be_within(1e-8).of(52.51), be_within(1e-8).of(13.41)])
+    expect(entry[:center]).to match({ lat: be_within(1e-8).of(52.51), lng: be_within(1e-8).of(13.41) })
+    expect(visit.reload.place_id).to be_nil
+  end
+
+  it 'renders coordinates and a place-search mount for an unlocated visit' do
+    get map_timeline_feeds_path, params: { start_at: day.to_i, end_at: (day + 1.day).to_i }
+    expect(response).to have_http_status(:ok)
+    row = Nokogiri::HTML(response.body).at_css("#visit_entry_#{visit.id}")
+    expect(row['data-visit-lat'].to_f).to be_within(1e-8).of(52.51)
+    expect(row['data-visit-lng'].to_f).to be_within(1e-8).of(13.41)
+    expect(row.at_css('[data-visit-place-search-target="mount"]')).to be_present
+  end
+
+  it 'keeps the location after a Turbo rename rebuilds the single row' do
+    patch visit_path(visit), params: { visit: { name: 'My stop' } },
+                            headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+    expect(response).to have_http_status(:ok)
+    row = Nokogiri::HTML(response.body).at_css("#visit_entry_#{visit.id}")
+    expect(row['data-visit-lat'].to_f).to be_within(1e-8).of(52.51)
+    expect(row.at_css('[data-visit-place-search-target="mount"]')).to be_present
+  end
+
+  it 'does not invent coordinates at zero when no points exist' do
+    visit.points.delete_all
+    expect(assembler.build_visit_entry(visit)[:center]).to be_nil
+  end
+
+  it 'includes the point-derived location in day bounds' do
+    expect(assembler.call.first[:bounds]).to match(
+      sw_lat: be_within(1e-8).of(52.51), ne_lat: be_within(1e-8).of(52.51),
+      sw_lng: be_within(1e-8).of(13.41), ne_lng: be_within(1e-8).of(13.41)
+    )
+  end
+
+  it 'aggregates multiple unlocated visits without loading Point objects or growing the query count' do
+    count_queries = lambda do
+      queries = []
+      record = lambda { |_name, _start, _finish, _id, payload|
+        queries << payload[:sql] if payload[:sql].match?(/FROM "points"/i)
+      }
+      instantiated_points = 0
+      record_objects = lambda do |_name, _start, _finish, _id, payload|
+        instantiated_points += payload[:record_count] if payload[:class_name] == 'Point'
+      end
+      ActiveSupport::Notifications.subscribed(record_objects, 'instantiation.active_record') do
+        ActiveSupport::Notifications.subscribed(record, 'sql.active_record') { assembler.call }
+      end
+      expect(instantiated_points).to eq(0)
+      queries.size
+    end
+    one_visit_queries = count_queries.call
+    5.times do |i|
+      extra = create(:visit, user: user, place: nil, area: nil, started_at: day + i.hours,
+                            ended_at: day + i.hours + 30.minutes, duration: 30)
+      create(:point, user: user, visit: extra, latitude: 52.5, longitude: 13.4)
+    end
+    expect(count_queries.call).to eq(one_visit_queries)
+    expect(assembler.call.first[:entries].map { |entry| entry[:center] }).to all(be_present)
+  end
+
+  it 'preserves real zero coordinates' do
+    visit.points.update_all(lonlat: 'POINT(0 0)')
+    expect(assembler.build_visit_entry(visit)[:center]).to eq({ lat: 0.0, lng: 0.0 })
+  end
+
+  it 'does not use a point belonging to another user even with an inconsistent visit association' do
+    create(:point, visit: visit, latitude: 10, longitude: 20)
+    expect(assembler.build_visit_entry(visit)[:center]).to match(
+      { lat: be_within(1e-8).of(52.51), lng: be_within(1e-8).of(13.41) }
+    )
+  end
+
+  it 'keeps the existing suggested-place coordinates ahead of GPS fallback' do
+    suggestion = create(:place, user: user, latitude: 51, longitude: 12)
+    visit.suggested_places << suggestion
+    get map_timeline_feeds_path, params: { start_at: day.to_i, end_at: (day + 1.day).to_i }
+    row = Nokogiri::HTML(response.body).at_css("#visit_entry_#{visit.id}")
+    expect(row['data-visit-lat'].to_f).to eq(51)
+    expect(row['data-visit-lng'].to_f).to eq(12)
+  end
+end

--- a/spec/regressions/visit_point_center_api_spec.rb
+++ b/spec/regressions/visit_point_center_api_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Visit map coordinates without an attached place', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+  let(:user) { create(:user) }
+  let(:day) { Time.zone.parse('2026-09-04') }
+  let(:headers) { { 'Authorization' => "Bearer #{user.api_key}" } }
+  let(:time_params) { { start_at: day.iso8601, end_at: (day + 1.day).iso8601 } }
+  let!(:visit) do
+    create(:visit, user: user, place: nil, area: nil, started_at: day + 12.hours,
+                   ended_at: day + 13.hours, duration: 60)
+  end
+
+  before do
+    create(:point, user: user, visit: visit, latitude: 52.50, longitude: 13.40, timestamp: (day + 12.hours).to_i)
+    create(:point, user: user, visit: visit, latitude: 52.52, longitude: 13.42, timestamp: (day + 13.hours).to_i)
+  end
+
+  def expect_point_center(payload)
+    expect(payload.fetch('place')).to include(
+      'id' => nil, 'latitude' => be_within(1e-8).of(52.51), 'longitude' => be_within(1e-8).of(13.41)
+    )
+    expect(visit.reload.place_id).to be_nil
+    expect(visit.area_id).to be_nil
+  end
+
+  it 'returns the GPS center for map markers without creating a place' do
+    get '/api/v1/visits', params: time_params, headers: headers
+    expect(response).to have_http_status(:ok)
+    expect_point_center(response.parsed_body.find { |entry| entry['id'] == visit.id })
+  end
+
+  it 'returns the same center in visit details' do
+    get "/api/v1/visits/#{visit.id}", headers: headers
+    expect(response).to have_http_status(:ok)
+    expect_point_center(response.parsed_body)
+  end
+
+  it 'preserves the coordinates in the response to a name update' do
+    patch "/api/v1/visits/#{visit.id}", params: { visit: { name: 'My stop' } }, headers: headers
+    expect(response).to have_http_status(:ok)
+    expect_point_center(response.parsed_body)
+  end
+
+  it 'selects the displayed center, even when neither original point is inside the rectangle' do
+    get '/api/v1/visits', params: time_params.merge(selection: 'true', sw_lat: 52.509, sw_lng: 13.409,
+                                                    ne_lat: 52.511, ne_lng: 13.411), headers: headers
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.pluck('id')).to eq([visit.id])
+    expect_point_center(response.parsed_body.first)
+  end
+
+  it 'does not select a visit merely because one of its points is inside the rectangle' do
+    get '/api/v1/visits', params: time_params.merge(selection: 'true', sw_lat: 52.499, sw_lng: 13.399,
+                                                    ne_lat: 52.501, ne_lng: 13.401), headers: headers
+    expect(response.parsed_body).to eq([])
+  end
+
+  it 'keeps missing coordinates absent when the visit has no points' do
+    visit.points.delete_all
+    get "/api/v1/visits/#{visit.id}", headers: headers
+    expect(response.parsed_body.fetch('place')).to eq('id' => nil, 'latitude' => nil, 'longitude' => nil)
+  end
+
+  it 'does not include a GPS-only visit outside the requested dates in a rectangle search' do
+    get '/api/v1/visits', params: time_params.merge(start_at: (day + 2.days).iso8601,
+                                                    end_at: (day + 3.days).iso8601, selection: 'true',
+                                                    sw_lat: 52, sw_lng: 13, ne_lat: 53, ne_lng: 14), headers: headers
+    expect(response.parsed_body).to eq([])
+  end
+
+  it 'keeps pagination totals and coordinates on the requested page' do
+    create(:visit, user: user, place: nil, area: nil, started_at: day + 9.hours,
+                   ended_at: day + 10.hours, duration: 60)
+    get '/api/v1/visits', params: time_params.merge(page: 2, per_page: 1), headers: headers
+    expect(response.headers['X-Total-Count']).to eq('2')
+    expect(response.headers['X-Total-Pages']).to eq('2')
+    expect(response.parsed_body.pluck('id')).to eq([visit.id])
+    expect_point_center(response.parsed_body.first)
+  end
+
+  it 'batches map coordinates without instantiating Point objects or adding queries per visit' do
+    5.times do |i|
+      extra = create(:visit, user: user, place: nil, area: nil, started_at: day + i.hours,
+                            ended_at: day + i.hours + 30.minutes, duration: 30)
+      create(:point, user: user, visit: extra, latitude: 52.51, longitude: 13.41)
+    end
+    point_objects = 0
+    aggregate_queries = 0
+    objects = lambda do |_name, _start, _finish, _id, payload|
+      point_objects += payload[:record_count] if payload[:class_name] == 'Point'
+    end
+    queries = lambda do |_name, _start, _finish, _id, payload|
+      aggregate_queries += 1 if payload[:sql].include?('AVG(ST_Y')
+    end
+    ActiveSupport::Notifications.subscribed(objects, 'instantiation.active_record') do
+      ActiveSupport::Notifications.subscribed(queries, 'sql.active_record') do
+        get '/api/v1/visits', params: time_params, headers: headers
+      end
+    end
+    expect(response.parsed_body.size).to eq(6)
+    expect(response.parsed_body.map { |entry| entry['place']['latitude'] }).to all(be_within(1e-8).of(52.51))
+    expect(aggregate_queries).to eq(1)
+    expect(point_objects).to eq(0)
+  end
+
+  it 'preserves the strict rectangle boundary for a real zero-valued center' do
+    visit.points.update_all(lonlat: 'POINT(0 0)')
+    get '/api/v1/visits', params: time_params.merge(selection: 'true', sw_lat: 0, sw_lng: 0,
+                                                    ne_lat: 1, ne_lng: 1), headers: headers
+    expect(response.parsed_body).to eq([])
+    get '/api/v1/visits', params: time_params.merge(selection: 'true', sw_lat: -1, sw_lng: -1,
+                                                    ne_lat: 1, ne_lng: 1), headers: headers
+    expect(response.parsed_body.first.fetch('place')).to eq('id' => nil, 'latitude' => 0.0, 'longitude' => 0.0)
+  end
+
+  it 'does not expose another users GPS-only visit in rectangle selection or details' do
+    other = create(:visit, area: nil, place: nil, started_at: day + 12.hours, ended_at: day + 13.hours)
+    create(:point, user: other.user, visit: other, latitude: 52.51, longitude: 13.41)
+    get '/api/v1/visits', params: time_params.merge(selection: 'true', sw_lat: 52, sw_lng: 13,
+                                                    ne_lat: 53, ne_lng: 14), headers: headers
+    expect(response.parsed_body.pluck('id')).to eq([visit.id])
+    get "/api/v1/visits/#{other.id}", headers: headers
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it 'excludes points outside a restricted users visibility window from the center' do
+    travel_to(day + 1.day) do
+      allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+      user.update!(plan: :lite)
+      create(:point, user: user, visit: visit, latitude: 10, longitude: 20, timestamp: (day - 2.years).to_i)
+      get "/api/v1/visits/#{visit.id}", headers: headers
+      expect_point_center(response.parsed_body)
+    end
+  end
+end


### PR DESCRIPTION
Visits with GPS points but no Place or Area could lose their location in the Timeline and API. They had no persistent map marker, were omitted from bounding-box selection, and could not mount the nearby-place search. Use the existing arithmetic GPS center as a fallback across these paths, while preserving Place/Area precedence and optional Place assignment.

Coordinate aggregation is shared, scoped to the user's visible points, and batched for the requested visits. Bounding-box selection tests the same center shown on the map, preserves strict boundary semantics, and applies existing visibility/date filters before aggregation. Visits without points remain unlocated; genuine zero coordinates are retained. This adds no migrations or database writes and does not create Places automatically.

Validation:
- Reproduced Timeline failures before the fix (4 failing cases) and API/bounding-box failures before the extension (4 failing cases).
- Added 21 regression examples covering Timeline rendering, API responses, ownership, plan visibility, dates, pagination, zero/boundary coordinates, and batched queries without Point instantiation. Original fix head bc92c990: related suite 266 examples and full suite 9,391 examples, both with 0 failures; desktop/mobile browser evidence below is from that head. After syncing with dev at 689ae1a6, the application/spec fix is unchanged: a fresh affected-area run passed 172 examples with 0 failures, and all 7 changed Ruby files pass RuboCop. The new CI run is pending.
- Real local Rails/PostGIS browser checks on desktop and 390px mobile: persistent marker, halo, visit count and nearby search work without a Place. Real bounding-box requests include the displayed center and exclude an outside rectangle. Rename/search and explicit Place attachment were also checked during Timeline validation.
- With 100 visits and 100,000 points, Timeline assembly took about 77ms with one 27ms aggregate; date-filtered bbox selection took 35ms, and selection without dates took 78ms. These are local measurements, not production guarantees. A bbox query without dates aggregates all visible unlocated history, so cost grows with that history; the selection benchmark excludes subsequent response serialization.

Refs #3384
