### PR TITLE
fix: calculate relation distances in SQL

### DIFF
--- a/app/models/concerns/distanceable.rb
+++ b/app/models/concerns/distanceable.rb
@@ -106,7 +106,7 @@ module Distanceable
         raise ArgumentError, "Invalid unit. Supported units are: #{::DISTANCE_UNITS.keys.join(', ')}"
       end
 
-      distance_in_meters = connection.select_value(<<-SQL.squish)
+      distance_in_meters = connection.select_value(<<~SQL.squish)
         WITH points_with_previous AS (
           SELECT
             lonlat,
@@ -158,7 +158,7 @@ module Distanceable
       end
 
       # Single query to calculate all distances using parameterized query
-      sql_with_params = ActiveRecord::Base.sanitize_sql_array([<<-SQL.squish] + params)
+      sql_with_params = ActiveRecord::Base.sanitize_sql_array([<<~SQL.squish] + params)
         WITH point_pairs AS (
           SELECT
             pair_id,
@@ -189,7 +189,7 @@ module Distanceable
     return nil if other_lonlat.nil?
 
     # Calculate distance in meters using PostGIS
-    distance_in_meters = self.class.connection.select_value(<<-SQL.squish)
+    distance_in_meters = self.class.connection.select_value(<<~SQL.squish)
       SELECT ST_Distance(
         ST_GeomFromEWKT('#{lonlat}')::geography,
         ST_GeomFromEWKT('#{other_lonlat}')::geography

--- a/app/models/concerns/distanceable.rb
+++ b/app/models/concerns/distanceable.rb
@@ -5,8 +5,10 @@ module Distanceable
 
   module ClassMethods
     def total_distance(points = nil, unit = :km)
-      if points.nil?
-        calculate_distance_for_relation(unit)
+      if points.is_a?(ActiveRecord::Relation)
+        calculate_distance_for_relation(unit, points)
+      elsif points.nil?
+        calculate_distance_for_relation(unit, all)
       else
         calculate_distance_for_array(points, unit)
       end
@@ -99,7 +101,7 @@ module Distanceable
 
     private
 
-    def calculate_distance_for_relation(unit)
+    def calculate_distance_for_relation(unit, relation = all)
       unless ::DISTANCE_UNITS.key?(unit.to_sym)
         raise ArgumentError, "Invalid unit. Supported units are: #{::DISTANCE_UNITS.keys.join(', ')}"
       end
@@ -109,7 +111,7 @@ module Distanceable
           SELECT
             lonlat,
             LAG(lonlat) OVER (ORDER BY timestamp) as prev_lonlat
-          FROM (#{to_sql}) AS points
+          FROM (#{relation.to_sql}) AS points
         )
         SELECT COALESCE(
           SUM(

--- a/spec/models/concerns/distanceable_spec.rb
+++ b/spec/models/concerns/distanceable_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Distanceable, type: :model do
+  describe '.total_distance' do
+    it 'uses a relation as SQL input without materializing its point records' do
+      user = create(:user)
+      create(:point, user:, timestamp: 1_700_000_000, lonlat: 'POINT(13.404954 52.520008)')
+      create(:point, user:, timestamp: 1_700_000_060, lonlat: 'POINT(13.064477 52.398862)')
+      relation = user.points.order(:timestamp)
+
+      distance = nil
+      expect { distance = Point.total_distance(relation, :m) }
+        .not_to change(relation, :loaded?)
+
+      expect(distance).to be_within(1_000).of(27_000)
+    end
+  end
+end


### PR DESCRIPTION
## Continuation of #3589

The contributor-owned head branch for #3589 is not writable by `zeitflowbot`, so this draft is a bot-owned continuation targeting the same `dev` base. It deliberately does not modify or force-push the contributor branch.

## Root cause

When `Point.total_distance` receives an `ActiveRecord::Relation`, the base implementation routes it through the array path, which materializes the relation and builds a `VALUES` query with one parameter set per point pair.

## Fix

- Route relation inputs to the SQL/window-function implementation.
- Build the subquery from the supplied relation's `to_sql`, preserving its scope and avoiding Ruby record materialization.
- Keep array inputs on the existing array path.

## Deterministic regression

The new spec creates two points and asserts that calculating a relation's distance:

1. returns the expected ~27 km in meters; and
2. leaves `relation.loaded?` unchanged.

That test fails on current `origin/dev` because the array path loads the relation, and passes with this change. It proves the allocation/path-selection bug without relying on an OOM condition.

## Verification

- `asdf exec bundle exec rspec spec/models/concerns/distanceable_spec.rb`
- `asdf exec bundle exec rspec spec/regressions/trip_excludes_anomaly_points_spec.rb`
- `asdf exec bundle exec rubocop app/models/concerns/distanceable.rb spec/models/concerns/distanceable_spec.rb`
- `git diff origin/dev...HEAD --check`