### PR TITLE
fix: limit digest generation to accessible years

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Cloud Lite users are only offered digest years available within their data window. (#3549)
+
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)
 - Reverse geocoding resolves countries sharing an ISO code correctly and repairs historical links (#3462)

--- a/app/controllers/api/v1/digests_controller.rb
+++ b/app/controllers/api/v1/digests_controller.rb
@@ -46,7 +46,7 @@ class Api::V1::DigestsController < ApiController
   private
 
   def available_years_for_generation
-    tracked_years = current_api_user.stats.select(:year).distinct.pluck(:year)
+    tracked_years = current_api_user.scoped_stats.select(:year).distinct.pluck(:year)
     existing_digests = current_api_user.digests.yearly.pluck(:year)
 
     (tracked_years - existing_digests - [Time.current.year]).sort.reverse
@@ -55,7 +55,7 @@ class Api::V1::DigestsController < ApiController
   def valid_year?(year)
     return false if year < 1970 || year >= Time.current.year
 
-    current_api_user.stats.exists?(year: year)
+    current_api_user.scoped_stats.exists?(year: year)
   end
 
   def distance_unit

--- a/app/controllers/users/digests_controller.rb
+++ b/app/controllers/users/digests_controller.rb
@@ -50,7 +50,7 @@ status: :see_other
   end
 
   def available_years_for_generation
-    tracked_years = current_user.stats.select(:year).distinct.pluck(:year)
+    tracked_years = current_user.scoped_stats.select(:year).distinct.pluck(:year)
     existing_digests = current_user.digests.yearly.pluck(:year)
 
     (tracked_years - existing_digests - [Time.current.year]).sort.reverse
@@ -59,6 +59,6 @@ status: :see_other
   def valid_year?(year)
     return false if year < 1970 || year > Time.current.year
 
-    current_user.stats.exists?(year: year)
+    current_user.scoped_stats.exists?(year: year)
   end
 end

--- a/spec/regressions/digests_lite_window_spec.rb
+++ b/spec/regressions/digests_lite_window_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Digest generation data window', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:user) { create(:user) }
+  let(:headers) { { 'Authorization' => "Bearer #{user.api_key}" } }
+
+  around { |example| travel_to(Time.utc(2026, 9, 6, 12)) { example.run } }
+
+  before do
+    allow(DawarichSettings).to receive(:self_hosted?).and_return(false)
+    user.update_columns(plan: User.plans[:lite], status: User.statuses[:active], active_until: 1.year.from_now)
+    create(:stat, user: user, year: 2023, month: 1)
+    create(:stat, user: user, year: 2025, month: 10)
+    sign_in user
+  end
+
+  it 'does not offer an inaccessible year in the web generation menu' do
+    get users_digests_path
+
+    expect(response).to have_http_status(:ok)
+    links = Nokogiri::HTML(response.body).css('a[data-turbo-method="post"]').map(&:text)
+    expect(links).not_to include('2023')
+    expect(links).to include('2025')
+  end
+
+  it 'does not offer an inaccessible year in the API' do
+    get api_v1_digests_path, headers: headers
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body['availableYears']).to eq([2025])
+  end
+
+  it 'rejects a web request for an inaccessible year without queuing a doomed job' do
+    expect do
+      post users_digests_path, params: { year: 2023 }
+    end.not_to have_enqueued_job(Users::Digests::Yearly::CalculatingJob)
+    expect(flash[:alert]).to be_present
+    expect(flash[:notice]).to be_nil
+  end
+
+  it 'rejects an API request for an inaccessible year without queuing a doomed job' do
+    expect do
+      post api_v1_digests_path, params: { year: 2023 }, headers: headers
+    end.not_to have_enqueued_job(Users::Digests::Yearly::CalculatingJob)
+    expect(response).to have_http_status(:unprocessable_content)
+  end
+
+  it 'still accepts a year with accessible stats from the web' do
+    expect do
+      post users_digests_path, params: { year: 2025 }
+    end.to have_enqueued_job(Users::Digests::Yearly::CalculatingJob).with(user.id, 2025)
+  end
+
+  it 'still accepts a year with accessible stats from the API' do
+    expect do
+      post api_v1_digests_path, params: { year: 2025 }, headers: headers
+    end.to have_enqueued_job(Users::Digests::Yearly::CalculatingJob).with(user.id, 2025)
+    expect(response).to have_http_status(:accepted)
+  end
+
+  %i[pro self_hosted].each do |access|
+    it "keeps older years available with #{access} access" do
+      if access == :pro
+        user.update_column(:plan, User.plans[:pro])
+      else
+        allow(DawarichSettings).to receive(:self_hosted?).and_return(true)
+      end
+      get api_v1_digests_path, headers: headers
+      expect(response.parsed_body['availableYears']).to include(2023)
+      expect do
+        post users_digests_path, params: { year: 2023 }
+      end.to have_enqueued_job(Users::Digests::Yearly::CalculatingJob).with(user.id, 2023)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Lite users could select or request a digest year outside their data window, enqueueing work that could not produce a digest. Use the scoped stats relation in both the web and API digest controllers so available years and generation requests follow the entitlement window.

Detail report: `bug_0df975c7-f639-4624-8df7-b56680940714`.

## How to validate

Covers web generation options, API requests, and accessible versus archived years.

```sh
RAILS_ENV=test bundle exec rspec spec/regressions/digests_lite_window_spec.rb
```

- Before the fix: 8 examples, 4 failures.
- Focused regression and related existing tests after the fix: **78 examples, 0 failures**.
- RuboCop on changed Ruby files and `git diff --check`: passed.
- `make test` was attempted, but these worktrees have no tracked Makefile/test target. The full suite and browser E2E were not run.

## Risk / rollout notes

Changes year eligibility for restricted plans; no schema migration.
