### PR TITLE
fix: preserve point ownership across overlapping track chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Overlapping track-generation chunks preserve point ownership and include single-point journey endpoints. (#3550)
+
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)
 - Reverse geocoding resolves countries sharing an ISO code correctly and repairs historical links (#3462)

--- a/app/jobs/tracks/time_chunk_processor_job.rb
+++ b/app/jobs/tracks/time_chunk_processor_job.rb
@@ -18,9 +18,9 @@ class Tracks::TimeChunkProcessorJob < ApplicationJob
 
     # No per-user lock here: chunks for the same user are deliberately allowed
     # to run concurrently (that's the whole point of ParallelGenerator's
-    # fan-out). Race-safety is provided by the (user_id, start_at, end_at)
-    # unique index plus the rescue paths in TrackBuilder, Merger, and
-    # BoundaryDetector — racing inserts collapse onto the winning track.
+    # fan-out). TrackBuilder locks and claims only orphan points, so overlapping
+    # chunks cannot drain one another. The unique time-span index and rescue
+    # paths also collapse racing inserts onto the winning track.
     tracks_created = process_chunk
     update_session_progress(tracks_created)
   rescue StandardError => e
@@ -111,7 +111,7 @@ class Tracks::TimeChunkProcessorJob < ApplicationJob
         return nil
       end
 
-      track = create_track_from_points(points, distance * 1000) # Convert km to meters
+      track = create_track_from_points(points, distance * 1000, orphan_only: true) # Convert km to meters
 
       unless track
         Rails.logger.warn "Failed to create track from #{points.size} points with distance #{distance.round(2)} km"

--- a/app/services/tracks/orphan_point_attacher.rb
+++ b/app/services/tracks/orphan_point_attacher.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Tracks
+  class OrphanPointAttacher
+    include Tracks::TrackBuilder
+
+    def initialize(user, point, segment_points)
+      @user = user
+      @point = point
+      @segment_ids = segment_points.map(&:id)
+    end
+
+    def call
+      neighbor = user.points.where(id: @segment_ids).where.not(track_id: nil)
+                     .min_by { |candidate| [(candidate.timestamp - point.timestamp).abs, candidate.id] }
+      track = neighbor && user.tracks.find_by(id: neighbor.track_id)
+      return unless track
+
+      track.with_lock do
+        locked = user.points.where(id: [point.id, neighbor.id]).order(:id).lock.index_by(&:id)
+        @point = locked[point.id]
+        neighbor = locked[neighbor.id]
+        next unless attachable?(neighbor, track)
+
+        TrackSegments::TimeAnchorBackfillJob.anchor_now(track.track_segments.where(start_at: nil).pluck(:id))
+        point.update!(track_id: track.id)
+        refresh_track(track)
+        track
+      end
+    end
+
+    private
+
+    attr_reader :user, :point
+
+    def attachable?(neighbor, track)
+      return false unless point && neighbor && point.track_id.nil? && neighbor.track_id == track.id
+      return false if point.anomaly? || neighbor.anomaly?
+      return false unless point.tracker_id.to_s == track.tracker_id.to_s
+      return false unless neighbor.tracker_id.to_s == point.tracker_id.to_s
+
+      (point.timestamp - neighbor.timestamp).abs <= user.safe_settings.minutes_between_routes.to_i.minutes
+    end
+
+    def refresh_track(track)
+      points = track.points.order(:timestamp, :id).to_a
+      elevation = calculate_elevation_stats(points)
+      track.update!(start_at: Time.zone.at(points.first.timestamp), end_at: Time.zone.at(points.last.timestamp),
+                    elevation_gain: elevation[:gain], elevation_loss: elevation[:loss],
+                    elevation_min: elevation[:min], elevation_max: elevation[:max])
+      track.recalculate_path_and_distance!
+      Tracks::Reprocessor.reprocess(track)
+    end
+  end
+end

--- a/app/services/tracks/track_builder.rb
+++ b/app/services/tracks/track_builder.rb
@@ -57,7 +57,12 @@ module Tracks::TrackBuilder
   MAX_DISTANCE_METERS = 100_000_000
 
   def create_track_from_points(points, pre_calculated_distance, tracker_id: nil,
-                               skip_segment_detection: false)
+                               skip_segment_detection: false, orphan_only: false)
+    if orphan_only
+      return create_track_from_orphan_points(points, tracker_id: tracker_id,
+                                            skip_segment_detection: skip_segment_detection)
+    end
+
     return nil if points.size < 2
 
     resolved_tracker_id = tracker_id || points.first.tracker_id
