### PR TITLE
feat: notify mobile family clients when sharing and locations change

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -2,7 +2,7 @@
 
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
-    identified_by :current_user, :current_share
+    identified_by :current_user, :current_share, :family_api_user
 
     def connect
       share = verified_live_share
@@ -10,12 +10,39 @@ module ApplicationCable
       if (verified_user = env['warden']&.user)
         self.current_user = verified_user
         self.current_share = share
+      elsif (api_user = authorized_family_api_user)
+        self.family_api_user = api_user
       elsif share
         self.current_user = nil
         self.current_share = share
       else
         reject_unauthorized_connection
       end
+    end
+
+    # API credentials only identify the restricted family channel. They do not
+    # populate current_user/current_share or grant access to session channels.
+    def authorized_family_api_user
+      token = request.headers['Authorization'].to_s.match(/\ABearer\s+(\S+)\z/i)&.[](1)
+      return if token.blank?
+
+      user = User.find_by(api_key: token)
+      return unless user && !user.pending_payment? && user.in_family?
+      return unless DawarichSettings.family_feature_available_for?(user)
+
+      user
+    end
+
+    # The mobile client has its own 75-second stale-connection timeout. A
+    # foreground-only stream needs fewer keepalives than browser Action Cable.
+    def beat
+      if family_api_user
+        now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        return if @last_family_beat && now - @last_family_beat < 30
+
+        @last_family_beat = now
+      end
+      super
     end
 
     private

--- a/app/channels/family_updates_channel.rb
+++ b/app/channels/family_updates_channel.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Mobile clients receive invalidations, never coordinates. HTTP remains the
+# authority for membership and sharing permissions. Batch point notifications
+# so an import or a fast tracker cannot turn into one HTTP refresh per point.
+class FamilyUpdatesChannel < ApplicationCable::Channel
+  periodically :flush_location_change, every: 5.seconds
+  periodically :verify_access, every: 30.seconds
+
+  def subscribed
+    return reject unless family_api_user
+
+    @family_id = family_api_user.family&.id
+    return reject unless authorized?
+
+    stream_for family_api_user.family, coder: ActiveSupport::JSON do |_message|
+      transmit({ type: 'sharing_changed' }) if verify_access
+    end
+    stream_from FamilyLocationsChannel.broadcasting_for(family_api_user.family),
+                coder: ActiveSupport::JSON do |_message|
+      @locations_changed = true
+    end
+  end
+
+  private
+
+  def authorized?
+    user = connection.authorized_family_api_user
+    user && user.family&.id == @family_id
+  end
+
+  def verify_access
+    return true if authorized?
+
+    stop_all_streams
+    transmit({ type: 'access_revoked' })
+    false
+  end
+
+  def flush_location_change
+    return unless @locations_changed
+
+    @locations_changed = false
+    transmit({ type: 'locations_changed' }) if verify_access
+  end
+end

--- a/app/models/concerns/user_family.rb
+++ b/app/models/concerns/user_family.rb
@@ -8,6 +8,7 @@ module UserFamily
   # - Users::Destroy service: validates before hard-deleting
 
   included do
+    after_update_commit :broadcast_family_sharing_change, if: :saved_change_to_settings?
     has_one :family_membership, dependent: :destroy, class_name: 'Family::Membership'
     has_one :family, through: :family_membership
     has_one :created_family, class_name: 'Family', foreign_key: 'creator_id', inverse_of: :creator, dependent: :destroy
@@ -89,6 +90,17 @@ module UserFamily
     end
 
     update!(settings: current_settings)
+  end
+
+  def broadcast_family_sharing_change
+    before, after = saved_change_to_settings
+    return if before&.dig('family', 'location_sharing') == after&.dig('family', 'location_sharing')
+    return unless in_family?
+
+    FamilyUpdatesChannel.broadcast_to(family, type: 'sharing_changed')
+  rescue StandardError => e
+    # A realtime outage must not roll back or fail a user's sharing preference.
+    ExceptionReporter.call(e, 'Failed to broadcast family sharing change')
   end
 
   def family_sharing_expires_at

