### PR TITLE
Skip raw data archive rows the export could not write

### DIFF
--- a/app/services/users/import_data/raw_data_archives.rb
+++ b/app/services/users/import_data/raw_data_archives.rb
@@ -18,6 +18,12 @@ class Users::ImportData::RawDataArchives
     archives_data.each do |archive_data|
       next unless archive_data.is_a?(Hash)
 
+      if archive_data['file_error'].present?
+        Rails.logger.warn "Skipping raw data archive #{archive_label(archive_data)}: " \
+                          "exported without its file (#{archive_data['file_error']})"
+        next
+      end
+
       existing = find_existing_archive(archive_data)
 
       if existing
@@ -30,8 +36,8 @@ class Users::ImportData::RawDataArchives
         archives_created += 1
 
         files_restored += 1 if archive_data['file_name'] && restore_archive_file(archive_record, archive_data)
-      rescue ActiveRecord::RecordInvalid, ActiveModel::UnknownAttributeError => e
-        Rails.logger.warn "Skipping invalid raw data archive: #{e.message}"
+      rescue ActiveRecord::RecordInvalid => e
+        Rails.logger.warn "Skipping invalid raw data archive #{archive_label(archive_data)}: #{e.message}"
         next
       end
     end
@@ -52,10 +58,12 @@ class Users::ImportData::RawDataArchives
     )
   end
 
+  def archive_label(archive_data)
+    "#{archive_data['year']}/#{archive_data['month']} chunk #{archive_data['chunk_number']}"
+  end
+
   def create_archive_record(archive_data)
-    attributes = archive_data.except(
-      'file_name', 'original_filename', 'content_type', 'file_error'
-    )
+    attributes = archive_data.slice(*Points::RawDataArchive.column_names).except('id', 'user_id')
 
     user.raw_data_archives.create!(attributes)
   end

--- a/spec/services/users/import_data/raw_data_archives_spec.rb
+++ b/spec/services/users/import_data/raw_data_archives_spec.rb
@@ -139,14 +139,14 @@ RSpec.describe Users::ImportData::RawDataArchives, type: :service do
         ]
       end
 
-      it 'creates the archive (file_error stripped) and does not try to restore the file' do
+      it 'skips the row instead of creating an archive record without a file' do
         service = described_class.new(user, archives_data, files_directory)
 
         archives_created, files_restored = service.call
 
-        expect(archives_created).to eq(1)
+        expect(archives_created).to eq(0)
         expect(files_restored).to eq(0)
-        expect(user.raw_data_archives.count).to eq(1)
+        expect(user.raw_data_archives.count).to eq(0)
       end
 
       it 'does not raise and does not roll back when the file was not exported' do
@@ -155,7 +155,17 @@ RSpec.describe Users::ImportData::RawDataArchives, type: :service do
         service = described_class.new(user, archives_data, files_directory)
 
         expect { service.call }.not_to raise_error
-        expect(user.raw_data_archives.count).to eq(1)
+        expect(user.raw_data_archives.count).to eq(0)
+      end
+
+      it 'leaves the slot free for a later export that carries the file' do
+        described_class.new(user, archives_data, files_directory).call
+
+        retry_row = archives_data.first.except('file_error', 'file_name')
+        archives_created, = described_class.new(user, [retry_row], files_directory).call
+
+        expect(archives_created).to eq(1)
+        expect(user.raw_data_archives.where(year: 2024, month: 6, chunk_number: 1).count).to eq(1)
       end
     end
 
@@ -185,12 +195,12 @@ RSpec.describe Users::ImportData::RawDataArchives, type: :service do
         }
       end
 
-      it 'imports every valid row and the file_error row without aborting the batch' do
+      it 'imports every valid row and skips the file_error row without aborting the batch' do
         archives_data = [valid_row, file_error_row, valid_row.merge('month' => 8)]
         service = described_class.new(user, archives_data, files_directory)
 
         expect { service.call }.not_to raise_error
-        expect(user.raw_data_archives.count).to eq(3)
+        expect(user.raw_data_archives.pluck(:month)).to contain_exactly(7, 8)
       end
     end
 
@@ -211,14 +221,14 @@ RSpec.describe Users::ImportData::RawDataArchives, type: :service do
         valid_row.merge('month' => 6, 'bogus_column' => 'no such column on Points::RawDataArchive')
       end
 
-      it 'skips the bad row and still imports the surrounding valid rows' do
+      it 'ignores the unknown attribute and imports every row' do
         archives_data = [valid_row, bad_row, valid_row.merge('month' => 8)]
         service = described_class.new(user, archives_data, files_directory)
 
         result = nil
         expect { result = service.call }.not_to raise_error
-        expect(result).to eq([2, 0])
-        expect(user.raw_data_archives.count).to eq(2)
+        expect(result).to eq([3, 0])
+        expect(user.raw_data_archives.pluck(:month)).to contain_exactly(6, 7, 8)
       end
     end
   end


### PR DESCRIPTION
Follow-up to #3564. That PR merged into `master` before these review fixes were pushed, so the issues below are live on `master` and `dev` today.

## What was wrong

A `raw_data_archives.jsonl` row carrying `file_error` (written by the exporter whenever an archive blob can't be downloaded) was imported as a real `Points::RawDataArchive` record with no file attached, keeping the source row's `verified_at` and checksum.

Two consequences:

- `Points::RawData::Verifier` finds it unattached, reports `file_not_attached` to Sentry and unsets `verified_at`.
- `find_existing_archive` treats the year/month/chunk slot as taken, so a later, good export that *does* carry the file can never fill it.

Separately, `rescue ActiveModel::UnknownAttributeError` turned any exporter schema drift into silent loss of *every* archive row: one new column on the exporting instance puts an unknown key on every row.

## What changed

- Rows with `file_error` are skipped with a warning naming the year, month and chunk. No record is created, so the slot stays free for a later export.
- Attributes are sliced to `Points::RawDataArchive.column_names` minus `id`/`user_id`, the pattern `import_data/points.rb` already uses. Unknown keys are ignored per key instead of dropping the row, so the extra rescue is no longer needed and is narrowed back to `RecordInvalid`.

## Testing

`spec/services/users/import_data/` and the export/import round trip: 265 examples, 0 failures. RuboCop clean.

A spec pins that a skipped `file_error` row leaves the slot free for a later export that carries the file, asserting the returned created-count rather than only the row count, so it fails if the old behaviour returns.
