### PR TITLE
Restore SMTP native address fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- SMTP delivery now falls back to IPv4 when an SMTP host's IPv6 address is unreachable (#3591).
 - Cities where you stayed but your phone reported infrequently are counted again. Time spent in a city was measured from how often your device sent points rather than from how long you were there, so a stationary phone saving battery could be credited no time at all and drop the city — including your home city — from statistics and from the map's visited-cities view. Recalculated months will generally show higher numbers than before. **Existing months keep their old numbers until recalculated: press "Update stats" on the Stats page.** (#2207)
 - Changing "Min Minutes in City" now recalculates your existing statistics, instead of leaving old numbers in place until you refreshed them by hand (#2207).
 - A GPX file holding only waypoints (such as an OsmAnd+ `favourites.gpx`) now says so when it imports 0 points, instead of reporting that the file lacks per-point timestamps. That advice was wrong: OsmAnd waypoints do carry a time, and adding more timestamps never helped. (#1261)

--- a/config/initializers/smtp_native_address_fallback.rb
+++ b/config/initializers/smtp_native_address_fallback.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# resolv-replace makes TCPSocket resolve a host to one address before connecting.
+# That removes Ruby's native address fallback (for example, unreachable IPv6 to
+# reachable IPv4). Keep resolv-replace and Dawarich's DNS cache for all ordinary
+# socket users, but let SMTP use the original TCPSocket initializer instead.
+Rails.application.config.after_initialize do
+  next unless TCPSocket.private_instance_methods.include?(:original_resolv_initialize)
+
+  Net::SMTP.prepend(Module.new do
+    private
+
+    def tcp_socket(address, port)
+      socket = TCPSocket.allocate
+      socket.__send__(:original_resolv_initialize, address, port)
+      socket
+    end
+  end)
+end

--- a/spec/regressions/tcp_socket_address_fallback_spec.rb
+++ b/spec/regressions/tcp_socket_address_fallback_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'resolv'
+
+RSpec.describe 'SMTP address fallback' do
+  it 'uses native resolution when the Ruby resolver returns an unreachable address' do
+    server = TCPServer.new('127.0.0.1', 0)
+    allow(Resolv).to receive(:getaddress).with('localhost').and_return('::1')
+
+    socket = Net::SMTP.new('localhost').send(:tcp_socket, 'localhost', server.local_address.ip_port)
+
+    expect(socket.remote_address).to be_ipv4
+  ensure
+    socket&.close
+    server&.close
+  end
+end


### PR DESCRIPTION
Fixes #3591

Continuation port of OneDev PR #195: https://onedev.dwri.xyz/projects/dawarich/~pulls/195
Source author: frey (OneDev account); source SHA: e98278f4f5ee9ac74c350befdf06c0211be636b2.

Root cause: resolv-replace resolves TCPSocket hosts to one cached address before connecting, preventing Ruby native IPv6-to-IPv4 fallback.
User-visible result: SMTP regains Ruby native address fallback while resolv-replace and the Redis-backed five-minute Dawarich DNS cache remain installed and covered by regression tests.

Tested SHA: updated by this PR head.
Verification: focused SMTP fallback and DNS cache RSpec pass (5 examples); changed-file RuboCop passes; diff check passes.
Scenario pair: pending — the frozen Product-API scenario contract has no supported synthetic SMTP/DNS control.
CI: pending.
Risk: SMTP alone bypasses resolv-replace socket substitution; ordinary resolution keeps the existing cache.
