### PR TITLE
fix: preserve Google activity hints during mode backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Historical Google Timeline activity hints are preserved when backfilling transportation modes. (#3548)
+
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)
 - Reverse geocoding resolves countries sharing an ISO code correctly and repairs historical links (#3462)

--- a/app/services/transportation_modes/activity_backfiller.rb
+++ b/app/services/transportation_modes/activity_backfiller.rb
@@ -89,8 +89,8 @@ module TransportationModes
     def process_activity_segment(segment)
       return unless segment.is_a?(Hash)
 
-      activities = segment['activities'] || []
-      travel_mode = segment.dig('waypointPath', 'travelMode')
+      motion_data = Points::MotionDataExtractor.from_google_semantic_history(segment)
+      return if motion_data.blank?
 
       start_time = parse_segment_timestamp(segment.dig('duration', 'startTimestamp'))
       end_time = parse_segment_timestamp(segment.dig('duration', 'endTimestamp'))
@@ -98,13 +98,7 @@ module TransportationModes
       return unless start_time && end_time
 
       @import.points.where(timestamp: start_time..end_time).find_each do |point|
-        activity_data = {
-          'activities' => activities,
-          'travelMode' => travel_mode,
-          'confidence' => segment['confidence']
-        }.compact
-
-        update_point_activity(point, activity_data)
+        point.update_column(:motion_data, (point.motion_data || {}).merge(motion_data))
       end
     end
 

--- a/spec/services/transportation_modes/activity_backfiller_spec.rb
+++ b/spec/services/transportation_modes/activity_backfiller_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TransportationModes::ActivityBackfiller do
+  let(:import) { create(:import, source: :google_semantic_history, skip_background_processing: true) }
+  let(:timestamp) { Time.utc(2025, 1, 1, 12).to_i }
+  let!(:point) do
+    create(:point, import: import, user: import.user, timestamp: timestamp, motion_data: { 'motion' => ['walking'] })
+  end
+
+  def attach_payload(payload)
+    import.file.attach(io: StringIO.new(payload.to_json), filename: 'synthetic.json', content_type: 'application/json')
+  end
+
+  def backfill_segment(activity)
+    segment = activity.merge('duration' => {
+                               'startTimestamp' => Time.at(timestamp - 60).utc.iso8601,
+                               'endTimestamp' => Time.at(timestamp + 60).utc.iso8601
+                             })
+    attach_payload('timelineObjects' => [{ 'activitySegment' => segment }])
+    expect(described_class.new(import).call).to be(true)
+  end
+
+  [
+    { 'activities' => [{ 'activityType' => 'CYCLING', 'probability' => 0.9 }] },
+    { 'activityType' => 'CYCLING' },
+    { 'waypointPath' => { 'travelMode' => 'CYCLING' } }
+  ].each do |activity|
+    it "makes #{activity.keys.first} hints consumable by the transportation detector" do
+      backfill_segment(activity)
+
+      expect(TransportationModes::HintScorer.call(point.reload.motion_data).keys).to eq([:cycling])
+      expect(point.motion_data).to include('motion' => ['walking'])
+    end
+  end
+
+  it 'only updates the current imports points within the segment time range' do
+    outside = create(:point, import: import, user: import.user, timestamp: timestamp + 3600, motion_data: {})
+    other = create(:point, user: import.user, timestamp: timestamp, motion_data: {})
+    backfill_segment('activityType' => 'CYCLING')
+
+    expect(outside.reload.motion_data).to eq({})
+    expect(other.reload.motion_data).to eq({})
+    expect(point.reload.motion_data).to include('activityType' => 'CYCLING')
+  end
+
+  it 'leaves motion data untouched when a segment has no activity information' do
+    backfill_segment({})
+
+    expect(point.reload.motion_data).to eq('motion' => ['walking'])
+  end
+
+  it 'preserves the phone takeout activityRecord shape' do
+    import.update!(source: :google_phone_takeout)
+    attach_payload('locations' => [{
+                     'timestamp' => Time.at(timestamp).utc.iso8601,
+                     'activityRecord' => { 'probableActivities' => [{ 'type' => 'CYCLING', 'confidence' => 0.9 }] }
+                   }])
+
+    described_class.new(import).call
+
+    expect(TransportationModes::HintScorer.call(point.reload.motion_data).keys).to eq([:cycling])
+    expect(point.motion_data).to include('motion' => ['walking'])
+  end
+end


### PR DESCRIPTION
## Summary

Google Semantic History activity data used a shape that the transportation-mode backfill did not recognize. Reuse the canonical motion-data extractor so the backfill preserves the same activity hints as the importer.

Detail report: `bug_54677222-0664-4852-9b80-e7364c7e5e07`.

## How to validate

Covers Google semantic activity shapes and the existing activity backfill behavior.

```sh
RAILS_ENV=test bundle exec rspec spec/services/transportation_modes/activity_backfiller_spec.rb
```

- Before the fix: 6 examples, 5 failures.
- Focused regression and related existing tests after the fix: **45 examples, 0 failures**.
- RuboCop on changed Ruby files and `git diff --check`: passed.
- `make test` was attempted, but these worktrees have no tracked Makefile/test target. The full suite and browser E2E were not run.

## Risk / rollout notes

No schema migration; existing backfill runs can recover the supported hints.
