### PR TITLE
fix: restore point JSONB values without double encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Restoring a user archive preserves structured geodata and raw point data. (#3552)
+
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)
 - Reverse geocoding resolves countries sharing an ISO code correctly and repairs historical links (#3462)

--- a/app/services/users/import_data/points.rb
+++ b/app/services/users/import_data/points.rb
@@ -203,6 +203,7 @@ class Users::ImportData::Points
 
     ensure_lonlat_field(attributes, point_data)
     deserialize_array_columns(attributes)
+    deserialize_jsonb_columns(attributes)
 
     attributes.delete('longitude')
     attributes.delete('latitude')
@@ -298,6 +299,15 @@ class Users::ImportData::Points
   # type so old and new dumps alike arrive as real arrays.
   def deserialize_array_columns(attributes)
     %w[inrids in_regions].each do |column|
+      value = attributes[column]
+      attributes[column] = Point.type_for_attribute(column).deserialize(value) if value.is_a?(String)
+    end
+  end
+
+  # SQL-backed exports encode these JSONB values as JSON text inside JSONL.
+  # Decode before upsert_all, otherwise its serializer stores string scalars.
+  def deserialize_jsonb_columns(attributes)
+    %w[geodata raw_data].each do |column|
       value = attributes[column]
       attributes[column] = Point.type_for_attribute(column).deserialize(value) if value.is_a?(String)
     end

--- a/spec/regressions/point_archive_jsonb_roundtrip_spec.rb
+++ b/spec/regressions/point_archive_jsonb_roundtrip_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Point archive JSONB round trip' do
+  let(:source_user) { create(:user) }
+  let(:restored_user) { create(:user) }
+  let(:geodata) { { 'properties' => { 'osm_id' => 12_345, 'name' => 'Synthetic Park' } } }
+  let(:raw_data) { { 'device' => 'synthetic-device', 'nested' => { 'enabled' => true, 'values' => [1, 2] } } }
+
+  def expect_json_objects(point)
+    expect(point.geodata).to eq(geodata)
+    expect(point.raw_data).to eq(raw_data)
+    types = Point.where(id: point.id).pick(Arel.sql('jsonb_typeof(geodata), jsonb_typeof(raw_data)'))
+    expect(types).to eq(%w[object object])
+    osm_id = Point.where(id: point.id).pick(Arel.sql("geodata -> 'properties' ->> 'osm_id'"))
+    expect(osm_id).to eq('12345')
+  end
+
+  it 'restores streamed JSONL from the real exporter as JSONB objects' do
+    source_point = create(:point, user: source_user, geodata: geodata, raw_data: raw_data,
+                                  reverse_geocoded_at: Time.utc(2025, 1, 1))
+    Dir.mktmpdir('point-archive-roundtrip') do |directory|
+      root = Pathname.new(directory)
+      paths = Users::ExportData::Points.new(source_user, root.join('points')).call
+      importer = Users::ImportData::Points.new(restored_user, batch_size: 1)
+      paths.each do |path|
+        File.foreach(root.join(path)) { |line| importer.add(Oj.load(line)) }
+      end
+      expect(importer.finalize).to eq(1)
+    end
+
+    restored = restored_user.points.sole
+    expect_json_objects(restored)
+    expect(restored.reverse_geocoded_at).to eq(source_point.reverse_geocoded_at)
+  end
+
+  it 'restores legacy in-memory exports as JSONB objects' do
+    create(:point, user: source_user, geodata: geodata, raw_data: raw_data)
+    data = Users::ExportData::Points.new(source_user).call
+
+    expect(Users::ImportData::Points.new(restored_user, data).call).to eq(1)
+    expect_json_objects(restored_user.points.sole)
+  end
+
+  it 'keeps already decoded objects intact' do
+    data = [{ 'longitude' => 13.4, 'latitude' => 52.5, 'timestamp' => Time.utc(2025, 1, 1).to_i,
+              'geodata' => geodata, 'raw_data' => raw_data }]
+
+    expect(Users::ImportData::Points.new(restored_user, data).call).to eq(1)
+    expect_json_objects(restored_user.points.sole)
+  end
+
+  it 'restores empty objects without making them candidates for raw-data archiving' do
+    data = [{ 'longitude' => 13.4, 'latitude' => 52.5, 'timestamp' => Time.utc(2025, 1, 1).to_i,
+              'geodata' => '{}', 'raw_data' => '{}' }]
+
+    expect(Users::ImportData::Points.new(restored_user, data).call).to eq(1)
+    expect(restored_user.points.sole.raw_data).to eq({})
+    expect(restored_user.points.where("raw_data <> '{}'::jsonb")).not_to exist
+  end
+end


### PR DESCRIPTION
## Summary

Point archive restoration could persist `geodata` and `raw_data` as JSON string scalars instead of structured JSONB. Decode serialized archive values before the bulk upsert while preserving values that are already structured.

Detail report: `bug_00707cfb-de4e-4ca2-8d58-1a44b290c070`.

## How to validate

Uses a real archive round trip and PostgreSQL JSONB queries to verify the restored value types.

```sh
RAILS_ENV=test bundle exec rspec spec/regressions/point_archive_jsonb_roundtrip_spec.rb
```

- Before the fix: 4 examples, 3 failures.
- Focused regression and related existing tests after the fix: **39 examples, 0 failures**.
- RuboCop on changed Ruby files and `git diff --check`: passed.
- `make test` was attempted, but these worktrees have no tracked Makefile/test target. The full suite and browser E2E were not run.

## Risk / rollout notes

Applies to new restores; this does not rewrite previously corrupted rows.
