### PR TITLE
fix: retry deferred per-tracker track migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Per-tracker migrations retry deferred track recalculation instead of reporting premature success. (#3556)
+
 - Renamed imports download using their current name and client-wrapped files retain their original format (#3455)
 - Password-protected shared links now unlock on self-hosted HTTP servers (#3314)
 - Reverse geocoding resolves countries sharing an ISO code correctly and repairs historical links (#3462)

--- a/app/jobs/data_migrations/recalculate_per_tracker_tracks_job.rb
+++ b/app/jobs/data_migrations/recalculate_per_tracker_tracks_job.rb
@@ -17,12 +17,23 @@ class DataMigrations::RecalculatePerTrackerTracksJob < ApplicationJob
     backfilled = backfill_google_records_devices(user)
     backfilled += Points::TrackerIdBackfiller.new(user).call
 
-    return unless backfilled.positive? || user.tracks.where(tracker_id: nil).exists?
+    return unless backfilled.positive? || tracks_need_recalculation?(user)
 
-    Users::RecalculateDataJob.perform_now(user.id, notify: false)
+    # perform_now consumes retry_on errors and silently moves the retry to
+    # :stats. Let lock failures reach this migration so its own retry can run.
+    Users::RecalculateDataJob.new.perform(user.id, notify: false)
   end
 
   private
+
+  def tracks_need_recalculation?(user)
+    return true if user.tracks.where(tracker_id: nil).exists?
+    return true if user.points.where(track_id: nil).exists?
+
+    # A failed attempt may already have backfilled the point IDs. Detect the
+    # remaining stale ownership rather than relying on the backfill count.
+    user.points.joins(:track).where('points.tracker_id IS DISTINCT FROM tracks.tracker_id').exists?
+  end
 
   def backfill_google_records_devices(user)
     user.imports.where(source: :google_records).sum do |import|

--- a/spec/jobs/data_migrations/recalculate_per_tracker_tracks_job_spec.rb
+++ b/spec/jobs/data_migrations/recalculate_per_tracker_tracks_job_spec.rb
@@ -90,12 +90,14 @@ RSpec.describe DataMigrations::RecalculatePerTrackerTracksJob do
   describe 'with user_id: processing one user' do
     let(:user) { create(:user) }
 
-    it 'backfills point tracker_ids first, then invokes RecalculateDataJob via the ActiveJob lifecycle' do
+    it 'backfills point tracker_ids first, then invokes recalculation without swallowing retry errors' do
       create(:track, user: user, tracker_id: nil)
 
       backfiller = instance_double(Points::TrackerIdBackfiller, call: 0)
       expect(Points::TrackerIdBackfiller).to receive(:new).with(user).and_return(backfiller)
-      expect(Users::RecalculateDataJob).to receive(:perform_now).with(user.id, notify: false)
+      recalculation = instance_double(Users::RecalculateDataJob)
+      expect(Users::RecalculateDataJob).to receive(:new).and_return(recalculation)
+      expect(recalculation).to receive(:perform).with(user.id, notify: false)
 
       described_class.new.perform(user.id)
     end
@@ -103,7 +105,7 @@ RSpec.describe DataMigrations::RecalculatePerTrackerTracksJob do
     it 'skips RecalculateDataJob when no nil-tracker tracks remain after backfill' do
       create(:track, user: user, tracker_id: 'iphone')
 
-      expect(Users::RecalculateDataJob).not_to receive(:perform_now)
+      expect(Users::RecalculateDataJob).not_to receive(:new)
 
       described_class.new.perform(user.id)
     end

--- a/spec/regressions/tracker_migration_lock_timeout_spec.rb
+++ b/spec/regressions/tracker_migration_lock_timeout_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Per-tracker migration lock contention' do
+  let(:user) { create(:user) }
+  let!(:track) do
+    create(:track, user: user, tracker_id: nil, start_at: Time.utc(2025, 1, 1), end_at: Time.utc(2025, 1, 2))
+  end
+  let!(:point) do
+    create(:point, user: user, track: track, timestamp: Time.utc(2025, 1, 1, 12).to_i,
+                   tracker_id: 'google-maps-timeline-export', raw_data: { 'deviceTag' => 123 })
+  end
+
+  before do
+    allow(Tracks::PerUserLock).to receive(:with_user_lock)
+      .and_raise(Tracks::PerUserLock::AcquisitionTimeout, 'synthetic occupied lock')
+  end
+
+  it 'propagates lock failure to the migration instead of reporting success and retrying on stats' do
+    expect do
+      DataMigrations::RecalculatePerTrackerTracksJob.perform_now(user.id)
+    end.to raise_error(Tracks::PerUserLock::AcquisitionTimeout)
+
+    expect(Users::RecalculateDataJob).not_to have_been_enqueued
+    expect(Track.exists?(track.id)).to be(true)
+  end
+
+  it 'still retries the rebuild after point IDs changed on the failed attempt' do
+    track.update!(tracker_id: 'old-device')
+    expect do
+      DataMigrations::RecalculatePerTrackerTracksJob.perform_now(user.id)
+    end.to raise_error(Tracks::PerUserLock::AcquisitionTimeout)
+    expect(point.reload.tracker_id).to eq('google-records-device-123')
+
+    allow(Tracks::PerUserLock).to receive(:with_user_lock).and_call_original
+    expect do
+      DataMigrations::RecalculatePerTrackerTracksJob.perform_now(user.id)
+    end.to have_enqueued_job(Tracks::TimeChunkProcessorJob)
+    expect(Track.exists?(track.id)).to be(false)
+  end
+end


### PR DESCRIPTION
## Summary

The migration could report success when nested `perform_now` handling swallowed a recalculation retry. Invoke the recalculation body directly so lock failures reach the migration job, and keep detecting mismatched tracks after tracker IDs have already been backfilled.

Detail report: `bug_e5c69122-bc2c-4bf4-b5da-277abc19b542`.

## How to validate

Covers simulated advisory-lock timeouts, propagated failures, and a real retry after partial backfill.

```sh
RAILS_ENV=test bundle exec rspec spec/jobs/data_migrations/recalculate_per_tracker_tracks_job_spec.rb spec/regressions/tracker_migration_lock_timeout_spec.rb
```

- Before the fix: 2 examples, 2 failures.
- Focused regression and related existing tests after the fix: **31 examples, 0 failures**.
- RuboCop on changed Ruby files and `git diff --check`: passed.
- `make test` was attempted, but these worktrees have no tracked Makefile/test target. The full suite and browser E2E were not run.

## Risk / rollout notes

Retries remain idempotent; this changes completion reporting for deferred work and adds no schema migration.