@@ -101,6 +106,22 @@ module Tracks::TrackBuilder
     saved_track
   rescue ActiveRecord::RecordNotUnique => e
     reuse_existing_track(track, points, e)
+  end
+
+  # Buffered chunks can load the same points before either chunk commits.
+  # Lock in ID order, then re-read ownership under the lock before calculating
+  # metadata. Filtering only the final UPDATE would leave a phantom path/track.
+  # Boundary merges deliberately use the default path to move owned points.
+  def create_track_from_orphan_points(points, tracker_id:, skip_segment_detection:)
+    Point.transaction do
+      orphans = Point.where(user_id: user.id, id: points.map(&:id), track_id: nil)
+                     .order(:id).lock.to_a.sort_by { |point| [point.timestamp, point.id] }
+      next if orphans.size < 2
+
+      distance = Point.calculate_distance_for_array_geocoder(orphans, :m)
+      create_track_from_points(orphans, distance, tracker_id: tracker_id,
+                               skip_segment_detection: skip_segment_detection)
+    end
   end
 
   def reuse_existing_track(track, points, original_error)

--- a/app/services/tracks/track_builder.rb
+++ b/app/services/tracks/track_builder.rb
@@ -113,15 +113,24 @@ module Tracks::TrackBuilder
   # metadata. Filtering only the final UPDATE would leave a phantom path/track.
   # Boundary merges deliberately use the default path to move owned points.
   def create_track_from_orphan_points(points, tracker_id:, skip_segment_detection:)
-    Point.transaction do
+    singleton = nil
+    track = Point.transaction do
       orphans = Point.where(user_id: user.id, id: points.map(&:id), track_id: nil)
                      .order(:id).lock.to_a.sort_by { |point| [point.timestamp, point.id] }
-      next if orphans.size < 2
+      if orphans.one?
+        singleton = orphans.first
+        next
+      end
+      next if orphans.empty?
 
       distance = Point.calculate_distance_for_array_geocoder(orphans, :m)
       create_track_from_points(orphans, distance, tracker_id: tracker_id,
                                skip_segment_detection: skip_segment_detection)
     end
+
+    return track unless singleton
+
+    Tracks::OrphanPointAttacher.new(user, singleton, points).call
   end
 
   def reuse_existing_track(track, points, original_error)

