### PR TITLE
Report the real remaining window in account-link Retry-After

### DIFF
--- a/app/controllers/api/v1/auth/apple_controller.rb
+++ b/app/controllers/api/v1/auth/apple_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::Auth::AppleController < Api::V1::Auth::BaseController
     }, status: :forbidden
   rescue Auth::FindOrCreateOauthUser::LinkVerificationSent => e
     if e.rate_limited
-      response.headers['Retry-After'] = Auth::FindOrCreateOauthUser::LINK_EMAIL_RATE_LIMIT_WINDOW.to_i.to_s
+      response.headers['Retry-After'] = e.retry_after.to_s
       render json: {
         error: 'verification_rate_limited',
         message: I18n.t('controllers.api.v1.auth.apple.verification_rate_limited')

--- a/app/controllers/api/v1/auth/google_controller.rb
+++ b/app/controllers/api/v1/auth/google_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::Auth::GoogleController < Api::V1::Auth::BaseController
     }, status: :forbidden
   rescue Auth::FindOrCreateOauthUser::LinkVerificationSent => e
     if e.rate_limited
-      response.headers['Retry-After'] = Auth::FindOrCreateOauthUser::LINK_EMAIL_RATE_LIMIT_WINDOW.to_i.to_s
+      response.headers['Retry-After'] = e.retry_after.to_s
       render json: {
         error: 'verification_rate_limited',
         message: I18n.t('controllers.api.v1.auth.google.verification_rate_limited')

--- a/app/controllers/auth/account_links_controller.rb
+++ b/app/controllers/auth/account_links_controller.rb
@@ -130,12 +130,7 @@ class Auth::AccountLinksController < ApplicationController
                          alert: I18n.t('controllers.auth.account_links.account_no_longer_exists'))
     end
 
