### PR TITLE
Reject out-of-range OIDC_PORT instead of composing an unreachable URL

### DIFF
--- a/lib/oidc_config.rb
+++ b/lib/oidc_config.rb
@@ -5,6 +5,8 @@ module OidcConfig
   DEFAULT_TOKEN_ENDPOINT = '/token'
   DEFAULT_USERINFO_ENDPOINT = '/userinfo'
   DEFAULT_PORT = 443
+  DEFAULT_HTTP_PORT = 80
+  PORT_RANGE = (1..65_535)
   DEFAULT_SCHEME = 'https'
 
   def self.enabled?(env = ENV)
@@ -77,7 +79,7 @@ module OidcConfig
     {
       host: env['OIDC_HOST'],
       scheme: env.fetch('OIDC_SCHEME', DEFAULT_SCHEME),
-      port: parse_port(env['OIDC_PORT']),
+      port: parse_port(env['OIDC_PORT'], env.fetch('OIDC_SCHEME', DEFAULT_SCHEME)),
       authorization_endpoint: env.fetch('OIDC_AUTHORIZATION_ENDPOINT', DEFAULT_AUTHORIZATION_ENDPOINT),
       token_endpoint: env.fetch('OIDC_TOKEN_ENDPOINT', DEFAULT_TOKEN_ENDPOINT),
       userinfo_endpoint: env.fetch('OIDC_USERINFO_ENDPOINT', DEFAULT_USERINFO_ENDPOINT)
@@ -85,13 +87,23 @@ module OidcConfig
   end
   private_class_method :manual_endpoints
 
-  def self.parse_port(value)
+  def self.parse_port(value, scheme)
+    default = scheme.to_s.casecmp('http').zero? ? DEFAULT_HTTP_PORT : DEFAULT_PORT
     port_str = value.to_s.strip
-    return DEFAULT_PORT if port_str.empty?
+    return default if port_str.empty?
 
-    Integer(port_str, 10)
+    port = Integer(port_str, 10)
+    return port if PORT_RANGE.cover?(port)
+
+    warn_invalid_port(port_str, default)
   rescue ArgumentError
-    DEFAULT_PORT
+    warn_invalid_port(port_str, default)
   end
   private_class_method :parse_port
+
+  def self.warn_invalid_port(port_str, default)
+    Rails.logger.warn("OIDC: ignoring invalid OIDC_PORT=#{port_str.inspect}, using #{default}")
+    default
+  end
+  private_class_method :warn_invalid_port
 end

--- a/spec/lib/oidc_config_spec.rb
+++ b/spec/lib/oidc_config_spec.rb
@@ -125,6 +125,29 @@ RSpec.describe OidcConfig do
         expect(described_class.build(env)[:client_options][:port]).to eq(443)
       end
 
+      it 'defaults to 80 when OIDC_SCHEME is http and OIDC_PORT is blank' do
+        %w[http HTTP].each do |scheme|
+          env = manual_env.merge('OIDC_SCHEME' => scheme, 'OIDC_PORT' => '')
+          expect(described_class.build(env)[:client_options][:port]).to eq(80)
+        end
+      end
+
+      it 'falls back to the default when OIDC_PORT is outside 1..65535' do
+        %w[0 -1 65536].each do |value|
+          env = manual_env.merge('OIDC_PORT' => value)
+          port = described_class.build(env)[:client_options][:port]
+          expect(port).to eq(443), "expected port 443 for OIDC_PORT=#{value.inspect}, got #{port}"
+        end
+      end
+
+      it 'warns when a non-blank OIDC_PORT is discarded' do
+        allow(Rails.logger).to receive(:warn)
+
+        described_class.build(manual_env.merge('OIDC_PORT' => 'abc'))
+
+        expect(Rails.logger).to have_received(:warn).with(/OIDC_PORT="abc"/)
+      end
+
       it 'falls back to the default when OIDC_PORT is non-numeric' do
         %w[abc 0x10 ${PORT} ---].each do |value|
           env = manual_env.merge('OIDC_PORT' => value)

--- a/spec/regressions/oidc_manual_issuer_configuration_spec.rb
+++ b/spec/regressions/oidc_manual_issuer_configuration_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe 'OIDC manual endpoint issuer configuration' do
     )
   end
 
-  it 'falls back to the default port when OIDC_PORT is blank or non-numeric' do
-    [[''], ['abc'], ['0x10'], ['${PORT}']].each do |(value)|
+  it 'falls back to the default port when OIDC_PORT is blank, non-numeric, or out of range' do
+    ['', 'abc', '0x10', '${PORT}', '0', '-1', '70000'].each do |value|
       config = OidcConfig.build(
         'OIDC_CLIENT_ID' => 'client-abc',
         'OIDC_CLIENT_SECRET' => 'secret-xyz',
@@ -43,7 +43,6 @@ RSpec.describe 'OIDC manual endpoint issuer configuration' do
 
       port = config[:client_options][:port]
       expect(port).to eq(443), "OIDC_PORT=#{value.inspect} should fall back to 443, got #{port}"
-      expect(config[:client_options]).not_to include(port: 0)
     end
   end
 


### PR DESCRIPTION
Follow-up to #3568. That PR merged into `master` before these review fixes were pushed, so the issues below are live on `master` and `dev` today.

## What was wrong

#3568 replaced `to_i` with `Integer(port_str, 10)`, which fixes the blank and non-numeric cases but still accepts `0`, negatives and values above 65535. `OIDC_PORT=0` therefore reproduces the exact `https://host:0/...` connect failure the PR set out to remove, and a Compose or Helm template expanding to `0` is a realistic way to get there.

Two smaller problems: a discarded value was substituted silently, so a typo'd port booted "clean" and failed against whatever listens on 443; and a blank port always defaulted to 443 even with `OIDC_SCHEME=http`.

## What changed

- Ports outside `1..65535` fall back to the default.
- A non-blank value that gets discarded is logged with `Rails.logger.warn`, naming the rejected value. A legitimately absent value stays silent.
- The default follows the scheme, so `http` with a blank port resolves to 80. The comparison is case-insensitive, matching the `OIDC_DISCOVERY` check two lines away.

## Testing

`spec/lib/oidc_config_spec.rb` and the OIDC regression specs: 56 examples, 0 failures. RuboCop clean.

New examples cover `0`, `-1` and `65536`, the `http` scheme in both cases, and the warning itself. The regression spec's value list was also unwrapped from single-element tuples, which is why its diff is larger than the behaviour change.