--- a/spec/regressions/chunk_orphan_claim_concurrency_spec.rb
+++ b/spec/regressions/chunk_orphan_claim_concurrency_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Chunk orphan claims under concurrency', :non_transactional, threads: 2 do
+  let(:user) { create(:user) }
+  let(:builder_class) do
+    Class.new do
+      include Tracks::TrackBuilder
+      attr_reader :user
+
+      def initialize(user)
+        @user = user
+      end
+    end
+  end
+
+  it 'claims overlapping stale snapshots without empty tracks or inaccurate bounds' do
+    points = 13.times.map do |index|
+      create(:point, user: user, timestamp: Time.utc(2026, 1, 14).to_i + index * 60,
+                     latitude: 40 + index * 0.001, longitude: 0)
+    end
+    ready = Concurrent::CountDownLatch.new(2)
+    start = Concurrent::CountDownLatch.new(1)
+    threads = [points.first(9), points].map do |snapshot|
+      Thread.new do
+        ActiveRecord::Base.connection_pool.with_connection do
+          builder = builder_class.new(User.find(user.id))
+          ready.count_down
+          start.wait
+          builder.create_track_from_points(snapshot, 999_999, orphan_only: true)
+        end
+      end
+    end
+
+    expect(ready.wait(5)).to be(true)
+    start.count_down
+    Timeout.timeout(15) { threads.each(&:value) }
+
+    expect(user.points.where(track_id: nil)).not_to exist
+    user.tracks.each do |track|
+      members = track.points.order(:timestamp).to_a
+      expect(members.size).to be >= 2
+      expect(track.start_at.to_i).to eq(members.first.timestamp)
+      expect(track.end_at.to_i).to eq(members.last.timestamp)
+      expect(track.distance).to eq(Point.calculate_distance_for_array_geocoder(members, :m).round)
+    end
+  ensure
+    start&.count_down
+    threads&.each { |thread| thread.kill if thread.alive? }
+    threads&.each(&:join)
+  end
+end

--- a/spec/regressions/chunk_overlap_point_ownership_spec.rb
+++ b/spec/regressions/chunk_overlap_point_ownership_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Chunk overlap point ownership' do
+  let(:user) { create(:user, settings: { 'minutes_between_routes' => 60 }) }
+  let(:day_start) { Time.utc(2026, 1, 14) }
+  let(:session) { Tracks::SessionManager.new(user.id) }
+  let!(:points) do
+    (22..34).map do |hour|
+      create(:point, user: user, timestamp: (day_start + hour.hours).to_i,
+                     latitude: 40.0 + hour * 0.01, longitude: 0, altitude: 100)
+    end
+  end
+
+  before do
+    session.create_session
+    session.mark_started(2)
+  end
+
+  after { session.cleanup_session }
+
+  def chunk(index)
+    start_at = day_start + index.days
+    end_at = start_at + 1.day
+    {
+      chunk_id: index,
+      start_timestamp: start_at.to_i,
+      end_timestamp: end_at.to_i,
+      buffer_start_timestamp: (start_at - 6.hours).to_i,
+      buffer_end_timestamp: (end_at + 6.hours).to_i,
+      untracked_only: false
+    }
+  end
+
+  [[0, 1], [1, 0]].each do |order|
+    it "keeps ownership and metadata consistent with chunk order #{order}" do
+      Tracks::TimeChunkProcessorJob.new.perform(user.id, session.session_id, chunk(order.first))
+      first_track = user.tracks.sole
+      owned_ids = first_track.points.pluck(:id)
+      expect(owned_ids.size).to be >= 2
+
+      Tracks::TimeChunkProcessorJob.new.perform(user.id, session.session_id, chunk(order.last))
+
+      expect(first_track.reload.points.pluck(:id)).to match_array(owned_ids)
+      expect(user.tracks.reload.all? { |track| track.points.count >= 2 }).to be(true)
+
+      Tracks::BoundaryResolverJob.new.perform(user.id, session.session_id)
+
+      expect(session.get_session_data['status']).to eq('completed')
+      expect(user.tracks.reload.all? { |track| track.points.count >= 2 }).to be(true)
+      expect(user.points.where(track_id: nil)).not_to exist
+      user.tracks.each do |track|
+        timestamps = track.points.order(:timestamp).pluck(:timestamp)
+        expect(track.start_at.to_i).to eq(timestamps.first)
+        expect(track.end_at.to_i).to eq(timestamps.last)
+      end
+    end
+  end
+end

--- a/spec/regressions/chunk_overlap_point_ownership_spec.rb
+++ b/spec/regressions/chunk_overlap_point_ownership_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe 'Chunk overlap point ownership' do
   let(:user) { create(:user, settings: { 'minutes_between_routes' => 60 }) }
   let(:day_start) { Time.utc(2026, 1, 14) }
   let(:session) { Tracks::SessionManager.new(user.id) }