-    cache_key = "#{Auth::FindOrCreateOauthUser::LINK_EMAIL_RATE_LIMIT_KEY_PREFIX}#{user.id}"
-    acquired = Rails.cache.write(cache_key, true,
-                                 expires_in: Auth::FindOrCreateOauthUser::LINK_EMAIL_RATE_LIMIT_WINDOW,
-                                 unless_exist: true)
-
-    if acquired
+    if Auth::FindOrCreateOauthUser.acquire_rate_limit(user.id)
       token = Auth::IssueAccountLinkToken.new(user, provider: pending['provider'], uid: pending['uid']).call
       link_url = auth_account_link_url(token: token)
       Users::MailerSendingJob.perform_later(

--- a/app/services/auth/find_or_create_oauth_user.rb
+++ b/app/services/auth/find_or_create_oauth_user.rb
@@ -16,19 +16,37 @@ module Auth
     end
 
     class LinkVerificationSent < StandardError
-      attr_reader :user, :provider, :uid, :rate_limited
+      attr_reader :user, :provider, :uid, :rate_limited, :retry_after
 
-      def initialize(user:, provider:, uid:, rate_limited: false)
+      def initialize(user:, provider:, uid:, rate_limited: false, retry_after: nil)
         @user = user
         @provider = provider
         @uid = uid
         @rate_limited = rate_limited
+        @retry_after = retry_after
         super('OAuth account link verification required for existing email')
       end
     end
 
     LINK_EMAIL_RATE_LIMIT_WINDOW = 1.hour
     LINK_EMAIL_RATE_LIMIT_KEY_PREFIX = 'oauth_account_link:rate_limit:'
+
+    # Stores the send time so a rate-limited retry can report how long is left.
+    def self.acquire_rate_limit(user_id)
+      Rails.cache.write(
+        "#{LINK_EMAIL_RATE_LIMIT_KEY_PREFIX}#{user_id}", Time.current.to_i,
+        expires_in: LINK_EMAIL_RATE_LIMIT_WINDOW,
+        unless_exist: true
+      )
+    end
+
+    def self.rate_limit_retry_after(user_id)
+      window = LINK_EMAIL_RATE_LIMIT_WINDOW.to_i
+      sent_at = Rails.cache.read("#{LINK_EMAIL_RATE_LIMIT_KEY_PREFIX}#{user_id}")
+      return window unless sent_at.is_a?(Integer)
+
+      (window - (Time.current.to_i - sent_at)).clamp(1, window)
+    end
 
     PROVIDERS_REQUIRING_EMAIL = %w[apple].freeze
 
@@ -93,7 +111,10 @@ module Auth
       end
 
       rate_limited = (@on_email_collision == :send_email) && send_verification_email(existing) == :rate_limited
-      raise LinkVerificationSent.new(user: existing, provider: @provider, uid: @uid, rate_limited: rate_limited)
+      raise LinkVerificationSent.new(
+        user: existing, provider: @provider, uid: @uid, rate_limited: rate_limited,
+        retry_after: (self.class.rate_limit_retry_after(existing.id) if rate_limited)
+      )
     end
 
     def auto_link_allowed?
@@ -101,13 +122,7 @@ module Auth
     end
 
     def send_verification_email(existing_user)
-      cache_key = "#{LINK_EMAIL_RATE_LIMIT_KEY_PREFIX}#{existing_user.id}"
-      acquired = Rails.cache.write(
-        cache_key, true,
-        expires_in: LINK_EMAIL_RATE_LIMIT_WINDOW,
-        unless_exist: true
-      )
-      return :rate_limited unless acquired
+      return :rate_limited unless self.class.acquire_rate_limit(existing_user.id)
 
       token = Auth::IssueAccountLinkToken.new(
         existing_user, provider: @provider, uid: @uid

--- a/spec/requests/api/v1/auth/apple_spec.rb
+++ b/spec/requests/api/v1/auth/apple_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'POST /api/v1/auth/apple', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:verifier_double) { instance_double(Auth::VerifyAppleToken) }
 
   before do
@@ -111,23 +113,37 @@ RSpec.describe 'POST /api/v1/auth/apple', type: :request do
       end
 
       it 'rate-limited retry returns 429 verification_rate_limited with Retry-After and no second mailer' do
-        # First collision seeds the rate-limit key and returns the genuine 202.
-        post '/api/v1/auth/apple', params: { id_token: 'fake_token' }
-        expect(response).to have_http_status(:accepted)
-
-        expect do
+        freeze_time do
+          # First collision seeds the rate-limit key and returns the genuine 202.
           post '/api/v1/auth/apple', params: { id_token: 'fake_token' }
-        end.not_to have_enqueued_job(Users::MailerSendingJob)
+          expect(response).to have_http_status(:accepted)
 
-        expect(response).to have_http_status(:too_many_requests)
-        expect(response.headers['Retry-After']).to eq(
-          Auth::FindOrCreateOauthUser::LINK_EMAIL_RATE_LIMIT_WINDOW.to_i.to_s
-        )
-        body = JSON.parse(response.body)
-        expect(body['error']).to eq('verification_rate_limited')
-        expect(body['message']).to be_present
-        expect(existing.reload.provider).to be_nil
-        expect(existing.reload.uid).to be_nil
+          expect do
+            post '/api/v1/auth/apple', params: { id_token: 'fake_token' }
+          end.not_to have_enqueued_job(Users::MailerSendingJob)
+
+          expect(response).to have_http_status(:too_many_requests)
+          expect(response.headers['Retry-After']).to eq(
+            Auth::FindOrCreateOauthUser::LINK_EMAIL_RATE_LIMIT_WINDOW.to_i.to_s
+          )
+          body = JSON.parse(response.body)
+          expect(body['error']).to eq('verification_rate_limited')
+          expect(body['message']).to be_present
+          expect(existing.reload.provider).to be_nil
+          expect(existing.reload.uid).to be_nil
+        end
+      end
+
+      it 'reports the time left in the window, not the full window, in Retry-After' do
+        freeze_time do
+          post '/api/v1/auth/apple', params: { id_token: 'fake_token' }
+
+          travel 20.minutes
+          post '/api/v1/auth/apple', params: { id_token: 'fake_token' }
+
+          expect(response).to have_http_status(:too_many_requests)
+          expect(response.headers['Retry-After']).to eq(40.minutes.to_i.to_s)
+        end
       end
     end
 

--- a/spec/requests/api/v1/auth/google_spec.rb
+++ b/spec/requests/api/v1/auth/google_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'POST /api/v1/auth/google', type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:verifier_double) { instance_double(Auth::VerifyGoogleToken) }
 
   before do
@@ -96,23 +98,37 @@ RSpec.describe 'POST /api/v1/auth/google', type: :request do
       end
 
       it 'rate-limited retry returns 429 verification_rate_limited with Retry-After and no second mailer' do
-        # First collision seeds the rate-limit key and returns the genuine 202.
-        post '/api/v1/auth/google', params: { id_token: 'fake_token' }
-        expect(response).to have_http_status(:accepted)
-
-        expect do
+        freeze_time do
+          # First collision seeds the rate-limit key and returns the genuine 202.
           post '/api/v1/auth/google', params: { id_token: 'fake_token' }
-        end.not_to have_enqueued_job(Users::MailerSendingJob)
+          expect(response).to have_http_status(:accepted)
 
-        expect(response).to have_http_status(:too_many_requests)
-        expect(response.headers['Retry-After']).to eq(
-          Auth::FindOrCreateOauthUser::LINK_EMAIL_RATE_LIMIT_WINDOW.to_i.to_s
-        )
-        body = JSON.parse(response.body)
-        expect(body['error']).to eq('verification_rate_limited')
-        expect(body['message']).to be_present
-        expect(existing.reload.provider).to be_nil
-        expect(existing.reload.uid).to be_nil
+          expect do
+            post '/api/v1/auth/google', params: { id_token: 'fake_token' }
+          end.not_to have_enqueued_job(Users::MailerSendingJob)
+
+          expect(response).to have_http_status(:too_many_requests)
+          expect(response.headers['Retry-After']).to eq(
+            Auth::FindOrCreateOauthUser::LINK_EMAIL_RATE_LIMIT_WINDOW.to_i.to_s
+          )
+          body = JSON.parse(response.body)
+          expect(body['error']).to eq('verification_rate_limited')
+          expect(body['message']).to be_present
+          expect(existing.reload.provider).to be_nil
+          expect(existing.reload.uid).to be_nil
+        end
+      end
+
+      it 'reports the time left in the window, not the full window, in Retry-After' do
+        freeze_time do
+          post '/api/v1/auth/google', params: { id_token: 'fake_token' }
+
+          travel 20.minutes
+          post '/api/v1/auth/google', params: { id_token: 'fake_token' }
+
+          expect(response).to have_http_status(:too_many_requests)
+          expect(response.headers['Retry-After']).to eq(40.minutes.to_i.to_s)
+        end
       end
     end
 

