### PR TITLE
fix: import nested Polarsteps step locations and timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Polarsteps step-array exports with nested locations and numeric timestamps import their points correctly. (#3551)
+
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)
 - Reverse geocoding resolves countries sharing an ISO code correctly and repairs historical links (#3462)

--- a/app/services/polarsteps/importer.rb
+++ b/app/services/polarsteps/importer.rb
@@ -39,11 +39,14 @@ class Polarsteps::Importer
   def build_point(loc)
     return nil unless loc.is_a?(Hash)
 
-    lat = loc['lat']
-    lon = loc['lon'] || loc['lng']
+    location = loc['location'].is_a?(Hash) ? loc['location'] : {}
+    lat = location['lat'] || loc['lat']
+    lon = location['lon'] || location['lng'] || loc['lon'] || loc['lng']
     return nil if lat.nil? || lon.nil?
 
-    timestamp = parse_timestamp(loc['time'] || loc['timestamp'])
+    timestamp = parse_timestamp(
+      loc['time'] || loc['timestamp'] || loc['arrived'] || loc['departed'] || loc['start_time'] || loc['end_time']
+    )
     return nil if timestamp.nil?
 
     {
@@ -58,6 +61,8 @@ class Polarsteps::Importer
 
   def parse_timestamp(value)
     return nil if value.nil?
+
+    return Time.zone.at(value.to_f).to_i if value.is_a?(Numeric) || value.to_s.match?(/\A-?\d+(?:\.\d+)?\z/)
 
     Time.zone.parse(value.to_s)&.to_i
   rescue ArgumentError, TypeError

--- a/spec/regressions/polarsteps_steps_points_spec.rb
+++ b/spec/regressions/polarsteps_steps_points_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Polarsteps step points' do
+  let(:user) { create(:user) }
+  let(:import) { create(:import, user: user, skip_background_processing: true) }
+
+  def attach_steps(steps)
+    import.file.attach(io: StringIO.new(steps.to_json), filename: 'steps.json', content_type: 'application/json')
+  end
+
+  it 'imports the detected step array and schedules point-derived processing' do
+    path = Rails.root.join('spec/fixtures/files/enhanced_import/polarsteps_steps_array.json')
+    attach_steps(JSON.parse(File.read(path)))
+    expect(Imports::SourceDetector.new_from_file_header(path).detect_source!).to eq(:polarsteps)
+
+    expect do
+      Imports::Create.new(user, import).call
+    end.to have_enqueued_job(Tracks::ParallelGeneratorJob)
+
+    expect(import.reload).to be_completed
+    expect(import.source).to eq('polarsteps')
+    expect(import.points.order(:timestamp).pluck(:timestamp)).to eq([1_735_689_600, 1_735_776_000])
+    expect(import.points.order(:timestamp).first.lat).to be_within(0.0001).of(35.6762)
+    expect(import.points.order(:timestamp).last.lon).to be_within(0.0001).of(135.7681)
+  end
+
+  %w[time timestamp arrived departed start_time end_time].each do |key|
+    [1_735_689_600, '1735689600'].each do |value|
+      it "accepts an epoch #{value.class} in #{key}" do
+        attach_steps([{ 'location' => { 'lat' => 0, 'lng' => 12.5 }, key => value }])
+
+        Polarsteps::Importer.new(import, user.id).call
+
+        point = import.points.sole
+        expect(point.timestamp).to eq(1_735_689_600)
+        expect(point.lat).to eq(0)
+        expect(point.lon).to eq(12.5)
+      end
+    end
+  end
+
+  it 'keeps top-level coordinates when location is not an object' do
+    attach_steps([{ 'location' => 'Berlin', 'lat' => 52.5, 'lon' => 13.4, 'arrived' => 1_735_689_600 }])
+
+    Polarsteps::Importer.new(import, user.id).call
+
+    expect(import.points.sole.timestamp).to eq(1_735_689_600)
+  end
+end


### PR DESCRIPTION
## Summary

Valid Polarsteps step-array exports could finish with zero points when coordinates were nested under `location` or timestamps were numeric epochs. Read the nested coordinates and support epoch and ISO timestamps while keeping flat-export compatibility.

Detail report: `bug_9f54ba9e-2158-4123-9516-177f14ad4e38`.

## How to validate

Covers nested and flat export shapes, numeric and ISO timestamps, and imported point values.

```sh
RAILS_ENV=test bundle exec rspec spec/regressions/polarsteps_steps_points_spec.rb
```

- Before the fix: 14 examples, 14 failures.
- Focused regression and related existing tests after the fix: **102 examples, 0 failures**.
- RuboCop on changed Ruby files and `git diff --check`: passed.
- `make test` was attempted, but these worktrees have no tracked Makefile/test target. The full suite and browser E2E were not run.

## Risk / rollout notes

No schema migration; affected exports can be imported again.
