### PR TITLE
Fix family map initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Family map now opens without an undefined theme error (#3415)
+
 ## [1.14.3] - 2026-09-05, Berlin
 
 ### Added

--- a/app/javascript/controllers/family_map_controller.js
+++ b/app/javascript/controllers/family_map_controller.js
@@ -71,6 +71,7 @@ export default class extends Controller {
   addMembers() {
     const locations = this.locationsValue
     if (!locations.length) return
+    const theme = getCurrentTheme()
 
     const features = locations.map((loc, i) => ({
       type: "Feature",

--- a/spec/javascript/family_map_controller_test.mjs
+++ b/spec/javascript/family_map_controller_test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+async function loadFamilyMapController(theme = "dark") {
+  const source = await readFile(
+    new URL(
+      "../../app/javascript/controllers/family_map_controller.js",
+      import.meta.url,
+    ),
+    "utf8",
+  )
+  const withoutImports = source.replace(/^import .*\n/gm, "")
+  const dependencies = `
+    class Controller {}
+    class LngLatBounds {
+      constructor() { this.coordinates = [] }
+      extend(coordinates) { this.coordinates.push(coordinates) }
+    }
+    const maplibregl = { LngLatBounds }
+    const escapeHtml = (value) => value
+    const getCurrentTheme = () => ${JSON.stringify(theme)}
+    const getMapStyle = async () => ({})
+  `
+  const url = `data:text/javascript;base64,${Buffer.from(`${dependencies}\n${withoutImports}`).toString("base64")}`
+
+  return (await import(`${url}#${Date.now()}`)).default
+}
+
+test("family member labels render before the map fits their bounds", async () => {
+  const FamilyMapController = await loadFamilyMapController()
+  const controller = new FamilyMapController()
+  const layers = []
+  const fitCalls = []
+  controller.locationsValue = [
+    {
+      user_id: 1,
+      email: "member@example.test",
+      longitude: 13.405,
+      latitude: 52.52,
+      timestamp: 1_700_000_000,
+    },
+  ]
+  controller.map = {
+    addSource() {},
+    addLayer(layer) {
+      layers.push(layer)
+    },
+    on() {},
+    fitBounds(bounds, options) {
+      fitCalls.push({ bounds, options })
+    },
+  }
+
+  controller.addMembers()
+
+  const labels = layers.find((layer) => layer.id === "family-labels")
+  assert.equal(labels.paint["text-color"], "#e5e7eb")
+  assert.deepEqual(fitCalls[0].bounds.coordinates, [[13.405, 52.52]])
+  assert.deepEqual(fitCalls[0].options, { padding: 60, maxZoom: 14 })
+})


### PR DESCRIPTION
Family map initialization no longer fails while adding member labels, allowing member bounds to be fitted.

Fixes #3415.

Validation: Family-map Node regression; full JavaScript suite. The combined nine-fix integration branch passed the full RSpec suite (9,566 examples, zero failures), all 258 JavaScript tests, and affected-file RuboCop/Biome checks.

Local dawarich-review: engineering, QA and product APPROVE at `75b614cb2447255307e066a85764a11a1a6b1d73`.