+  let(:hours) { 22..34 }
   let!(:points) do
-    (22..34).map do |hour|
+    hours.map do |hour|
       create(:point, user: user, timestamp: (day_start + hour.hours).to_i,
                      latitude: 40.0 + hour * 0.01, longitude: 0, altitude: 100)
     end
@@ -54,6 +55,24 @@ RSpec.describe 'Chunk overlap point ownership' do
         timestamps = track.points.order(:timestamp).pluck(:timestamp)
         expect(track.start_at.to_i).to eq(timestamps.first)
         expect(track.end_at.to_i).to eq(timestamps.last)
+      end
+    end
+  end
+  [22..31, 17..26].each do |range|
+    context "when a single endpoint remains in hours #{range}" do
+      let(:hours) { range }
+
+      [[0, 1], [1, 0]].each do |order|
+        it "includes the terminal point with chunk order #{order}" do
+          order.each do |index|
+            Tracks::TimeChunkProcessorJob.new.perform(user.id, session.session_id, chunk(index))
+          end
+          Tracks::BoundaryResolverJob.new.perform(user.id, session.session_id)
+
+          expect(user.points.where(track_id: nil)).not_to exist
+          expect(user.tracks.sum { |track| track.points.count }).to eq(points.size)
+          expect(user.tracks.maximum(:end_at).to_i).to eq(points.last.timestamp)
+        end
       end
     end
   end

--- a/spec/regressions/completed_chunk_track_metadata_spec.rb
+++ b/spec/regressions/completed_chunk_track_metadata_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Completed chunk track metadata' do
     data = generate_chunks([0, 1, 2])
 
     expect(data.dig('metadata', 'track_metadata_refresh')).to include(
-      'refreshed' => 2, 'skipped' => 1, 'reasons' => { 'insufficient_points' => 1 }, 'sample_ids' => [historical.id]
+      'refreshed' => 0, 'skipped' => 1, 'reasons' => { 'insufficient_points' => 1 }, 'sample_ids' => [historical.id]
     )
     expect(historical.reload.attributes).to eq(original)
     expect(user.tracks.where.not(id: historical.id).count).to eq(3)


### PR DESCRIPTION
## Summary

Adjacent buffered chunks can load the same orphan points before either commits. A later chunk could then take points already assigned to the first track and leave phantom geometry. Lock and re-read orphan ownership before computing track metadata, and build each chunk from the points it actually claims. If the remainder is a single endpoint, attach it to a compatible neighboring track after rechecking ownership under locks; preserve segment anchors and refresh metadata atomically.

Detail report: `bug_9aad4a59-32ca-4db6-8064-17ff4e3035ef`.

## How to validate

Includes real concurrent PostgreSQL transactions, overlapping chunks, and geometry/metadata assertions. Follow-up regressions cover historical leading and trailing singleton endpoints with both chunk completion orders; the trailing case failed before the follow-up fix.

```sh
RAILS_ENV=test bundle exec rspec spec/regressions/chunk_orphan_claim_concurrency_spec.rb spec/regressions/chunk_overlap_point_ownership_spec.rb spec/regressions/completed_chunk_track_metadata_spec.rb
```

- Before the fix: 2 examples, 2 failures.
- Focused regression and related existing tests after the fix: **76 examples, 0 failures**.
- RuboCop on changed Ruby files and `git diff --check`: passed.
- Full RSpec: **9,573 examples, 1 failure**. The existing TERM-resistant poster renderer test intermittently raised `Errno::EPERM` instead of its expected timeout error; no causal link to these changes was found. The renderer suite passed on a control branch (10 examples), and renderer plus overlap regressions passed on this head (16 examples). This is not a clean full-suite result.
- `make test` is unavailable because the worktree has no tracked Makefile/test target. Browser E2E were not run.

## Risk / rollout notes

The orphan-only path is enabled for chunk generation; intentional boundary merges retain their existing ownership-transfer behavior.
