### PR TITLE
Keep fitted routes clear of the map toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Map auto-centering now keeps route points clear of the map toolbar (#3342)
+
 ## [1.11.0] - 2026-08-02, Berlin
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Map auto-centering keeps route points clear of the toolbar (#3342).
+
 - Upgrades rebuild invalid statistics indexes left by interrupted migrations and restore duplicate protection (#2700)
 - Browser and API password sign-in now respect OIDC-only configuration (#2961)
 

--- a/app/javascript/controllers/maps/maplibre/map_data_manager.js
+++ b/app/javascript/controllers/maps/maplibre/map_data_manager.js
@@ -9,6 +9,7 @@ import {
 } from "maps_maplibre/utils/flight_mask"
 import { trimOutlierCoords } from "maps_maplibre/utils/geometry"
 import { isGatedPlan } from "maps_maplibre/utils/layer_gate"
+import { overlayAwarePadding } from "maps_maplibre/utils/map_padding"
 import { performanceMonitor } from "maps_maplibre/utils/performance_monitor"
 
 const EMPTY_GEOJSON = { type: "FeatureCollection", features: [] }
@@ -485,8 +486,13 @@ export class MapDataManager {
     if (bounds.isEmpty()) return
     if (skipIfCovered && this._boundsCovered(bounds)) return
 
+    const mapRect = this.map.getContainer()?.getBoundingClientRect()
+    const toolbarRect = document
+      .querySelector(".map-button-cluster")
+      ?.getBoundingClientRect()
+
     this.map.fitBounds(bounds, {
-      padding: 50,
+      padding: overlayAwarePadding(mapRect, toolbarRect),
       maxZoom: 15,
       animate,
     })

--- a/app/javascript/controllers/maps/maplibre/map_data_manager.js
+++ b/app/javascript/controllers/maps/maplibre/map_data_manager.js
@@ -9,6 +9,7 @@ import {
 } from "maps_maplibre/utils/flight_mask"
 import { trimOutlierCoords } from "maps_maplibre/utils/geometry"
 import { isGatedPlan } from "maps_maplibre/utils/layer_gate"
+import { overlayAwarePadding } from "maps_maplibre/utils/map_padding"
 import { performanceMonitor } from "maps_maplibre/utils/performance_monitor"
 
 const EMPTY_GEOJSON = { type: "FeatureCollection", features: [] }
@@ -487,8 +488,13 @@ export class MapDataManager {
     if (bounds.isEmpty()) return
     if (skipIfCovered && this._boundsCovered(bounds)) return
 
+    const mapRect = this.map.getContainer()?.getBoundingClientRect()
+    const toolbarRect = document
+      .querySelector(".map-button-cluster")
+      ?.getBoundingClientRect()
+
     this.map.fitBounds(bounds, {
-      padding: 50,
+      padding: overlayAwarePadding(mapRect, toolbarRect),
       maxZoom: 15,
       animate,
     })

--- a/app/javascript/maps_maplibre/utils/map_padding.js
+++ b/app/javascript/maps_maplibre/utils/map_padding.js
@@ -1,0 +1,24 @@
+const BASE_MAP_PADDING = 50
+const OVERLAY_GAP = 12
+
+export function overlayAwarePadding(mapRect, overlayRect) {
+  const padding = {
+    top: BASE_MAP_PADDING,
+    right: BASE_MAP_PADDING,
+    bottom: BASE_MAP_PADDING,
+    left: BASE_MAP_PADDING,
+  }
+
+  if (!mapRect || !overlayRect) return padding
+
+  const overlapsLeftEdge =
+    overlayRect.left < mapRect.right && overlayRect.right > mapRect.left
+  if (!overlapsLeftEdge) return padding
+
+  padding.left = Math.max(
+    padding.left,
+    Math.ceil(overlayRect.right - mapRect.left + OVERLAY_GAP),
+  )
+
+  return padding
+}

--- a/spec/javascript/map_bounds_padding_test.mjs
+++ b/spec/javascript/map_bounds_padding_test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+
+const source = await readFile(
+  new URL(
+    "../../app/javascript/maps_maplibre/utils/map_padding.js",
+    import.meta.url,
+  ),
+  "utf8",
+)
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`
+const { overlayAwarePadding } = await import(moduleUrl)
+
+test("keeps fitted data clear of a left-edge map toolbar", () => {
+  const padding = overlayAwarePadding(
+    { left: 0, right: 1280, top: 100, bottom: 720, width: 1280 },
+    { left: 12, right: 64, top: 112, bottom: 336 },
+  )
+
+  assert.deepEqual(padding, { top: 50, right: 50, bottom: 50, left: 76 })
+})
+
+test("uses base padding without a measurable toolbar", () => {
+  assert.deepEqual(overlayAwarePadding(null, null), {
+    top: 50,
+    right: 50,
+    bottom: 50,
+    left: 50,
+  })
+})
+
+test("measures toolbar clearance from a shifted map viewport", () => {
+  const padding = overlayAwarePadding(
+    { left: 480, right: 1280, top: 100, bottom: 720, width: 800 },
+    { left: 492, right: 544, top: 112, bottom: 336 },
+  )
+
+  assert.equal(padding.left, 76)
+})


### PR DESCRIPTION
Map auto-centering leaves room for the top-left toolbar, keeping fitted routes visible on desktop and narrow screens. Padding is calculated from the actual toolbar and map positions.

Validation: focused bounds tests and the 284-test combined JavaScript suite passed; actual MapLibre fitBounds verified at 1440 px and 390 px.

Fixes #3342.

Final combined verification on dev 5eb0e15c: 9721 RSpec examples, 0 failures, using a freshly prepared disposable test database; 284 JavaScript tests passed. Current CI status is shown in the PR checks.