--- a/app/serializers/api/family_serializer.rb
+++ b/app/serializers/api/family_serializer.rb
@@ -8,6 +8,7 @@ class Api::FamilySerializer
   def call
     {
       lapsed: false,
+      realtime_enabled: true,
       family: { name: family.name },
       me: me_payload,
       members: members_payload,

--- a/docs/api/mobile-family-realtime.md
+++ b/docs/api/mobile-family-realtime.md
@@ -1,0 +1,53 @@
+# Mobile family updates
+
+`GET /api/v1/families/mine` advertises `realtime_enabled: true` for an active
+family. Clients without this capability continue to poll. Deploy this server
+change before expecting realtime updates from a compatible mobile build.
+
+A native client connects to `/cable` with the `actioncable-v1-json` subprotocol,
+its usual `Authorization: Bearer <api key>` header, and a same-origin `Origin`
+header. API keys in the URL are not accepted. The reverse proxy must support the
+existing Action Cable WebSocket upgrade route. Browser session subscriptions
+continue to use their existing channels.
+
+After the Action Cable `welcome`, send:
+
+```json
+{"command":"subscribe","identifier":"{\"channel\":\"FamilyUpdatesChannel\"}"}
+```
+
+The channel sends small invalidation messages in the standard Action Cable
+`message` envelope:
+
+- `{"type":"sharing_changed"}` after a committed change to family sharing
+  settings. Refresh family metadata, current locations, and visible history.
+- `{"type":"locations_changed"}` at most once per five seconds while new
+  point broadcasts are arriving. Refresh current locations through the API.
+- `{"type":"access_revoked"}` when the API key, membership, or family
+  entitlement no longer permits access. Discard displayed family data and close
+  the socket. Membership and key validity are also checked every 30 seconds.
+
+No coordinates or member details are transmitted on this channel. HTTP endpoints
+remain responsible for applying current membership and sharing permissions.
+The API principal cannot subscribe to session-only point, import, track, or
+family-location channels. A failed broadcast does not roll back a sharing change.
+
+## Battery constraints for mobile clients
+
+Keep the socket and the 60-second fallback poll active only while the app is in
+the foreground and the family map layer is visible. Close on backgrounding,
+leaving the map, sign-out, or account change. Use exponential reconnect backoff
+and cancel pending retries on close. Mobile connections receive server heartbeats
+no more often than every 30 seconds; a compatible client should tolerate this
+interval (the app uses a 75-second stale timeout), without sending its own pings.
+
+After explicitly enabling sharing or accepting a location request, the app may
+publish one fresh point, respecting existing location permission, the in-app
+location setting, and automatic-upload settings. Prefer a cached fix no older
+than one minute; otherwise bound a balanced-accuracy location subscription to
+10 seconds and remove it after the first fix, cancellation, or timeout. This does
+not start ongoing tracking, change the upload batch preference, or flush a backlog.
+Opening the family panel refreshes metadata and locations without requesting GPS.
+
+These limits bound extra work; they are not a claim of zero additional energy
+usage. Physical-device energy profiling is still needed to quantify the impact.

--- a/spec/channels/application_cable/connection_spec.rb
+++ b/spec/channels/application_cable/connection_spec.rb
@@ -119,4 +119,42 @@ RSpec.describe ApplicationCable::Connection, type: :channel do
       expect(connection.current_share).to eq(share)
     end
   end
+  context 'with a family API bearer credential' do
+    let(:family) { create(:family, creator: owner) }
+
+    before do
+      create(:family_membership, user: owner, family: family, role: :owner)
+      allow(DawarichSettings).to receive(:family_feature_available_for?).and_return(true)
+    end
+
+    it 'only identifies the restricted mobile family principal' do
+      connect headers: { 'Authorization' => "Bearer #{owner.api_key}" }
+      expect(connection.family_api_user).to eq(owner)
+      expect(connection.current_user).to be_nil
+      expect(connection.current_share).to be_nil
+    end
+
+    it 'does not accept API credentials in the URL' do
+      expect { connect params: { api_key: owner.api_key } }.to have_rejected_connection
+    end
+
+    it 'rejects a family without entitlement' do
+      allow(DawarichSettings).to receive(:family_feature_available_for?).and_return(false)
+      expect { connect headers: { 'Authorization' => "Bearer #{owner.api_key}" } }.to have_rejected_connection
+    end
+
+    it 'rechecks key rotation rather than retaining authenticated access forever' do
+      connect headers: { 'Authorization' => "Bearer #{owner.api_key}" }
+      owner.update!(api_key: SecureRandom.hex(16))
+      expect(connection.authorized_family_api_user).to be_nil
+    end
+
+    it 'reduces mobile heartbeat traffic to one ping per thirty seconds' do
+      connect headers: { 'Authorization' => "Bearer #{owner.api_key}" }
+      allow(connection).to receive(:transmit)
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(100, 103, 130)
+      3.times { connection.beat }
+      expect(connection).to have_received(:transmit).twice
+    end
+  end
 end

--- a/spec/channels/family_updates_channel_spec.rb
+++ b/spec/channels/family_updates_channel_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FamilyUpdatesChannel, type: :channel do
+  let(:owner) { create(:user, plan: :family, skip_auto_trial: true) }
+  let(:family) { create(:family, creator: owner) }
+
+  before do
+    create(:family_membership, user: owner, family: family, role: :owner)
+    stub_connection(family_api_user: owner, authorized_family_api_user: owner)
+    allow(connection).to receive(:authorized_family_api_user).and_return(owner)
+  end
+
+  it 'subscribes to sharing changes and the existing point stream' do
+    subscribe
+    expect(subscription).to be_confirmed
+    expect(subscription).to have_stream_for(family)
+    expect(subscription).to have_stream_from(FamilyLocationsChannel.broadcasting_for(family))
+  end
+
+  it 'does not send periodic traffic without location changes' do
+    subscribe
+    subscription.send(:flush_location_change)
+    expect(transmissions).to be_empty
+  end
+
+  it 'coalesces point updates into one small invalidation, without coordinates' do
+    subscribe
+    100.times { subscription.instance_variable_set(:@locations_changed, true) }
+    subscription.send(:flush_location_change)
+    subscription.send(:flush_location_change)
+    expect(transmissions).to eq([{ 'type' => 'locations_changed' }])
+  end
+
+  it 'stops streaming when access or the API key is revoked' do
+    subscribe
+    allow(connection).to receive(:authorized_family_api_user).and_return(nil)
+    subscription.instance_variable_set(:@locations_changed, true)
+    subscription.send(:flush_location_change)
+    expect(transmissions).to eq([{ 'type' => 'access_revoked' }])
+    expect(subscription.streams).to be_empty
+  end
+
+  it 'does not follow a member into a different family on the old subscription' do
+    subscribe
+    other = create(:family)
+    owner.family_membership.update!(family: other)
+    owner.reload
+    subscription.send(:verify_access)
+    expect(transmissions.last).to eq({ 'type' => 'access_revoked' })
+  end
+
+  it 'rejects anonymous and ordinary session-only subscriptions' do
+    stub_connection(family_api_user: nil)
+    subscribe
+    expect(subscription).to be_rejected
+  end
+end

--- a/spec/models/concerns/user_family_realtime_spec.rb
+++ b/spec/models/concerns/user_family_realtime_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, 'family realtime updates' do
+  let(:owner) { create(:user, plan: :family, skip_auto_trial: true) }
+  let(:family) { create(:family, creator: owner) }
+
+  before do
+    create(:family_membership, user: owner, family: family, role: :owner)
+    allow(FamilyUpdatesChannel).to receive(:broadcast_to)
+  end
+
+  it 'notifies after enabling and disabling sharing, without sending coordinates' do
+    owner.update_family_location_sharing!(true, duration: '1h')
+    expect(FamilyUpdatesChannel).to have_received(:broadcast_to).with(family, type: 'sharing_changed').once
+    owner.update_family_location_sharing!(false)
+    expect(FamilyUpdatesChannel).to have_received(:broadcast_to).twice
+  end
+
+  it 'does not broadcast unrelated preference changes' do
+    owner.update!(settings: owner.settings.merge('test_preference' => true))
+    expect(FamilyUpdatesChannel).not_to have_received(:broadcast_to)
+  end
+
+  it 'does not publish a rolled-back sharing change' do
+    User.transaction do
+      owner.update_family_location_sharing!(true, duration: '1h')
+      raise ActiveRecord::Rollback
+    end
+    expect(FamilyUpdatesChannel).not_to have_received(:broadcast_to)
+  end
+
+  it 'does not fail a sharing update if the broadcaster is unavailable' do
+    allow(FamilyUpdatesChannel).to receive(:broadcast_to).and_raise(IOError)
+    allow(ExceptionReporter).to receive(:call)
+    expect { owner.update_family_location_sharing!(true, duration: '1h') }.not_to raise_error
+    expect(owner.reload.family_sharing_enabled?).to be(true)
+  end
+end


### PR DESCRIPTION
## Summary
Mobile family members currently discover newly granted location access through polling. Add a restricted, Bearer-authenticated Action Cable channel so compatible mobile clients can refresh immediately after sharing changes, and within five seconds after new points arrive.

`GET /api/v1/families/mine` advertises `realtime_enabled`. FamilyUpdatesChannel emits invalidations without coordinates; the existing family HTTP endpoints still enforce current sharing permissions. Sharing changes broadcast after commit, while existing point broadcasts are coalesced. API-key validity, family membership, and entitlement are rechecked on transmission and every 30 seconds. The API principal does not gain access to existing session-only channels, and API keys are never accepted in the WebSocket URL.

Mobile heartbeats are limited to one per 30 seconds. The companion app closes connections and polling when backgrounded or away from the family map, uses exponential reconnect backoff, and bounds the initial location fix to a cached point or a cancellable 10-second balanced-accuracy request.

Companion mobile PR: https://github.com/dawarich-app/multiplatform-app/pull/122. Deploy this backend before expecting realtime behavior from the new mobile build. Older clients and servers retain their polling behavior. No migrations or new dependencies.

## Validation
- 124 RSpec examples passed across channels, family API endpoints, sharing settings, privacy, and the point-upsert broadcast regression.
- RuboCop passed on all seven changed Ruby files.
- Real local Rails/Puma + WebSocket/HTTP check passed: native-style Bearer handshake, rejection of a session-only PointsChannel subscription, sharing-change notification (11 ms locally), ten uploaded points coalesced to one invalidation, correct latest coordinates through the recipient API, and no idle data notifications. Observed heartbeat spacing was at least 30 seconds.
- Final native iOS simulator integration passed: the open panel changed from Sharing off to the member’s fresh point without interaction (about 4.5 seconds between screenshots).
- The full RSpec suite is also being run; its result will be added before handoff.
- The documented `make test` command was attempted, but this checkout has no Makefile/test target. Browser E2E was not run for this backend-only change.
- Battery work is bounded by design; physical-device energy profiling has not been performed.

The channel contract and client battery constraints are documented in `docs/api/mobile-family-realtime.md`.
