### PR TITLE
Recover invalid stats indexes after interrupted upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Upgrades rebuild invalid statistics indexes left by interrupted migrations and restore duplicate protection (#2700)
+
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)
 - Reverse geocoding resolves countries sharing an ISO code correctly and repairs historical links (#3462)

--- a/db/migrate/20251208210410_add_composite_index_to_stats.rb
+++ b/db/migrate/20251208210410_add_composite_index_to_stats.rb
@@ -6,7 +6,7 @@ class AddCompositeIndexToStats < ActiveRecord::Migration[8.0]
   BATCH_SIZE = 1000
 
   def change
-    total_duplicates = execute(<<-SQL.squish).first['count'].to_i
+    total_duplicates = execute(<<~SQL.squish).first['count'].to_i
       SELECT COUNT(*) as count
       FROM stats s1
       WHERE EXISTS (
@@ -26,7 +26,7 @@ class AddCompositeIndexToStats < ActiveRecord::Migration[8.0]
 
     deleted_count = 0
     loop do
-      batch_deleted = execute(<<-SQL.squish).cmd_tuples
+      batch_deleted = execute(<<~SQL.squish).cmd_tuples
         DELETE FROM stats
         WHERE id IN (
           SELECT s1.id
@@ -49,6 +49,14 @@ class AddCompositeIndexToStats < ActiveRecord::Migration[8.0]
     end
 
     Rails.logger.info("Completed cleanup: removed #{deleted_count} duplicate stats records") if deleted_count.positive?
+
+    invalid = select_value(<<~SQL)
+      SELECT NOT i.indisvalid
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      WHERE i.indrelid = 'stats'::regclass AND c.relname = 'index_stats_on_user_id_year_month'
+    SQL
+    remove_index :stats, name: 'index_stats_on_user_id_year_month', algorithm: :concurrently if invalid
 
     add_index :stats, %i[user_id year month],
               name: 'index_stats_on_user_id_year_month',

--- a/db/migrate/20260906103000_repair_invalid_stats_unique_index.rb
+++ b/db/migrate/20260906103000_repair_invalid_stats_unique_index.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class RepairInvalidStatsUniqueIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  INDEX_NAME = 'index_stats_on_user_id_year_month'
+  BATCH_SIZE = 1000
+
+  def up
+    valid = select_value(<<~SQL)
+      SELECT i.indisvalid
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      WHERE i.indrelid = 'stats'::regclass AND c.relname = '#{INDEX_NAME}'
+    SQL
+    return if valid
+
+    loop do
+      deleted = execute(<<~SQL).cmd_tuples
+        DELETE FROM stats
+        WHERE id IN (
+          SELECT s1.id FROM stats s1
+          WHERE EXISTS (
+            SELECT 1 FROM stats s2
+            WHERE s2.user_id = s1.user_id
+              AND s2.year = s1.year
+              AND s2.month = s1.month
+              AND s2.id > s1.id
+          )
+          LIMIT #{BATCH_SIZE}
+        )
+      SQL
+      break if deleted.zero?
+    end
+
+    remove_index :stats, name: INDEX_NAME, algorithm: :concurrently if valid == false
+    add_index :stats, %i[user_id year month], name: INDEX_NAME, unique: true, algorithm: :concurrently
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_05_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_06_103000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"

--- a/spec/regressions/stats_index_recovery_spec.rb
+++ b/spec/regressions/stats_index_recovery_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20251208210410_add_composite_index_to_stats')
+require Rails.root.join('db/migrate/20260906103000_repair_invalid_stats_unique_index')
+
+RSpec.describe 'Stats uniqueness after an interrupted upgrade' do
+  self.use_transactional_tests = false
+
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:index_name) { 'index_stats_on_user_id_year_month' }
+
+  around do |example|
+    schema = "stats_recovery_#{SecureRandom.hex(6)}"
+    original_path = connection.schema_search_path
+    connection.execute("CREATE SCHEMA #{schema}")
+    connection.schema_search_path = "#{schema},public"
+    connection.execute(<<~SQL)
+      CREATE TABLE stats (
+        id bigserial PRIMARY KEY, user_id bigint NOT NULL, year integer NOT NULL, month integer NOT NULL
+      )
+    SQL
+    example.run
+  ensure
+    connection.schema_search_path = original_path
+    connection.execute("DROP SCHEMA #{schema} CASCADE")
+  end
+
+  it 'replaces a failed concurrent index on retry and enforces uniqueness' do
+    seed_duplicates
+    expect { create_index }.to raise_error(ActiveRecord::RecordNotUnique)
+    expect(index_valid?).to be(false)
+    expected = connection.select_values('SELECT max(id) FROM stats GROUP BY user_id, year, month ORDER BY max(id)')
+
+    2.times { AddCompositeIndexToStats.new.migrate(:up) }
+
+    expect(connection.select_values('SELECT id FROM stats ORDER BY id')).to eq(expected)
+    expect(index_valid?).to be(true)
+    expect { insert_duplicate }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
+  it 'repairs an invalid index even after the original migration was recorded as complete' do
+    seed_duplicates
+    expect { create_index }.to raise_error(ActiveRecord::RecordNotUnique)
+    connection.execute('CREATE TABLE schema_migrations (version varchar NOT NULL PRIMARY KEY)')
+    connection.execute("INSERT INTO schema_migrations (version) VALUES ('20251208210410')")
+    expected = connection.select_values('SELECT max(id) FROM stats GROUP BY user_id, year, month ORDER BY max(id)')
+
+    2.times { RepairInvalidStatsUniqueIndex.new.migrate(:up) }
+
+    expect(connection.select_values('SELECT id FROM stats ORDER BY id')).to eq(expected)
+    expect(index_valid?).to be(true)
+    expect(connection.select_values('SELECT version FROM schema_migrations')).to eq(['20251208210410'])
+    expect { insert_duplicate }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
+  it 'does not rebuild a healthy index or delete existing records' do
+    connection.execute('INSERT INTO stats (user_id, year, month) VALUES (1, 2024, 1), (1, 2024, 2)')
+    create_index
+    original_oid = connection.select_value("SELECT '#{index_name}'::regclass::oid")
+    original_rows = connection.select_all('SELECT * FROM stats ORDER BY id').to_a
+
+    RepairInvalidStatsUniqueIndex.new.migrate(:up)
+
+    expect(connection.select_value("SELECT '#{index_name}'::regclass::oid")).to eq(original_oid)
+    expect(connection.select_all('SELECT * FROM stats ORDER BY id').to_a).to eq(original_rows)
+  end
+
+  it 'creates a missing index after deduplicating records' do
+    seed_duplicates
+
+    RepairInvalidStatsUniqueIndex.new.migrate(:up)
+
+    expect(index_valid?).to be(true)
+    expect(connection.select_value('SELECT count(*) FROM stats')).to eq(3)
+    expect { insert_duplicate }.to raise_error(ActiveRecord::RecordNotUnique)
+  end
+
+  def seed_duplicates
+    connection.execute('INSERT INTO stats (user_id, year, month) SELECT 1, 2024, 1 FROM generate_series(1, 1005)')
+    connection.execute('INSERT INTO stats (user_id, year, month) VALUES (2, 2024, 1), (2, 2024, 1), (1, 2024, 2)')
+  end
+
+  def create_index
+    connection.execute("CREATE UNIQUE INDEX CONCURRENTLY #{index_name} ON stats (user_id, year, month)")
+  end
+
+  def index_valid?
+    connection.select_value("SELECT indisvalid FROM pg_index WHERE indexrelid = '#{index_name}'::regclass")
+  end
+
+  def insert_duplicate
+    connection.execute('INSERT INTO stats (user_id, year, month) VALUES (1, 2024, 1)')
+  end
+end


### PR DESCRIPTION
A failed `CREATE UNIQUE INDEX CONCURRENTLY` leaves an invalid stats index. The old migration removed duplicate rows but then skipped that index because its name already existed, leaving uniqueness unenforced. Some installations have already recorded that migration as successful.

Rebuild invalid indexes when retrying the original migration and add a separate repair migration for installations that already completed it. Cleanup keeps the highest-ID row per user/year/month in batches of 1,000, matching the existing policy. A healthy index is left unchanged; index creation/removal runs concurrently outside a DDL transaction. Rollback leaves the recovered pre-existing uniqueness constraint in place.

Fixes #2700.

Validation:
- Reproduced using a real failed concurrent index build, not manually edited catalog flags.
- Four PostgreSQL regression scenarios pass: invalid index retry, old migration already recorded, missing index and healthy-index no-op.
- More than 1,000 duplicate rows, distinct users/months, preservation of newest records, repeated execution and actual rejection of duplicate inserts are covered in isolated test schemas.
- The combined final integration branch passed the full suite: 9,580 RSpec examples, zero failures; all 258 JavaScript tests also pass.
- Affected-file RuboCop passes.

Local dawarich-review: engineering, QA and product APPROVE at `758999a249392606641aecae47dbc937ef4f2f42`.
