### PR TITLE
Preserve fractional metadata in phone Timeline imports

### DIFF
--- a/app/services/google_maps/phone_takeout_importer.rb
+++ b/app/services/google_maps/phone_takeout_importer.rb
@@ -36,7 +36,6 @@ class GoogleMaps::PhoneTakeoutImporter
     parser = Oj::Parser.new(:validate)
     File.open(path, 'rb') { |io| parser.load(io) }
   rescue EncodingError, JSON::ParserError
-    @legacy_parser_required = true
     File.open(path, 'rb') { |io| Oj.saj_parse(nil, io) }
   end
 
@@ -58,11 +57,9 @@ class GoogleMaps::PhoneTakeoutImporter
     )
 
     File.open(path, 'rb') do |io|
-      if @legacy_parser_required
-        Oj.saj_parse(handler, io)
-      else
-        Oj::Parser.new(:saj, handler:).load(io)
-      end
+      # Oj 3.17's newer SAJ parser can lose the decimal point in long 0.xxx
+      # literals. The original streaming API preserves those numeric values.
+      Oj.saj_parse(handler, io)
     end
   end
 

--- a/spec/regressions/google_phone_takeout_numeric_ranges_spec.rb
+++ b/spec/regressions/google_phone_takeout_numeric_ranges_spec.rb
@@ -6,6 +6,20 @@ RSpec.describe 'Google phone takeout numeric metadata ranges' do
   let(:user) { create(:user) }
   let(:import) { create(:import, user:, name: 'phone_takeout.json') }
 
+  it 'preserves long fractional metadata instead of scaling it into an out-of-range integer' do
+    document = <<~JSON
+      {"semanticSegments":[{"startTime":"2024-06-15T09:00:00Z",
+      "altitudeMeters":-0.40511831641197205,"accuracyMeters":0.36759892106056213,
+      "visit":{"topCandidate":{"placeLocation":{"latLng":"48.8566,2.3522"}}}}]}
+    JSON
+
+    import_document(document)
+
+    point = user.points.find_by!(timestamp: Time.utc(2024, 6, 15, 9).to_i)
+    expect(point.altitude_decimal).to eq(BigDecimal('-0.41'))
+    expect(point.accuracy).to eq(0)
+  end
+
   it 'imports points when optional numeric metadata exceeds point column ranges' do
     document = {
       semanticSegments: [
@@ -63,7 +77,7 @@ RSpec.describe 'Google phone takeout numeric metadata ranges' do
 
   def import_document(document)
     Tempfile.create(['phone-takeout-numeric-ranges', '.json']) do |file|
-      file.write(JSON.generate(document))
+      file.write(document.is_a?(String) ? document : JSON.generate(document))
       file.flush
 
       expect do


### PR DESCRIPTION
Google phone Timeline imports can silently discard valid fractional altitude and accuracy values. Oj 3.17.3's newer SAJ parser reads a literal such as `-0.40511831641197205` as an enormous number; the existing range guards then discard it.

Use Oj's original streaming SAJ API, which preserves these literals. Keep the validation pass, bounded batches, invalid-encoding fallback, transaction rollback, and numeric range guards. Add a regression using literal JSON so Rails JSON serialization cannot round away the reproducing input.

Addresses #3370.

Verification: the new regression fails on dev with missing altitude and passes after the change. All 36 phone-import and numeric-range examples pass, including malformed input, streaming and rollback coverage. RuboCop passes. An 11.3 MB synthetic file remains streamed; the original SAJ path read 400,000 numeric values in 0.066 seconds locally. This is a bounded local check, not a production throughput claim.

No migration. Previously imported values are not rewritten; affected source files need re-import to recover discarded metadata.
