### PR TITLE
fix: filter repeated Android tower fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Android cell-tower location bursts no longer draw repeated spikes away from the real route when precise fixes from the same device are available nearby (#3417)
 - Yearly digests for cloud-Lite users read seasonality and country time spent from the same data window as monthly distances and toponyms.
 - The per-email API login brute-force throttle now counts `application/json` request bodies, so password grinding against `POST /api/v1/auth/login` is bounded per account even when an attacker rotates source IPs.
 

--- a/app/services/points/anomaly_filter.rb
+++ b/app/services/points/anomaly_filter.rb
@@ -189,11 +189,23 @@ class Points::AnomalyFilter
     # tower fix often arrives in a batch of one, before the precise fixes
     # that condemn it exist, and the batch that brings those fixes starts
     # after it. Each run therefore re-judges the recent past.
+    sentinel_conditions = <<~SQL.squish
+      (vertical_accuracy < 0 AND velocity LIKE '-%') OR (
+        vertical_accuracy = 0 AND velocity ~ '^0+(\.0+)?$' AND
+        EXISTS (SELECT 1 FROM points repeated
+          WHERE repeated.user_id = points.user_id
+          AND repeated.tracker_id IS NOT DISTINCT FROM points.tracker_id
+          AND repeated.timestamp BETWEEN points.timestamp - :repeat_window
+          AND points.timestamp + :repeat_window
+          AND repeated.id <> points.id
+          AND repeated.lonlat = points.lonlat)
+      )
+    SQL
+
     relation = Point.where(user_id: @user_id,
                            timestamp: (@start_time - SENTINEL_PRECISE_NEIGHBOR_SECONDS)..@end_time)
                     .not_anomaly
-                    .where(vertical_accuracy: ...0)
-                    .where("velocity LIKE '-%'")
+                    .where(sentinel_conditions, repeat_window: SENTINEL_PRECISE_NEIGHBOR_SECONDS)
                     .where('accuracy > ?', SENTINEL_ACCURACY_METERS)
                     .where(
                       'EXISTS (SELECT 1 FROM points precise ' \

--- a/db/migrate/20260907060000_enqueue_android_coarse_location_recalculation.rb
+++ b/db/migrate/20260907060000_enqueue_android_coarse_location_recalculation.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class EnqueueAndroidCoarseLocationRecalculation < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def up
+    clear_completion_stamps
+    enqueue_recalculation
+  end
+
+  def down; end
+
+  private
+
+  def stamp_keys
+    [
+      DataMigrations::RecalculateAnomaliesUserJob::QUEUED_SETTINGS_KEY,
+      DataMigrations::RecalculateAnomaliesUserJob::RECALCULATED_SETTINGS_KEY,
+      DataMigrations::RecalculateAnomaliesUserJob::FAILED_SETTINGS_KEY
+    ]
+  end
+
+  def clear_completion_stamps
+    quoted = stamp_keys.map { |key| connection.quote(key) }.join(', ')
+
+    execute(<<~SQL.squish)
+      UPDATE users
+      SET settings = settings - ARRAY[#{quoted}]::text[]
+      WHERE settings ?| ARRAY[#{quoted}]::text[]
+    SQL
+  end
+
+  def enqueue_recalculation
+    DataMigrations::RecalculateAnomaliesJob.perform_later
+  rescue NameError
+    raise
+  rescue StandardError => e
+    Rails.logger.error(
+      '[EnqueueAndroidCoarseLocationRecalculation] could not enqueue the anomaly recalculation: ' \
+      "#{e.class}: #{e.message}. " \
+      'Start it later with: DataMigrations::RecalculateAnomaliesJob.perform_later'
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_06_103000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_07_060000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"

--- a/spec/migrations/enqueue_android_coarse_location_recalculation_spec.rb
+++ b/spec/migrations/enqueue_android_coarse_location_recalculation_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('db/migrate/20260907060000_enqueue_android_coarse_location_recalculation.rb')
+
+RSpec.describe EnqueueAndroidCoarseLocationRecalculation do
+  subject(:migration) { described_class.new }
+
+  let(:queued_key) { DataMigrations::RecalculateAnomaliesUserJob::QUEUED_SETTINGS_KEY }
+  let(:done_key) { DataMigrations::RecalculateAnomaliesUserJob::RECALCULATED_SETTINGS_KEY }
+  let(:failed_key) { DataMigrations::RecalculateAnomaliesUserJob::FAILED_SETTINGS_KEY }
+
+  it 'clears prior completion state and enqueues a fresh sweep' do
+    user = create(:user)
+    user.update!(settings: user.settings.merge(queued_key => 'queued', done_key => 'done', failed_key => 'failed'))
+
+    expect { migration.up }.to have_enqueued_job(DataMigrations::RecalculateAnomaliesJob)
+    expect(user.reload.settings.keys).not_to include(queued_key, done_key, failed_key)
+  end
+
+  it 'runs without a wrapping transaction' do
+    expect(described_class.disable_ddl_transaction).to be true
+  end
+
+  it 'keeps deployment running when the queue is unavailable' do
+    allow(DataMigrations::RecalculateAnomaliesJob).to receive(:perform_later).and_raise(StandardError, 'offline')
+
+    expect { migration.up }.not_to raise_error
+  end
+end

--- a/spec/regressions/android_coarse_location_filtering_spec.rb
+++ b/spec/regressions/android_coarse_location_filtering_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Android coarse location filtering' do
+  let(:user) { create(:user) }
+  let(:base_time) { 1.hour.ago.to_i }
+
+  let!(:precise_points) do
+    [0, 300].map do |offset|
+      create(:point, user: user, tracker_id: 'android-phone', accuracy: 20,
+                     velocity: '1.5', vertical_accuracy: 4, timestamp: base_time + offset,
+                     lonlat: "POINT(13.405#{offset / 300} 52.520#{offset / 300})")
+    end
+  end
+
+  let!(:coarse_points) do
+    [
+      [60, '0'],
+      [120, '0.0'],
+      [180, '00.00']
+    ].map do |offset, velocity|
+      create(:point, user: user, tracker_id: 'android-phone', accuracy: 600,
+                     velocity: velocity, vertical_accuracy: 0, timestamp: base_time + offset,
+                     lonlat: 'POINT(13.435 52.54)')
+    end
+  end
+
+  let!(:coarse_singleton) do
+    create(:point, user: user, tracker_id: 'android-phone', accuracy: 600,
+                   velocity: '0', vertical_accuracy: 0, timestamp: base_time + 240,
+                   lonlat: 'POINT(13.425 52.53)')
+  end
+
+  before { Points::AnomalyFilter.new(user.id, base_time, base_time + 300).call }
+
+  it 'flags repeated coarse motionless fixes surrounded by precise fixes from the same device' do
+    expect(coarse_points.map { |point| point.reload.anomaly }).to all(be(true))
+    expect(precise_points.map { |point| point.reload.anomaly }).to all(be_falsey)
+  end
+
+  it 'keeps a single coarse point that may carry real route geometry' do
+    expect(coarse_singleton.reload.anomaly).to be_falsey
+  end
+end


### PR DESCRIPTION
## Summary
- Flags repeated, motionless Android coarse cell-tower fixes only when nearby precise points from the same tracker establish that they are anomalous.
- Preserves singleton coarse fixes that may represent legitimate route geometry.

## Migration / recalculation
- Adds `EnqueueAndroidCoarseLocationRecalculation`, preserving the source migration behavior: clears prior per-user anomaly-recalculation queued/completed/failed stamps, then queues a fresh `DataMigrations::RecalculateAnomaliesJob` sweep.
- Queue-unavailable errors are logged without blocking deployment; a missing job constant still raises.

Fixes #3417

## Source port
- Source OneDev PR: https://onedev.dwri.xyz/projects/dawarich/pulls/192 (internal pull ID `192`, visible PR `#128`)
- Source author: `frey`
- Source commit: `ec25b3aa02d578c6b54225db5a6b5b47ce47cc43`

## Verification
- `asdf exec bundle exec rspec spec/regressions/android_coarse_location_filtering_spec.rb spec/migrations/enqueue_android_coarse_location_recalculation_spec.rb` — 5 examples, 0 failures
  - The RSpec invocation also ran the project's Swagger dry run: 241 examples, 0 failures.
- `asdf exec bundle exec rubocop app/services/points/anomaly_filter.rb db/migrate/20260907060000_enqueue_android_coarse_location_recalculation.rb spec/migrations/enqueue_android_coarse_location_recalculation_spec.rb spec/regressions/android_coarse_location_filtering_spec.rb` — 4 files inspected, no offenses.
- Ruby syntax checks for all four changed Ruby files — passed.
- `git diff --check` — passed.

> Draft port of the current OneDev fix; no merge or auto-merge is enabled.
