### PR TITLE
Update deleted imports through Turbo Streams

### DIFF
--- a/app/jobs/imports/destroy_job.rb
+++ b/app/jobs/imports/destroy_job.rb
@@ -42,6 +42,13 @@ class Imports::DestroyJob < ApplicationJob
         }
       }
     )
+
+    Turbo::StreamsChannel.broadcast_replace_to(
+      [import.user, :imports],
+      target: ActionView::RecordIdentifier.dom_id(import),
+      partial: 'imports/table_row',
+      locals: { import: import, timezone: import.user.safe_settings.timezone }
+    )
   end
 
   def broadcast_deletion_complete(import)
@@ -53,6 +60,10 @@ class Imports::DestroyJob < ApplicationJob
           id: import.id
         }
       }
+    )
+
+    Turbo::StreamsChannel.broadcast_remove_to(
+      [import.user, :imports], target: ActionView::RecordIdentifier.dom_id(import)
     )
   end
 end

--- a/spec/regressions/import_deletion_turbo_stream_spec.rb
+++ b/spec/regressions/import_deletion_turbo_stream_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Import deletion updates the subscribed Turbo stream' do
+  include ActionCable::TestHelper
+  include Turbo::Streams::StreamName
+
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, status: :completed) }
+
+  it 'replaces the deleting row and removes it when the background job finishes' do
+    import_id = import.id
+    messages = capture_broadcasts(stream_name_from([user, :imports])) do
+      Imports::DestroyJob.perform_now(import_id)
+    end
+    streams = Nokogiri::HTML.fragment(messages.join).css('turbo-stream')
+
+    expect(Import.find_by(id: import_id)).to be_nil
+    expect(streams.map { |stream| [stream['action'], stream['target']] })
+      .to eq([['replace', "import_#{import_id}"], ['remove', "import_#{import_id}"]])
+  end
+end


### PR DESCRIPTION
The imports page subscribes to Turbo Streams, but the background deletion job only publishes legacy ImportsChannel messages. Deleting an import therefore removes it from the database while leaving its row on the open page.

Publish a Turbo row replacement when deletion starts (and when failure restores a retryable status), then remove the row when deletion completes. Preserve the existing legacy messages and user-scoped streams.

Addresses #3174. Processing/completion broadcasts already use Turbo; this fixes the remaining deletion path.

Verification: a regression runs the real deletion job, confirms the database record is gone, and checks the matching Turbo replace/remove actions. It fails before this change. All 30 deletion-related examples pass, including failure recovery and point cleanup. RuboCop passes. A real Chromium session with Redis ActionCable reproduced the stale row before the fix and confirmed removal without page reload after it; ordinary processing-to-completed updates also arrived live.

No migration or change to deletion permissions, data selection, or background-job scheduling.
