### PR TITLE
fix: preserve spaces in legacy OwnTracks record payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Legacy OwnTracks record imports preserve JSON values containing spaces. (#3553)
+
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)
 - Reverse geocoding resolves countries sharing an ISO code correctly and repairs historical links (#3462)

--- a/app/services/own_tracks/rec_parser.rb
+++ b/app/services/own_tracks/rec_parser.rb
@@ -13,7 +13,7 @@ class OwnTracks::RecParser
       parts = line.split("\t")
 
       # If tab splitting didn't work (only 1 part), try whitespace splitting
-      parts = line.split(/\s+/) if parts.size == 1
+      parts = line.split(/\s+/, 3) if parts.size == 1
 
       Oj.load(parts[2]) if parts.size > 2 && parts[1].strip == '*'
     end.compact

--- a/spec/regressions/owntracks_legacy_rec_spaces_spec.rb
+++ b/spec/regressions/owntracks_legacy_rec_spaces_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'OwnTracks legacy REC payload whitespace' do
+  let(:payload) do
+    { '_type' => 'location', 'lat' => 52.5, 'lon' => 13.4, 'tst' => 1_735_689_600,
+      'SSID' => 'Home Wifi', 'topic' => 'owntracks/test/iPhone 12 Pro', 'inregions' => ['Home Office'] }
+  end
+
+  [' ', '   ', "\t"].each do |separator|
+    it "preserves JSON strings and formatting with #{separator.inspect} columns" do
+      line = ['2025-01-01T00:00:00Z', '*', JSON.generate(payload)].join(separator)
+
+      expect(OwnTracks::RecParser.new(line).call).to eq([payload])
+    end
+  end
+
+  it 'imports a legacy record containing spaces without dropping the file' do
+    user = create(:user)
+    import = create(:import, user: user, name: 'legacy.rec', skip_background_processing: true)
+    line = "2025-01-01T00:00:00Z * #{JSON.generate(payload)}\n"
+    import.file.attach(io: StringIO.new(line), filename: 'legacy.rec', content_type: 'text/plain')
+
+    OwnTracks::Importer.new(import, user.id).call
+
+    point = import.points.sole
+    expect(point.ssid).to eq('Home Wifi')
+    expect(point.topic).to eq('owntracks/test/iPhone 12 Pro')
+    expect(point.timestamp).to eq(1_735_689_600)
+  end
+end


### PR DESCRIPTION
## Summary

The legacy `.rec` fallback parser split on every space and lost JSON containing values such as device names with spaces. Split the record into at most three fields so the JSON payload remains intact.

Detail report: `bug_66747a45-e78b-4e6e-9f8c-62b42342c147`.

## How to validate

Covers legacy record framing, whitespace separators, and JSON values containing spaces.

```sh
RAILS_ENV=test bundle exec rspec spec/regressions/owntracks_legacy_rec_spaces_spec.rb
```

- Before the fix: 4 examples, 3 failures.
- Focused regression and related existing tests after the fix: **10 examples, 0 failures**.
- RuboCop on changed Ruby files and `git diff --check`: passed.
- `make test` was attempted, but these worktrees have no tracked Makefile/test target. The full suite and browser E2E were not run.

## Risk / rollout notes

The fallback retains the full payload; ordinary JSON records continue through the existing parser.
