### PR TITLE
Preserve remember me across two-factor sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Remember me now persists across two-factor sign-in (#3416)
+
 ## [1.14.3] - 2026-09-05, Berlin
 
 ### Added

--- a/app/controllers/users/otp_challenge_controller.rb
+++ b/app/controllers/users/otp_challenge_controller.rb
@@ -19,8 +19,10 @@ class Users::OtpChallengeController < ApplicationController
     otp_code = params[:otp_attempt]
 
     if authenticate_otp(user, otp_code)
+      remember_me = session[:otp_remember_me]
       clear_otp_session
       user.reset_failed_otp_attempts!
+      user.remember_me = remember_me
       sign_in(user)
       redirect_to after_sign_in_path_for(user), notice: I18n.t('controllers.users.otp_challenge.signed_in_successfully')
     elsif user.otp_locked?
@@ -69,5 +71,6 @@ class Users::OtpChallengeController < ApplicationController
     session.delete(:otp_user_id)
     session.delete(:otp_challenge_at)
     session.delete(:otp_failed_attempts)
+    session.delete(:otp_remember_me)
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -32,6 +32,7 @@ class Users::SessionsController < Devise::SessionsController
 
     session[:otp_user_id] = user.id
     session[:otp_challenge_at] = Time.current.to_i
+    session[:otp_remember_me] = params.dig(:user, :remember_me) == '1'
     self.resource = user
     render :otp_challenge, status: :unprocessable_entity
   end

--- a/spec/regressions/remember_me_during_two_factor_sign_in_spec.rb
+++ b/spec/regressions/remember_me_during_two_factor_sign_in_spec.rb
@@ -60,4 +60,22 @@ RSpec.describe 'Remembering a two-factor sign-in', type: :request do
       expect(response.cookies['remember_user_token']).to be_blank
     end
   end
+
+  it 'restores a remembered sign-in in a new browser session only after completing OTP' do
+    post user_session_path,
+         params: { user: { email: user.email, password: password, remember_me: '1' } }
+    get imports_path
+    expect(response).to redirect_to(new_user_session_path)
+
+    post user_otp_challenge_path, params: { otp_attempt: user.current_otp }
+    remember_cookie = cookies['remember_user_token']
+    expect(remember_cookie).to be_present
+
+    returning_browser = ActionDispatch::Integration::Session.new(Rails.application)
+    returning_browser.cookies['remember_user_token'] = remember_cookie
+    returning_browser.get imports_path
+
+    expect(returning_browser.response).to have_http_status(:ok)
+  end
+
 end

--- a/spec/regressions/remember_me_during_two_factor_sign_in_spec.rb
+++ b/spec/regressions/remember_me_during_two_factor_sign_in_spec.rb
@@ -77,5 +77,4 @@ RSpec.describe 'Remembering a two-factor sign-in', type: :request do
 
     expect(returning_browser.response).to have_http_status(:ok)
   end
-
 end

--- a/spec/regressions/remember_me_during_two_factor_sign_in_spec.rb
+++ b/spec/regressions/remember_me_during_two_factor_sign_in_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Remembering a two-factor sign-in', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:password) { 'test_password_123' }
+  let(:user) { create(:user, password: password) }
+
+  before do
+    allow(DawarichSettings).to receive(:two_factor_available?).and_return(true)
+    user.update!(
+      otp_secret: User.generate_otp_secret,
+      otp_required_for_login: true
+    )
+  end
+
+  it 'sets the remember cookie after a successful challenge' do
+    post user_session_path,
+         params: { user: { email: user.email, password: password, remember_me: '1' } }
+    post user_otp_challenge_path, params: { otp_attempt: user.current_otp }
+
+    expect(response.cookies['remember_user_token']).to be_present
+  end
+
+  it 'does not remember an unchecked sign-in' do
+    post user_session_path,
+         params: { user: { email: user.email, password: password, remember_me: '0' } }
+    post user_otp_challenge_path, params: { otp_attempt: user.current_otp }
+
+    expect(response.cookies['remember_user_token']).to be_blank
+  end
+
+  it 'only remembers after a valid OTP, retaining the choice through a retry' do
+    post user_session_path,
+         params: { user: { email: user.email, password: password, remember_me: '1' } }
+    post user_otp_challenge_path, params: { otp_attempt: 'invalid' }
+
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response.cookies['remember_user_token']).to be_blank
+
+    post user_otp_challenge_path, params: { otp_attempt: user.current_otp }
+
+    expect(response.cookies['remember_user_token']).to be_present
+  end
+
+  it 'does not carry an expired remember choice into a new unchecked challenge' do
+    post user_session_path,
+         params: { user: { email: user.email, password: password, remember_me: '1' } }
+    travel 6.minutes do
+      post user_otp_challenge_path, params: { otp_attempt: user.current_otp }
+      expect(response).to redirect_to(new_user_session_path)
+      expect(response.cookies['remember_user_token']).to be_blank
+
+      post user_session_path,
+           params: { user: { email: user.email, password: password, remember_me: '0' } }
+      post user_otp_challenge_path, params: { otp_attempt: user.current_otp }
+
+      expect(response.cookies['remember_user_token']).to be_blank
+    end
+  end
+end


### PR DESCRIPTION
Carry the Remember me choice through the OTP challenge, clear it with challenge state, and set the persistent cookie only after successful verification. A new request regression restores authentication in a fresh browser session using only that cookie.

Fixes #3416.


Validation: OTP requests and remembered-session restoration before/after verification. The combined nine-fix integration branch passed the full RSpec suite (9,566 examples, zero failures), all 258 JavaScript tests, and affected-file RuboCop/Biome checks.

Local dawarich-review: engineering, QA and product APPROVE at `ae326898ff5ba3858981941e76600c30db7d21b3`.
