### PR TITLE
fix: stop notifying about suggested visits

### DIFF
--- a/app/services/visits/suggest.rb
+++ b/app/services/visits/suggest.rb
@@ -17,7 +17,6 @@ class Visits::Suggest
     fresh = visits.reject { |visit| covered_by_known?(visit, known) }
     return visits if fresh.empty?
 
-    create_visits_notification(user)
     if Geocoding::Config.for(user).enabled?
       fresh.filter_map(&:place_id).uniq.each do |place_id|
         ReverseGeocodingJob.perform_later('place', place_id)
@@ -40,7 +39,6 @@ class Visits::Suggest
   private
 
   ERROR_DEDUP_WINDOW = 1.hour
-  TIMELINE_PATH = '/map/v2?panel=timeline&date=today&status=suggested'
 
   # Detection replaces machine rows wholesale, so a debounced re-run over an
   # ongoing stay "creates" visits every few minutes. Only a visit that does
@@ -79,18 +77,5 @@ class Visits::Suggest
   rescue StandardError => e
     Rails.logger.warn("[Visits::Suggest] error-notification dedupe unavailable: #{e.class}: #{e.message}")
     true
-  end
-
-  def create_visits_notification(user)
-    I18n.with_locale(user.locale) do
-      user.notifications.create!(
-        kind: :info,
-        title: I18n.t('services.visits.suggest.new_visits_suggested'),
-        content: I18n.t(
-          'services.visits.suggest.new_visits_suggested_message',
-          start_at: Time.zone.at(start_at), end_at: Time.zone.at(end_at), url: TIMELINE_PATH
-        )
-      )
-    end
   end
 end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -3594,9 +3594,7 @@ ca:
     visits:
       suggest:
         error_suggesting_visits_message: 'Error en suggerir visites: %{message}'
-        new_visits_suggested: S'han suggerit visites noves
         error_suggesting_visits: 'Error en suggerir visites'
-        new_visits_suggested_message: 'S''han suggerit visites noves basades en les teves dades d''ubicació del %{start_at} al %{end_at}. Les pots revisar a la pàgina <a href="%{url}" class="link">Línia de temps</a>.'
       merge_service:
         minimum_visits: Cal seleccionar almenys 2 visites per fusionar-les
       bulk_destroy:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -3656,9 +3656,7 @@ de:
     visits:
       suggest:
         error_suggesting_visits_message: 'Fehler beim Vorschlagen von Aufenthalten: %{message}'
-        new_visits_suggested: Neue Aufenthalte vorgeschlagen
         error_suggesting_visits: 'Fehler beim Vorschlagen von Aufenthalten'
-        new_visits_suggested_message: 'Basierend auf deinen Standortdaten von %{start_at} bis %{end_at} wurden neue Aufenthalte vorgeschlagen. Du kannst sie auf der Seite <a href="%{url}" class="link">Zeitleiste</a> durchsehen.'
       merge_service:
         minimum_visits: Mindestens 2 Aufenthalte müssen ausgewählt werden, um sie zu verbinden
       bulk_destroy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3582,9 +3582,7 @@ en:
     visits:
       suggest:
         error_suggesting_visits_message: 'Error suggesting visits: %{message}'
-        new_visits_suggested: New visits suggested
         error_suggesting_visits: 'Error suggesting visits'
-        new_visits_suggested_message: 'New visits have been suggested based on your location data from %{start_at} to %{end_at}. You can review them on the <a href="%{url}" class="link">Timeline</a> page.'
       merge_service:
         minimum_visits: At least 2 visits must be selected for merging
       bulk_destroy:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3601,9 +3601,7 @@ es:
     visits:
       suggest:
         error_suggesting_visits_message: 'Error al sugerir visitas: %{message}'
-        new_visits_suggested: Se sugirieron nuevas visitas
         error_suggesting_visits: 'Error al sugerir visitas'
-        new_visits_suggested_message: 'Se han sugerido nuevas visitas a partir de tus datos de ubicación del %{start_at} al %{end_at}. Puedes revisarlas en la página <a href="%{url}" class="link">Cronología</a>.'
       merge_service:
         minimum_visits: Deben seleccionarse al menos 2 visitas para fusionarlas
       bulk_destroy:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4772,9 +4772,7 @@ fr:
       suggest:
         error_suggesting_visits_message: 'Erreur lors de la suggestion de visites :
           %{message}'
-        new_visits_suggested: Nouvelles visites suggérées
         error_suggesting_visits: 'Erreur lors de la suggestion de visites'
