### PR TITLE
Enforce OIDC-only password policy for browser and API sign-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- OIDC-only installations reject direct password sign-in before a session can be created (#2961)
+
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)
 - Reverse geocoding resolves countries sharing an ISO code correctly and repairs historical links (#3462)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- OIDC-only installations reject direct password sign-in before a session can be created (#2961)
+- Browser and API password sign-in now respect OIDC-only configuration (#2961)
 
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)

--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -9,6 +9,8 @@ class Api::V1::Auth::SessionsController < Api::V1::Auth::BaseController
   # side channel.
   DUMMY_PASSWORD_HASH = BCrypt::Password.create(SecureRandom.hex(16)).to_s.freeze
 
+  before_action :check_email_password_login_allowed, only: [:create]
+
   def create
     user = User.find_by(email: params[:email]&.downcase)
 
@@ -30,6 +32,15 @@ class Api::V1::Auth::SessionsController < Api::V1::Auth::BaseController
   end
 
   private
+
+  def check_email_password_login_allowed
+    return unless DawarichSettings.oidc_enabled? && !ALLOW_EMAIL_PASSWORD_LOGIN
+
+    render_auth_error(
+      I18n.t('controllers.users.sessions.email_password_login_is_disabled_please_use_oidc_to_sign'),
+      http_status: :forbidden
+    )
+  end
 
   # Always performs a bcrypt verification whether or not the user exists, so
   # response time does not leak account existence.

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,8 +4,8 @@ class Users::SessionsController < Devise::SessionsController
   include PendingImportClaimable
 
   before_action :load_invitation_context, only: [:new]
-  before_action :check_email_password_login_allowed, only: [:create]
   prepend_before_action :check_otp_required, only: [:create]
+  prepend_before_action :check_email_password_login_allowed, only: [:create]
 
   def new
     super

--- a/spec/regressions/oidc_only_api_password_login_spec.rb
+++ b/spec/regressions/oidc_only_api_password_login_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API password sign-in on OIDC-only installations', type: :request do
+  let(:password) { 'SyntheticPassword123!' }
+  let(:user) { create(:user, password:) }
+
+  before do
+    allow(DawarichSettings).to receive(:oidc_enabled?).and_return(true)
+    stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', false)
+  end
+
+  [false, true].each do |two_factor|
+    it "rejects password login without issuing credentials when two-factor is #{two_factor}" do
+      user.update!(otp_secret: User.generate_otp_secret, otp_required_for_login: two_factor)
+
+      post '/api/v1/auth/login', params: { email: user.email, password: }, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+      expect(response.parsed_body).not_to have_key('api_key')
+      expect(response.parsed_body).not_to have_key('challenge_token')
+    end
+  end
+
+  it 'returns the same disabled response for an unknown account' do
+    post '/api/v1/auth/login', params: { email: 'unknown@example.test', password: }, as: :json
+
+    expect(response).to have_http_status(:forbidden)
+    expect(response.parsed_body).not_to have_key('api_key')
+  end
+
+  it 'allows password login alongside OIDC when enabled' do
+    stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', true)
+
+    post '/api/v1/auth/login', params: { email: user.email, password: }, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body['api_key']).to eq(user.api_key)
+  end
+
+  it 'allows password login without an OIDC provider' do
+    allow(DawarichSettings).to receive(:oidc_enabled?).and_return(false)
+
+    post '/api/v1/auth/login', params: { email: user.email, password: }, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body['api_key']).to eq(user.api_key)
+  end
+end

--- a/spec/regressions/oidc_only_password_login_spec.rb
+++ b/spec/regressions/oidc_only_password_login_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Password sign-in on OIDC-only installations', type: :request do
+  let(:password) { 'SyntheticPassword123!' }
+  let(:user) { create(:user, password:) }
+
+  before do
+    allow(DawarichSettings).to receive(:oidc_enabled?).and_return(true)
+    stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', false)
+  end
+
+  [false, true].each do |two_factor|
+    it "rejects valid credentials without creating a session when two-factor is #{two_factor}" do
+      user.update!(otp_secret: User.generate_otp_secret, otp_required_for_login: two_factor)
+
+      post user_session_path, params: { user: { email: user.email, password:, remember_me: '1' } }
+
+      expect(response).to redirect_to(root_path)
+      expect(cookies['remember_user_token']).to be_blank
+      get imports_path
+      expect(response).to redirect_to(new_user_session_path)
+      expect(user.reload.sign_in_count).to eq(0)
+    end
+  end
+
+  it 'keeps the password form hidden while rejecting direct JSON login requests' do
+    get new_user_session_path
+    expect(Nokogiri::HTML(response.body).at_css('input[name="user[password]"]')).to be_nil
+
+    post user_session_path, params: { user: { email: user.email, password: } }, as: :json
+
+    expect(response).to redirect_to(root_path)
+    get imports_path
+    expect(response).to redirect_to(new_user_session_path)
+    expect(user.reload.sign_in_count).to eq(0)
+  end
+
+  it 'still allows password login when the operator enables it alongside OIDC' do
+    stub_const('ALLOW_EMAIL_PASSWORD_LOGIN', true)
+    post user_session_path, params: { user: { email: user.email, password: } }
+
+    get imports_path
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.sign_in_count).to eq(1)
+  end
+
+  it 'keeps password login available when OIDC is not configured' do
+    allow(DawarichSettings).to receive(:oidc_enabled?).and_return(false)
+    post user_session_path, params: { user: { email: user.email, password: } }
+
+    get imports_path
+    expect(response).to have_http_status(:ok)
+    expect(user.reload.sign_in_count).to eq(1)
+  end
+end


### PR DESCRIPTION
When OIDC is configured and `ALLOW_EMAIL_PASSWORD_LOGIN=false`, a direct browser password POST could authenticate through shared callbacks before reaching the policy check. The API password endpoint also ignored that setting and could return an API key or an OTP challenge.

Run the browser guard before authentication-capable callbacks and reject disabled API password sign-in with HTTP 403. Password login remains available when explicitly enabled or when OIDC is absent. Existing sessions, issued API keys and in-flight authentication challenges are not revoked.

Fixes #2961.

Validation:
- Browser regression: 5 examples, 2 failures before the fix; protected follow-up requests demonstrated the unwanted session.
- API regression: 5 examples, 3 failures before the API fix; no API key or OTP challenge is issued after it.
- 300 related browser/API/OIDC/2FA request examples pass; an additional nested-credential probe confirms API callbacks cannot create a browser session.
- The combined final integration branch passed the full suite: 9,580 RSpec examples, zero failures; all 258 JavaScript tests also pass.
- Affected-file RuboCop passes.

Local dawarich-review: engineering, QA and product APPROVE at `608dd64e03eddbd5cab1ba9dc466b123f50cfcf5`.