--- a/spec/swagger/api/v1/auth/apple_controller_spec.rb
+++ b/spec/swagger/api/v1/auth/apple_controller_spec.rb
@@ -61,6 +61,24 @@ describe 'Auth Apple API', type: :request do
         run_test!
       end
 
+      response '429', 'a verification email for this address was already sent within the last hour' do
+        schema type: :object,
+               properties: { error: { type: :string }, message: { type: :string } }
+        header 'Retry-After', schema: { type: :string },
+                              description: 'Seconds until another verification email can be requested'
+
+        before do
+          existing = create(:user, email: 'apple@example.com')
+          Auth::FindOrCreateOauthUser.acquire_rate_limit(existing.id)
+        end
+
+        let(:payload) { { id_token: 'fake_token' } }
+
+        run_test! do |response|
+          expect(response.parsed_body['error']).to eq('verification_rate_limited')
+        end
+      end
+
       response '409', 'account deletion is in progress' do
         schema type: :object,
                properties: { error: { type: :string }, message: { type: :string } }

--- a/spec/swagger/api/v1/auth/google_controller_spec.rb
+++ b/spec/swagger/api/v1/auth/google_controller_spec.rb
@@ -61,6 +61,24 @@ describe 'Auth Google API', type: :request do
         run_test!
       end
 
+      response '429', 'a verification email for this address was already sent within the last hour' do
+        schema type: :object,
+               properties: { error: { type: :string }, message: { type: :string } }
+        header 'Retry-After', schema: { type: :string },
+                              description: 'Seconds until another verification email can be requested'
+
+        before do
+          existing = create(:user, email: 'google@example.com')
+          Auth::FindOrCreateOauthUser.acquire_rate_limit(existing.id)
+        end
+
+        let(:payload) { { id_token: 'fake_token' } }
+
+        run_test! do |response|
+          expect(response.parsed_body['error']).to eq('verification_rate_limited')
+        end
+      end
+
       response '409', 'account deletion is in progress' do
         schema type: :object,
                properties: { error: { type: :string }, message: { type: :string } }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -337,6 +337,23 @@ paths:
                     type: string
                   message:
                     type: string
+        '429':
+          description: a verification email for this address was already sent within
+            the last hour
+          headers:
+            Retry-After:
+              schema:
+                type: string
+              description: Seconds until another verification email can be requested
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
         '409':
           description: account deletion is in progress
           content:
@@ -400,6 +417,23 @@ paths:
                     nullable: true
         '401':
           description: google token verification failed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+        '429':
+          description: a verification email for this address was already sent within
+            the last hour
+          headers:
+            Retry-After:
+              schema:
+                type: string
+              description: Seconds until another verification email can be requested
           content:
             application/json:
               schema:


### PR DESCRIPTION
Follow-up to #3567. That PR merged into `master` before these review fixes were pushed, so the issues below are live on `master` and `dev` today.

## What was wrong

`Retry-After` was hardcoded to the full window, so a retry fifty-five minutes into the hour was still told to wait `3600`. The rate-limit cache key held `true`, so there was nothing to compute a remainder from.

The new `429 verification_rate_limited` response was also undocumented. `swagger/v1/swagger.yaml` still described only `201`/`401`/`409` for the Google and Apple endpoints, so the mobile client's contract had no mention of the status it now has to handle.

## What changed

- The cache stores the send time, `LinkVerificationSent` carries `retry_after`, and `rate_limit_retry_after` returns the remaining seconds clamped to `1..window`. A legacy `true` value still in the cache falls back to the full window.
- `Auth::FindOrCreateOauthUser.acquire_rate_limit` is now the single place that writes the key, used by both the service and `Auth::AccountLinksController#email_fallback`, so a send from either path is accounted the same way.
- Both rswag specs document the `429` with its schema and the `Retry-After` header, and `swagger.yaml` is regenerated — 34 additive lines, exactly the two response blocks.

## Testing

Service, request and swagger specs for both providers plus the web account-link flow: 128 examples, 0 failures. RuboCop clean.

The request specs run under `freeze_time`, and a new example travels twenty minutes into the window and expects `Retry-After: 2400`, so it fails against the previous constant.

## Note for the mobile app

`verification_rate_limited` is a new error code on `POST /api/v1/auth/google` and `/api/v1/auth/apple`. The client in `multiplatform-app` needs to handle it. Worth checking at the same time that it handles the genuine `202 verification_sent`, which it currently surfaces as a generic error.
