### PR TITLE
fix: enforce archive extraction limits on actual output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- User archive restoration enforces ZIP extraction limits against actual output size. (#3555)
+
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)
 - Reverse geocoding resolves countries sharing an ISO code correctly and repairs historical links (#3462)

--- a/app/services/users/import_data.rb
+++ b/app/services/users/import_data.rb
@@ -115,10 +115,12 @@ class Users::ImportData
 
         FileUtils.mkdir_p(File.dirname(extraction_path))
 
-        # Manual extraction to bypass size validation for large files
+        # The directory size is untrusted. Bound decompressed output too;
+        # checking one extra byte detects overflow without writing past the cap.
         entry.get_input_stream do |input|
           File.open(extraction_path, 'wb') do |output|
-            IO.copy_stream(input, output)
+            IO.copy_stream(input, output, MAX_ENTRY_SIZE)
+            raise "Archive entry #{entry.name} exceeds maximum allowed size" if input.read(1)
           end
         end
       end

--- a/spec/regressions/archive_actual_extraction_limit_spec.rb
+++ b/spec/regressions/archive_actual_extraction_limit_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'User archive actual extraction size' do
+  let(:user) { create(:user) }
+
+  around do |example|
+    Dir.mktmpdir('archive-size-limit') do |directory|
+      @directory = Pathname.new(directory)
+      example.run
+    end
+  end
+
+  before { stub_const('Users::ImportData::MAX_ENTRY_SIZE', 1024) }
+
+  def archive(size, declared_size: size)
+    path = @directory.join('archive.zip')
+    Zip::OutputStream.open(path) do |zip|
+      zip.put_next_entry('payload.txt')
+      zip.write('x' * size)
+    end
+    bytes = File.binread(path)
+    central_directory = bytes.index("PK\x01\x02".b)
+    bytes[central_directory + 24, 4] = [declared_size].pack('V')
+    File.binwrite(path, bytes)
+    path
+  end
+
+  def extractor(path)
+    service = Users::ImportData.new(user, path)
+    service.instance_variable_set(:@import_directory, @directory.join('extracted'))
+    service
+  end
+
+  it 'rejects an understated ZIP size before writing beyond the actual-byte ceiling' do
+    path = archive(4096, declared_size: 1)
+    Zip::File.open(path) { |zip| expect(zip.entries.sole.size).to eq(1) }
+
+    expect { extractor(path).send(:extract_archive) }.to raise_error(/exceeds maximum allowed size/)
+    expect(File.size(@directory.join('extracted/payload.txt'))).to be <= 1024
+  end
+
+  [1023, 1024].each do |size|
+    it "extracts a legitimate #{size}-byte entry intact" do
+      extractor(archive(size)).send(:extract_archive)
+
+      expect(File.binread(@directory.join('extracted/payload.txt'))).to eq('x' * size)
+    end
+  end
+
+  it 'cleans up the restore directory after detecting a forged size' do
+    service = Users::ImportData.new(user, archive(4096, declared_size: 1))
+
+    expect { service.import }.to raise_error(/exceeds maximum allowed size/)
+    expect(service.instance_variable_get(:@import_directory)).not_to exist
+    expect(user.notifications.where(kind: :error)).to exist
+  end
+end


### PR DESCRIPTION
## Summary

The ZIP metadata size check could be bypassed by a forged central-directory size. Bound the streamed copy by the configured entry limit and probe for one extra byte, preventing oversized output from being written to disk.

Detail report: `bug_3bcc0ffd-defd-4c50-8e6c-a4fde62f5766`.

## How to validate

Uses a real forged ZIP, exact-limit valid entries, cleanup, and restore failure notification assertions.

```sh
RAILS_ENV=test bundle exec rspec spec/regressions/archive_actual_extraction_limit_spec.rb
```

- Before the fix: 4 examples, 2 failures.
- Focused regression and related existing tests after the fix: **11 examples, 0 failures**.
- RuboCop on changed Ruby files and `git diff --check`: passed.
- `make test` was attempted, but these worktrees have no tracked Makefile/test target. The full suite and browser E2E were not run.

## Risk / rollout notes

Keeps streaming extraction and the existing entry-size policy; no schema migration.
