### PR TITLE
Align API registration with web registration settings

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V1::Auth::RegistrationsController < Api::V1::Auth::BaseController
+  before_action :check_registration_allowed, only: :create
+
   def create
     user = User.new(new_user_attrs)
 
@@ -16,6 +18,32 @@ class Api::V1::Auth::RegistrationsController < Api::V1::Auth::BaseController
   end
 
   private
+
+  def check_registration_allowed
+    return unless DawarichSettings.self_hosted?
+
+    # When OIDC is enabled and email/password registration is disabled,
+    # block all email/password registration including family invitations
+    if DawarichSettings.oidc_enabled? && !DawarichSettings.registration_enabled?
+      render json: {
+        error: 'registration_disabled',
+        message: I18n.t(
+          'controllers.users.registrations.email_password_registration_is_disabled_please_use_oidc_to_sign'
+        )
+      }, status: :forbidden
+      return
+    end
+
+    return if joining_family?
+    return if DawarichSettings.registration_enabled?
+
+    render json: {
+      error: 'registration_disabled',
+      message: I18n.t(
+        'controllers.users.registrations.registration_is_not_available_please_contact_your_administrator_for_acce'
+      )
+    }, status: :forbidden
+  end
 
   def new_user_attrs
     base = {

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -74,7 +74,10 @@ RSpec.describe 'POST /api/v1/auth/register', type: :request do
   end
 
   context 'on a self-hosted instance' do
-    before { allow(DawarichSettings).to receive(:self_hosted?).and_return(true) }
+    before do
+      allow(DawarichSettings).to receive(:self_hosted?).and_return(true)
+      allow(DawarichSettings).to receive(:registration_enabled?).and_return(true)
+    end
 
     it 'creates a user in active status (not pending_payment)' do
       expect do
@@ -100,6 +103,22 @@ RSpec.describe 'POST /api/v1/auth/register', type: :request do
 
       expect { post '/api/v1/auth/register', params: valid_params }
         .not_to have_enqueued_job(Users::CreationWebhookJob)
+    end
+
+    context 'when accessing registration without invitation token and email/password registration disabled' do
+      before { allow(DawarichSettings).to receive(:registration_enabled?).and_return(false) }
+
+      it 'prevents account creation' do
+        expect do
+          post '/api/v1/auth/register', params: valid_params
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)).to include(
+          'error' => 'registration_disabled',
+          'message' => include('Registration is not available')
+        )
+      end
     end
   end
 
@@ -161,6 +180,75 @@ RSpec.describe 'POST /api/v1/auth/register', type: :request do
       post '/api/v1/auth/register', params: invitee_params.merge(email: 'someone.else@example.com')
 
       expect(User.find_by(email: 'someone.else@example.com')).to be_pending_payment
+    end
+
+    context 'on a self-hosted instance with registration disabled' do
+      before do
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(true)
+        allow(DawarichSettings).to receive(:registration_enabled?).and_return(false)
+        allow(DawarichSettings).to receive(:oidc_enabled?).and_return(false)
+      end
+
+      context 'when accessing registration with valid invitation token' do
+        it 'allows account creation' do
+          expect do
+            post '/api/v1/auth/register', params: invitee_params
+          end.to change(User, :count).by(1)
+
+          expect(response).to have_http_status(:created)
+          expect(invitation.reload).to be_accepted
+        end
+      end
+
+      context 'when accessing registration with expired invitation' do
+        before { invitation.update!(expires_at: 1.day.ago) }
+
+        it 'prevents account creation' do
+          expect do
+            post '/api/v1/auth/register', params: invitee_params
+          end.not_to change(User, :count)
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context 'when accessing registration with cancelled invitation' do
+        before { invitation.update!(status: :cancelled) }
+
+        it 'prevents account creation' do
+          expect do
+            post '/api/v1/auth/register', params: invitee_params
+          end.not_to change(User, :count)
+
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      it 'prevents account creation when the invitation email does not match' do
+        expect do
+          post '/api/v1/auth/register', params: invitee_params.merge(email: 'someone.else@example.com')
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(invitation.reload).to be_pending
+      end
+
+      it 'blocks family invitations in OIDC-only mode' do
+        allow(DawarichSettings).to receive(:oidc_enabled?).and_return(true)
+
+        expect do
+          post '/api/v1/auth/register', params: invitee_params
+        end.not_to change(User, :count)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(JSON.parse(response.body)).to include(
+          'error' => 'registration_disabled',
+          'message' => I18n.t(
+            'controllers.users.registrations.email_password_registration_is_disabled_please_use_oidc_to_sign'
+          )
+        )
+        expect(invitation.reload).to be_pending
+      end
     end
   end
 end

--- a/spec/swagger/api/v1/auth/registrations_controller_spec.rb
+++ b/spec/swagger/api/v1/auth/registrations_controller_spec.rb
@@ -54,6 +54,25 @@ describe 'Auth Registrations API', type: :request do
 
         run_test!
       end
+
+      response '403', 'registration disabled on a self-hosted instance' do
+        schema type: :object,
+               properties: {
+                 error: { type: :string },
+                 message: { type: :string }
+               }
+
+        before do
+          allow(DawarichSettings).to receive(:self_hosted?).and_return(true)
+          allow(DawarichSettings).to receive(:registration_enabled?).and_return(false)
+        end
+
+        let(:credentials) do
+          { email: 'new@example.com', password: 'secret123456', password_confirmation: 'secret123456' }
+        end
+
+        run_test!
+      end
     end
   end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -545,6 +545,17 @@ paths:
                   details:
                     type: object
                     additionalProperties: true
+        '403':
+          description: registration disabled on a self-hosted instance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
The web registration controller already respects the self-hosted email/password registration setting, but `POST /api/v1/auth/register` currently creates accounts without checking it.

This PR applies the web controller’s registration guard to the API, following the same method name, check order, and translated messages, with HTTP 403 and JSON responses instead of redirects and flash alerts. I’m happy to extract a shared guard if you’d prefer.

Valid family invitations remain allowed unless OIDC-only mode is enabled, and the API’s existing invitation email-match check is preserved. Cloud registration is unchanged.

### Testing

Added request specs for disabled registration, valid/expired/cancelled invitations, mismatched invitation emails, and OIDC-only mode, plus OpenAPI coverage for the 403 response.

- Focused RSpec run: 170 examples, 0 failures.
- RuboCop: all three changed Ruby files pass.
- Full-suite verification is incomplete: an interrupted run reported 6 failures in data-migration specs; those specs passed when rerun with CI’s `db:schema:load` setup.

### Manual verification

On a disposable self-hosted instance with email/password registration disabled:

```sh
curl -i http://localhost:3000/api/v1/auth/register \
  -H 'Content-Type: application/json' \
  --data '{"email":"registration-check@example.com","password":"test-password-123456","password_confirmation":"test-password-123456"}'
```

Expected: HTTP 403 with `error: registration_disabled`, and no new user.

(This PR was developed with AI assistance.)