-        new_visits_suggested_message: 'De nouvelles visites ont été suggérées à partir de vos données de localisation du %{start_at} au %{end_at}. Vous pouvez les consulter sur la page <a href="%{url}" class="link">Chronologie</a>.'
       merge_service:
         minimum_visits: Au moins 2 visites doivent être sélectionnées pour les fusionner
       bulk_destroy:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -3651,9 +3651,7 @@ pl:
     visits:
       suggest:
         error_suggesting_visits_message: 'Błąd podczas sugerowania wizyt: %{message}'
-        new_visits_suggested: Zasugerowano nowe wizyty
         error_suggesting_visits: Błąd podczas sugerowania wizyt
-        new_visits_suggested_message: Na podstawie danych lokalizacji od %{start_at} do %{end_at} zasugerowano nowe wizyty. Możesz je przejrzeć na stronie <a href="%{url}" class="link">Osi czasu</a>.
       merge_service:
         minimum_visits: Do scalenia trzeba wybrać co najmniej 2 wizyty
       bulk_destroy:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -3620,10 +3620,7 @@ zh:
     visits:
       suggest:
         error_suggesting_visits_message: 生成到访建议时出错：%{message}
-        new_visits_suggested: 已生成新的到访建议
         error_suggesting_visits: 生成到访建议时出错
-        new_visits_suggested_message: 已根据您 %{start_at} 至 %{end_at} 的位置数据生成了新的到访建议。您可以在<a
-          href="%{url}" class="link">时间线</a>页面中查看。
       merge_service:
         minimum_visits: 至少需要选择 2 条到访记录才能合并
       bulk_destroy:

--- a/spec/regressions/notification_recipient_locale_spec.rb
+++ b/spec/regressions/notification_recipient_locale_spec.rb
@@ -35,17 +35,6 @@ RSpec.describe 'Notification recipient locale' do
     expect(german_user.notifications.last.title).to eq('Export fehlgeschlagen')
   end
 
-  it 'localizes both halves of the suggested-visits notification' do
-    allow_any_instance_of(Visits::SmartDetect).to receive(:call).and_return([build(:visit)])
-
-    Visits::Suggest.new(german_user, start_at: 1.day.ago.to_i, end_at: Time.current.to_i).call
-
-    notification = german_user.notifications.last
-    expect(notification.title).to eq('Neue Aufenthalte vorgeschlagen')
-    expect(notification.content).to include('Zeitleiste')
-    expect(notification.content).not_to include('have been suggested')
-  end
-
   it 'localizes the suggested-visits failure notification' do
     allow_any_instance_of(Visits::SmartDetect).to receive(:call).and_raise(StandardError, 'boom')
 

--- a/spec/services/visits/suggest_spec.rb
+++ b/spec/services/visits/suggest_spec.rb
@@ -74,11 +74,11 @@ RSpec.describe Visits::Suggest do
       expect(visit.ended_at).to eq(start_at + 190.minutes)
     end
 
-    it 'creates visits notification' do
-      expect { subject }.to change(Notification, :count).by(1)
+    it 'does not notify the user about newly suggested visits' do
+      expect { subject }.not_to change(Notification, :count)
     end
 
-    it 'does not notify again when a re-run merely regenerates the same stays' do
+    it 'does not notify when a re-run merely regenerates the same stays' do
       described_class.new(user, start_at:, end_at:).call
       create(:point, :with_known_location, user:, timestamp: start_at + 191.minutes)
 


### PR DESCRIPTION
## Summary
- stop creating informational notifications when visit detection finds new suggested visits
- remove the now-unused success-notification translations
- update regression coverage while preserving detector failure notifications

## Why
Suggested visits no longer require explicit confirmation, so prompting users to review every newly detected visit is redundant and creates notification spam.

## How to validate
1. Run visit suggestion for a range that produces a new visit.
2. Confirm the visit is created without adding an informational notification.
3. Force the detector to fail and confirm the localized error notification is still created.

Automated checks:
- asdf exec bundle exec rspec spec/services/visits/suggest_spec.rb spec/regressions/notification_recipient_locale_spec.rb — 18 examples, 0 failures
- asdf exec bundle exec rubocop app/services/visits/suggest.rb spec/services/visits/suggest_spec.rb spec/regressions/notification_recipient_locale_spec.rb — no offenses
- locale lookup check across all available locales — passed

## Screenshots / GIF
Not applicable; there are no UI changes.

## Risk / rollout notes
- no database migration
- existing notification rows are left intact
- visit-detector failure notifications remain enabled