### PR TITLE
fix: synchronize family access before accepting invitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Family invitation acceptance uses the current subscription period even when background synchronization is delayed. (#3554)
+
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)
 - Reverse geocoding resolves countries sharing an ISO code correctly and repairs historical links (#3462)

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -18,6 +18,20 @@ class Family < ApplicationRecord
     owner_holds_plan?
   end
 
+  # A live family subscription supplies its current period. After a downgrade,
+  # retain already paid access but never extend it from a non-family renewal.
+  # A callback without a date must not erase the previously recorded period.
+  def refresh_access_until!(subscription_owner)
+    return if DawarichSettings.self_hosted? || subscription_owner&.active_until.blank?
+
+    period_end = if subscription_owner.family?
+                   subscription_owner.active_until
+                 elsif access_until
+                   [access_until, subscription_owner.active_until].min
+                 end
+    update!(access_until: period_end) unless access_until == period_end
+  end
+
   def can_add_members?
     return true if DawarichSettings.self_hosted?
 

--- a/app/services/families/accept_invitation.rb
+++ b/app/services/families/accept_invitation.rb
@@ -11,7 +11,7 @@ module Families
     end
 
     def call
-      return false unless can_accept?
+      return false unless validate_invitation && validate_email_match
 
       if user.in_family?
         @error_message = I18n.t(
@@ -21,14 +21,25 @@ module Families
         return false
       end
 
-      ActiveRecord::Base.transaction do
-        create_membership
-        settle_new_member
-        update_invitation
-        send_notifications
+      accepted = false
+      family = invitation.family
+      family.with_lock do
+        # Keep subscription callbacks from changing the period between the
+        # acceptance gate and settlement, and re-read queued webhook changes.
+        family.creator.with_lock do
+          family.refresh_access_until!(family.creator)
+          invitation.reload
+          if can_accept?
+            create_membership
+            settle_new_member
+            update_invitation
+            send_notifications
+            accepted = true
+          end
+        end
       end
 
-      true
+      accepted
     rescue ActiveRecord::RecordInvalid => e
       handle_record_invalid_error(e)
       false

--- a/app/services/families/sync_members.rb
+++ b/app/services/families/sync_members.rb
@@ -34,10 +34,7 @@ module Families
     end
 
     def refresh_access_until
-      return unless owner&.family?
-      return if owner.active_until.blank?
-
-      family.update!(access_until: owner.active_until)
+      family.refresh_access_until!(owner)
     end
 
     def granted?

--- a/spec/regressions/family_invitation_stale_subscription_spec.rb
+++ b/spec/regressions/family_invitation_stale_subscription_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Family invitation subscription synchronization' do
+  let(:owner) { create(:user, plan: :family, active_until: 1.month.from_now, status: :active, skip_auto_trial: true) }
+  let(:family) { create(:family, creator: owner, access_until: owner.active_until) }
+  let!(:owner_membership) { create(:family_membership, :owner, family: family, user: owner) }
+  let(:invitee) { create(:user, plan: :lite, status: :inactive, skip_auto_trial: true) }
+  let!(:invitation) { create(:family_invitation, family: family, invited_by: owner, email: invitee.email) }
+  let(:service) { Families::AcceptInvitation.new(invitation: invitation, user: invitee) }
+
+  before { allow(DawarichSettings).to receive(:self_hosted?).and_return(false) }
+
+  %i[family lite].each do |plan|
+    it "rejects an expired owner with plan #{plan} before the queued sync runs" do
+      owner.update!(plan: plan, status: :inactive, active_until: 1.day.ago)
+
+      expect { expect(service.call).to be(false) }.not_to change(Family::Membership, :count)
+      expect(invitation.reload).to be_pending
+      expect(invitee.reload).to be_lite
+      expect(invitee.notifications).not_to exist
+      expect(Families::LapseNotificationJob).not_to have_been_enqueued
+      expect(family.reload.access_until).to be_past
+    end
+  end
+
+  it 'accepts a renewed family owner before the queued sync runs' do
+    family.update!(access_until: 1.day.ago)
+
+    expect(service.call).to be(true)
+
+    expect(invitation.reload).to be_accepted
+    expect(invitee.reload).to be_active
+    expect(invitee).to be_pro
+    expect(invitee.active_until).to be_within(1.second).of(owner.active_until)
+    expect(Families::LapseNotificationJob).not_to have_been_enqueued
+  end
+
+  it 'keeps the recorded paid-through period after a downgrade without extending it' do
+    paid_until = family.access_until
+    owner.update!(plan: :pro, active_until: 1.year.from_now)
+
+    expect(service.call).to be(true)
+    expect(invitee.reload.active_until).to be_within(1.second).of(paid_until)
+  end
+
+  it 'keeps paid access if a callback omits the expiry date' do
+    paid_until = family.access_until
+    owner.update!(active_until: nil)
+
+    expect(service.call).to be(true)
+    expect(invitee.reload.active_until).to be_within(1.second).of(paid_until)
+  end
+
+  it 'also clears stale access when the background sync sees an expired downgrade' do
+    owner.update!(plan: :lite, status: :inactive, active_until: 1.day.ago)
+
+    Families::SyncMembers.new(family: family).call
+
+    expect(family.reload.access_until).to be_past
+    expect(family.access_live?).to be(false)
+  end
+end


### PR DESCRIPTION
## Summary

An invitation accepted before queued subscription synchronization could immediately lapse a renewed member or grant access from a stale period. Refresh family access from the current owner subscription under family and owner locks, then reload and validate the invitation before creating and settling the membership.

Detail report: `bug_3dfed7d0-1ebc-496c-8371-1776b789cd86`.

## How to validate

Covers renewal, downgrade, stale acceptance state, and the existing invitation/member synchronization suites.

```sh
RAILS_ENV=test bundle exec rspec spec/regressions/family_invitation_stale_subscription_spec.rb
```

- Before the fix: 6 examples, 4 failures.
- Focused regression and related existing tests after the fix: **73 examples, 0 failures**.
- RuboCop on changed Ruby files and `git diff --check`: passed.
- `make test` was attempted, but these worktrees have no tracked Makefile/test target. The full suite and browser E2E were not run.

## Risk / rollout notes

Preserves already-paid family access without extending it from a non-family renewal; no schema migration.
